### PR TITLE
[codex] Skip coverage for dependency-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,53 @@ jobs:
           path: nx-tests-attempt-*.log
           if-no-files-found: ignore
 
+  coverage-scope:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    outputs:
+      should_run: ${{ steps.scope.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEPENDENCIES_PR: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" != "pull_request" || "$DEPENDENCIES_PR" != "true" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA")"
+          if [[ -z "$changed_files" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          should_run=false
+          while IFS= read -r path; do
+            case "$path" in
+              .github/*|docs/*|README.md|CHANGELOG.md|package.json|package-lock.json|bun.lockb|flake.lock|flake.nix|tool-versions.json|packages/*/package.json)
+                ;;
+              *)
+                should_run=true
+                break
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+
   coverage:
+    needs: coverage-scope
+    if: ${{ needs.coverage-scope.outputs.should_run == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Summary
- add a lightweight `coverage-scope` job ahead of `coverage`
- skip coverage only for pull requests labeled `dependencies` when every changed file is dependency or CI metadata
- keep coverage running for all pushes and for dependency PRs that also touch real source paths

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts \"yaml-ok\""`
- `actionlint .github/workflows/ci.yml`

Closes #11.
