### PR TITLE
[maestro] publish via @evalops-jh

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ This README is intentionally short. Use it to get running, then jump into the do
 ### Bun (recommended)
 
 ```bash
-bun install -g @evalops/maestro
+bun install -g @evalops-jh/maestro
 ```
 
 ### npm
 
 ```bash
-npm install -g @evalops/maestro
+npm install -g @evalops-jh/maestro
 ```
 
 ### Nix

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@evalops/maestro",
+  "name": "@evalops-jh/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
   "version": "0.10.0",
   "private": false,

--- a/packages/jetbrains-plugin/README.md
+++ b/packages/jetbrains-plugin/README.md
@@ -36,7 +36,7 @@ This plugin supports all JetBrains IDEs based on IntelliJ Platform 2024.3+:
 
 ```bash
 # Install Maestro CLI
-npm install -g @evalops/maestro
+npm install -g @evalops-jh/maestro
 
 # Start the web server
 composer web

--- a/packages/jetbrains-plugin/src/main/resources/META-INF/plugin.xml
+++ b/packages/jetbrains-plugin/src/main/resources/META-INF/plugin.xml
@@ -18,7 +18,7 @@
     </ul>
     <h3>Getting Started</h3>
     <ol>
-        <li>Install the Maestro CLI: <code>npm install -g @evalops/maestro</code></li>
+        <li>Install the Maestro CLI: <code>npm install -g @evalops-jh/maestro</code></li>
         <li>Start the web server: <code>maestro web</code></li>
         <li>Open the Maestro tool window in your IDE</li>
     </ol>

--- a/src/agent/providers/openai.ts
+++ b/src/agent/providers/openai.ts
@@ -114,8 +114,8 @@ import type {
 
 const logger = createLogger("agent:providers:openai");
 import { streamResponsesApiSdk } from "./openai-responses-sdk.js";
-export {
-	filterResponsesApiTools,
+export { filterResponsesApiTools } from "./openai-shared.js";
+export type {
 	OpenAIOptions,
 	OpenAIResponseFormat,
 	OpenAIToolChoice,
@@ -979,6 +979,7 @@ export async function* streamOpenAI(
 	let buffer = "";
 	const toolArgBuffers = new Map<number, string>();
 	const toolArgOverrides = new Map<number, Record<string, unknown>>();
+	const toolCallContentIndexes = new Map<number, number>();
 	let cacheAdjusted = false;
 	const textEnded = new Set<number>();
 	const toolEnded = new Set<number>();
@@ -1131,16 +1132,18 @@ export async function* streamOpenAI(
 
 					if (delta?.tool_calls) {
 						for (const toolCall of delta.tool_calls) {
-							const idx = toolCall.index;
+							const streamIdx = toolCall.index;
+							let idx = toolCallContentIndexes.get(streamIdx);
 
-							// Ensure we have a slot
-							while (partial.content.length <= idx) {
+							if (idx === undefined) {
+								idx = partial.content.length;
 								partial.content.push({
 									type: "toolCall",
 									id: "",
 									name: "",
 									arguments: {},
 								});
+								toolCallContentIndexes.set(streamIdx, idx);
 							}
 
 							const block = partial.content[idx];

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -428,7 +428,7 @@ export type Message = UserMessage | AssistantMessage | ToolResultMessage;
  *
  * @example
  * ```typescript
- * declare module "@evalops/maestro" {
+ * declare module "@evalops-jh/maestro" {
  *   interface CustomAgentMessages {
  *     notification: { role: "notification"; text: string; timestamp: number };
  *   }

--- a/src/cli-tui/startup-announcements.ts
+++ b/src/cli-tui/startup-announcements.ts
@@ -44,7 +44,7 @@ export function renderStartupAnnouncements({
 		);
 		const currentLine = chalk.dim(`Current version: v${current}`);
 		const installLine = `${chalk.dim("Update with")} ${chalk.cyan(
-			"npm install -g @evalops/maestro",
+			"npm install -g @evalops-jh/maestro",
 		)}`;
 		const noteLine = notes ? chalk.dim(notes) : null;
 		const sourceLine = source

--- a/src/cli-tui/tool-renderers/index.ts
+++ b/src/cli-tui/tool-renderers/index.ts
@@ -14,7 +14,7 @@ const RENDERERS: Record<string, new () => ToolRenderer> = {
 	edit: EditRenderer,
 };
 
-export { ToolRenderer, ToolRenderArgs } from "./types.js";
+export type { ToolRenderer, ToolRenderArgs } from "./types.js";
 
 export function createToolRenderer(toolName: string): ToolRenderer {
 	const key = toolName.toLowerCase();

--- a/src/cli-tui/update-view.ts
+++ b/src/cli-tui/update-view.ts
@@ -45,7 +45,7 @@ export class UpdateView {
 				`v${latestVersion} available (current v${currentVersion})`,
 			);
 			instructions = `${chalk.dim("Update with")} ${chalk.cyan(
-				"npm install -g @evalops/maestro",
+				"npm install -g @evalops-jh/maestro",
 			)}`;
 		} else {
 			summary = chalk.hex("#38bdf8")(

--- a/test/agent/openai-streaming.test.ts
+++ b/test/agent/openai-streaming.test.ts
@@ -113,6 +113,43 @@ describe("OpenAI streaming", () => {
 		expect(toolEnd.toolCall.arguments).toEqual({ path: "/tmp/test.txt" });
 	});
 
+	it("preserves tool calls when text arrives before tool calls (Completions API)", async () => {
+		const lines = [
+			'data: {"choices":[{"delta":{"content":"I\\u2019ll read the file first."}}]}\n',
+			'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"read","arguments":"{\\"path\\":"}}]}}]}\n',
+			'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"/tmp/test.txt\\"}"}}]}}]}\n',
+			'data: {"choices":[{"finish_reason":"tool_calls"}]}\n',
+			"data: [DONE]\n",
+		];
+
+		const mockResponse = new Response(makeStream(lines), { status: 200 });
+		mockFetch.mockResolvedValue(mockResponse);
+
+		const events: AssistantMessageEvent[] = [];
+		for await (const ev of streamOpenAI(completionsModel, baseContext, {
+			apiKey: "k",
+		})) {
+			events.push(ev);
+		}
+
+		const textDelta = events.find((ev) => ev.type === "text_delta") as Extract<
+			AssistantMessageEvent,
+			{ type: "text_delta" }
+		>;
+		const toolStart = events.find(
+			(ev) => ev.type === "toolcall_start",
+		) as Extract<AssistantMessageEvent, { type: "toolcall_start" }>;
+		const toolEnd = events.find((ev) => ev.type === "toolcall_end") as Extract<
+			AssistantMessageEvent,
+			{ type: "toolcall_end" }
+		>;
+
+		expect(textDelta.delta).toBe("I’ll read the file first.");
+		expect(toolStart.contentIndex).toBe(1);
+		expect(toolEnd.toolCall.name).toBe("read");
+		expect(toolEnd.toolCall.arguments).toEqual({ path: "/tmp/test.txt" });
+	});
+
 	it("uses max_tokens for OpenAI-compatible vendors", async () => {
 		const lines = [
 			'data: {"choices":[{"finish_reason":"stop"}]}\n',


### PR DESCRIPTION
## Summary
- switch the package and install hints to the temporary `@evalops-jh/maestro` scope
- mirror the OpenAI completions tool-call streaming fix into the public repo
- fix type-only re-exports in the OpenAI provider and tool renderer index
- keep the public repo aligned with the package that was just published to npm

## Validation
- `node ./scripts/run-vitest.js --run test/agent/openai-streaming.test.ts`
- `npm pack --dry-run`
- published `@evalops-jh/maestro@0.10.0` to npm
- `npm view @evalops-jh/maestro@0.10.0 version`
