### PR TITLE
[maestro] switch npm release to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -220,9 +219,7 @@ jobs:
           name: npm-tarball-${{ needs.prepare.outputs.release_tag }}
           path: ${{ steps.pack.outputs.tarball }}
 
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm with trusted publishing
         run: |
           set -euo pipefail
           npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance


### PR DESCRIPTION
## Summary
- remove token-based npm auth from the release workflow
- publish via GitHub OIDC trusted publishing only
- drop the unused workflow-level package write permission

## Validation
- registered npm trusted publisher for `@evalops-jh/maestro` and `evalops/maestro` `release.yml`
- removed `NPM_TOKEN` from GitHub Actions secrets
- local guardrails passed during commit hook