### PR TITLE
[maestro] fix release pipeline packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,8 @@ jobs:
           ensure-ripgrep: "true"
 
       - run: bun run bun:lint
-      - run: bun run build
+      - run: npm run build:all
+      - run: bun run openapi:generate
       - run: bun run bun:test
       - name: Run evals chunk
         env:
@@ -196,7 +197,7 @@ jobs:
             exit 1
           fi
 
-      - run: bun run build
+      - run: npm run build:all
       - name: Generate version metadata
         run: node scripts/create-version-json.js
 

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Composer Web API",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [
@@ -31,6 +31,213 @@
             "description": "OK"
           }
         }
+      }
+    },
+    "/api/headless/connections": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/headless/sessions": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/headless/sessions/{id}": {
+      "get": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/headless/sessions/{id}/events": {
+      "get": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/headless/sessions/{id}/subscribe": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/headless/sessions/{id}/unsubscribe": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/headless/sessions/{id}/heartbeat": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/headless/sessions/{id}/disconnect": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/headless/sessions/{id}/messages": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
       }
     },
     "/debug/z": {
@@ -189,6 +396,52 @@
             }
           }
         }
+      },
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/prompt-suggestion": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/bridge/status": {
+      "get": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
       }
     },
     "/api/config": {
@@ -397,6 +650,50 @@
             "ComposerApiKey": []
           }
         ]
+      },
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/package": {
+      "get": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
       }
     },
     "/api/usage": {
@@ -487,6 +784,141 @@
             "description": "Invalid background action"
           }
         }
+      }
+    },
+    "/api/automations": {
+      "get": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      },
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/automations/preview": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/automations/magic-docs": {
+      "get": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/automations/{id}": {
+      "patch": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/automations/{id}/run": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
       }
     },
     "/api/undo": {
@@ -1377,6 +1809,22 @@
         ]
       }
     },
+    "/api/chat/tool-retry": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
     "/api/attachments/extract": {
       "post": {
         "summary": "Auto-generated from route definition",
@@ -1394,6 +1842,31 @@
       }
     },
     "/api/sessions/{id}/artifacts": {
+      "get": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/sessions/{id}/artifact-access": {
       "get": {
         "summary": "Auto-generated from route definition",
         "parameters": [
@@ -1932,6 +2405,9 @@
     "schemas": {
       "ChatRequest": {
         "type": "object",
+        "required": [
+          "messages"
+        ],
         "properties": {
           "model": {
             "type": "string"
@@ -1940,6 +2416,10 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "role",
+                "content"
+              ],
               "properties": {
                 "role": {
                   "anyOf": [
@@ -1972,6 +2452,10 @@
                         "anyOf": [
                           {
                             "type": "object",
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "const": "text",
@@ -1983,14 +2467,15 @@
                               "textSignature": {
                                 "type": "string"
                               }
-                            },
-                            "required": [
-                              "type",
-                              "text"
-                            ]
+                            }
                           },
                           {
                             "type": "object",
+                            "required": [
+                              "type",
+                              "data",
+                              "mimeType"
+                            ],
                             "properties": {
                               "type": {
                                 "const": "image",
@@ -2002,15 +2487,14 @@
                               "mimeType": {
                                 "type": "string"
                               }
-                            },
-                            "required": [
-                              "type",
-                              "data",
-                              "mimeType"
-                            ]
+                            }
                           },
                           {
                             "type": "object",
+                            "required": [
+                              "type",
+                              "thinking"
+                            ],
                             "properties": {
                               "type": {
                                 "const": "thinking",
@@ -2022,14 +2506,16 @@
                               "thinkingSignature": {
                                 "type": "string"
                               }
-                            },
-                            "required": [
-                              "type",
-                              "thinking"
-                            ]
+                            }
                           },
                           {
                             "type": "object",
+                            "required": [
+                              "type",
+                              "id",
+                              "name",
+                              "arguments"
+                            ],
                             "properties": {
                               "type": {
                                 "const": "toolCall",
@@ -2050,13 +2536,7 @@
                               "thoughtSignature": {
                                 "type": "string"
                               }
-                            },
-                            "required": [
-                              "type",
-                              "id",
-                              "name",
-                              "arguments"
-                            ]
+                            }
                           }
                         ]
                       }
@@ -2067,6 +2547,13 @@
                   "type": "array",
                   "items": {
                     "type": "object",
+                    "required": [
+                      "id",
+                      "type",
+                      "fileName",
+                      "mimeType",
+                      "size"
+                    ],
                     "properties": {
                       "id": {
                         "type": "string"
@@ -2104,14 +2591,7 @@
                       "preview": {
                         "type": "string"
                       }
-                    },
-                    "required": [
-                      "id",
-                      "type",
-                      "fileName",
-                      "mimeType",
-                      "size"
-                    ]
+                    }
                   }
                 },
                 "timestamp": {
@@ -2124,6 +2604,10 @@
                   "type": "array",
                   "items": {
                     "type": "object",
+                    "required": [
+                      "name",
+                      "status"
+                    ],
                     "properties": {
                       "name": {
                         "type": "string"
@@ -2158,11 +2642,7 @@
                       "toolCallId": {
                         "type": "string"
                       }
-                    },
-                    "required": [
-                      "name",
-                      "status"
-                    ]
+                    }
                   }
                 },
                 "toolName": {
@@ -2173,6 +2653,10 @@
                 },
                 "usage": {
                   "type": "object",
+                  "required": [
+                    "input",
+                    "output"
+                  ],
                   "properties": {
                     "input": {
                       "type": "number"
@@ -2188,6 +2672,10 @@
                     },
                     "cost": {
                       "type": "object",
+                      "required": [
+                        "input",
+                        "output"
+                      ],
                       "properties": {
                         "input": {
                           "type": "number"
@@ -2204,23 +2692,20 @@
                         "total": {
                           "type": "number"
                         }
-                      },
-                      "required": [
-                        "input",
-                        "output"
-                      ]
+                      }
                     }
-                  },
-                  "required": [
-                    "input",
-                    "output"
-                  ]
+                  }
+                },
+                "provider": {
+                  "type": "string"
+                },
+                "api": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
                 }
-              },
-              "required": [
-                "role",
-                "content"
-              ]
+              }
             }
           },
           "thinkingLevel": {
@@ -2253,25 +2738,26 @@
           "stream": {
             "type": "boolean"
           }
-        },
-        "required": [
-          "messages"
-        ]
+        }
       },
       "ModelSetRequest": {
         "type": "object",
+        "required": [
+          "model"
+        ],
         "properties": {
           "model": {
             "minLength": 1,
             "type": "string"
           }
-        },
-        "required": [
-          "model"
-        ]
+        }
       },
       "ChatMessage": {
         "type": "object",
+        "required": [
+          "role",
+          "content"
+        ],
         "properties": {
           "role": {
             "anyOf": [
@@ -2304,6 +2790,10 @@
                   "anyOf": [
                     {
                       "type": "object",
+                      "required": [
+                        "type",
+                        "text"
+                      ],
                       "properties": {
                         "type": {
                           "const": "text",
@@ -2315,14 +2805,15 @@
                         "textSignature": {
                           "type": "string"
                         }
-                      },
-                      "required": [
-                        "type",
-                        "text"
-                      ]
+                      }
                     },
                     {
                       "type": "object",
+                      "required": [
+                        "type",
+                        "data",
+                        "mimeType"
+                      ],
                       "properties": {
                         "type": {
                           "const": "image",
@@ -2334,15 +2825,14 @@
                         "mimeType": {
                           "type": "string"
                         }
-                      },
-                      "required": [
-                        "type",
-                        "data",
-                        "mimeType"
-                      ]
+                      }
                     },
                     {
                       "type": "object",
+                      "required": [
+                        "type",
+                        "thinking"
+                      ],
                       "properties": {
                         "type": {
                           "const": "thinking",
@@ -2354,14 +2844,16 @@
                         "thinkingSignature": {
                           "type": "string"
                         }
-                      },
-                      "required": [
-                        "type",
-                        "thinking"
-                      ]
+                      }
                     },
                     {
                       "type": "object",
+                      "required": [
+                        "type",
+                        "id",
+                        "name",
+                        "arguments"
+                      ],
                       "properties": {
                         "type": {
                           "const": "toolCall",
@@ -2382,13 +2874,7 @@
                         "thoughtSignature": {
                           "type": "string"
                         }
-                      },
-                      "required": [
-                        "type",
-                        "id",
-                        "name",
-                        "arguments"
-                      ]
+                      }
                     }
                   ]
                 }
@@ -2399,6 +2885,13 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "id",
+                "type",
+                "fileName",
+                "mimeType",
+                "size"
+              ],
               "properties": {
                 "id": {
                   "type": "string"
@@ -2436,14 +2929,7 @@
                 "preview": {
                   "type": "string"
                 }
-              },
-              "required": [
-                "id",
-                "type",
-                "fileName",
-                "mimeType",
-                "size"
-              ]
+              }
             }
           },
           "timestamp": {
@@ -2456,6 +2942,10 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "name",
+                "status"
+              ],
               "properties": {
                 "name": {
                   "type": "string"
@@ -2490,11 +2980,7 @@
                 "toolCallId": {
                   "type": "string"
                 }
-              },
-              "required": [
-                "name",
-                "status"
-              ]
+              }
             }
           },
           "toolName": {
@@ -2505,6 +2991,10 @@
           },
           "usage": {
             "type": "object",
+            "required": [
+              "input",
+              "output"
+            ],
             "properties": {
               "input": {
                 "type": "number"
@@ -2520,6 +3010,10 @@
               },
               "cost": {
                 "type": "object",
+                "required": [
+                  "input",
+                  "output"
+                ],
                 "properties": {
                   "input": {
                     "type": "number"
@@ -2536,26 +3030,28 @@
                   "total": {
                     "type": "number"
                   }
-                },
-                "required": [
-                  "input",
-                  "output"
-                ]
+                }
               }
-            },
-            "required": [
-              "input",
-              "output"
-            ]
+            }
+          },
+          "provider": {
+            "type": "string"
+          },
+          "api": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
           }
-        },
-        "required": [
-          "role",
-          "content"
-        ]
+        }
       },
       "ModelEntry": {
         "type": "object",
+        "required": [
+          "id",
+          "provider",
+          "name"
+        ],
         "properties": {
           "id": {
             "type": "string"
@@ -2583,6 +3079,10 @@
           },
           "cost": {
             "type": "object",
+            "required": [
+              "input",
+              "output"
+            ],
             "properties": {
               "input": {
                 "type": "number"
@@ -2599,11 +3099,7 @@
               "total": {
                 "type": "number"
               }
-            },
-            "required": [
-              "input",
-              "output"
-            ]
+            }
           },
           "capabilities": {
             "type": "object",
@@ -2622,20 +3118,23 @@
               }
             }
           }
-        },
-        "required": [
-          "id",
-          "provider",
-          "name"
-        ]
+        }
       },
       "ModelsResponse": {
         "type": "object",
+        "required": [
+          "models"
+        ],
         "properties": {
           "models": {
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "id",
+                "provider",
+                "name"
+              ],
               "properties": {
                 "id": {
                   "type": "string"
@@ -2663,6 +3162,10 @@
                 },
                 "cost": {
                   "type": "object",
+                  "required": [
+                    "input",
+                    "output"
+                  ],
                   "properties": {
                     "input": {
                       "type": "number"
@@ -2679,11 +3182,7 @@
                     "total": {
                       "type": "number"
                     }
-                  },
-                  "required": [
-                    "input",
-                    "output"
-                  ]
+                  }
                 },
                 "capabilities": {
                   "type": "object",
@@ -2702,21 +3201,18 @@
                     }
                   }
                 }
-              },
-              "required": [
-                "id",
-                "provider",
-                "name"
-              ]
+              }
             }
           }
-        },
-        "required": [
-          "models"
-        ]
+        }
       },
       "ModelSelectionResponse": {
         "type": "object",
+        "required": [
+          "id",
+          "provider",
+          "name"
+        ],
         "properties": {
           "id": {
             "type": "string"
@@ -2744,6 +3240,10 @@
           },
           "cost": {
             "type": "object",
+            "required": [
+              "input",
+              "output"
+            ],
             "properties": {
               "input": {
                 "type": "number"
@@ -2760,11 +3260,7 @@
               "total": {
                 "type": "number"
               }
-            },
-            "required": [
-              "input",
-              "output"
-            ]
+            }
           },
           "capabilities": {
             "type": "object",
@@ -2783,20 +3279,22 @@
               }
             }
           }
-        },
-        "required": [
-          "id",
-          "provider",
-          "name"
-        ]
+        }
       },
       "CommandsResponse": {
         "type": "object",
+        "required": [
+          "commands"
+        ],
         "properties": {
           "commands": {
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "name",
+                "prompt"
+              ],
               "properties": {
                 "name": {
                   "type": "string"
@@ -2811,6 +3309,9 @@
                   "type": "array",
                   "items": {
                     "type": "object",
+                    "required": [
+                      "name"
+                    ],
                     "properties": {
                       "name": {
                         "type": "string"
@@ -2818,26 +3319,20 @@
                       "required": {
                         "type": "boolean"
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 }
-              },
-              "required": [
-                "name",
-                "prompt"
-              ]
+              }
             }
           }
-        },
-        "required": [
-          "commands"
-        ]
+        }
       },
       "CommandPrefs": {
         "type": "object",
+        "required": [
+          "favorites",
+          "recents"
+        ],
         "properties": {
           "favorites": {
             "type": "array",
@@ -2851,25 +3346,24 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "favorites",
-          "recents"
-        ]
+        }
       },
       "CommandPrefsWriteResponse": {
         "type": "object",
+        "required": [
+          "ok"
+        ],
         "properties": {
           "ok": {
             "type": "boolean"
           }
-        },
-        "required": [
-          "ok"
-        ]
+        }
       },
       "FilesResponse": {
         "type": "object",
+        "required": [
+          "files"
+        ],
         "properties": {
           "files": {
             "type": "array",
@@ -2877,13 +3371,13 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "files"
-        ]
+        }
       },
       "ConfigWriteRequest": {
         "type": "object",
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -2891,13 +3385,14 @@
               "^(.*)$": {}
             }
           }
-        },
-        "required": [
-          "config"
-        ]
+        }
       },
       "ConfigResponse": {
         "type": "object",
+        "required": [
+          "config",
+          "configPath"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -2908,37 +3403,50 @@
           "configPath": {
             "type": "string"
           }
-        },
-        "required": [
-          "config",
-          "configPath"
-        ]
+        }
       },
       "ConfigWriteResponse": {
         "type": "object",
+        "required": [
+          "success"
+        ],
         "properties": {
           "success": {
             "type": "boolean"
           }
-        },
-        "required": [
-          "success"
-        ]
+        }
       },
       "GuardianStatusResponse": {
         "type": "object",
+        "required": [
+          "enabled",
+          "state"
+        ],
         "properties": {
           "enabled": {
             "type": "boolean"
           },
           "state": {
             "type": "object",
+            "required": [
+              "enabled"
+            ],
             "properties": {
               "enabled": {
                 "type": "boolean"
               },
               "lastRun": {
                 "type": "object",
+                "required": [
+                  "status",
+                  "exitCode",
+                  "startedAt",
+                  "durationMs",
+                  "target",
+                  "filesScanned",
+                  "summary",
+                  "toolResults"
+                ],
                 "properties": {
                   "status": {
                     "anyOf": [
@@ -3003,6 +3511,13 @@
                     "type": "array",
                     "items": {
                       "type": "object",
+                      "required": [
+                        "tool",
+                        "exitCode",
+                        "stdout",
+                        "stderr",
+                        "durationMs"
+                      ],
                       "properties": {
                         "tool": {
                           "type": "string"
@@ -3025,41 +3540,27 @@
                         "reason": {
                           "type": "string"
                         }
-                      },
-                      "required": [
-                        "tool",
-                        "exitCode",
-                        "stdout",
-                        "stderr",
-                        "durationMs"
-                      ]
+                      }
                     }
                   }
-                },
-                "required": [
-                  "status",
-                  "exitCode",
-                  "startedAt",
-                  "durationMs",
-                  "target",
-                  "filesScanned",
-                  "summary",
-                  "toolResults"
-                ]
+                }
               }
-            },
-            "required": [
-              "enabled"
-            ]
+            }
           }
-        },
-        "required": [
-          "enabled",
-          "state"
-        ]
+        }
       },
       "GuardianRunResponse": {
         "type": "object",
+        "required": [
+          "status",
+          "exitCode",
+          "startedAt",
+          "durationMs",
+          "target",
+          "filesScanned",
+          "summary",
+          "toolResults"
+        ],
         "properties": {
           "status": {
             "anyOf": [
@@ -3124,6 +3625,13 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "tool",
+                "exitCode",
+                "stdout",
+                "stderr",
+                "durationMs"
+              ],
               "properties": {
                 "tool": {
                   "type": "string"
@@ -3146,41 +3654,28 @@
                 "reason": {
                   "type": "string"
                 }
-              },
-              "required": [
-                "tool",
-                "exitCode",
-                "stdout",
-                "stderr",
-                "durationMs"
-              ]
+              }
             }
           }
-        },
-        "required": [
-          "status",
-          "exitCode",
-          "startedAt",
-          "durationMs",
-          "target",
-          "filesScanned",
-          "summary",
-          "toolResults"
-        ]
+        }
       },
       "GuardianConfigRequest": {
         "type": "object",
+        "required": [
+          "enabled"
+        ],
         "properties": {
           "enabled": {
             "type": "boolean"
           }
-        },
-        "required": [
-          "enabled"
-        ]
+        }
       },
       "GuardianConfigResponse": {
         "type": "object",
+        "required": [
+          "success",
+          "enabled"
+        ],
         "properties": {
           "success": {
             "type": "boolean"
@@ -3188,19 +3683,25 @@
           "enabled": {
             "type": "boolean"
           }
-        },
-        "required": [
-          "success",
-          "enabled"
-        ]
+        }
       },
       "PlanStatusResponse": {
         "type": "object",
+        "required": [
+          "state",
+          "content"
+        ],
         "properties": {
           "state": {
             "anyOf": [
               {
                 "type": "object",
+                "required": [
+                  "active",
+                  "filePath",
+                  "createdAt",
+                  "updatedAt"
+                ],
                 "properties": {
                   "active": {
                     "type": "boolean"
@@ -3226,13 +3727,7 @@
                   "name": {
                     "type": "string"
                   }
-                },
-                "required": [
-                  "active",
-                  "filePath",
-                  "createdAt",
-                  "updatedAt"
-                ]
+                }
               },
               {
                 "type": "null"
@@ -3249,16 +3744,15 @@
               }
             ]
           }
-        },
-        "required": [
-          "state",
-          "content"
-        ]
+        }
       },
       "PlanRequest": {
         "anyOf": [
           {
             "type": "object",
+            "required": [
+              "action"
+            ],
             "properties": {
               "action": {
                 "const": "enter",
@@ -3270,25 +3764,26 @@
               "sessionId": {
                 "type": "string"
               }
-            },
-            "required": [
-              "action"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "action"
+            ],
             "properties": {
               "action": {
                 "const": "exit",
                 "type": "string"
               }
-            },
-            "required": [
-              "action"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "action",
+              "content"
+            ],
             "properties": {
               "action": {
                 "const": "update",
@@ -3297,11 +3792,7 @@
               "content": {
                 "type": "string"
               }
-            },
-            "required": [
-              "action",
-              "content"
-            ]
+            }
           }
         ]
       },
@@ -3309,12 +3800,22 @@
         "anyOf": [
           {
             "type": "object",
+            "required": [
+              "success",
+              "state"
+            ],
             "properties": {
               "success": {
                 "type": "boolean"
               },
               "state": {
                 "type": "object",
+                "required": [
+                  "active",
+                  "filePath",
+                  "createdAt",
+                  "updatedAt"
+                ],
                 "properties": {
                   "active": {
                     "type": "boolean"
@@ -3340,38 +3841,36 @@
                   "name": {
                     "type": "string"
                   }
-                },
-                "required": [
-                  "active",
-                  "filePath",
-                  "createdAt",
-                  "updatedAt"
-                ]
+                }
               }
-            },
-            "required": [
-              "success",
-              "state"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "success"
+            ],
             "properties": {
               "success": {
                 "type": "boolean"
               }
-            },
-            "required": [
-              "success"
-            ]
+            }
           }
         ]
       },
       "BackgroundStatusResponse": {
         "type": "object",
+        "required": [
+          "settings",
+          "snapshot"
+        ],
         "properties": {
           "settings": {
             "type": "object",
+            "required": [
+              "notificationsEnabled",
+              "statusDetailsEnabled"
+            ],
             "properties": {
               "notificationsEnabled": {
                 "type": "boolean"
@@ -3379,16 +3878,18 @@
               "statusDetailsEnabled": {
                 "type": "boolean"
               }
-            },
-            "required": [
-              "notificationsEnabled",
-              "statusDetailsEnabled"
-            ]
+            }
           },
           "snapshot": {
             "anyOf": [
               {
                 "type": "object",
+                "required": [
+                  "running",
+                  "total",
+                  "failed",
+                  "detailsRedacted"
+                ],
                 "properties": {
                   "running": {
                     "type": "number"
@@ -3402,32 +3903,32 @@
                   "detailsRedacted": {
                     "type": "boolean"
                   }
-                },
-                "required": [
-                  "running",
-                  "total",
-                  "failed",
-                  "detailsRedacted"
-                ]
+                }
               },
               {
                 "type": "null"
               }
             ]
           }
-        },
-        "required": [
-          "settings",
-          "snapshot"
-        ]
+        }
       },
       "BackgroundHistoryResponse": {
         "type": "object",
+        "required": [
+          "history",
+          "truncated"
+        ],
         "properties": {
           "history": {
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "timestamp",
+                "event",
+                "taskId",
+                "command"
+              ],
               "properties": {
                 "timestamp": {
                   "type": "string"
@@ -3467,6 +3968,11 @@
                 },
                 "limitBreach": {
                   "type": "object",
+                  "required": [
+                    "kind",
+                    "limit",
+                    "actual"
+                  ],
                   "properties": {
                     "kind": {
                       "anyOf": [
@@ -3486,33 +3992,23 @@
                     "actual": {
                       "type": "number"
                     }
-                  },
-                  "required": [
-                    "kind",
-                    "limit",
-                    "actual"
-                  ]
+                  }
                 }
-              },
-              "required": [
-                "timestamp",
-                "event",
-                "taskId",
-                "command"
-              ]
+              }
             }
           },
           "truncated": {
             "type": "boolean"
           }
-        },
-        "required": [
-          "history",
-          "truncated"
-        ]
+        }
       },
       "BackgroundPathResponse": {
         "type": "object",
+        "required": [
+          "path",
+          "exists",
+          "overridden"
+        ],
         "properties": {
           "path": {
             "type": "string"
@@ -3523,26 +4019,25 @@
           "overridden": {
             "type": "boolean"
           }
-        },
-        "required": [
-          "path",
-          "exists",
-          "overridden"
-        ]
+        }
       },
       "BackgroundUpdateRequest": {
         "type": "object",
+        "required": [
+          "enabled"
+        ],
         "properties": {
           "enabled": {
             "type": "boolean"
           }
-        },
-        "required": [
-          "enabled"
-        ]
+        }
       },
       "BackgroundUpdateResponse": {
         "type": "object",
+        "required": [
+          "success",
+          "message"
+        ],
         "properties": {
           "success": {
             "type": "boolean"
@@ -3550,14 +4045,14 @@
           "message": {
             "type": "string"
           }
-        },
-        "required": [
-          "success",
-          "message"
-        ]
+        }
       },
       "ApprovalsStatusResponse": {
         "type": "object",
+        "required": [
+          "mode",
+          "availableModes"
+        ],
         "properties": {
           "mode": {
             "anyOf": [
@@ -3594,14 +4089,13 @@
               ]
             }
           }
-        },
-        "required": [
-          "mode",
-          "availableModes"
-        ]
+        }
       },
       "ApprovalsUpdateRequest": {
         "type": "object",
+        "required": [
+          "mode"
+        ],
         "properties": {
           "mode": {
             "anyOf": [
@@ -3622,13 +4116,15 @@
           "sessionId": {
             "type": "string"
           }
-        },
-        "required": [
-          "mode"
-        ]
+        }
       },
       "ApprovalsUpdateResponse": {
         "type": "object",
+        "required": [
+          "success",
+          "mode",
+          "message"
+        ],
         "properties": {
           "success": {
             "type": "boolean"
@@ -3652,15 +4148,16 @@
           "message": {
             "type": "string"
           }
-        },
-        "required": [
-          "success",
-          "mode",
-          "message"
-        ]
+        }
       },
       "FrameworkStatusResponse": {
         "type": "object",
+        "required": [
+          "framework",
+          "source",
+          "locked",
+          "scope"
+        ],
         "properties": {
           "framework": {
             "type": "string"
@@ -3683,21 +4180,22 @@
               }
             ]
           }
-        },
-        "required": [
-          "framework",
-          "source",
-          "locked",
-          "scope"
-        ]
+        }
       },
       "FrameworkListResponse": {
         "type": "object",
+        "required": [
+          "frameworks"
+        ],
         "properties": {
           "frameworks": {
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "id",
+                "summary"
+              ],
               "properties": {
                 "id": {
                   "type": "string"
@@ -3705,17 +4203,10 @@
                 "summary": {
                   "type": "string"
                 }
-              },
-              "required": [
-                "id",
-                "summary"
-              ]
+              }
             }
           }
-        },
-        "required": [
-          "frameworks"
-        ]
+        }
       },
       "FrameworkUpdateRequest": {
         "type": "object",
@@ -3746,6 +4237,11 @@
       },
       "FrameworkUpdateResponse": {
         "type": "object",
+        "required": [
+          "success",
+          "message",
+          "framework"
+        ],
         "properties": {
           "success": {
             "type": "boolean"
@@ -3778,15 +4274,15 @@
               }
             ]
           }
-        },
-        "required": [
-          "success",
-          "message",
-          "framework"
-        ]
+        }
       },
       "UndoStatusResponse": {
         "type": "object",
+        "required": [
+          "totalChanges",
+          "canUndo",
+          "checkpoints"
+        ],
         "properties": {
           "totalChanges": {
             "type": "number"
@@ -3798,6 +4294,11 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "name",
+                "changeCount",
+                "timestamp"
+              ],
               "properties": {
                 "name": {
                   "type": "string"
@@ -3811,28 +4312,26 @@
                 "timestamp": {
                   "type": "number"
                 }
-              },
-              "required": [
-                "name",
-                "changeCount",
-                "timestamp"
-              ]
+              }
             }
           }
-        },
-        "required": [
-          "totalChanges",
-          "canUndo",
-          "checkpoints"
-        ]
+        }
       },
       "UndoHistoryResponse": {
         "type": "object",
+        "required": [
+          "history"
+        ],
         "properties": {
           "history": {
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "description",
+                "fileCount",
+                "timestamp"
+              ],
               "properties": {
                 "description": {
                   "type": "string"
@@ -3843,18 +4342,10 @@
                 "timestamp": {
                   "type": "number"
                 }
-              },
-              "required": [
-                "description",
-                "fileCount",
-                "timestamp"
-              ]
+              }
             }
           }
-        },
-        "required": [
-          "history"
-        ]
+        }
       },
       "UndoRequest": {
         "type": "object",
@@ -3896,6 +4387,11 @@
         "anyOf": [
           {
             "type": "object",
+            "required": [
+              "success",
+              "undone",
+              "errors"
+            ],
             "properties": {
               "success": {
                 "type": "boolean"
@@ -3909,15 +4405,14 @@
                   "type": "string"
                 }
               }
-            },
-            "required": [
-              "success",
-              "undone",
-              "errors"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "success",
+              "message"
+            ],
             "properties": {
               "success": {
                 "type": "boolean"
@@ -3931,35 +4426,50 @@
                   "type": "string"
                 }
               }
-            },
-            "required": [
-              "success",
-              "message"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "message"
+            ],
             "properties": {
               "message": {
                 "type": "string"
               }
-            },
-            "required": [
-              "message"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "preview"
+            ],
             "properties": {
               "preview": {
                 "anyOf": [
                   {
                     "type": "object",
+                    "required": [
+                      "changes",
+                      "restores",
+                      "conflicts"
+                    ],
                     "properties": {
                       "changes": {
                         "type": "array",
                         "items": {
                           "type": "object",
+                          "required": [
+                            "id",
+                            "type",
+                            "path",
+                            "before",
+                            "after",
+                            "toolName",
+                            "toolCallId",
+                            "timestamp",
+                            "isGitTracked"
+                          ],
                           "properties": {
                             "id": {
                               "type": "string"
@@ -4018,24 +4528,17 @@
                             "messageId": {
                               "type": "string"
                             }
-                          },
-                          "required": [
-                            "id",
-                            "type",
-                            "path",
-                            "before",
-                            "after",
-                            "toolName",
-                            "toolCallId",
-                            "timestamp",
-                            "isGitTracked"
-                          ]
+                          }
                         }
                       },
                       "restores": {
                         "type": "array",
                         "items": {
                           "type": "object",
+                          "required": [
+                            "path",
+                            "action"
+                          ],
                           "properties": {
                             "path": {
                               "type": "string"
@@ -4056,17 +4559,17 @@
                                 }
                               ]
                             }
-                          },
-                          "required": [
-                            "path",
-                            "action"
-                          ]
+                          }
                         }
                       },
                       "conflicts": {
                         "type": "array",
                         "items": {
                           "type": "object",
+                          "required": [
+                            "path",
+                            "reason"
+                          ],
                           "properties": {
                             "path": {
                               "type": "string"
@@ -4074,22 +4577,16 @@
                             "reason": {
                               "type": "string"
                             }
-                          },
-                          "required": [
-                            "path",
-                            "reason"
-                          ]
+                          }
                         }
                       }
-                    },
-                    "required": [
-                      "changes",
-                      "restores",
-                      "conflicts"
-                    ]
+                    }
                   },
                   {
                     "type": "object",
+                    "required": [
+                      "message"
+                    ],
                     "properties": {
                       "message": {
                         "type": "string"
@@ -4100,26 +4597,29 @@
                       "description": {
                         "type": "string"
                       }
-                    },
-                    "required": [
-                      "message"
-                    ]
+                    }
                   }
                 ]
               }
-            },
-            "required": [
-              "preview"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "success",
+              "checkpoint"
+            ],
             "properties": {
               "success": {
                 "type": "boolean"
               },
               "checkpoint": {
                 "type": "object",
+                "required": [
+                  "name",
+                  "changeCount",
+                  "timestamp"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -4130,26 +4630,25 @@
                   "timestamp": {
                     "type": "number"
                   }
-                },
-                "required": [
-                  "name",
-                  "changeCount",
-                  "timestamp"
-                ]
+                }
               }
-            },
-            "required": [
-              "success",
-              "checkpoint"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "checkpoints"
+            ],
             "properties": {
               "checkpoints": {
                 "type": "array",
                 "items": {
                   "type": "object",
+                  "required": [
+                    "name",
+                    "changeCount",
+                    "timestamp"
+                  ],
                   "properties": {
                     "name": {
                       "type": "string"
@@ -4163,23 +4662,26 @@
                     "timestamp": {
                       "type": "number"
                     }
-                  },
-                  "required": [
-                    "name",
-                    "changeCount",
-                    "timestamp"
-                  ]
+                  }
                 }
               }
-            },
-            "required": [
-              "checkpoints"
-            ]
+            }
           }
         ]
       },
       "StatusResponse": {
         "type": "object",
+        "required": [
+          "cwd",
+          "git",
+          "context",
+          "server",
+          "database",
+          "backgroundTasks",
+          "hooks",
+          "lastUpdated",
+          "lastLatencyMs"
+        ],
         "properties": {
           "cwd": {
             "type": "string"
@@ -4188,12 +4690,23 @@
             "anyOf": [
               {
                 "type": "object",
+                "required": [
+                  "branch",
+                  "status"
+                ],
                 "properties": {
                   "branch": {
                     "type": "string"
                   },
                   "status": {
                     "type": "object",
+                    "required": [
+                      "modified",
+                      "added",
+                      "deleted",
+                      "untracked",
+                      "total"
+                    ],
                     "properties": {
                       "modified": {
                         "type": "number"
@@ -4210,20 +4723,9 @@
                       "total": {
                         "type": "number"
                       }
-                    },
-                    "required": [
-                      "modified",
-                      "added",
-                      "deleted",
-                      "untracked",
-                      "total"
-                    ]
+                    }
                   }
-                },
-                "required": [
-                  "branch",
-                  "status"
-                ]
+                }
               },
               {
                 "type": "null"
@@ -4232,6 +4734,10 @@
           },
           "context": {
             "type": "object",
+            "required": [
+              "agentMd",
+              "claudeMd"
+            ],
             "properties": {
               "agentMd": {
                 "type": "boolean"
@@ -4239,14 +4745,69 @@
               "claudeMd": {
                 "type": "boolean"
               }
-            },
+            }
+          },
+          "onboarding": {
+            "type": "object",
             "required": [
-              "agentMd",
-              "claudeMd"
-            ]
+              "shouldShow",
+              "completed",
+              "seenCount",
+              "steps"
+            ],
+            "properties": {
+              "shouldShow": {
+                "type": "boolean"
+              },
+              "completed": {
+                "type": "boolean"
+              },
+              "seenCount": {
+                "type": "number"
+              },
+              "steps": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "key",
+                    "text",
+                    "isComplete",
+                    "isEnabled"
+                  ],
+                  "properties": {
+                    "key": {
+                      "anyOf": [
+                        {
+                          "const": "workspace",
+                          "type": "string"
+                        },
+                        {
+                          "const": "instructions",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "text": {
+                      "type": "string"
+                    },
+                    "isComplete": {
+                      "type": "boolean"
+                    },
+                    "isEnabled": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
           },
           "server": {
             "type": "object",
+            "required": [
+              "uptime",
+              "version"
+            ],
             "properties": {
               "uptime": {
                 "type": "number"
@@ -4257,14 +4818,14 @@
               "staticCacheMaxAgeSeconds": {
                 "type": "number"
               }
-            },
-            "required": [
-              "uptime",
-              "version"
-            ]
+            }
           },
           "database": {
             "type": "object",
+            "required": [
+              "configured",
+              "connected"
+            ],
             "properties": {
               "configured": {
                 "type": "boolean"
@@ -4272,16 +4833,24 @@
               "connected": {
                 "type": "boolean"
               }
-            },
-            "required": [
-              "configured",
-              "connected"
-            ]
+            }
           },
           "backgroundTasks": {
             "anyOf": [
               {
                 "type": "object",
+                "required": [
+                  "total",
+                  "running",
+                  "restarting",
+                  "failed",
+                  "entries",
+                  "truncated",
+                  "notificationsEnabled",
+                  "detailsRedacted",
+                  "history",
+                  "historyTruncated"
+                ],
                 "properties": {
                   "total": {
                     "type": "number"
@@ -4299,6 +4868,14 @@
                     "type": "array",
                     "items": {
                       "type": "object",
+                      "required": [
+                        "id",
+                        "status",
+                        "summary",
+                        "command",
+                        "issues",
+                        "durationSeconds"
+                      ],
                       "properties": {
                         "id": {
                           "type": "string"
@@ -4330,15 +4907,7 @@
                         "durationSeconds": {
                           "type": "number"
                         }
-                      },
-                      "required": [
-                        "id",
-                        "status",
-                        "summary",
-                        "command",
-                        "issues",
-                        "durationSeconds"
-                      ]
+                      }
                     }
                   },
                   "truncated": {
@@ -4354,6 +4923,14 @@
                     "type": "array",
                     "items": {
                       "type": "object",
+                      "required": [
+                        "event",
+                        "taskId",
+                        "status",
+                        "command",
+                        "timestamp",
+                        "restartAttempts"
+                      ],
                       "properties": {
                         "event": {
                           "anyOf": [
@@ -4399,6 +4976,11 @@
                         },
                         "limitBreach": {
                           "type": "object",
+                          "required": [
+                            "kind",
+                            "limit",
+                            "actual"
+                          ],
                           "properties": {
                             "kind": {
                               "anyOf": [
@@ -4418,40 +5000,15 @@
                             "actual": {
                               "type": "number"
                             }
-                          },
-                          "required": [
-                            "kind",
-                            "limit",
-                            "actual"
-                          ]
+                          }
                         }
-                      },
-                      "required": [
-                        "event",
-                        "taskId",
-                        "status",
-                        "command",
-                        "timestamp",
-                        "restartAttempts"
-                      ]
+                      }
                     }
                   },
                   "historyTruncated": {
                     "type": "boolean"
                   }
-                },
-                "required": [
-                  "total",
-                  "running",
-                  "restarting",
-                  "failed",
-                  "entries",
-                  "truncated",
-                  "notificationsEnabled",
-                  "detailsRedacted",
-                  "history",
-                  "historyTruncated"
-                ]
+                }
               },
               {
                 "type": "null"
@@ -4460,12 +5017,21 @@
           },
           "hooks": {
             "type": "object",
+            "required": [
+              "asyncInFlight",
+              "concurrency"
+            ],
             "properties": {
               "asyncInFlight": {
                 "type": "number"
               },
               "concurrency": {
                 "type": "object",
+                "required": [
+                  "max",
+                  "active",
+                  "queued"
+                ],
                 "properties": {
                   "max": {
                     "type": "number"
@@ -4476,18 +5042,9 @@
                   "queued": {
                     "type": "number"
                   }
-                },
-                "required": [
-                  "max",
-                  "active",
-                  "queued"
-                ]
+                }
               }
-            },
-            "required": [
-              "asyncInFlight",
-              "concurrency"
-            ]
+            }
           },
           "lastUpdated": {
             "type": "number"
@@ -4495,24 +5052,28 @@
           "lastLatencyMs": {
             "type": "number"
           }
-        },
-        "required": [
-          "cwd",
-          "git",
-          "context",
-          "server",
-          "database",
-          "backgroundTasks",
-          "hooks",
-          "lastUpdated",
-          "lastLatencyMs"
-        ]
+        }
       },
       "UsageResponse": {
         "type": "object",
+        "required": [
+          "summary",
+          "hasData"
+        ],
         "properties": {
           "summary": {
             "type": "object",
+            "required": [
+              "totalCost",
+              "totalRequests",
+              "totalTokens",
+              "tokensDetailed",
+              "totalTokensDetailed",
+              "totalTokensBreakdown",
+              "totalCachedTokens",
+              "byProvider",
+              "byModel"
+            ],
             "properties": {
               "totalCost": {
                 "type": "number"
@@ -4525,6 +5086,13 @@
               },
               "tokensDetailed": {
                 "type": "object",
+                "required": [
+                  "input",
+                  "output",
+                  "cacheRead",
+                  "cacheWrite",
+                  "total"
+                ],
                 "properties": {
                   "input": {
                     "type": "number"
@@ -4541,17 +5109,17 @@
                   "total": {
                     "type": "number"
                   }
-                },
-                "required": [
-                  "input",
-                  "output",
-                  "cacheRead",
-                  "cacheWrite",
-                  "total"
-                ]
+                }
               },
               "totalTokensDetailed": {
                 "type": "object",
+                "required": [
+                  "input",
+                  "output",
+                  "cacheRead",
+                  "cacheWrite",
+                  "total"
+                ],
                 "properties": {
                   "input": {
                     "type": "number"
@@ -4568,17 +5136,17 @@
                   "total": {
                     "type": "number"
                   }
-                },
-                "required": [
-                  "input",
-                  "output",
-                  "cacheRead",
-                  "cacheWrite",
-                  "total"
-                ]
+                }
               },
               "totalTokensBreakdown": {
                 "type": "object",
+                "required": [
+                  "input",
+                  "output",
+                  "cacheRead",
+                  "cacheWrite",
+                  "total"
+                ],
                 "properties": {
                   "input": {
                     "type": "number"
@@ -4595,14 +5163,7 @@
                   "total": {
                     "type": "number"
                   }
-                },
-                "required": [
-                  "input",
-                  "output",
-                  "cacheRead",
-                  "cacheWrite",
-                  "total"
-                ]
+                }
               },
               "totalCachedTokens": {
                 "type": "number"
@@ -4612,6 +5173,14 @@
                 "patternProperties": {
                   "^(.*)$": {
                     "type": "object",
+                    "required": [
+                      "cost",
+                      "requests",
+                      "tokens",
+                      "tokensDetailed",
+                      "calls",
+                      "cachedTokens"
+                    ],
                     "properties": {
                       "cost": {
                         "type": "number"
@@ -4624,6 +5193,13 @@
                       },
                       "tokensDetailed": {
                         "type": "object",
+                        "required": [
+                          "input",
+                          "output",
+                          "cacheRead",
+                          "cacheWrite",
+                          "total"
+                        ],
                         "properties": {
                           "input": {
                             "type": "number"
@@ -4640,14 +5216,7 @@
                           "total": {
                             "type": "number"
                           }
-                        },
-                        "required": [
-                          "input",
-                          "output",
-                          "cacheRead",
-                          "cacheWrite",
-                          "total"
-                        ]
+                        }
                       },
                       "calls": {
                         "type": "number"
@@ -4655,15 +5224,7 @@
                       "cachedTokens": {
                         "type": "number"
                       }
-                    },
-                    "required": [
-                      "cost",
-                      "requests",
-                      "tokens",
-                      "tokensDetailed",
-                      "calls",
-                      "cachedTokens"
-                    ]
+                    }
                   }
                 }
               },
@@ -4672,6 +5233,14 @@
                 "patternProperties": {
                   "^(.*)$": {
                     "type": "object",
+                    "required": [
+                      "cost",
+                      "requests",
+                      "tokens",
+                      "tokensDetailed",
+                      "calls",
+                      "cachedTokens"
+                    ],
                     "properties": {
                       "cost": {
                         "type": "number"
@@ -4684,6 +5253,13 @@
                       },
                       "tokensDetailed": {
                         "type": "object",
+                        "required": [
+                          "input",
+                          "output",
+                          "cacheRead",
+                          "cacheWrite",
+                          "total"
+                        ],
                         "properties": {
                           "input": {
                             "type": "number"
@@ -4700,14 +5276,7 @@
                           "total": {
                             "type": "number"
                           }
-                        },
-                        "required": [
-                          "input",
-                          "output",
-                          "cacheRead",
-                          "cacheWrite",
-                          "total"
-                        ]
+                        }
                       },
                       "calls": {
                         "type": "number"
@@ -4715,47 +5284,33 @@
                       "cachedTokens": {
                         "type": "number"
                       }
-                    },
-                    "required": [
-                      "cost",
-                      "requests",
-                      "tokens",
-                      "tokensDetailed",
-                      "calls",
-                      "cachedTokens"
-                    ]
+                    }
                   }
                 }
               }
-            },
-            "required": [
-              "totalCost",
-              "totalRequests",
-              "totalTokens",
-              "tokensDetailed",
-              "totalTokensDetailed",
-              "totalTokensBreakdown",
-              "totalCachedTokens",
-              "byProvider",
-              "byModel"
-            ]
+            }
           },
           "hasData": {
             "type": "boolean"
           }
-        },
-        "required": [
-          "summary",
-          "hasData"
-        ]
+        }
       },
       "SessionSummary": {
         "type": "object",
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt",
+          "messageCount"
+        ],
         "properties": {
           "id": {
             "type": "string"
           },
           "title": {
+            "type": "string"
+          },
+          "resumeSummary": {
             "type": "string"
           },
           "createdAt": {
@@ -4776,21 +5331,25 @@
               "type": "string"
             }
           }
-        },
+        }
+      },
+      "Session": {
+        "type": "object",
         "required": [
           "id",
           "createdAt",
           "updatedAt",
-          "messageCount"
-        ]
-      },
-      "Session": {
-        "type": "object",
+          "messageCount",
+          "messages"
+        ],
         "properties": {
           "id": {
             "type": "string"
           },
           "title": {
+            "type": "string"
+          },
+          "resumeSummary": {
             "type": "string"
           },
           "createdAt": {
@@ -4815,6 +5374,10 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "role",
+                "content"
+              ],
               "properties": {
                 "role": {
                   "anyOf": [
@@ -4847,6 +5410,10 @@
                         "anyOf": [
                           {
                             "type": "object",
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "const": "text",
@@ -4858,14 +5425,15 @@
                               "textSignature": {
                                 "type": "string"
                               }
-                            },
-                            "required": [
-                              "type",
-                              "text"
-                            ]
+                            }
                           },
                           {
                             "type": "object",
+                            "required": [
+                              "type",
+                              "data",
+                              "mimeType"
+                            ],
                             "properties": {
                               "type": {
                                 "const": "image",
@@ -4877,15 +5445,14 @@
                               "mimeType": {
                                 "type": "string"
                               }
-                            },
-                            "required": [
-                              "type",
-                              "data",
-                              "mimeType"
-                            ]
+                            }
                           },
                           {
                             "type": "object",
+                            "required": [
+                              "type",
+                              "thinking"
+                            ],
                             "properties": {
                               "type": {
                                 "const": "thinking",
@@ -4897,14 +5464,16 @@
                               "thinkingSignature": {
                                 "type": "string"
                               }
-                            },
-                            "required": [
-                              "type",
-                              "thinking"
-                            ]
+                            }
                           },
                           {
                             "type": "object",
+                            "required": [
+                              "type",
+                              "id",
+                              "name",
+                              "arguments"
+                            ],
                             "properties": {
                               "type": {
                                 "const": "toolCall",
@@ -4925,13 +5494,7 @@
                               "thoughtSignature": {
                                 "type": "string"
                               }
-                            },
-                            "required": [
-                              "type",
-                              "id",
-                              "name",
-                              "arguments"
-                            ]
+                            }
                           }
                         ]
                       }
@@ -4942,6 +5505,13 @@
                   "type": "array",
                   "items": {
                     "type": "object",
+                    "required": [
+                      "id",
+                      "type",
+                      "fileName",
+                      "mimeType",
+                      "size"
+                    ],
                     "properties": {
                       "id": {
                         "type": "string"
@@ -4979,14 +5549,7 @@
                       "preview": {
                         "type": "string"
                       }
-                    },
-                    "required": [
-                      "id",
-                      "type",
-                      "fileName",
-                      "mimeType",
-                      "size"
-                    ]
+                    }
                   }
                 },
                 "timestamp": {
@@ -4999,6 +5562,10 @@
                   "type": "array",
                   "items": {
                     "type": "object",
+                    "required": [
+                      "name",
+                      "status"
+                    ],
                     "properties": {
                       "name": {
                         "type": "string"
@@ -5033,11 +5600,7 @@
                       "toolCallId": {
                         "type": "string"
                       }
-                    },
-                    "required": [
-                      "name",
-                      "status"
-                    ]
+                    }
                   }
                 },
                 "toolName": {
@@ -5048,6 +5611,10 @@
                 },
                 "usage": {
                   "type": "object",
+                  "required": [
+                    "input",
+                    "output"
+                  ],
                   "properties": {
                     "input": {
                       "type": "number"
@@ -5063,6 +5630,10 @@
                     },
                     "cost": {
                       "type": "object",
+                      "required": [
+                        "input",
+                        "output"
+                      ],
                       "properties": {
                         "input": {
                           "type": "number"
@@ -5079,46 +5650,158 @@
                         "total": {
                           "type": "number"
                         }
-                      },
-                      "required": [
-                        "input",
-                        "output"
-                      ]
+                      }
                     }
-                  },
-                  "required": [
-                    "input",
-                    "output"
-                  ]
+                  }
+                },
+                "provider": {
+                  "type": "string"
+                },
+                "api": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
                 }
-              },
+              }
+            }
+          },
+          "pendingApprovalRequests": {
+            "type": "array",
+            "items": {
+              "type": "object",
               "required": [
-                "role",
-                "content"
-              ]
+                "id",
+                "toolName",
+                "args",
+                "reason"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "toolName": {
+                  "type": "string"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "summaryLabel": {
+                  "type": "string"
+                },
+                "actionDescription": {
+                  "type": "string"
+                },
+                "args": {},
+                "reason": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "pendingClientToolRequests": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "toolCallId",
+                "toolName",
+                "args"
+              ],
+              "properties": {
+                "toolCallId": {
+                  "type": "string"
+                },
+                "toolName": {
+                  "type": "string"
+                },
+                "args": {},
+                "kind": {
+                  "anyOf": [
+                    {
+                      "const": "client_tool",
+                      "type": "string"
+                    },
+                    {
+                      "const": "mcp_elicitation",
+                      "type": "string"
+                    },
+                    {
+                      "const": "user_input",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "reason": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "pendingToolRetryRequests": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "toolCallId",
+                "toolName",
+                "args",
+                "errorMessage",
+                "attempt"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "toolCallId": {
+                  "type": "string"
+                },
+                "toolName": {
+                  "type": "string"
+                },
+                "args": {},
+                "errorMessage": {
+                  "type": "string"
+                },
+                "attempt": {
+                  "type": "number"
+                },
+                "maxAttempts": {
+                  "type": "number"
+                },
+                "summary": {
+                  "type": "string"
+                }
+              }
             }
           }
-        },
-        "required": [
-          "id",
-          "createdAt",
-          "updatedAt",
-          "messageCount",
-          "messages"
-        ]
+        }
       },
       "SessionsResponse": {
         "type": "object",
+        "required": [
+          "sessions"
+        ],
         "properties": {
           "sessions": {
             "type": "array",
             "items": {
               "type": "object",
+              "required": [
+                "id",
+                "createdAt",
+                "updatedAt",
+                "messageCount"
+              ],
               "properties": {
                 "id": {
                   "type": "string"
                 },
                 "title": {
+                  "type": "string"
+                },
+                "resumeSummary": {
                   "type": "string"
                 },
                 "createdAt": {
@@ -5139,22 +5822,16 @@
                     "type": "string"
                   }
                 }
-              },
-              "required": [
-                "id",
-                "createdAt",
-                "updatedAt",
-                "messageCount"
-              ]
+              }
             }
           }
-        },
-        "required": [
-          "sessions"
-        ]
+        }
       },
       "ErrorResponse": {
         "type": "object",
+        "required": [
+          "error"
+        ],
         "properties": {
           "error": {
             "type": "string"
@@ -5171,8 +5848,12 @@
               }
             }
           },
-          "composer": {
+          "maestro": {
             "type": "object",
+            "required": [
+              "code",
+              "category"
+            ],
             "properties": {
               "code": {
                 "type": "string"
@@ -5246,16 +5927,9 @@
                   "^(.*)$": {}
                 }
               }
-            },
-            "required": [
-              "code",
-              "category"
-            ]
+            }
           }
-        },
-        "required": [
-          "error"
-        ]
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "dist",
     "skills"
   ],
+  "bundleDependencies": [
+    "@evalops/contracts",
+    "@evalops/memory",
+    "@evalops/tui"
+  ],
   "scripts": {
     "clean": "node ./scripts/clean-paths.js dist ./tmp/tsbuildinfo/composer.tsbuildinfo",
     "prepare": "husky",
@@ -108,6 +113,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.67.3",
+    "@opentelemetry/resources": "^2.6.1",
     "@opentelemetry/sdk-node": "0.210.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@sinclair/typebox": "^0.34.49",
@@ -122,6 +128,7 @@
     "drizzle-orm": "0.45.1",
     "fflate": "^0.8.2",
     "glob": "^11.1.0",
+    "google-auth-library": "^9.0.0",
     "ioredis": "^5.10.1",
     "jiti": "^2.6.1",
     "jose": "^6.2.2",
@@ -133,6 +140,7 @@
     "marked": "^17.0.5",
     "mime-types": "^3.0.2",
     "minimatch": "^10.2.5",
+    "luxon": "^3.7.2",
     "openai": "^6.33.0",
     "otplib": "^12.0.1",
     "partial-json": "^0.1.7",
@@ -155,7 +163,6 @@
     "@bufbuild/protoc-gen-es": "^2.11.0",
     "@biomejs/biome": "^1.9.4",
     "@nrwl/tao": "19.8.4",
-    "@opentelemetry/resources": "^2.6.1",
     "@smithy/types": "^4.13.1",
     "@types/bcrypt": "^6.0.0",
     "@types/better-sqlite3": "^7.6.13",
@@ -173,7 +180,6 @@
     "esbuild": "^0.27.4",
     "fast-check": "^4.6.0",
     "husky": "^9.1.7",
-    "luxon": "^3.7.2",
     "nx": "19.7.3",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -68,6 +68,16 @@ function updatePackageLock(newVersion) {
 	}
 }
 
+function updateOpenApiSpec() {
+	try {
+		execSync("npm run openapi:generate", { stdio: "inherit" });
+		console.log("📘 Updated openapi.json");
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : "unknown error";
+		throw new Error(`Failed to update openapi.json: ${reason}`);
+	}
+}
+
 function restoreBackups(backups) {
 	for (const backup of backups) {
 		writePackageJson(backup.path, backup.original);
@@ -123,6 +133,9 @@ function main() {
 
 		// Update changelog
 		updateChangelog(newVersion);
+
+		// Update OpenAPI spec
+		updateOpenApiSpec();
 
 		// Update package-lock.json
 		updatePackageLock(newVersion);

--- a/test/cli-tui/startup-announcements.test.ts
+++ b/test/cli-tui/startup-announcements.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Container, type TUI } from "@evalops/tui";
@@ -8,6 +8,9 @@ import { renderStartupAnnouncements } from "../../src/cli-tui/startup-announceme
 import { stripAnsiSequences } from "../../src/cli-tui/utils/text-formatting.js";
 
 const tempDirs: string[] = [];
+const rootPackageName = JSON.parse(
+	readFileSync(new URL("../../package.json", import.meta.url), "utf-8"),
+).name as string;
 
 function renderAnnouncements(): string {
 	const container = new Container();
@@ -43,7 +46,7 @@ describe("renderStartupAnnouncements", () => {
 	it("renders the Maestro package name in update instructions", () => {
 		const output = renderAnnouncements();
 
-		expect(output).toContain("npm install -g @evalops/maestro");
+		expect(output).toContain(`npm install -g ${rootPackageName}`);
 		expect(output).not.toContain("@evalops/composer");
 	});
 

--- a/test/packages/core/naming-consistency.test.ts
+++ b/test/packages/core/naming-consistency.test.ts
@@ -62,9 +62,10 @@ describe("Naming Consistency", () => {
 	});
 
 	describe("package.json names", () => {
-		it("root package is @evalops/maestro", () => {
+		it("root package uses the maestro name and not composer", () => {
 			const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
-			expect(pkg.name).toBe("@evalops/maestro");
+			expect(pkg.name).toContain("maestro");
+			expect(pkg.name).not.toContain("composer");
 		});
 
 		it("web package is @evalops/maestro-web", () => {

--- a/test/tui/update-view.test.ts
+++ b/test/tui/update-view.test.ts
@@ -1,7 +1,12 @@
+import { readFileSync } from "node:fs";
 import { Container, type TUI } from "@evalops/tui";
 import { describe, expect, it, vi } from "vitest";
 import { UpdateView } from "../../src/cli-tui/update-view.js";
 import { stripAnsiSequences } from "../../src/cli-tui/utils/text-formatting.js";
+
+const rootPackageName = JSON.parse(
+	readFileSync(new URL("../../package.json", import.meta.url), "utf-8"),
+).name as string;
 
 describe("UpdateView", () => {
 	it("renders Maestro update instructions when an update is available", async () => {
@@ -22,7 +27,7 @@ describe("UpdateView", () => {
 		await view.handleUpdateCommand();
 
 		const output = stripAnsiSequences(container.render(120).join("\n"));
-		expect(output).toContain("npm install -g @evalops/maestro");
+		expect(output).toContain(`npm install -g ${rootPackageName}`);
 		expect(output).not.toContain("@evalops/composer");
 	});
 });


### PR DESCRIPTION
## Summary
- align release quality-gate with the full workspace build and regenerate `openapi.json`
- make package-name assertions follow the current root package name
- bundle internal workspace packages into the published tarball and declare missing runtime dependencies

## Validation
- `npm run build:all`
- `node ./scripts/run-vitest.js --run test/packages/core/naming-consistency.test.ts test/tui/update-view.test.ts test/cli-tui/startup-announcements.test.ts test/build/package-builds.test.ts test/openapi-spec.test.ts`
- fresh temp install of the packed tarball plus `npx maestro --version`