### PR TITLE
Release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ versioning when releases are cut.
 
 
 
+
+## [0.10.3] - 2026-04-15
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Treat `tree-sitter` and `tree-sitter-bash` as optional install-time dependencies so Linux/Node 24 consumers can install Maestro even when native parser bindings are unavailable.
+
+
 ## [0.10.2] - 2026-04-15
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Composer Web API",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@evalops-jh/maestro",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@evalops-jh/maestro",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "bundleDependencies": [
         "@evalops/contracts",
         "@evalops/memory",
@@ -20,9 +20,9 @@
         "@aws-sdk/client-bedrock-runtime": "^3.1020.0",
         "@crosscopy/clipboard": "^0.2.8",
         "@daytonaio/sdk": "^0.155.0",
-        "@evalops/contracts": "^0.10.2",
-        "@evalops/memory": "^0.10.2",
-        "@evalops/tui": "^0.10.2",
+        "@evalops/contracts": "^0.10.3",
+        "@evalops/memory": "^0.10.3",
+        "@evalops/tui": "^0.10.3",
         "@google/genai": "^1.47.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.1",
@@ -62,8 +62,6 @@
         "postgres": "^3.4.8",
         "smol-toml": "^1.6.1",
         "string-width": "^8.2.0",
-        "tree-sitter": "^0.25.0",
-        "tree-sitter-bash": "^0.25.1",
         "uuid": "^13.0.0",
         "vscode-jsonrpc": "^8.2.1",
         "ws": "^8.20.0",
@@ -107,7 +105,9 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "sharp": "0.34.5"
+        "sharp": "0.34.5",
+        "tree-sitter": "^0.25.0",
+        "tree-sitter-bash": "^0.25.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -13788,19 +13788,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/@web/dev-server-core/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@web/dev-server-core/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -13887,19 +13874,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@web/test-runner-core/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -22305,18 +22279,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -24061,8 +24023,7 @@
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -27056,6 +27017,7 @@
       "integrity": "sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^8.3.0",
         "node-gyp-build": "^4.8.4"
@@ -27067,6 +27029,7 @@
       "integrity": "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^8.2.1",
         "node-gyp-build": "^4.8.2"
@@ -28359,11 +28322,11 @@
     },
     "packages/ai": {
       "name": "@evalops/ai",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.2",
-        "@evalops/tui": "^0.10.2",
+        "@evalops/contracts": "^0.10.3",
+        "@evalops/tui": "^0.10.3",
         "@google/genai": "^1.29.1",
         "@sinclair/typebox": "^0.34.0"
       },
@@ -28378,7 +28341,7 @@
     },
     "packages/contracts": {
       "name": "@evalops/contracts",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
@@ -28387,7 +28350,7 @@
     },
     "packages/core": {
       "name": "@evalops/maestro-core",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.966.0",
@@ -28419,7 +28382,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "@evalops/tui": "^0.10.2"
+        "@evalops/tui": "^0.10.3"
       },
       "peerDependenciesMeta": {
         "@evalops/tui": {
@@ -28429,10 +28392,10 @@
     },
     "packages/desktop": {
       "name": "@evalops/maestro-desktop",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.2",
+        "@evalops/contracts": "^0.10.3",
         "electron-store": "^10.0.1",
         "electron-updater": "^6.3.9"
       },
@@ -29046,7 +29009,7 @@
     },
     "packages/github-agent": {
       "name": "@evalops/github-agent",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^21.0.0",
@@ -29070,11 +29033,11 @@
     },
     "packages/governance": {
       "name": "@evalops/governance",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.2",
-        "@evalops/tui": "^0.10.2",
+        "@evalops/contracts": "^0.10.3",
+        "@evalops/tui": "^0.10.3",
         "@sinclair/typebox": "^0.34.0"
       },
       "devDependencies": {
@@ -29088,10 +29051,10 @@
     },
     "packages/governance-mcp-server": {
       "name": "@evalops/governance-mcp-server",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
-        "@evalops/governance": "^0.10.2",
+        "@evalops/governance": "^0.10.3",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "zod": "^4.3.5"
       },
@@ -29109,18 +29072,18 @@
     },
     "packages/memory": {
       "name": "@evalops/memory",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0"
       }
     },
     "packages/slack-agent": {
       "name": "@evalops/slack-agent",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
         "@daytonaio/sdk": "^0.139.0",
-        "@evalops/ai": "^0.10.2",
+        "@evalops/ai": "^0.10.3",
         "@sinclair/typebox": "^0.34.0",
         "@slack/socket-mode": "^2.0.0",
         "@slack/web-api": "^7.0.0",
@@ -29144,7 +29107,7 @@
     },
     "packages/slack-agent-ui": {
       "name": "@evalops/slack-agent-ui",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -29801,7 +29764,7 @@
     },
     "packages/tui": {
       "name": "@evalops/tui",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.5.0",
@@ -29820,10 +29783,10 @@
     },
     "packages/vscode-extension": {
       "name": "maestro-vscode",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.2"
+        "@evalops/contracts": "^0.10.3"
       },
       "devDependencies": {
         "@types/node": "^24.10.7",
@@ -29839,10 +29802,10 @@
     },
     "packages/web": {
       "name": "@evalops/maestro-web",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.2",
+        "@evalops/contracts": "^0.10.3",
         "docx-preview": "^0.3.7",
         "dompurify": "^3.3.0",
         "highlight.js": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evalops-jh/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": false,
   "type": "module",
   "workspaces": [
@@ -111,9 +111,9 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1020.0",
     "@crosscopy/clipboard": "^0.2.8",
     "@daytonaio/sdk": "^0.155.0",
-    "@evalops/contracts": "^0.10.2",
-    "@evalops/memory": "^0.10.2",
-    "@evalops/tui": "^0.10.2",
+    "@evalops/contracts": "^0.10.3",
+    "@evalops/memory": "^0.10.3",
+    "@evalops/tui": "^0.10.3",
     "@google/genai": "^1.47.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.1",
@@ -153,8 +153,6 @@
     "postgres": "^3.4.8",
     "smol-toml": "^1.6.1",
     "string-width": "^8.2.0",
-    "tree-sitter": "^0.25.0",
-    "tree-sitter-bash": "^0.25.1",
     "uuid": "^13.0.0",
     "vscode-jsonrpc": "^8.2.1",
     "ws": "^8.20.0",
@@ -219,7 +217,9 @@
     "qs": ">=6.14.2"
   },
   "optionalDependencies": {
-    "sharp": "0.34.5"
+    "sharp": "0.34.5",
+    "tree-sitter": "^0.25.0",
+    "tree-sitter-bash": "^0.25.1"
   },
   "packageManager": "bun@1.3.6",
   "trustedDependencies": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/ai",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "Shared Maestro AI SDK (models, transport, and agent event stream facade).",
 	"type": "module",
 	"main": "./dist/packages/ai/src/index.js",
@@ -124,8 +124,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.2",
-		"@evalops/tui": "^0.10.2",
+		"@evalops/contracts": "^0.10.3",
+		"@evalops/tui": "^0.10.3",
 		"@google/genai": "^1.29.1",
 		"@sinclair/typebox": "^0.34.0"
 	},

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/contracts",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "Shared Maestro contracts for frontend/backend integration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-core",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "Maestro agent loop, transport, types, and sandbox primitives — the engine behind all Maestro interfaces",
 	"type": "module",
 	"main": "./dist/packages/core/src/index.js",
@@ -58,7 +58,7 @@
 		"xlsx": "^0.18.5"
 	},
 	"peerDependencies": {
-		"@evalops/tui": "^0.10.2"
+		"@evalops/tui": "^0.10.3"
 	},
 	"peerDependenciesMeta": {
 		"@evalops/tui": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-desktop",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "Maestro Desktop - Beautiful Electron app for AI-assisted development",
 	"type": "module",
 	"main": "dist-electron/main/index.js",
@@ -36,7 +36,7 @@
 		"directory": "packages/desktop"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.2",
+		"@evalops/contracts": "^0.10.3",
 		"electron-store": "^10.0.1",
 		"electron-updater": "^6.3.9"
 	},

--- a/packages/github-agent/package.json
+++ b/packages/github-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/github-agent",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "Autonomous GitHub agent - Maestro building Maestro",
 	"type": "module",
 	"bin": {

--- a/packages/governance-mcp-server/package.json
+++ b/packages/governance-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance-mcp-server",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "MCP server exposing governance tools (firewall, policy, credential scanning) to any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -43,7 +43,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/governance": "^0.10.2",
+		"@evalops/governance": "^0.10.3",
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"zod": "^4.3.5"
 	},

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "Agent governance library — safety pipeline, firewall, and policy enforcement for any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/packages/governance/src/index.js",
@@ -40,8 +40,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.2",
-		"@evalops/tui": "^0.10.2",
+		"@evalops/contracts": "^0.10.3",
+		"@evalops/tui": "^0.10.3",
 		"@sinclair/typebox": "^0.34.0"
 	},
 	"devDependencies": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/memory",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"private": true,
 	"type": "module",
 	"sideEffects": false,

--- a/packages/slack-agent-ui/package.json
+++ b/packages/slack-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent-ui",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "Web UI for Slack Agent - Dashboard gallery, connector management, OAuth flows",
 	"type": "module",
 	"private": true,

--- a/packages/slack-agent/package.json
+++ b/packages/slack-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "Slack bot agent with Docker sandbox support for Maestro",
 	"type": "module",
 	"bin": {
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@daytonaio/sdk": "^0.139.0",
-		"@evalops/ai": "^0.10.2",
+		"@evalops/ai": "^0.10.3",
 		"@sinclair/typebox": "^0.34.0",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/tui",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "Terminal UI library with differential rendering for Maestro",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Maestro",
 	"description": "Use Maestro's deterministic AI assistant inside VS Code.",
 	"publisher": "evalops",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"license": "MIT",
 	"type": "commonjs",
 	"main": "./dist/extension.js",
@@ -139,7 +139,7 @@
 		"test": "vitest --run"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.2"
+		"@evalops/contracts": "^0.10.3"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-web",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "Web UI for Maestro - Browser-based AI coding assistant interface",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,7 +24,7 @@
 		"directory": "packages/web"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.2",
+		"@evalops/contracts": "^0.10.3",
 		"docx-preview": "^0.3.7",
 		"dompurify": "^3.3.0",
 		"highlight.js": "^11.10.0",


### PR DESCRIPTION
## Summary
- bump Maestro and workspace packages to 0.10.3
- make tree-sitter parser dependencies optional so install can succeed when native bindings are unavailable
- keep the release metadata in sync after the failed 0.10.2 smoke-test run

## Verification
- npm run clean && npm run build:all
- npm run verify:runtime-deps
- packed tarball install with tree-sitter packages removed still prints `maestro --version`