### PR TITLE
Release v0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ versioning when releases are cut.
 
 
 
+
+## [0.10.5] - 2026-04-15
+
+### Added
+
+### Changed
+
+- Tightened shared Bun cache keying in CI and release workflows to use exact, versioned cache hits instead of broad fallback restores.
+
+### Fixed
+
+- Prevented stale Bun cache restores on Linux release runners from causing `bun install --frozen-lockfile` to rewrite state and fail the publish pipeline.
+
+
 ## [0.10.4] - 2026-04-15
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Composer Web API",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@evalops-jh/maestro",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@evalops-jh/maestro",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "bundleDependencies": [
         "@evalops/contracts",
         "@evalops/memory",
@@ -20,9 +20,9 @@
         "@aws-sdk/client-bedrock-runtime": "^3.1020.0",
         "@crosscopy/clipboard": "^0.2.8",
         "@daytonaio/sdk": "^0.155.0",
-        "@evalops/contracts": "^0.10.4",
-        "@evalops/memory": "^0.10.4",
-        "@evalops/tui": "^0.10.4",
+        "@evalops/contracts": "^0.10.5",
+        "@evalops/memory": "^0.10.5",
+        "@evalops/tui": "^0.10.5",
         "@google/genai": "^1.50.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.1",
@@ -28416,11 +28416,11 @@
     },
     "packages/ai": {
       "name": "@evalops/ai",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.4",
-        "@evalops/tui": "^0.10.4",
+        "@evalops/contracts": "^0.10.5",
+        "@evalops/tui": "^0.10.5",
         "@google/genai": "^1.29.1",
         "@sinclair/typebox": "^0.34.0"
       },
@@ -28435,7 +28435,7 @@
     },
     "packages/contracts": {
       "name": "@evalops/contracts",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
@@ -28444,7 +28444,7 @@
     },
     "packages/core": {
       "name": "@evalops/maestro-core",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.966.0",
@@ -28476,7 +28476,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "@evalops/tui": "^0.10.4"
+        "@evalops/tui": "^0.10.5"
       },
       "peerDependenciesMeta": {
         "@evalops/tui": {
@@ -28503,10 +28503,10 @@
     },
     "packages/desktop": {
       "name": "@evalops/maestro-desktop",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.4",
+        "@evalops/contracts": "^0.10.5",
         "electron-store": "^10.0.1",
         "electron-updater": "^6.3.9"
       },
@@ -29120,7 +29120,7 @@
     },
     "packages/github-agent": {
       "name": "@evalops/github-agent",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^21.0.0",
@@ -29144,11 +29144,11 @@
     },
     "packages/governance": {
       "name": "@evalops/governance",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.4",
-        "@evalops/tui": "^0.10.4",
+        "@evalops/contracts": "^0.10.5",
+        "@evalops/tui": "^0.10.5",
         "@sinclair/typebox": "^0.34.0"
       },
       "devDependencies": {
@@ -29162,10 +29162,10 @@
     },
     "packages/governance-mcp-server": {
       "name": "@evalops/governance-mcp-server",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
-        "@evalops/governance": "^0.10.4",
+        "@evalops/governance": "^0.10.5",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "zod": "^4.3.5"
       },
@@ -29183,18 +29183,18 @@
     },
     "packages/memory": {
       "name": "@evalops/memory",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0"
       }
     },
     "packages/slack-agent": {
       "name": "@evalops/slack-agent",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
         "@daytonaio/sdk": "^0.139.0",
-        "@evalops/ai": "^0.10.4",
+        "@evalops/ai": "^0.10.5",
         "@sinclair/typebox": "^0.34.0",
         "@slack/socket-mode": "^2.0.0",
         "@slack/web-api": "^7.0.0",
@@ -29218,7 +29218,7 @@
     },
     "packages/slack-agent-ui": {
       "name": "@evalops/slack-agent-ui",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -29875,7 +29875,7 @@
     },
     "packages/tui": {
       "name": "@evalops/tui",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.5.0",
@@ -29894,10 +29894,10 @@
     },
     "packages/vscode-extension": {
       "name": "maestro-vscode",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.4"
+        "@evalops/contracts": "^0.10.5"
       },
       "devDependencies": {
         "@types/node": "^24.10.7",
@@ -29913,10 +29913,10 @@
     },
     "packages/web": {
       "name": "@evalops/maestro-web",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.4",
+        "@evalops/contracts": "^0.10.5",
         "docx-preview": "^0.3.7",
         "dompurify": "^3.3.0",
         "highlight.js": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evalops-jh/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "private": false,
   "type": "module",
   "workspaces": [
@@ -111,9 +111,9 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1020.0",
     "@crosscopy/clipboard": "^0.2.8",
     "@daytonaio/sdk": "^0.155.0",
-    "@evalops/contracts": "^0.10.4",
-    "@evalops/memory": "^0.10.4",
-    "@evalops/tui": "^0.10.4",
+    "@evalops/contracts": "^0.10.5",
+    "@evalops/memory": "^0.10.5",
+    "@evalops/tui": "^0.10.5",
     "@google/genai": "^1.50.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.1",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/ai",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "Shared Maestro AI SDK (models, transport, and agent event stream facade).",
 	"type": "module",
 	"main": "./dist/packages/ai/src/index.js",
@@ -124,8 +124,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.4",
-		"@evalops/tui": "^0.10.4",
+		"@evalops/contracts": "^0.10.5",
+		"@evalops/tui": "^0.10.5",
 		"@google/genai": "^1.29.1",
 		"@sinclair/typebox": "^0.34.0"
 	},

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/contracts",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "Shared Maestro contracts for frontend/backend integration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-core",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "Maestro agent loop, transport, types, and sandbox primitives — the engine behind all Maestro interfaces",
 	"type": "module",
 	"main": "./dist/packages/core/src/index.js",
@@ -58,7 +58,7 @@
 		"xlsx": "^0.18.5"
 	},
 	"peerDependencies": {
-		"@evalops/tui": "^0.10.4"
+		"@evalops/tui": "^0.10.5"
 	},
 	"peerDependenciesMeta": {
 		"@evalops/tui": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-desktop",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "Maestro Desktop - Beautiful Electron app for AI-assisted development",
 	"type": "module",
 	"main": "dist-electron/main/index.js",
@@ -36,7 +36,7 @@
 		"directory": "packages/desktop"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.4",
+		"@evalops/contracts": "^0.10.5",
 		"electron-store": "^10.0.1",
 		"electron-updater": "^6.3.9"
 	},

--- a/packages/github-agent/package.json
+++ b/packages/github-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/github-agent",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "Autonomous GitHub agent - Maestro building Maestro",
 	"type": "module",
 	"bin": {

--- a/packages/governance-mcp-server/package.json
+++ b/packages/governance-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance-mcp-server",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "MCP server exposing governance tools (firewall, policy, credential scanning) to any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -43,7 +43,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/governance": "^0.10.4",
+		"@evalops/governance": "^0.10.5",
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"zod": "^4.3.5"
 	},

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "Agent governance library — safety pipeline, firewall, and policy enforcement for any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/packages/governance/src/index.js",
@@ -40,8 +40,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.4",
-		"@evalops/tui": "^0.10.4",
+		"@evalops/contracts": "^0.10.5",
+		"@evalops/tui": "^0.10.5",
 		"@sinclair/typebox": "^0.34.0"
 	},
 	"devDependencies": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/memory",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"private": true,
 	"type": "module",
 	"sideEffects": false,

--- a/packages/slack-agent-ui/package.json
+++ b/packages/slack-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent-ui",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "Web UI for Slack Agent - Dashboard gallery, connector management, OAuth flows",
 	"type": "module",
 	"private": true,

--- a/packages/slack-agent/package.json
+++ b/packages/slack-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "Slack bot agent with Docker sandbox support for Maestro",
 	"type": "module",
 	"bin": {
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@daytonaio/sdk": "^0.139.0",
-		"@evalops/ai": "^0.10.4",
+		"@evalops/ai": "^0.10.5",
 		"@sinclair/typebox": "^0.34.0",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/tui",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "Terminal UI library with differential rendering for Maestro",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Maestro",
 	"description": "Use Maestro's deterministic AI assistant inside VS Code.",
 	"publisher": "evalops",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"license": "MIT",
 	"type": "commonjs",
 	"main": "./dist/extension.js",
@@ -139,7 +139,7 @@
 		"test": "vitest --run"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.4"
+		"@evalops/contracts": "^0.10.5"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-web",
-	"version": "0.10.4",
+	"version": "0.10.5",
 	"description": "Web UI for Maestro - Browser-based AI coding assistant interface",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,7 +24,7 @@
 		"directory": "packages/web"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.4",
+		"@evalops/contracts": "^0.10.5",
 		"docx-preview": "^0.3.7",
 		"dompurify": "^3.3.0",
 		"highlight.js": "^11.10.0",


### PR DESCRIPTION
## Summary
- release the current `main` state after the CI/cache fixes landed
- include the `0.10.5` changelog entry for the Bun cache-key tightening
- refresh workspace package versions and generated OpenAPI metadata

## Testing
- pre-commit validation suite (Biome, eval checks, proto/codegen checks, build)
- prior release repro/diagnosis against GitHub Actions and Linux Bun cache behavior
