### PR TITLE
Release v0.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@ All notable changes to this project will be documented here. The format loosely
 follows [Keep a Changelog](https://keepachangelog.com/) and adheres to semantic
 versioning when releases are cut.
 
+## [0.10.6] - 2026-04-15
 
+### Added
 
+### Changed
 
+- Rebundled Google provider runtime dependencies into the built CLI and provider artifacts so installs no longer need the Google SDKs as direct runtime package requirements.
 
+### Fixed
+
+- Removed the unused root `better-sqlite3` dependency from the published package and eliminated the remaining install-time deprecation warnings from `prebuild-install` and `node-domexception`.
+- Hardened runtime dependency verification so bundled code comments do not produce false positives during release validation.
 
 ## [0.10.5] - 2026-04-15
 

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Composer Web API",
-    "version": "0.10.5",
+    "version": "0.10.6",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@evalops-jh/maestro",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@evalops-jh/maestro",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "bundleDependencies": [
         "@evalops/contracts",
         "@evalops/memory",
@@ -20,9 +20,9 @@
         "@aws-sdk/client-bedrock-runtime": "^3.1020.0",
         "@crosscopy/clipboard": "^0.2.8",
         "@daytonaio/sdk": "^0.155.0",
-        "@evalops/contracts": "^0.10.5",
-        "@evalops/memory": "^0.10.5",
-        "@evalops/tui": "^0.10.5",
+        "@evalops/contracts": "^0.10.6",
+        "@evalops/memory": "^0.10.6",
+        "@evalops/tui": "^0.10.6",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.67.3",
@@ -28446,11 +28446,11 @@
     },
     "packages/ai": {
       "name": "@evalops/ai",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.5",
-        "@evalops/tui": "^0.10.5",
+        "@evalops/contracts": "^0.10.6",
+        "@evalops/tui": "^0.10.6",
         "@google/genai": "^1.29.1",
         "@sinclair/typebox": "^0.34.0"
       },
@@ -28465,7 +28465,7 @@
     },
     "packages/contracts": {
       "name": "@evalops/contracts",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
@@ -28474,7 +28474,7 @@
     },
     "packages/core": {
       "name": "@evalops/maestro-core",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.966.0",
@@ -28506,7 +28506,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "@evalops/tui": "^0.10.5"
+        "@evalops/tui": "^0.10.6"
       },
       "peerDependenciesMeta": {
         "@evalops/tui": {
@@ -28533,10 +28533,10 @@
     },
     "packages/desktop": {
       "name": "@evalops/maestro-desktop",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.5",
+        "@evalops/contracts": "^0.10.6",
         "electron-store": "^10.0.1",
         "electron-updater": "^6.3.9"
       },
@@ -29150,7 +29150,7 @@
     },
     "packages/github-agent": {
       "name": "@evalops/github-agent",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^21.0.0",
@@ -29174,11 +29174,11 @@
     },
     "packages/governance": {
       "name": "@evalops/governance",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.5",
-        "@evalops/tui": "^0.10.5",
+        "@evalops/contracts": "^0.10.6",
+        "@evalops/tui": "^0.10.6",
         "@sinclair/typebox": "^0.34.0"
       },
       "devDependencies": {
@@ -29192,10 +29192,10 @@
     },
     "packages/governance-mcp-server": {
       "name": "@evalops/governance-mcp-server",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
-        "@evalops/governance": "^0.10.5",
+        "@evalops/governance": "^0.10.6",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "zod": "^4.3.5"
       },
@@ -29213,18 +29213,18 @@
     },
     "packages/memory": {
       "name": "@evalops/memory",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0"
       }
     },
     "packages/slack-agent": {
       "name": "@evalops/slack-agent",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
         "@daytonaio/sdk": "^0.139.0",
-        "@evalops/ai": "^0.10.5",
+        "@evalops/ai": "^0.10.6",
         "@sinclair/typebox": "^0.34.0",
         "@slack/socket-mode": "^2.0.0",
         "@slack/web-api": "^7.0.0",
@@ -29248,7 +29248,7 @@
     },
     "packages/slack-agent-ui": {
       "name": "@evalops/slack-agent-ui",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -29905,7 +29905,7 @@
     },
     "packages/tui": {
       "name": "@evalops/tui",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.5.0",
@@ -29924,10 +29924,10 @@
     },
     "packages/vscode-extension": {
       "name": "maestro-vscode",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.5"
+        "@evalops/contracts": "^0.10.6"
       },
       "devDependencies": {
         "@types/node": "^24.10.7",
@@ -29943,10 +29943,10 @@
     },
     "packages/web": {
       "name": "@evalops/maestro-web",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "MIT",
       "dependencies": {
-        "@evalops/contracts": "^0.10.5",
+        "@evalops/contracts": "^0.10.6",
         "docx-preview": "^0.3.7",
         "dompurify": "^3.3.0",
         "highlight.js": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evalops-jh/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "private": false,
   "type": "module",
   "workspaces": [
@@ -111,9 +111,9 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1020.0",
     "@crosscopy/clipboard": "^0.2.8",
     "@daytonaio/sdk": "^0.155.0",
-    "@evalops/contracts": "^0.10.5",
-    "@evalops/memory": "^0.10.5",
-    "@evalops/tui": "^0.10.5",
+    "@evalops/contracts": "^0.10.6",
+    "@evalops/memory": "^0.10.6",
+    "@evalops/tui": "^0.10.6",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.67.3",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/ai",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "Shared Maestro AI SDK (models, transport, and agent event stream facade).",
 	"type": "module",
 	"main": "./dist/packages/ai/src/index.js",
@@ -124,8 +124,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.5",
-		"@evalops/tui": "^0.10.5",
+		"@evalops/contracts": "^0.10.6",
+		"@evalops/tui": "^0.10.6",
 		"@google/genai": "^1.29.1",
 		"@sinclair/typebox": "^0.34.0"
 	},

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/contracts",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "Shared Maestro contracts for frontend/backend integration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-core",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "Maestro agent loop, transport, types, and sandbox primitives — the engine behind all Maestro interfaces",
 	"type": "module",
 	"main": "./dist/packages/core/src/index.js",
@@ -58,7 +58,7 @@
 		"xlsx": "^0.18.5"
 	},
 	"peerDependencies": {
-		"@evalops/tui": "^0.10.5"
+		"@evalops/tui": "^0.10.6"
 	},
 	"peerDependenciesMeta": {
 		"@evalops/tui": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-desktop",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "Maestro Desktop - Beautiful Electron app for AI-assisted development",
 	"type": "module",
 	"main": "dist-electron/main/index.js",
@@ -36,7 +36,7 @@
 		"directory": "packages/desktop"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.5",
+		"@evalops/contracts": "^0.10.6",
 		"electron-store": "^10.0.1",
 		"electron-updater": "^6.3.9"
 	},

--- a/packages/github-agent/package.json
+++ b/packages/github-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/github-agent",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "Autonomous GitHub agent - Maestro building Maestro",
 	"type": "module",
 	"bin": {

--- a/packages/governance-mcp-server/package.json
+++ b/packages/governance-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance-mcp-server",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "MCP server exposing governance tools (firewall, policy, credential scanning) to any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -43,7 +43,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/governance": "^0.10.5",
+		"@evalops/governance": "^0.10.6",
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"zod": "^4.3.5"
 	},

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "Agent governance library — safety pipeline, firewall, and policy enforcement for any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/packages/governance/src/index.js",
@@ -40,8 +40,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.5",
-		"@evalops/tui": "^0.10.5",
+		"@evalops/contracts": "^0.10.6",
+		"@evalops/tui": "^0.10.6",
 		"@sinclair/typebox": "^0.34.0"
 	},
 	"devDependencies": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/memory",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"private": true,
 	"type": "module",
 	"sideEffects": false,

--- a/packages/slack-agent-ui/package.json
+++ b/packages/slack-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent-ui",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "Web UI for Slack Agent - Dashboard gallery, connector management, OAuth flows",
 	"type": "module",
 	"private": true,

--- a/packages/slack-agent/package.json
+++ b/packages/slack-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "Slack bot agent with Docker sandbox support for Maestro",
 	"type": "module",
 	"bin": {
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@daytonaio/sdk": "^0.139.0",
-		"@evalops/ai": "^0.10.5",
+		"@evalops/ai": "^0.10.6",
 		"@sinclair/typebox": "^0.34.0",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/tui",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "Terminal UI library with differential rendering for Maestro",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Maestro",
 	"description": "Use Maestro's deterministic AI assistant inside VS Code.",
 	"publisher": "evalops",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"license": "MIT",
 	"type": "commonjs",
 	"main": "./dist/extension.js",
@@ -139,7 +139,7 @@
 		"test": "vitest --run"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.5"
+		"@evalops/contracts": "^0.10.6"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-web",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "Web UI for Maestro - Browser-based AI coding assistant interface",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,7 +24,7 @@
 		"directory": "packages/web"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.5",
+		"@evalops/contracts": "^0.10.6",
 		"docx-preview": "^0.3.7",
 		"dompurify": "^3.3.0",
 		"highlight.js": "^11.10.0",


### PR DESCRIPTION
## Summary\n- bump Maestro and workspace packages to 0.10.6\n- document the runtime dependency packaging cleanup in the changelog\n- refresh generated release metadata for the next npm publish\n\n## Validation\n- version bump commit passed the repository pre-commit guardrails (biome, lint:evals, build, bun compile)\n- release workflow will run the full quality gate before publish