### PR TITLE
[maestro] improve cutover readiness

### DIFF
--- a/.github/actions/release-context/action.yml
+++ b/.github/actions/release-context/action.yml
@@ -1,0 +1,129 @@
+name: Release Context
+description: Resolve release tag, version, and package metadata from the checked-out repo.
+
+inputs:
+  requested-version:
+    description: Release version or tag to resolve.
+    required: false
+    default: ""
+  fallback-to-package-version:
+    description: Use the current package.json version when no explicit version is provided.
+    required: false
+    default: "false"
+  create-tag-if-missing:
+    description: Create and push the resolved tag when it does not already exist.
+    required: false
+    default: "false"
+
+outputs:
+  release_tag:
+    description: Normalized semver tag, including leading v.
+    value: ${{ steps.context.outputs.release_tag }}
+  release_version:
+    description: Semver release version without the leading v.
+    value: ${{ steps.context.outputs.release_version }}
+  package_name:
+    description: Current published package name from package.json.
+    value: ${{ steps.context.outputs.package_name }}
+  package_version:
+    description: Current package version from package.json.
+    value: ${{ steps.context.outputs.package_version }}
+  cli_command:
+    description: Declared CLI command from package.json bin map.
+    value: ${{ steps.context.outputs.cli_command }}
+  canonical_package_name:
+    description: Canonical package name once npm scope recovery is complete.
+    value: ${{ steps.context.outputs.canonical_package_name }}
+  package_aliases_json:
+    description: JSON array of recognized package-name aliases.
+    value: ${{ steps.context.outputs.package_aliases_json }}
+  tag_exists:
+    description: Whether the resolved tag already exists in git.
+    value: ${{ steps.context.outputs.tag_exists }}
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch tags
+      shell: bash
+      run: git fetch --tags --force
+
+    - id: context
+      shell: bash
+      env:
+        MAESTRO_RELEASE_REQUESTED_VERSION: ${{ inputs.requested-version }}
+        MAESTRO_RELEASE_FALLBACK_TO_PACKAGE_VERSION: ${{ inputs.fallback-to-package-version }}
+      run: |
+        node --input-type=module <<'EOF' >> "$GITHUB_OUTPUT"
+        import { execFileSync } from "node:child_process";
+        import { pathToFileURL } from "node:url";
+
+        const modulePath = pathToFileURL(
+          `${process.env.GITHUB_ACTION_PATH}/../../../scripts/package-metadata.js`,
+        );
+        const { getPackageMetadata } = await import(modulePath.href);
+        const metadata = getPackageMetadata();
+        const requestedVersion =
+          (process.env.MAESTRO_RELEASE_REQUESTED_VERSION ?? "").trim();
+        const fallbackToPackageVersion =
+          (process.env.MAESTRO_RELEASE_FALLBACK_TO_PACKAGE_VERSION ?? "false") ===
+          "true";
+        const sourceVersion =
+          requestedVersion || (fallbackToPackageVersion ? metadata.version : "");
+
+        if (!sourceVersion) {
+          throw new Error("No release version provided to release-context.");
+        }
+
+        const releaseTag = sourceVersion.startsWith("v")
+          ? sourceVersion
+          : `v${sourceVersion}`;
+
+        if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(releaseTag)) {
+          throw new Error(
+            `Release tag must follow semver (vX.Y.Z), received: ${releaseTag}`,
+          );
+        }
+
+        const releaseVersion = releaseTag.slice(1);
+        if (releaseVersion !== metadata.version) {
+          throw new Error(
+            `package.json version ${metadata.version} does not match release version ${releaseVersion}`,
+          );
+        }
+
+        let tagExists = false;
+        try {
+          execFileSync("git", ["rev-parse", `refs/tags/${releaseTag}`], {
+            stdio: "ignore",
+          });
+          tagExists = true;
+        } catch {
+          tagExists = false;
+        }
+
+        const outputs = {
+          release_tag: releaseTag,
+          release_version: releaseVersion,
+          package_name: metadata.name,
+          package_version: metadata.version,
+          cli_command: metadata.cliCommand,
+          canonical_package_name: metadata.canonicalPackageName,
+          package_aliases_json: JSON.stringify(metadata.packageAliases),
+          tag_exists: String(tagExists),
+        };
+
+        for (const [key, value] of Object.entries(outputs)) {
+          process.stdout.write(`${key}=${value}\n`);
+        }
+        EOF
+
+    - name: Create missing tag
+      if: ${{ inputs.create-tag-if-missing == 'true' && steps.context.outputs.tag_exists != 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag -a "${{ steps.context.outputs.release_tag }}" -m "Release ${{ steps.context.outputs.release_tag }}"
+        git push origin "${{ steps.context.outputs.release_tag }}"

--- a/.github/actions/release-notify/action.yml
+++ b/.github/actions/release-notify/action.yml
@@ -1,0 +1,84 @@
+name: Release Notify
+description: Compute release status and send the shared release notification payload.
+
+inputs:
+  release-version:
+    description: Release version being reported.
+    required: true
+  package-name:
+    description: Package name to include in the notification.
+    required: false
+    default: ""
+  package-version:
+    description: Package version to include in the notification.
+    required: false
+    default: ""
+  quality-gate-result:
+    description: Result of the release quality gate job.
+    required: false
+    default: ""
+  publish-result:
+    description: Result of the publish job.
+    required: false
+    default: ""
+  canary-result:
+    description: Result of the post-publish canary job.
+    required: false
+    default: ""
+  webhook-url:
+    description: Release notification webhook URL.
+    required: false
+    default: ""
+
+outputs:
+  status:
+    description: Computed release status sent to the notification script.
+    value: ${{ steps.status.outputs.status }}
+
+runs:
+  using: composite
+  steps:
+    - id: status
+      shell: bash
+      env:
+        QUALITY_GATE_RESULT: ${{ inputs.quality-gate-result }}
+        PUBLISH_RESULT: ${{ inputs.publish-result }}
+        CANARY_RESULT: ${{ inputs.canary-result }}
+      run: |
+        set -euo pipefail
+        status="success"
+        for result in "$QUALITY_GATE_RESULT" "$PUBLISH_RESULT" "$CANARY_RESULT"; do
+          if [[ -z "$result" ]]; then
+            continue
+          fi
+          case "$result" in
+            success)
+              ;;
+            failure)
+              status="failure"
+              break
+              ;;
+            cancelled)
+              status="cancelled"
+              break
+              ;;
+            skipped)
+              status="skipped"
+              break
+              ;;
+            *)
+              status="$result"
+              break
+              ;;
+          esac
+        done
+        echo "status=$status" >> "$GITHUB_OUTPUT"
+
+    - shell: bash
+      env:
+        RELEASE_STATUS: ${{ steps.status.outputs.status }}
+        RELEASE_VERSION: ${{ inputs.release-version }}
+        RELEASE_PACKAGE_NAME: ${{ inputs.package-name }}
+        RELEASE_PACKAGE_VERSION: ${{ inputs.package-version || inputs.release-version }}
+        SLACK_RELEASE_WEBHOOK_URL: ${{ inputs.webhook-url }}
+      run: node "$GITHUB_ACTION_PATH/../../../scripts/send-release-notification.mjs"

--- a/.github/release-mirror-manifest.json
+++ b/.github/release-mirror-manifest.json
@@ -1,8 +1,11 @@
 {
   "files": [
+    ".github/actions/release-context/action.yml",
+    ".github/actions/release-notify/action.yml",
     ".github/actions/setup-bun-nx/action.yml",
     ".github/workflows/tag-release.yml",
     ".github/workflows/version-bump.yml",
+    "scripts/check-package-cutover-readiness.js",
     "scripts/check-headless-proto-generated.mjs",
     "scripts/generate-openapi.ts",
     "scripts/headless-protocol-codegen.mjs",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,79 +64,21 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     outputs:
-      release_tag: ${{ steps.meta.outputs.release_tag }}
-      release_version: ${{ steps.meta.outputs.release_version }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      release_version: ${{ steps.release.outputs.release_version }}
+      package_name: ${{ steps.release.outputs.package_name }}
+      package_version: ${{ steps.release.outputs.package_version }}
+      canonical_package_name: ${{ steps.release.outputs.canonical_package_name }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - id: meta
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          DISPATCH_VERSION: ${{ github.event.inputs.version || '' }}
-          REF_NAME_VALUE: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
-            RAW_TAG="${DISPATCH_VERSION}"
-          else
-            RAW_TAG="${REF_NAME_VALUE}"
-          fi
-
-          if [[ -z "$RAW_TAG" ]]; then
-            echo "::error::Release version is required" >&2
-            exit 1
-          fi
-
-          if [[ "$RAW_TAG" != v* ]]; then
-            RAW_TAG="v${RAW_TAG}"
-          fi
-
-          if ! [[ "$RAW_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Release tag must follow semver (vX.Y.Z)" >&2
-            exit 1
-          fi
-
-          VERSION="${RAW_TAG#v}"
-
-          echo "release_tag=$RAW_TAG" >> "$GITHUB_OUTPUT"
-          echo "release_version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - id: tag-state
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.meta.outputs.release_tag }}"
-          git fetch --tags --force
-          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create tag from workflow dispatch
-        if: github.event_name == 'workflow_dispatch' && steps.tag-state.outputs.tag_exists != 'true'
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.meta.outputs.release_tag }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-
-      - name: Verify release version matches package.json
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.meta.outputs.release_tag }}"
-          EXPECTED_VERSION="${{ steps.meta.outputs.release_version }}"
-          PACKAGE_VERSION=$(
-            git show "${TAG}:package.json" | python3 -c 'import json, sys; print(json.load(sys.stdin)["version"])'
-          )
-          if [[ "${PACKAGE_VERSION}" != "${EXPECTED_VERSION}" ]]; then
-            echo "::error::package.json version ${PACKAGE_VERSION} does not match release version ${EXPECTED_VERSION}" >&2
-            exit 1
-          fi
+      - id: release
+        uses: ./.github/actions/release-context
+        with:
+          requested-version: ${{ github.event.inputs.version || github.ref_name }}
+          create-tag-if-missing: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
 
   quality-gate:
     if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
@@ -323,50 +265,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.prepare.outputs.release_tag }}
 
-      - id: status
-        env:
-          QUALITY_GATE_RESULT: ${{ needs.quality-gate.result }}
-          PUBLISH_RESULT: ${{ needs.publish.result }}
-          CANARY_RESULT: ${{ needs.post-publish-canary.result }}
-        run: |
-          set -euo pipefail
-          status="success"
-          for result in "$QUALITY_GATE_RESULT" "$PUBLISH_RESULT" "$CANARY_RESULT"; do
-            case "$result" in
-              success)
-                ;;
-              failure)
-                status="failure"
-                break
-                ;;
-              cancelled)
-                status="cancelled"
-                break
-                ;;
-              skipped)
-                status="skipped"
-                break
-                ;;
-              *)
-                status="$result"
-                break
-                ;;
-            esac
-          done
-          echo "status=$status" >> "$GITHUB_OUTPUT"
-
-      - id: package
-        run: |
-          set -euo pipefail
-          package_name=$(node -p "require('./package.json').name")
-          echo "name=$package_name" >> "$GITHUB_OUTPUT"
-
       - name: Notify release channel
         continue-on-error: true
-        env:
-          RELEASE_STATUS: ${{ steps.status.outputs.status }}
-          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
-          RELEASE_PACKAGE_NAME: ${{ steps.package.outputs.name }}
-          RELEASE_PACKAGE_VERSION: ${{ needs.prepare.outputs.release_version }}
-          SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
-        run: node scripts/send-release-notification.mjs
+        uses: ./.github/actions/release-notify
+        with:
+          quality-gate-result: ${{ needs.quality-gate.result }}
+          publish-result: ${{ needs.publish.result }}
+          canary-result: ${{ needs.post-publish-canary.result }}
+          release-version: ${{ needs.prepare.outputs.release_version }}
+          package-name: ${{ needs.prepare.outputs.package_name }}
+          package-version: ${{ needs.prepare.outputs.package_version }}
+          webhook-url: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -24,39 +24,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - id: version
-        run: |
-          set -euo pipefail
-          VERSION=$(node -p "require('./package.json').version")
-          TAG="v${VERSION}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-
-      - id: tag-state
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.version.outputs.tag }}"
-          git fetch --tags --force
-          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create missing semver tag
-        if: steps.tag-state.outputs.tag_exists != 'true'
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.version.outputs.tag }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG" "$GITHUB_SHA"
-          git push origin "$TAG"
+      - id: release
+        uses: ./.github/actions/release-context
+        with:
+          fallback-to-package-version: "true"
+          create-tag-if-missing: "true"
 
       - name: Summarize tag status
         run: |
-          if [[ "${{ steps.tag-state.outputs.tag_exists }}" == "true" ]]; then
-            echo "Semver tag ${{ steps.version.outputs.tag }} already exists."
+          if [[ "${{ steps.release.outputs.tag_exists }}" == "true" ]]; then
+            echo "Semver tag ${{ steps.release.outputs.release_tag }} already exists."
           else
-            echo "Created semver tag ${{ steps.version.outputs.tag }}."
+            echo "Created semver tag ${{ steps.release.outputs.release_tag }}."
           fi

--- a/.github/workflows/verify-published-package.yml
+++ b/.github/workflows/verify-published-package.yml
@@ -1,0 +1,65 @@
+name: verify-published-package
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: Optional package name override.
+        required: false
+        default: ""
+        type: string
+      version:
+        description: Optional version override.
+        required: false
+        default: ""
+        type: string
+      cli_command:
+        description: Optional CLI command override.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.package_name || github.event.inputs.version || github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - id: defaults
+        run: |
+          set -euo pipefail
+          {
+            echo "package_name=$(node -p 'require(\"./package.json\").name')"
+            echo "version=$(node -p 'require(\"./package.json\").version')"
+            echo "cli_command=$(node -p 'Object.keys(require(\"./package.json\").bin)[0]')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify published package from npm
+        env:
+          PACKAGE_NAME: ${{ github.event.inputs.package_name || steps.defaults.outputs.package_name }}
+          PACKAGE_VERSION: ${{ github.event.inputs.version || steps.defaults.outputs.version }}
+          CLI_COMMAND: ${{ github.event.inputs.cli_command || steps.defaults.outputs.cli_command }}
+        run: |
+          set -euo pipefail
+          node scripts/smoke-registry-install.js \
+            --package "$PACKAGE_NAME" \
+            --version "$PACKAGE_VERSION" \
+            --cli-command "$CLI_COMMAND"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -50,12 +50,13 @@ jobs:
           BUMP_TYPE: ${{ github.event.inputs.bump_type }}
         run: npm run "version:${BUMP_TYPE}"
 
+      - id: release
+        uses: ./.github/actions/release-context
+        with:
+          fallback-to-package-version: "true"
+
       - id: version
-        run: |
-          set -euo pipefail
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "branch=release/v${VERSION}" >> "$GITHUB_OUTPUT"
+        run: echo "branch=release/v${{ steps.release.outputs.release_version }}" >> "$GITHUB_OUTPUT"
 
       - name: Commit release branch
         env:
@@ -72,7 +73,7 @@ jobs:
           fi
           git switch -c "$RELEASE_BRANCH"
           git add .
-          git commit -m "Release v${{ steps.version.outputs.version }}"
+          git commit -m "Release v${{ steps.release.outputs.release_version }}"
           git push --set-upstream origin "$RELEASE_BRANCH"
 
       - name: Open or reuse release PR
@@ -80,7 +81,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BASE_REF: ${{ github.event.inputs.base_ref || 'main' }}
           RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
         run: |
           set -euo pipefail
           pr_body=$(cat <<EOF

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ We follow a 90-day coordinated disclosure window. If you report a vulnerability,
 
 This policy applies to the Maestro codebase and its official packages:
 
-- `@evalops/maestro` and all `@evalops/*` packages
+- `@evalops-jh/maestro` and all `@evalops/*` packages
 - Official Docker images (`ghcr.io/evalops/maestro`)
 - The Maestro VS Code extension and JetBrains plugin
 

--- a/docs/TOOLS_REFERENCE.md
+++ b/docs/TOOLS_REFERENCE.md
@@ -106,7 +106,7 @@ export const myTool = createTool({
 
 ## SDK Tool Types
 
-For external SDK consumers, tool input schemas are exported from `@evalops/maestro`:
+For external SDK consumers, tool input schemas are exported from `@evalops-jh/maestro`:
 
 ```typescript
 import {
@@ -118,7 +118,7 @@ import {
   getToolSchema,
   type ReadInput,
   type EditInput,
-} from '@evalops/maestro';
+} from '@evalops-jh/maestro';
 
 // Get schema at runtime
 const schema = getToolSchema('read');

--- a/docs/release-ops.md
+++ b/docs/release-ops.md
@@ -4,7 +4,7 @@
 
 - `main` is the release source of truth.
 - The public repo owns npm publishing.
-- The release workflow publishes `@evalops-jh/maestro` through npm trusted publishing.
+- The release workflow currently publishes `@evalops-jh/maestro`; the cutover target is `@evalops/maestro`.
 
 ## Automated Flow
 
@@ -21,8 +21,25 @@
   Runs the shared CI-mode release checks used by PR validation.
 - `npm run release:check`
   Runs the full release gate locally, including build, runtime-dependency verification, npm audit, and packed CLI smoke test.
+- `npm run cutover:check`
+  Verifies that root package names and install commands stay centralized in the approved cutover-aware files.
 
 ## PR Automation
 
 - Repos are configured for GitHub-side auto-merge and automatic branch deletion on merge.
 - Use `gh pr merge <pr> --auto --merge --repo evalops/maestro` to avoid local worktree branch-switch issues.
+
+## Namespace Cutover
+
+- The current published package name comes from `package.json:name`.
+- The long-term package target lives in `package.json:maestro.canonicalPackageName`.
+- Keep README, JetBrains plugin docs, SDK docs, and release ops text in sync with `npm run metadata:sync`.
+- Run `npm run cutover:check` before changing package names or install instructions.
+- Use `.github/workflows/verify-published-package.yml` for a manual npm verification run against either the current package metadata or an override package/version during scope recovery.
+
+## Rollback And Deprecation
+
+- Verify a published package manually with `npm run release:verify:published -- --package <name> --version <version>`.
+- Deprecate a bad version or temporary package path from a logged-in machine with `npm run release:deprecate -- --range <version-or-range>`.
+- Add `--replacement-package @evalops/maestro` when retiring the temporary namespace, or provide `--message` for a custom rollback notice.
+- Use `--dry-run` first to inspect the exact `npm deprecate` command before making registry changes.

--- a/package.json
+++ b/package.json
@@ -79,7 +79,10 @@
     "smoke:registry": "node scripts/smoke-registry-install.js",
     "metadata:sync": "node scripts/sync-package-metadata.js",
     "metadata:check": "node scripts/sync-package-metadata.js --check",
+    "cutover:check": "node scripts/check-package-cutover-readiness.js",
     "verify:runtime-deps": "node scripts/check-runtime-deps.js",
+    "release:verify:published": "node scripts/smoke-registry-install.js",
+    "release:deprecate": "node scripts/deprecate-release.js",
     "factory:import": "npm run build && node dist/scripts/import-factory-config.js",
     "factory:export": "npm run build && node dist/scripts/export-factory-config.js",
     "version:patch": "node scripts/version.js patch",
@@ -200,6 +203,13 @@
   ],
   "author": "EvalOps",
   "license": "BUSL-1.1",
+  "maestro": {
+    "canonicalPackageName": "@evalops/maestro",
+    "packageAliases": [
+      "@evalops-jh/maestro",
+      "@evalops/maestro"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/evalops/maestro.git"

--- a/scripts/check-package-cutover-readiness.js
+++ b/scripts/check-package-cutover-readiness.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// @ts-check
+
+import { readFileSync } from "node:fs";
+import { globSync } from "glob";
+import { getPackageMetadata } from "./package-metadata.js";
+
+const { packageAliases } = getPackageMetadata();
+const aliasMatchers = packageAliases.map((alias) => ({
+	alias,
+	pattern: new RegExp(`(^|[^\\w/-])${escapeRegExp(alias)}(?![-\\w/])`, "m"),
+}));
+
+const allowedFiles = new Set(
+	[
+		"CHANGELOG.md",
+		"README.md",
+		"SECURITY.md",
+		"docs/TOOLS_REFERENCE.md",
+		"docs/release-ops.md",
+		"package.json",
+		"package-lock.json",
+		"packages/jetbrains-plugin/README.md",
+		"packages/jetbrains-plugin/src/main/resources/META-INF/plugin.xml",
+		"scripts/check-package-cutover-readiness.js",
+		"scripts/package-metadata.js",
+		"scripts/sync-package-metadata.js",
+		"src/agent/types.ts",
+		"src/package-metadata.ts",
+	]
+		.filter(Boolean)
+		.map((file) => file.replaceAll("\\", "/")),
+);
+
+const ignoredPatterns = [
+	"**/.git/**",
+	"**/.nx/**",
+	"**/coverage/**",
+	"**/dist/**",
+	"**/node_modules/**",
+	"**/tmp/**",
+	"bun.lockb",
+	"**/*.png",
+	"**/*.jpg",
+	"**/*.jpeg",
+	"**/*.gif",
+	"**/*.ico",
+	"**/*.pdf",
+	"**/*.woff",
+	"**/*.woff2",
+	"**/*.ttf",
+];
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const offenders = [];
+
+for (const file of globSync("**/*", {
+	dot: true,
+	nodir: true,
+	ignore: ignoredPatterns,
+})) {
+	const normalizedFile = file.replaceAll("\\", "/");
+	if (allowedFiles.has(normalizedFile)) {
+		continue;
+	}
+
+	let content;
+	try {
+		content = readFileSync(file, "utf8");
+	} catch {
+		continue;
+	}
+
+	const matches = aliasMatchers
+		.filter(({ pattern }) => pattern.test(content))
+		.map(({ alias }) => alias);
+	if (matches.length === 0) {
+		continue;
+	}
+
+	offenders.push({ file: normalizedFile, matches });
+}
+
+if (offenders.length > 0) {
+	console.error("Unexpected hard-coded root package references found:");
+	for (const offender of offenders) {
+		console.error(`- ${offender.file}: ${offender.matches.join(", ")}`);
+	}
+	process.exit(1);
+}
+
+console.log("Package cutover references are scoped to approved files.");

--- a/scripts/deprecate-release.js
+++ b/scripts/deprecate-release.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// @ts-check
+
+import { execFileSync } from "node:child_process";
+import { getPackageMetadata } from "./package-metadata.js";
+
+function parseArgs(argv) {
+	/** @type {{range: string; packageName: string; message: string; otp: string; dryRun: boolean; replacementPackage: string}} */
+	const options = {
+		range: "",
+		packageName: "",
+		message: "",
+		otp: "",
+		dryRun: false,
+		replacementPackage: "",
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		switch (arg) {
+			case "--range":
+				options.range = argv[++index] ?? "";
+				break;
+			case "--package":
+				options.packageName = argv[++index] ?? "";
+				break;
+			case "--message":
+				options.message = argv[++index] ?? "";
+				break;
+			case "--otp":
+				options.otp = argv[++index] ?? "";
+				break;
+			case "--replacement-package":
+				options.replacementPackage = argv[++index] ?? "";
+				break;
+			case "--dry-run":
+				options.dryRun = true;
+				break;
+			default:
+				throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+
+	return options;
+}
+
+const { name, canonicalPackageName } = getPackageMetadata();
+const options = parseArgs(process.argv.slice(2));
+
+if (!options.range) {
+	console.error(
+		"Usage: node scripts/deprecate-release.js --range <version-or-range> [--package <name>] [--message <text>] [--replacement-package <name>] [--otp <code>] [--dry-run]",
+	);
+	process.exit(1);
+}
+
+const packageName = options.packageName || name;
+const replacementPackage =
+	options.replacementPackage ||
+	(packageName === canonicalPackageName ? "" : canonicalPackageName);
+const defaultMessage = replacementPackage
+	? `Deprecated package path. Install ${replacementPackage} instead.`
+	: "Deprecated release. Upgrade to a supported Maestro version.";
+const message = options.message || defaultMessage;
+const spec = `${packageName}@${options.range}`;
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const npmArgs = ["deprecate", spec, message];
+
+if (options.otp) {
+	npmArgs.push("--otp", options.otp);
+}
+
+if (options.dryRun) {
+	console.log(`[dry-run] ${npmCommand} ${npmArgs.join(" ")}`);
+	process.exit(0);
+}
+
+execFileSync(npmCommand, npmArgs, { stdio: "inherit" });
+console.log(`Deprecated ${spec}`);

--- a/scripts/package-metadata.js
+++ b/scripts/package-metadata.js
@@ -12,7 +12,24 @@ function isStringRecord(value) {
 }
 
 /**
- * @returns {{name: string; version: string; cliCommand: string}}
+ * @param {unknown} value
+ * @returns {value is string[]}
+ */
+function isStringArray(value) {
+	return (
+		Array.isArray(value) &&
+		value.every((entry) => typeof entry === "string" && entry.trim().length > 0)
+	);
+}
+
+/**
+ * @returns {{
+ *   name: string;
+ *   version: string;
+ *   cliCommand: string;
+ *   canonicalPackageName: string;
+ *   packageAliases: string[];
+ * }}
  */
 export function getPackageMetadata() {
 	const rootPackage = loadRootPackage();
@@ -37,13 +54,38 @@ export function getPackageMetadata() {
 		throw new Error("Root package.json bin map does not declare a CLI command");
 	}
 
-	return { name, version, cliCommand };
+	const maestroMetadata =
+		rootPackage.maestro &&
+		typeof rootPackage.maestro === "object" &&
+		!Array.isArray(rootPackage.maestro)
+			? rootPackage.maestro
+			: {};
+	const canonicalPackageName =
+		typeof maestroMetadata.canonicalPackageName === "string" &&
+		maestroMetadata.canonicalPackageName.trim().length > 0
+			? maestroMetadata.canonicalPackageName
+			: name;
+	const configuredAliases = isStringArray(maestroMetadata.packageAliases)
+		? maestroMetadata.packageAliases
+		: [];
+	const packageAliases = Array.from(
+		new Set([name, canonicalPackageName, ...configuredAliases]),
+	);
+
+	return {
+		name,
+		version,
+		cliCommand,
+		canonicalPackageName,
+		packageAliases,
+	};
 }
 
 /**
  * @param {"npm" | "bun"} packageManager
+ * @param {string} [packageName]
  */
-export function getGlobalInstallCommand(packageManager) {
-	const { name } = getPackageMetadata();
-	return `${packageManager} install -g ${name}`;
+export function getGlobalInstallCommand(packageManager, packageName) {
+	const installPackageName = packageName ?? getPackageMetadata().name;
+	return `${packageManager} install -g ${installPackageName}`;
 }

--- a/scripts/release-readiness.js
+++ b/scripts/release-readiness.js
@@ -57,6 +57,7 @@ function runPackSmoke() {
 
 function runCiChecks() {
 	maybeRunScript("metadata:check");
+	maybeRunScript("cutover:check");
 	run("bun run bun:lint");
 	run("npm run build");
 	run("npm run verify:runtime-deps");
@@ -65,6 +66,7 @@ function runCiChecks() {
 
 function runReleaseChecks() {
 	maybeRunScript("metadata:check");
+	maybeRunScript("cutover:check");
 	run("bun run bun:lint");
 	run("npm run clean && npm run build:all");
 	run("npm run verify:runtime-deps");

--- a/scripts/smoke-registry-install.js
+++ b/scripts/smoke-registry-install.js
@@ -7,7 +7,39 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { getPackageMetadata } from "./package-metadata.js";
 
-const { cliCommand, name, version } = getPackageMetadata();
+function parseArgs(argv) {
+	/** @type {{packageName: string; version: string; cliCommand: string}} */
+	const options = {
+		packageName: "",
+		version: "",
+		cliCommand: "",
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		switch (arg) {
+			case "--package":
+				options.packageName = argv[++index] ?? "";
+				break;
+			case "--version":
+				options.version = argv[++index] ?? "";
+				break;
+			case "--cli-command":
+				options.cliCommand = argv[++index] ?? "";
+				break;
+			default:
+				throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+
+	return options;
+}
+
+const defaults = getPackageMetadata();
+const overrides = parseArgs(process.argv.slice(2));
+const cliCommand = overrides.cliCommand || defaults.cliCommand;
+const name = overrides.packageName || defaults.name;
+const version = overrides.version || defaults.version;
 const packageSpec = `${name}@${version}`;
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";

--- a/scripts/sync-package-metadata.js
+++ b/scripts/sync-package-metadata.js
@@ -5,9 +5,17 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { getGlobalInstallCommand, getPackageMetadata } from "./package-metadata.js";
 
 const checkOnly = process.argv.includes("--check");
-const { name, cliCommand } = getPackageMetadata();
+const { name, cliCommand, canonicalPackageName } = getPackageMetadata();
 const npmInstall = getGlobalInstallCommand("npm");
 const bunInstall = getGlobalInstallCommand("bun");
+const publishedPackageSummary =
+	name === canonicalPackageName
+		? `- The release workflow currently publishes \`${name}\`.`
+		: `- The release workflow currently publishes \`${name}\`; the cutover target is \`${canonicalPackageName}\`.`;
+const internalPublishedPackageSummary =
+	name === canonicalPackageName
+		? `- The public npm package currently resolves to \`${name}\`.`
+		: `- The public npm package currently resolves to \`${name}\`; the cutover target is \`${canonicalPackageName}\`.`;
 
 /**
  * @param {string} content
@@ -75,6 +83,55 @@ const targets = [
 				"JetBrains plugin XML web command",
 			);
 			return next;
+		},
+	},
+	{
+		path: "SECURITY.md",
+		transform(content) {
+			return replaceRequired(
+				content,
+				/^- `[^`]+` and all `@evalops\/\*` packages$/m,
+				`- \`${name}\` and all \`@evalops/*\` packages`,
+				"Security policy package scope",
+			);
+		},
+	},
+	{
+		path: "docs/TOOLS_REFERENCE.md",
+		transform(content) {
+			let next = replaceRequired(
+				content,
+				/exported from `[^`]+`:/,
+				`exported from \`${name}\`:`,
+				"Tools reference SDK package sentence",
+			);
+			next = replaceRequired(
+				next,
+				/from '[^']+';/,
+				`from '${name}';`,
+				"Tools reference SDK package import",
+			);
+			return next;
+		},
+	},
+	{
+		path: "docs/release-ops.md",
+		transform(content) {
+			if (content.includes("The internal repo does not publish npm packages.")) {
+				return replaceRequired(
+					content,
+					/- The public repo owns npm publishing and trusted publishing setup\.\n(?:- The public npm package currently resolves to `[^`]+`(?:; the cutover target is `[^`]+`)?\.\n)?/,
+					`- The public repo owns npm publishing and trusted publishing setup.\n${internalPublishedPackageSummary}\n`,
+					"Internal release ops package summary",
+				);
+			}
+
+			return replaceRequired(
+				content,
+				/- The release workflow (?:publishes|currently publishes) `[^`]+`(?: through npm trusted publishing)?(?:; the cutover target is `[^`]+`)?\.$/m,
+				publishedPackageSummary,
+				"Release ops package summary",
+			);
 		},
 	},
 	{

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -161,6 +161,13 @@ function main() {
 			console.log("🧭 Skipped package metadata sync (script missing)");
 		}
 
+		if (hasScript(rootPkg, "cutover:check")) {
+			execSync("npm run cutover:check", { stdio: "inherit" });
+			console.log("🚚 Verified package cutover readiness");
+		} else {
+			console.log("🚚 Skipped package cutover readiness check (script missing)");
+		}
+
 		// Update package-lock.json
 		if (shouldManagePackageLock(rootPkg)) {
 			updatePackageLock();

--- a/src/package-metadata.ts
+++ b/src/package-metadata.ts
@@ -4,6 +4,10 @@ type RootPackageMetadata = {
 	name?: string;
 	version?: string;
 	bin?: Record<string, string>;
+	maestro?: {
+		canonicalPackageName?: string;
+		packageAliases?: string[];
+	};
 };
 
 let cachedPackageMetadata: RootPackageMetadata | null = null;
@@ -32,7 +36,34 @@ export function getPackageVersion(): string {
 }
 
 export function getPackageName(): string {
-	return loadPackageMetadata().name ?? "@evalops/maestro";
+	const metadata = loadPackageMetadata();
+	return (
+		process.env.MAESTRO_PACKAGE_NAME ??
+		metadata.name ??
+		metadata.maestro?.canonicalPackageName ??
+		"@evalops/maestro"
+	);
+}
+
+export function getCanonicalPackageName(): string {
+	const metadata = loadPackageMetadata();
+	return metadata.maestro?.canonicalPackageName ?? getPackageName();
+}
+
+export function getPackageAliases(): string[] {
+	const metadata = loadPackageMetadata();
+	return Array.from(
+		new Set([
+			getPackageName(),
+			getCanonicalPackageName(),
+			...(Array.isArray(metadata.maestro?.packageAliases)
+				? metadata.maestro.packageAliases.filter(
+						(alias): alias is string =>
+							typeof alias === "string" && alias.trim().length > 0,
+					)
+				: []),
+		]),
+	);
 }
 
 export function getCliCommand(): string {
@@ -43,6 +74,7 @@ export function getCliCommand(): string {
 
 export function getGlobalInstallCommand(
 	packageManager: "npm" | "bun" = "npm",
+	packageName = getPackageName(),
 ): string {
-	return `${packageManager} install -g ${getPackageName()}`;
+	return `${packageManager} install -g ${packageName}`;
 }


### PR DESCRIPTION
## Summary
- centralize package/cutover metadata and add a repo-level cutover audit
- add shared release-context and release-notify actions plus a manual published-package verification workflow
- add public rollback/deprecate tooling and document the namespace-cutover path

## Validation
- actionlint on touched public workflows
- npm run release:check:ci
- npm run release:check
- node scripts/deprecate-release.js --range 0.10.6 --dry-run
- npm run release:verify:published -- --package @evalops-jh/maestro --version 0.10.6 --cli-command maestro