### PR TITLE
[maestro] audit installed package smoke tests

### DIFF
--- a/.github/release-mirror-manifest.json
+++ b/.github/release-mirror-manifest.json
@@ -9,6 +9,7 @@
     "scripts/check-headless-proto-generated.mjs",
     "scripts/generate-openapi.ts",
     "scripts/headless-protocol-codegen.mjs",
+    "scripts/install-smoke-utils.js",
     "scripts/package-metadata.js",
     "scripts/release-readiness.js",
     "scripts/send-release-notification.mjs",

--- a/scripts/install-smoke-utils.js
+++ b/scripts/install-smoke-utils.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// @ts-check
+
+import { execFileSync } from "node:child_process";
+
+export function getNpmCommand() {
+	return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+export function getNpxCommand() {
+	return process.platform === "win32" ? "npx.cmd" : "npx";
+}
+
+function parseAuditJson(output) {
+	try {
+		return JSON.parse(output);
+	} catch {
+		return null;
+	}
+}
+
+function formatVulnerabilitySummary(report) {
+	const counts = report?.metadata?.vulnerabilities;
+	if (!counts || typeof counts !== "object") {
+		return "unknown vulnerability counts";
+	}
+
+	return [
+		`info=${counts.info ?? 0}`,
+		`low=${counts.low ?? 0}`,
+		`moderate=${counts.moderate ?? 0}`,
+		`high=${counts.high ?? 0}`,
+		`critical=${counts.critical ?? 0}`,
+	]
+		.join(", ");
+}
+
+/**
+ * @param {string} cwd
+ * @param {{label: string; auditLevel?: string}} options
+ */
+export function runInstalledPackageAudit(
+	cwd,
+	{ label, auditLevel = process.env.MAESTRO_INSTALL_AUDIT_LEVEL ?? "high" },
+) {
+	if (
+		process.env.MAESTRO_SKIP_INSTALL_AUDIT === "1" ||
+		!auditLevel ||
+		auditLevel === "none"
+	) {
+		console.log(`Skipping installed package audit for ${label}.`);
+		return;
+	}
+
+	const npmCommand = getNpmCommand();
+
+	try {
+		const output = execFileSync(
+			npmCommand,
+			["audit", "--omit=dev", "--audit-level", auditLevel, "--json"],
+			{
+				cwd,
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+		const report = parseAuditJson(output);
+		console.log(
+			`Installed package audit passed for ${label} (${formatVulnerabilitySummary(report)}).`,
+		);
+	} catch (error) {
+		const stdout =
+			error && typeof error === "object" && "stdout" in error
+				? String(error.stdout ?? "")
+				: "";
+		const stderr =
+			error && typeof error === "object" && "stderr" in error
+				? String(error.stderr ?? "")
+				: "";
+		const report =
+			parseAuditJson(stdout) ??
+			parseAuditJson(stderr) ?? { metadata: { vulnerabilities: {} } };
+		console.error(
+			`Installed package audit failed for ${label} at level ${auditLevel}: ${formatVulnerabilitySummary(report)}`,
+		);
+		const vulnerabilities =
+			report && report.vulnerabilities && typeof report.vulnerabilities === "object"
+				? report.vulnerabilities
+				: {};
+		for (const [name, details] of Object.entries(vulnerabilities)) {
+			if (!details || typeof details !== "object") {
+				continue;
+			}
+			const severity =
+				"severity" in details && typeof details.severity === "string"
+					? details.severity
+					: "unknown";
+			const via =
+				Array.isArray(details.via) && details.via.length > 0
+					? details.via
+							.map((entry) =>
+								typeof entry === "string"
+									? entry
+									: entry && typeof entry === "object" && "name" in entry
+										? String(entry.name)
+										: "unknown",
+							)
+							.join(", ")
+					: "direct";
+			console.error(`- ${name}: ${severity} (${via})`);
+		}
+		throw new Error(`Installed package audit failed for ${label}`);
+	}
+}

--- a/scripts/smoke-packed-cli.js
+++ b/scripts/smoke-packed-cli.js
@@ -5,6 +5,11 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import {
+	getNpmCommand,
+	getNpxCommand,
+	runInstalledPackageAudit,
+} from "./install-smoke-utils.js";
 import { getPackageMetadata } from "./package-metadata.js";
 
 const tarballArg = process.argv[2];
@@ -34,8 +39,8 @@ if (tarballSizeBytes > maxTarballSizeBytes) {
 
 const { version, cliCommand } = getPackageMetadata();
 const tempDir = mkdtempSync(join(tmpdir(), "maestro-pack-smoke-"));
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
+const npmCommand = getNpmCommand();
+const npxCommand = getNpxCommand();
 
 try {
 	execFileSync(npmCommand, ["init", "-y"], {
@@ -45,6 +50,9 @@ try {
 	execFileSync(npmCommand, ["install", tarballPath], {
 		cwd: tempDir,
 		stdio: "inherit",
+	});
+	runInstalledPackageAudit(tempDir, {
+		label: tarballPath,
 	});
 	const output = execFileSync(npxCommand, [cliCommand, "--version"], {
 		cwd: tempDir,

--- a/scripts/smoke-registry-install.js
+++ b/scripts/smoke-registry-install.js
@@ -5,6 +5,11 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+	getNpmCommand,
+	getNpxCommand,
+	runInstalledPackageAudit,
+} from "./install-smoke-utils.js";
 import { getPackageMetadata } from "./package-metadata.js";
 
 function parseArgs(argv) {
@@ -41,8 +46,8 @@ const cliCommand = overrides.cliCommand || defaults.cliCommand;
 const name = overrides.packageName || defaults.name;
 const version = overrides.version || defaults.version;
 const packageSpec = `${name}@${version}`;
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
+const npmCommand = getNpmCommand();
+const npxCommand = getNpxCommand();
 const maxAttempts = Number.parseInt(
 	process.env.MAESTRO_REGISTRY_POLL_ATTEMPTS ?? "24",
 	10,
@@ -101,6 +106,9 @@ async function main() {
 		execFileSync(npmCommand, ["install", packageSpec], {
 			cwd: tempDir,
 			stdio: "inherit",
+		});
+		runInstalledPackageAudit(tempDir, {
+			label: packageSpec,
 		});
 
 		const versionOutput = execFileSync(npxCommand, [cliCommand, "--version"], {


### PR DESCRIPTION
## Summary
- add a shared installed-package audit helper for smoke installs
- fail packed and post-publish registry smoke tests when consumer installs have high advisories
- lock the release mirror manifest to keep the new helper mirrored to internal

## Root cause
- local tarballs from current main install cleanly and audit cleanly
- the currently published  registry artifact is stale and still resolves vulnerable  and 
- this PR makes that discrepancy fail loudly in smoke checks so the next publish must clear it

## Validation
- node scripts/smoke-packed-cli.js <local tarball>
- node scripts/smoke-registry-install.js --package @evalops-jh/maestro --version 0.10.6 --cli-command maestro (fails as expected on 3 high advisories)
- npm run release:check:ci