### PR TITLE
Fix Maestro hosted web and auth defaults

### DIFF
--- a/deploy/helm/maestro/templates/deployment.yaml
+++ b/deploy/helm/maestro/templates/deployment.yaml
@@ -34,13 +34,13 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
             initialDelaySeconds: 10
             periodSeconds: 15
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -19,9 +19,6 @@
         })();
     </script>
 
-    <!-- Preconnect to API -->
-    <link rel="preconnect" href="http://localhost:8080">
-
     <!-- Favicon -->
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='40' fill='%2358a6ff'/></svg>">
 
@@ -212,7 +209,6 @@
 
     <!-- Main app -->
     <composer-chat
-        api-endpoint="http://localhost:8080"
         model="claude-sonnet-4-5">
     </composer-chat>
 

--- a/packages/web/src/components/model-selector.ts
+++ b/packages/web/src/components/model-selector.ts
@@ -198,7 +198,7 @@ export class ModelSelector extends LitElement {
 	`;
 
 	@property({ type: Boolean }) open = false;
-	@property() apiEndpoint = "http://localhost:8080";
+	@property() apiEndpoint = "";
 	@property() currentModel = "";
 	@property({ attribute: false }) modelsPrefetch: Model[] | null = null;
 	@property({ attribute: false }) apiClient: ApiClient | null = null;

--- a/packages/web/src/services/enterprise-api.ts
+++ b/packages/web/src/services/enterprise-api.ts
@@ -238,12 +238,22 @@ export function getStoredComposerCsrfToken(): string | null {
 	return tokenStorage.get("csrf");
 }
 
+function resolveDefaultBaseUrl(): string {
+	if (typeof window !== "undefined" && window.location?.origin) {
+		return window.location.origin;
+	}
+	return "http://localhost:8080";
+}
+
 export class EnterpriseApiClient {
 	private baseUrl: string;
 	private accessToken: string | null = null;
 
 	constructor(baseUrl?: string) {
-		this.baseUrl = (baseUrl || "http://localhost:8080").replace(/\/$/, "");
+		this.baseUrl = (baseUrl?.trim() || resolveDefaultBaseUrl()).replace(
+			/\/$/,
+			"",
+		);
 		this.accessToken = tokenStorage.get("access");
 	}
 

--- a/src/server/authz.ts
+++ b/src/server/authz.ts
@@ -2,7 +2,6 @@ import { createHash, createHmac } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { type JWTPayload, createRemoteJWKSet, jwtVerify } from "jose";
 import {
-	authenticateRequest,
 	getRequestHeader,
 	getRequestToken,
 	secureCompare,
@@ -17,6 +16,9 @@ const JWT_JWKS_URL = process.env.MAESTRO_JWT_JWKS_URL?.trim() || null;
 const JWT_AUDIENCE = process.env.MAESTRO_JWT_AUD?.trim() || undefined;
 const JWT_ISSUER = process.env.MAESTRO_JWT_ISS?.trim() || undefined;
 const JWT_ALG = process.env.MAESTRO_JWT_ALG?.trim() || "HS256";
+const API_AUTH_CONFIGURED = Boolean(
+	WEB_API_KEY || SHARED_SECRET || JWT_SECRET || JWT_JWKS_URL,
+);
 
 function base64UrlDecode(input: string): string {
 	return Buffer.from(
@@ -90,7 +92,14 @@ export async function checkApiAuth(req: IncomingMessage): Promise<{
 		}
 		return { ok: false, error: "Unauthorized" };
 	}
+	if (API_AUTH_CONFIGURED) {
+		return { ok: false, error: "Unauthorized" };
+	}
 	return { ok: true };
+}
+
+export function isApiAuthConfigured(): boolean {
+	return API_AUTH_CONFIGURED;
 }
 
 export async function requireApiAuth(

--- a/src/server/server-middlewares.ts
+++ b/src/server/server-middlewares.ts
@@ -1,16 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { parse } from "node:url";
 import { createLogger } from "../utils/logger.js";
 import { getArtifactAccessGrantFromRequest } from "./artifact-access.js";
-import { isOverloaded, logRequest } from "./logger.js";
+import { checkApiAuth, isApiAuthConfigured } from "./authz.js";
+import { isOverloaded } from "./logger.js";
 import type { Middleware } from "./middleware.js";
 import type { RateLimiter, TieredRateLimiter } from "./rate-limiter.js";
-import {
-	authenticateRequest,
-	getRequestHeader,
-	secureCompare,
-	sendJson,
-} from "./server-utils.js";
+import { getRequestHeader, secureCompare, sendJson } from "./server-utils.js";
 
 const logger = createLogger("middleware:ip-access");
 
@@ -23,6 +18,14 @@ function getPathname(req: IncomingMessage): string {
 	} catch {
 		return "/";
 	}
+}
+
+function isPublicApiPath(pathname: string): boolean {
+	return (
+		pathname === "/api/auth/login" ||
+		pathname === "/api/auth/register" ||
+		pathname.startsWith("/api/sessions/shared/")
+	);
 }
 
 export function createLoadSheddingMiddleware(
@@ -202,43 +205,46 @@ export function createCorsMiddleware(
 }
 
 export function createAuthMiddleware(
-	apiKey: string | null,
+	_apiKey: string | null,
 	corsHeaders: Record<string, string>,
 	requireApiKey = false,
 ): Middleware {
-	return (req, res, next) => {
+	return async (req, res, next) => {
 		const pathname = getPathname(req);
-		if (pathname.startsWith("/api")) {
-			const missingKey = !apiKey || apiKey.length === 0;
-
-			// No key provided
-			if (missingKey) {
-				if (requireApiKey) {
-					sendJson(
-						res,
-						401,
-						{
-							error:
-								"MAESTRO_WEB_API_KEY is required for all API requests. Set the environment variable or disable requirement explicitly with MAESTRO_WEB_REQUIRE_KEY=0 for local testing only.",
-						},
-						corsHeaders,
-						req,
-					);
-					return;
-				}
-				// Requirement off and no key: allow through.
-				return next();
-			}
-
-			// Key provided: validate it.
-			if (getArtifactAccessGrantFromRequest(req)) {
-				return next();
-			}
-			if (!authenticateRequest(req, res, corsHeaders, apiKey)) {
-				return;
-			}
+		if (!pathname.startsWith("/api") || isPublicApiPath(pathname)) {
+			return next();
 		}
-		return next();
+
+		if (getArtifactAccessGrantFromRequest(req)) {
+			return next();
+		}
+
+		const auth = await checkApiAuth(req);
+		if (auth.ok) {
+			return next();
+		}
+
+		if (requireApiKey && !isApiAuthConfigured()) {
+			sendJson(
+				res,
+				401,
+				{
+					error:
+						"Protected API routes require configured authentication. Set MAESTRO_WEB_API_KEY, MAESTRO_AUTH_SHARED_SECRET, or MAESTRO_JWT_* for hosted deployments, or disable the requirement explicitly with MAESTRO_WEB_REQUIRE_KEY=0 for local-only testing.",
+				},
+				corsHeaders,
+				req,
+			);
+			return;
+		}
+
+		sendJson(
+			res,
+			401,
+			{ error: auth.error || "Unauthorized" },
+			corsHeaders,
+			req,
+		);
 	};
 }
 
@@ -256,7 +262,10 @@ export function createCsrfMiddleware(
 			return next();
 		}
 		const pathname = getPathname(req);
-		if (!pathname.startsWith("/api")) {
+		if (!pathname.startsWith("/api") || isPublicApiPath(pathname)) {
+			return next();
+		}
+		if (req.headers.authorization?.trim().startsWith("Bearer ")) {
 			return next();
 		}
 		const value = getRequestHeader(

--- a/test/web/enterprise-api-client.test.ts
+++ b/test/web/enterprise-api-client.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+declare global {
+	var window:
+		| {
+				location?: { origin?: string };
+				sessionStorage?: {
+					getItem(key: string): string | null;
+					setItem(key: string, value: string): void;
+					removeItem(key: string): void;
+				};
+		  }
+		| undefined;
+}
+
+function makeSessionStorage() {
+	const store = new Map<string, string>();
+	return {
+		getItem(key: string) {
+			return store.get(key) ?? null;
+		},
+		setItem(key: string, value: string) {
+			store.set(key, value);
+		},
+		removeItem(key: string) {
+			store.delete(key);
+		},
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("EnterpriseApiClient", () => {
+	it("defaults to same-origin in hosted browser environments", async () => {
+		vi.resetModules();
+		vi.stubGlobal("window", {
+			location: { origin: "https://maestro.evalops.dev" },
+			sessionStorage: makeSessionStorage(),
+		});
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					id: "user-1",
+					email: "user@example.com",
+					name: "User",
+					isActive: true,
+					organization: null,
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { EnterpriseApiClient } = await import(
+			"../../packages/web/src/services/enterprise-api.js"
+		);
+		const client = new EnterpriseApiClient();
+
+		await client.getMe();
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://maestro.evalops.dev/api/auth/me",
+			expect.objectContaining({
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+	});
+});

--- a/test/web/hosted-auth-middleware.test.ts
+++ b/test/web/hosted-auth-middleware.test.ts
@@ -1,0 +1,170 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { TextEncoder } from "node:util";
+import { SignJWT } from "jose";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface MockRequest {
+	method: string;
+	url: string;
+	headers: Record<string, string>;
+	socket: { remoteAddress: string };
+}
+
+interface MockResponse {
+	statusCode: number;
+	headers: Record<string, string | number>;
+	body: string;
+	headersSent: boolean;
+	writableEnded: boolean;
+	writeHead(status: number, headers?: Record<string, string | number>): void;
+	setHeader(name: string, value: string | number): void;
+	end(chunk?: string): void;
+}
+
+function makeReq(overrides: Partial<MockRequest> = {}): IncomingMessage {
+	return {
+		method: "GET",
+		url: "/api/status",
+		headers: {},
+		socket: { remoteAddress: "127.0.0.1" },
+		...overrides,
+	} as unknown as IncomingMessage;
+}
+
+function makeRes(): MockResponse & ServerResponse {
+	const res: MockResponse = {
+		statusCode: 200,
+		headers: {},
+		body: "",
+		headersSent: false,
+		writableEnded: false,
+		writeHead(status, headers) {
+			this.statusCode = status;
+			Object.assign(this.headers, headers);
+			this.headersSent = true;
+		},
+		setHeader(name, value) {
+			this.headers[name] = value;
+		},
+		end(chunk) {
+			this.body = chunk ?? "";
+			this.writableEnded = true;
+		},
+	};
+	return res as MockResponse & ServerResponse;
+}
+
+const corsHeaders = { "Access-Control-Allow-Origin": "*" };
+const jwtSecret = "0123456789abcdef0123456789abcdef";
+
+async function signJwt(): Promise<string> {
+	return new SignJWT({})
+		.setProtectedHeader({ alg: "HS256" })
+		.setSubject("user-123")
+		.setIssuedAt()
+		.setExpirationTime("2h")
+		.sign(new TextEncoder().encode(jwtSecret));
+}
+
+async function loadMiddlewares() {
+	vi.resetModules();
+	vi.stubEnv("MAESTRO_WEB_API_KEY", "");
+	vi.stubEnv("MAESTRO_WEB_CSRF_TOKEN", "csrf-token");
+	vi.stubEnv("MAESTRO_AUTH_SHARED_SECRET", "");
+	vi.stubEnv("MAESTRO_JWT_SECRET", jwtSecret);
+	vi.stubEnv("MAESTRO_JWT_JWKS_URL", "");
+	return import("../../src/server/server-middlewares.js");
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+});
+
+describe("hosted Maestro auth middlewares", () => {
+	it("allows unauthenticated login requests through auth and csrf middleware", async () => {
+		const { createAuthMiddleware, createCsrfMiddleware } =
+			await loadMiddlewares();
+		const auth = createAuthMiddleware(null, corsHeaders, true);
+		const csrf = createCsrfMiddleware("csrf-token", corsHeaders, true);
+		const req = makeReq({
+			method: "POST",
+			url: "/api/auth/login",
+		});
+		const res = makeRes();
+		let authNextCalled = false;
+		let csrfNextCalled = false;
+
+		await auth(req, res, () => {
+			authNextCalled = true;
+		});
+		await csrf(req, res, () => {
+			csrfNextCalled = true;
+		});
+
+		expect(authNextCalled).toBe(true);
+		expect(csrfNextCalled).toBe(true);
+		expect(res.statusCode).toBe(200);
+	});
+
+	it("rejects protected API routes without credentials when JWT auth is configured", async () => {
+		const { createAuthMiddleware } = await loadMiddlewares();
+		const auth = createAuthMiddleware(null, corsHeaders, true);
+		const req = makeReq({
+			method: "GET",
+			url: "/api/status",
+		});
+		const res = makeRes();
+		let nextCalled = false;
+
+		await auth(req, res, () => {
+			nextCalled = true;
+		});
+
+		expect(nextCalled).toBe(false);
+		expect(res.statusCode).toBe(401);
+		expect(JSON.parse(res.body)).toEqual({ error: "Unauthorized" });
+	});
+
+	it("accepts bearer JWTs on protected API routes", async () => {
+		const { createAuthMiddleware } = await loadMiddlewares();
+		const auth = createAuthMiddleware(null, corsHeaders, true);
+		const req = makeReq({
+			method: "GET",
+			url: "/api/status",
+			headers: {
+				authorization: `Bearer ${await signJwt()}`,
+			},
+		});
+		const res = makeRes();
+		let nextCalled = false;
+
+		await auth(req, res, () => {
+			nextCalled = true;
+		});
+
+		expect(nextCalled).toBe(true);
+		expect(res.writableEnded).toBe(false);
+	});
+
+	it("skips CSRF enforcement for bearer-authenticated state-changing requests", async () => {
+		const { createCsrfMiddleware } = await loadMiddlewares();
+		const csrf = createCsrfMiddleware("csrf-token", corsHeaders, true);
+		const req = makeReq({
+			method: "POST",
+			url: "/api/chat",
+			headers: {
+				authorization: `Bearer ${await signJwt()}`,
+			},
+		});
+		const res = makeRes();
+		let nextCalled = false;
+
+		await csrf(req, res, () => {
+			nextCalled = true;
+		});
+
+		expect(nextCalled).toBe(true);
+		expect(res.writableEnded).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- make hosted web clients resolve Maestro APIs from same-origin instead of hardcoded localhost defaults
- allow enterprise login/register routes to work under hosted JWT auth while still protecting private APIs
- align the first-party Helm chart probes with the actual `/healthz` and `/readyz` routes

## Validation
- `node ./scripts/run-vitest.js --run test/web/hosted-auth-middleware.test.ts test/web/enterprise-api-client.test.ts`
- `helm template maestro deploy/helm/maestro >/tmp/maestro-helm-rendered.yaml`
- `rg -n "healthz|readyz" /tmp/maestro-helm-rendered.yaml`
- `git diff --check`