### PR TITLE
Serve built Maestro web shell in production

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
 	"files": ["dist", "README.md"],
 	"scripts": {
 		"clean": "node ../../scripts/clean-paths.js dist",
-		"build": "node ../../scripts/clean-paths.js dist && node ../../node_modules/vite/bin/vite.js build",
+		"build": "node ../../scripts/clean-paths.js dist && node ../../node_modules/vite/bin/vite.js build && node scripts/build-hosted-shell.mjs",
 		"dev": "vite",
 		"preview": "vite preview",
 		"check": "tsc --noEmit",

--- a/packages/web/scripts/build-hosted-shell.mjs
+++ b/packages/web/scripts/build-hosted-shell.mjs
@@ -1,0 +1,21 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const sourcePath = join(packageRoot, "index.html");
+const distRoot = join(packageRoot, "dist");
+const distPath = join(distRoot, "index.html");
+
+const source = readFileSync(sourcePath, "utf8");
+const hosted = source.replace(
+	'<script type="module" src="/src/index.ts"></script>',
+	'<script type="module" src="/composer-web.es.js"></script>',
+);
+
+if (source === hosted) {
+	throw new Error("Failed to rewrite web shell entrypoint for hosted build");
+}
+
+mkdirSync(distRoot, { recursive: true });
+writeFileSync(distPath, hosted);

--- a/src/server/web-root.ts
+++ b/src/server/web-root.ts
@@ -1,0 +1,20 @@
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export function resolveWebRoot(options: {
+	baseDir: string;
+	env?: NodeJS.ProcessEnv;
+}): string {
+	const env = options.env ?? process.env;
+	const configuredRoot = env.MAESTRO_WEB_ROOT?.trim();
+	if (configuredRoot) {
+		return resolve(configuredRoot);
+	}
+
+	const builtWebRoot = join(options.baseDir, "../packages/web/dist");
+	if (existsSync(join(builtWebRoot, "index.html"))) {
+		return builtWebRoot;
+	}
+
+	return join(options.baseDir, "../packages/web");
+}

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -9,7 +9,7 @@ import {
 	createServer,
 } from "node:http";
 import type { Socket } from "node:net";
-import { dirname, join, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath, parse } from "node:url";
 import { WebSocketServer } from "ws";
 import type {
@@ -149,6 +149,7 @@ import {
 	sendJson,
 } from "./server/server-utils.js";
 import { serveStatic } from "./server/static-server.js";
+import { resolveWebRoot } from "./server/web-root.js";
 
 // Re-export for existing test imports
 export { SseSession } from "./server/sse-session.js";
@@ -527,7 +528,7 @@ async function createBackgroundAgent(
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const WEB_ROOT = join(__dirname, "../packages/web");
+const WEB_ROOT = resolveWebRoot({ baseDir: __dirname });
 const ALLOWED_ORIGIN = DEFAULT_WEB_ORIGIN;
 const CORS_HEADERS = createCorsHeaders(ALLOWED_ORIGIN);
 const SECURITY_HEADERS: Record<string, string> =

--- a/test/web/web-root.test.ts
+++ b/test/web/web-root.test.ts
@@ -1,0 +1,32 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveWebRoot } from "../../src/server/web-root.js";
+
+describe("resolveWebRoot", () => {
+	it("uses built web assets when only the production image layout exists", () => {
+		const root = mkdtempSync(join(tmpdir(), "maestro-web-root-"));
+		try {
+			const distRoot = join(root, "packages/web/dist");
+			mkdirSync(distRoot, { recursive: true });
+			writeFileSync(join(distRoot, "index.html"), "<html></html>");
+
+			expect(resolveWebRoot({ baseDir: join(root, "dist"), env: {} })).toBe(
+				distRoot,
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("honors MAESTRO_WEB_ROOT when explicitly configured", () => {
+		const configured = "/srv/maestro-web";
+		expect(
+			resolveWebRoot({
+				baseDir: "/app/dist",
+				env: { MAESTRO_WEB_ROOT: configured },
+			}),
+		).toBe(configured);
+	});
+});


### PR DESCRIPTION
## Summary
- emit a hosted `packages/web/dist/index.html` after the Maestro web Vite library build
- load `/composer-web.es.js` from that hosted shell instead of the dev-only `/src/index.ts`
- resolve the web server static root to `packages/web/dist` when the built shell exists, with source-root fallback for local dev

## Root cause
The production Docker image copies `packages/web/dist` but not `packages/web/index.html`. The web server hardcoded `packages/web` as its static root, so live `maestro.evalops.dev/` tried to stat `/app/packages/web/index.html` and returned 500.

## Validation
- `docker run --rm -v /tmp/maestro-static-fix:/app -w /app oven/bun:1.3-alpine sh -lc 'bun run test -- test/web/web-root.test.ts test/static-server-spa-fallback.test.ts test/web/static-server.test.ts'`
- `docker build -t maestro-static-fix:local .`
- `docker run --rm --entrypoint sh maestro-static-fix:local -lc 'test -f /app/packages/web/dist/index.html; grep -q "/composer-web.es.js" /app/packages/web/dist/index.html; ! grep -q "/src/index.ts" /app/packages/web/dist/index.html; node -e "import(\"./dist/server/web-root.js\").then(m=>console.log(m.resolveWebRoot({baseDir:\"/app/dist\", env:{}})))"'`