### PR TITLE
Fix release-context CI: lazy-load glob in workspace-utils

### DIFF
--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -17,9 +17,9 @@ import {
 	writePackageJson,
 } from "./workspace-utils.js";
 
-function main() {
+async function main() {
 	const rootPkg = loadRootPackage();
-	const workspacePkgs = getWorkspacePackages(rootPkg);
+	const workspacePkgs = await getWorkspacePackages(rootPkg);
 	const internalNames = new Set(workspacePkgs.map((pkg) => pkg.name));
 	const targetVersion = rootPkg.version;
 

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -99,16 +99,16 @@ function restoreBackups(backups) {
 	}
 }
 
-function main() {
+async function main() {
 	const bumpType = process.argv[2];
-	
+
 	if (!bumpType || !["patch", "minor", "major"].includes(bumpType)) {
 		console.error("Usage: node version.js <patch|minor|major>");
 		process.exit(1);
 	}
 
 	const rootPkg = loadRootPackage();
-	const workspacePkgs = getWorkspacePackages(rootPkg);
+	const workspacePkgs = await getWorkspacePackages(rootPkg);
 	const internalNames = new Set(workspacePkgs.map((pkg) => pkg.name));
 
 	const currentVersion = rootPkg.version;

--- a/scripts/workspace-utils.d.ts
+++ b/scripts/workspace-utils.d.ts
@@ -7,7 +7,7 @@ export interface WorkspacePackage {
 export function loadRootPackage(): Record<string, unknown>;
 export function getWorkspacePackagePaths(
 	rootPackage: Record<string, unknown>,
-): string[];
+): Promise<string[]>;
 export function readPackageJson(path: string): Record<string, unknown>;
 export function writePackageJson(
 	path: string,
@@ -15,7 +15,7 @@ export function writePackageJson(
 ): void;
 export function getWorkspacePackages(
 	rootPackage: Record<string, unknown>,
-): WorkspacePackage[];
+): Promise<WorkspacePackage[]>;
 export function syncInternalDependencies(
 	pkg: Record<string, unknown>,
 	version: string,

--- a/scripts/workspace-utils.js
+++ b/scripts/workspace-utils.js
@@ -8,7 +8,6 @@
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve as resolvePath } from "node:path";
-import { globSync } from "glob";
 
 /**
  * @param {unknown} value
@@ -97,7 +96,8 @@ function getWorkspaceGlobs(rootPackage) {
 /**
  * @param {Record<string, unknown>} rootPackage
  */
-export function getWorkspacePackagePaths(rootPackage) {
+export async function getWorkspacePackagePaths(rootPackage) {
+	const { globSync } = await import("glob");
 	const globs = getWorkspaceGlobs(rootPackage);
 	const paths = new Set(
 		globs.flatMap((pattern) =>
@@ -137,10 +137,10 @@ export function writePackageJson(path, pkg) {
 
 /**
  * @param {Record<string, unknown>} rootPackage
- * @returns {Array<{name: string; path: string; data: Record<string, unknown>}>}
+ * @returns {Promise<Array<{name: string; path: string; data: Record<string, unknown>}>>}
  */
-export function getWorkspacePackages(rootPackage) {
-	const packagePaths = getWorkspacePackagePaths(rootPackage);
+export async function getWorkspacePackages(rootPackage) {
+	const packagePaths = await getWorkspacePackagePaths(rootPackage);
 	return packagePaths.map((path) => {
 		const data = readPackageJson(path);
 		return { name: /** @type {string} */ (data.name), path, data };


### PR DESCRIPTION
## Summary

- The `tag-release` workflow [failed](https://github.com/evalops/maestro/actions/runs/24490062857/job/71573059626) because `scripts/workspace-utils.js` has a top-level `import { globSync } from "glob"` that blows up when `node_modules` isn't installed
- The `release-context` composite action only needs `loadRootPackage()` (no glob), but ESM evaluates all top-level imports at module load time
- Converts `getWorkspacePackagePaths` and `getWorkspacePackages` to `async` functions that `await import("glob")` lazily — only resolving the dependency when actually calling workspace-enumeration functions
- Updates callers (`version.js`, `sync-versions.js`) and the `.d.ts` file to match

## Test plan

- [ ] Merge and verify `tag-release` workflow passes on the resulting main push
- [ ] Run `node scripts/version.js patch --dry-run` locally to verify workspace scripts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)