### PR TITLE
Add distributed locks repair migration

### DIFF
--- a/src/db/migrations/0002_ensure_distributed_locks.sql
+++ b/src/db/migrations/0002_ensure_distributed_locks.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS "distributed_locks" (
+	"id" varchar(100) PRIMARY KEY NOT NULL,
+	"holder_id" varchar(100) NOT NULL,
+	"acquired_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "distributed_lock_expires_idx" ON "distributed_locks" USING btree ("expires_at");

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
 			"when": 1733108401000,
 			"tag": "0001_shared_sessions",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1776800458000,
+			"tag": "0002_ensure_distributed_locks",
+			"breakpoints": true
 		}
 	]
 }

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+interface MigrationJournal {
+	entries: Array<{
+		idx: number;
+		tag: string;
+	}>;
+}
+
+const migrationsDir = join(process.cwd(), "src/db/migrations");
+
+describe("database migration files", () => {
+	it("includes an idempotent repair migration for distributed_locks", () => {
+		const journal = JSON.parse(
+			readFileSync(join(migrationsDir, "meta", "_journal.json"), "utf-8"),
+		) as MigrationJournal;
+		const tags = journal.entries.map((entry) => entry.tag);
+
+		expect(tags).toContain("0002_ensure_distributed_locks");
+		expect(tags.indexOf("0002_ensure_distributed_locks")).toBeGreaterThan(
+			tags.indexOf("0000_initial"),
+		);
+
+		const repairSql = readFileSync(
+			join(migrationsDir, "0002_ensure_distributed_locks.sql"),
+			"utf-8",
+		);
+
+		expect(repairSql).toContain(
+			'CREATE TABLE IF NOT EXISTS "distributed_locks"',
+		);
+		expect(repairSql).toContain(
+			'CREATE INDEX IF NOT EXISTS "distributed_lock_expires_idx"',
+		);
+		expect(repairSql).toContain("--> statement-breakpoint");
+		expect(repairSql).not.toMatch(/\bDROP\b/i);
+		expect(repairSql).not.toMatch(/\bDELETE\b/i);
+	});
+});


### PR DESCRIPTION
## Summary
- add a forward-only idempotent migration to create distributed_locks and its expiry index when production/staging drift has left it missing
- register the migration in the journal after the historical initial migration
- add a file-level regression test that keeps the repair migration idempotent and non-destructive

## Verification
- npm install --ignore-scripts --no-package-lock --no-audit --no-fund
- node ./scripts/run-vitest.js --run test/db/migration-files.test.ts test/db/db-integration.test.ts
- npx biome check test/db/migration-files.test.ts src/db/migrations/meta/_journal.json
- git diff --check

Note: npm ci currently fails in this worktree before tests because package-lock.json has a stale integrity for rollup@4.59.0 relative to the npm registry; I used the no-package-lock install path to validate the migration without including lockfile churn in this PR.