### PR TITLE
Integrate Maestro with Platform core services

### DIFF
--- a/packages/ai/tsconfig.build.json
+++ b/packages/ai/tsconfig.build.json
@@ -35,6 +35,7 @@
 		"../../src/config/lsp-config.ts",
 		"../../src/config/toml-config.ts",
 		"../../src/oauth/**/*.ts",
+		"../../src/platform/**/*.ts",
 		"../../src/sandbox/**/*.ts",
 		"../../src/cli/system-prompt.ts",
 		"../../src/prompts/**/*.ts",

--- a/packages/memory/dist/client.d.ts
+++ b/packages/memory/dist/client.d.ts
@@ -8,6 +8,69 @@ export interface MemoryClientOptions {
     fetch?: FetchLike;
     headers?: HeadersInit;
 }
+export interface MemorySourceReference {
+    uri: string;
+    title?: string;
+    type?: string;
+    metadata?: Record<string, string>;
+}
+export type MemoryReviewStatus = "approved" | "proposed" | "rejected";
+export type ExtendedStoreRequest = MessageInitShape<typeof StoreRequestSchema> & {
+    agentId?: string;
+    userId?: string;
+    source?: string;
+    confidence?: number;
+    pinned?: boolean;
+    isPolicy?: boolean;
+    sourceReferences?: MemorySourceReference[];
+    expiresAt?: string | Date;
+    supersedesMemoryId?: string;
+    reviewStatus?: MemoryReviewStatus | string;
+    proposedBy?: string;
+    proposalReason?: string;
+    entityIds?: string[];
+};
+export type ExtendedUpdateRequest = MessageInitShape<typeof UpdateMemoryRequestSchema> & {
+    type?: string;
+    source?: string;
+    confidence?: number;
+    pinned?: boolean;
+    isPolicy?: boolean;
+    sourceReferences?: MemorySourceReference[];
+    expiresAt?: string | Date;
+    reviewStatus?: MemoryReviewStatus | string;
+    proposedBy?: string;
+    proposalReason?: string;
+    entityIds?: string[];
+};
+export type ExtendedListRequest = MessageInitShape<typeof ListMemoriesRequestSchema> & {
+    agentId?: string;
+    userId?: string;
+    reviewStatus?: MemoryReviewStatus | string;
+    entityIds?: string[];
+};
+export type ExtendedRecallRequest = MessageInitShape<typeof RecallRequestSchema> & {
+    agentId?: string;
+    userId?: string;
+    reviewStatus?: MemoryReviewStatus | string;
+    entityIds?: string[];
+    relationshipDepth?: number;
+    relationshipTypes?: string[];
+    asOf?: string | Date;
+    topK?: number;
+    minSimilarity?: number;
+};
+export type ExtendedRecallKnowledgeRequest = MessageInitShape<typeof RecallKnowledgeRequestSchema> & {
+    agentId?: string;
+    userId?: string;
+    reviewStatus?: MemoryReviewStatus | string;
+    topK?: number;
+};
+export type ExtendedOperatingRulesRequest = MessageInitShape<typeof GetOperatingRulesRequestSchema> & {
+    agentId?: string;
+    userId?: string;
+    reviewStatus?: MemoryReviewStatus | string;
+};
 export declare class MemoryClientError extends Error {
     readonly status: number;
     readonly code?: string;
@@ -17,15 +80,15 @@ export declare class MemoryClientError extends Error {
 export declare class MemoryClient {
     #private;
     constructor(options: MemoryClientOptions);
-    store(request: MessageInitShape<typeof StoreRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").StoreResponse>;
+    store(request: ExtendedStoreRequest): Promise<import("@evalops/memory/memory/v1/memory_pb").StoreResponse>;
     get(request: MessageInitShape<typeof GetMemoryRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").GetMemoryResponse>;
-    list(request?: MessageInitShape<typeof ListMemoriesRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").ListMemoriesResponse>;
-    update(request: MessageInitShape<typeof UpdateMemoryRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").UpdateMemoryResponse>;
+    list(request?: ExtendedListRequest): Promise<import("@evalops/memory/memory/v1/memory_pb").ListMemoriesResponse>;
+    update(request: ExtendedUpdateRequest): Promise<import("@evalops/memory/memory/v1/memory_pb").UpdateMemoryResponse>;
     delete(request: MessageInitShape<typeof DeleteMemoryRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").DeleteMemoryResponse>;
     history(request: MessageInitShape<typeof GetHistoryRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").GetHistoryResponse>;
     setEmbedding(request: MessageInitShape<typeof SetEmbeddingRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").SetEmbeddingResponse>;
-    recall(request: MessageInitShape<typeof RecallRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").RecallResponse>;
-    recallKnowledge(request: MessageInitShape<typeof RecallKnowledgeRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").RecallResponse>;
-    getOperatingRules(request?: MessageInitShape<typeof GetOperatingRulesRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").ListMemoriesResponse>;
+    recall(request: ExtendedRecallRequest): Promise<import("@evalops/memory/memory/v1/memory_pb").RecallResponse>;
+    recallKnowledge(request: ExtendedRecallKnowledgeRequest): Promise<import("@evalops/memory/memory/v1/memory_pb").RecallResponse>;
+    getOperatingRules(request?: ExtendedOperatingRulesRequest): Promise<import("@evalops/memory/memory/v1/memory_pb").ListMemoriesResponse>;
     consolidate(request?: MessageInitShape<typeof ConsolidateRequestSchema>): Promise<import("@evalops/memory/memory/v1/memory_pb").ConsolidateResponse>;
 }

--- a/packages/memory/dist/client.js
+++ b/packages/memory/dist/client.js
@@ -479,7 +479,8 @@ function requestArray(request, camelKey, snakeKey = camelKey) {
     return Array.isArray(value) && value.length > 0 ? value : undefined;
 }
 function requestStringArray(request, camelKey, snakeKey = camelKey) {
-    return requestArray(request, camelKey, snakeKey)?.filter((entry) => typeof entry === "string" && entry.trim().length > 0);
+    const values = requestArray(request, camelKey, snakeKey)?.filter((entry) => typeof entry === "string" && entry.trim().length > 0);
+    return values && values.length > 0 ? values : undefined;
 }
 function requestTimestamp(request, camelKey, snakeKey = camelKey) {
     const value = requestValue(request, camelKey, snakeKey);

--- a/packages/memory/dist/client.js
+++ b/packages/memory/dist/client.js
@@ -33,7 +33,7 @@ export class MemoryClient {
     async store(request) {
         const message = create(StoreRequestSchema, request);
         const payload = await this.#requestJson("/v1/memories", {
-            body: serializeStoreRequest(message),
+            body: serializeStoreRequest(message, request),
             method: "POST",
         });
         return create(StoreResponseSchema, {
@@ -53,7 +53,7 @@ export class MemoryClient {
         const message = create(ListMemoriesRequestSchema, request);
         const payload = await this.#requestJson("/v1/memories", {
             method: "GET",
-            query: buildListQuery(message),
+            query: buildListQuery(message, request),
         });
         return create(ListMemoriesResponseSchema, {
             limit: getIntField(payload, "limit"),
@@ -65,7 +65,7 @@ export class MemoryClient {
     async update(request) {
         const message = create(UpdateMemoryRequestSchema, request);
         const payload = await this.#requestJson(`/v1/memories/${encodeURIComponent(message.id)}`, {
-            body: serializeUpdateRequest(message),
+            body: serializeUpdateRequest(message, request),
             method: "PUT",
         });
         return create(UpdateMemoryResponseSchema, {
@@ -105,7 +105,7 @@ export class MemoryClient {
     async recall(request) {
         const message = create(RecallRequestSchema, request);
         const payload = await this.#requestJson("/v1/memories/recall", {
-            body: serializeRecallRequest(message),
+            body: serializeRecallRequest(message, request),
             method: "POST",
         });
         return create(RecallResponseSchema, {
@@ -117,7 +117,7 @@ export class MemoryClient {
     async recallKnowledge(request) {
         const message = create(RecallKnowledgeRequestSchema, request);
         const payload = await this.#requestJson("/v1/memories/knowledge/recall", {
-            body: serializeRecallKnowledgeRequest(message),
+            body: serializeRecallKnowledgeRequest(message, request),
             method: "POST",
         });
         return create(RecallResponseSchema, {
@@ -130,7 +130,7 @@ export class MemoryClient {
         const message = create(GetOperatingRulesRequestSchema, request);
         const payload = await this.#requestJson("/v1/memories/operating-rules", {
             method: "GET",
-            query: buildOperatingRulesQuery(message),
+            query: buildOperatingRulesQuery(message, request),
         });
         return create(ListMemoriesResponseSchema, {
             limit: getIntField(payload, "limit"),
@@ -178,65 +178,109 @@ export class MemoryClient {
 function normalizeBaseUrl(baseUrl) {
     return baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
 }
-function buildListQuery(message) {
+function buildListQuery(message, request) {
     const params = new URLSearchParams();
     appendStringParam(params, "type", serializeMemoryType(message.type));
     appendStringParam(params, "project_id", message.projectId);
     appendStringParam(params, "team_id", message.teamId);
+    appendStringParam(params, "user_id", requestString(request, "userId", "user_id"));
     appendStringParam(params, "repository", message.repository);
     appendStringParam(params, "agent", message.agent);
+    appendStringParam(params, "agent_id", requestString(request, "agentId", "agent_id"));
+    appendStringParam(params, "review_status", requestString(request, "reviewStatus", "review_status"));
+    appendRepeatedStringParam(params, "entity_id", requestStringArray(request, "entityIds", "entity_ids"));
     appendNumberParam(params, "limit", message.limit);
     appendNumberParam(params, "offset", message.offset);
     return params;
 }
-function buildOperatingRulesQuery(message) {
+function buildOperatingRulesQuery(message, request) {
     const params = new URLSearchParams();
     appendStringParam(params, "project_id", message.projectId);
     appendStringParam(params, "team_id", message.teamId);
+    appendStringParam(params, "user_id", requestString(request, "userId", "user_id"));
     appendStringParam(params, "repository", message.repository);
     appendStringParam(params, "agent", message.agent);
+    appendStringParam(params, "agent_id", requestString(request, "agentId", "agent_id"));
+    appendStringParam(params, "review_status", requestString(request, "reviewStatus", "review_status"));
     appendNumberParam(params, "limit", message.limit);
     appendNumberParam(params, "offset", message.offset);
     return params;
 }
-function serializeStoreRequest(message) {
+function serializeStoreRequest(message, request) {
     return compactObject({
         agent: emptyStringToUndefined(message.agent),
+        agent_id: requestString(request, "agentId", "agent_id"),
         content: emptyStringToUndefined(message.content),
+        confidence: requestNumber(request, "confidence"),
+        entity_ids: requestStringArray(request, "entityIds", "entity_ids"),
+        expires_at: requestTimestamp(request, "expiresAt", "expires_at"),
         id: emptyStringToUndefined(message.id),
+        is_policy: requestBoolean(request, "isPolicy", "is_policy"),
+        pinned: requestBoolean(request, "pinned"),
+        proposed_by: requestString(request, "proposedBy", "proposed_by"),
+        proposal_reason: requestString(request, "proposalReason", "proposal_reason"),
         project_id: emptyStringToUndefined(message.projectId),
         repository: emptyStringToUndefined(message.repository),
+        review_status: requestString(request, "reviewStatus", "review_status"),
+        source: requestString(request, "source"),
+        source_references: requestArray(request, "sourceReferences", "source_references"),
+        supersedes_memory_id: requestString(request, "supersedesMemoryId", "supersedes_memory_id"),
         tags: message.tags.length > 0 ? message.tags : undefined,
         team_id: emptyStringToUndefined(message.teamId),
         type: serializeMemoryType(message.type),
+        user_id: requestString(request, "userId", "user_id"),
     });
 }
-function serializeUpdateRequest(message) {
+function serializeUpdateRequest(message, request) {
     return compactObject({
         content: emptyStringToUndefined(message.content),
+        confidence: requestNumber(request, "confidence"),
+        entity_ids: requestStringArray(request, "entityIds", "entity_ids"),
+        expires_at: requestTimestamp(request, "expiresAt", "expires_at"),
+        is_policy: requestBoolean(request, "isPolicy", "is_policy"),
+        pinned: requestBoolean(request, "pinned"),
+        proposed_by: requestString(request, "proposedBy", "proposed_by"),
+        proposal_reason: requestString(request, "proposalReason", "proposal_reason"),
+        review_status: requestString(request, "reviewStatus", "review_status"),
+        source: requestString(request, "source"),
+        source_references: requestArray(request, "sourceReferences", "source_references"),
         tags: message.tags.length > 0 ? message.tags : undefined,
+        type: requestString(request, "type"),
     });
 }
-function serializeRecallRequest(message) {
+function serializeRecallRequest(message, request) {
     return compactObject({
         agent: emptyStringToUndefined(message.agent),
+        agent_id: requestString(request, "agentId", "agent_id"),
+        as_of: requestTimestamp(request, "asOf", "as_of"),
         embedding: message.embedding.length > 0 ? message.embedding : undefined,
+        entity_ids: requestStringArray(request, "entityIds", "entity_ids"),
         limit: message.limit > 0 ? message.limit : undefined,
+        min_similarity: requestNumber(request, "minSimilarity", "min_similarity"),
         project_id: emptyStringToUndefined(message.projectId),
         query: emptyStringToUndefined(message.query),
+        relationship_depth: requestNumber(request, "relationshipDepth", "relationship_depth"),
+        relationship_types: requestStringArray(request, "relationshipTypes", "relationship_types"),
         repository: emptyStringToUndefined(message.repository),
+        review_status: requestString(request, "reviewStatus", "review_status"),
         team_id: emptyStringToUndefined(message.teamId),
+        top_k: requestNumber(request, "topK", "top_k"),
         type: serializeMemoryType(message.type),
+        user_id: requestString(request, "userId", "user_id"),
     });
 }
-function serializeRecallKnowledgeRequest(message) {
+function serializeRecallKnowledgeRequest(message, request) {
     return compactObject({
         agent: emptyStringToUndefined(message.agent),
+        agent_id: requestString(request, "agentId", "agent_id"),
         conditions: message.conditions.length > 0 ? message.conditions : undefined,
         limit: message.limit > 0 ? message.limit : undefined,
         project_id: emptyStringToUndefined(message.projectId),
         repository: emptyStringToUndefined(message.repository),
+        review_status: requestString(request, "reviewStatus", "review_status"),
         team_id: emptyStringToUndefined(message.teamId),
+        top_k: requestNumber(request, "topK", "top_k"),
+        user_id: requestString(request, "userId", "user_id"),
     });
 }
 function deserializeMemory(value) {
@@ -341,6 +385,13 @@ function appendStringParam(params, key, value) {
         params.set(key, value);
     }
 }
+function appendRepeatedStringParam(params, key, values) {
+    for (const value of values ?? []) {
+        if (value) {
+            params.append(key, value);
+        }
+    }
+}
 function appendNumberParam(params, key, value) {
     if (value > 0) {
         params.set(key, String(value));
@@ -399,6 +450,46 @@ function getNumberArray(value) {
         return [];
     }
     return value.filter((entry) => typeof entry === "number" && Number.isFinite(entry));
+}
+function requestRecord(value) {
+    return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+function requestValue(request, camelKey, snakeKey = camelKey) {
+    const record = requestRecord(request);
+    return record[camelKey] ?? record[snakeKey];
+}
+function requestString(request, camelKey, snakeKey = camelKey) {
+    const value = requestValue(request, camelKey, snakeKey);
+    if (typeof value !== "string") {
+        return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+}
+function requestNumber(request, camelKey, snakeKey = camelKey) {
+    const value = requestValue(request, camelKey, snakeKey);
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+function requestBoolean(request, camelKey, snakeKey = camelKey) {
+    const value = requestValue(request, camelKey, snakeKey);
+    return typeof value === "boolean" ? value : undefined;
+}
+function requestArray(request, camelKey, snakeKey = camelKey) {
+    const value = requestValue(request, camelKey, snakeKey);
+    return Array.isArray(value) && value.length > 0 ? value : undefined;
+}
+function requestStringArray(request, camelKey, snakeKey = camelKey) {
+    return requestArray(request, camelKey, snakeKey)?.filter((entry) => typeof entry === "string" && entry.trim().length > 0);
+}
+function requestTimestamp(request, camelKey, snakeKey = camelKey) {
+    const value = requestValue(request, camelKey, snakeKey);
+    if (typeof value === "string") {
+        return value.trim() || undefined;
+    }
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+        return value.toISOString();
+    }
+    return undefined;
 }
 function asJsonRecord(value, required = true) {
     if (value && typeof value === "object" && !Array.isArray(value)) {

--- a/src/memory/service-client.ts
+++ b/src/memory/service-client.ts
@@ -1,7 +1,11 @@
 import { MemoryType } from "@evalops/memory";
 import { MemoryClient } from "@evalops/memory/client";
-import { getOAuthToken } from "../oauth/index.js";
-import { loadOAuthCredentials } from "../oauth/storage.js";
+import {
+	getEnvValue,
+	resolveOrganizationId,
+	resolvePlatformToken,
+	resolveTeamId,
+} from "../platform/client.js";
 import { createLogger } from "../utils/logger.js";
 import { getMemoryProjectScope } from "./team-memory.js";
 import type { MemoryEntry, MemorySearchResult } from "./types.js";
@@ -15,6 +19,7 @@ const TOPIC_TAG_PREFIX = "maestro-topic:";
 const PROJECT_NAME_TAG_PREFIX = "maestro-project-name:";
 
 type RemoteMemoryConfig = {
+	agentId: string;
 	client: MemoryClient;
 	teamId?: string;
 };
@@ -34,15 +39,28 @@ type TimestampLike = {
 	seconds?: bigint | number | string;
 };
 
-function getEnvValue(names: string[]): string | undefined {
-	for (const name of names) {
-		const value = process.env[name]?.trim();
-		if (value) {
-			return value;
-		}
-	}
-	return undefined;
-}
+type MemorySourceReference = {
+	uri: string;
+	title: string;
+	type: string;
+	metadata?: Record<string, string>;
+};
+
+type RemoteStoreRequest = Parameters<MemoryClient["store"]>[0] & {
+	agentId?: string;
+	reviewStatus?: string;
+	sourceReferences?: MemorySourceReference[];
+};
+
+type RemoteListRequest = Parameters<MemoryClient["list"]>[0] & {
+	agentId?: string;
+	reviewStatus?: string;
+};
+
+type RemoteRecallRequest = Parameters<MemoryClient["recall"]>[0] & {
+	agentId?: string;
+	reviewStatus?: string;
+};
 
 function normalizeTopic(topic: string): string {
 	return topic.toLowerCase().trim();
@@ -80,28 +98,31 @@ function firstNonEmptyString(
 	return undefined;
 }
 
-function resolveOrganizationId(): string | undefined {
-	const envOrgId = getEnvValue([
-		"MAESTRO_EVALOPS_ORG_ID",
-		"EVALOPS_ORGANIZATION_ID",
-		"MAESTRO_ENTERPRISE_ORG_ID",
-	]);
-	if (envOrgId) {
-		return envOrgId;
-	}
-	const stored = loadOAuthCredentials("evalops")?.metadata?.organizationId;
-	return typeof stored === "string" && stored.trim().length > 0
-		? stored.trim()
-		: undefined;
+function resolveMemoryAgentId(): string {
+	return (
+		getEnvValue(["MAESTRO_MEMORY_AGENT_ID", "MAESTRO_AGENT_ID"]) ??
+		MAESTRO_AGENT
+	);
 }
 
 async function resolveRemoteMemoryConfig(): Promise<RemoteMemoryConfig | null> {
-	const baseUrl = getEnvValue(["MAESTRO_MEMORY_BASE"]);
+	const baseUrl = getEnvValue([
+		"MAESTRO_MEMORY_BASE",
+		"MAESTRO_MEMORY_SERVICE_URL",
+		"MAESTRO_PLATFORM_BASE_URL",
+		"MAESTRO_EVALOPS_BASE_URL",
+		"EVALOPS_BASE_URL",
+	]);
 	if (!baseUrl) {
 		return null;
 	}
 
-	const organizationId = resolveOrganizationId();
+	const organizationId = resolveOrganizationId([
+		"MAESTRO_MEMORY_ORGANIZATION_ID",
+		"MAESTRO_EVALOPS_ORG_ID",
+		"EVALOPS_ORGANIZATION_ID",
+		"MAESTRO_ENTERPRISE_ORG_ID",
+	]);
 	if (!organizationId) {
 		logger.warn(
 			"Remote memory configured without organization id; falling back to local memory store",
@@ -109,11 +130,11 @@ async function resolveRemoteMemoryConfig(): Promise<RemoteMemoryConfig | null> {
 		return null;
 	}
 
-	const token =
-		getEnvValue([
-			"MAESTRO_MEMORY_ACCESS_TOKEN",
-			"MAESTRO_EVALOPS_ACCESS_TOKEN",
-		]) ?? (await getOAuthToken("evalops"));
+	const token = await resolvePlatformToken([
+		"MAESTRO_MEMORY_ACCESS_TOKEN",
+		"MAESTRO_EVALOPS_ACCESS_TOKEN",
+		"EVALOPS_TOKEN",
+	]);
 	if (!token) {
 		logger.warn(
 			"Remote memory configured without access token; falling back to local memory store",
@@ -122,12 +143,13 @@ async function resolveRemoteMemoryConfig(): Promise<RemoteMemoryConfig | null> {
 	}
 
 	return {
+		agentId: resolveMemoryAgentId(),
 		client: new MemoryClient({
 			baseUrl,
 			accessToken: token,
 			organizationId,
 		}),
-		teamId: getEnvValue([
+		teamId: resolveTeamId([
 			"MAESTRO_MEMORY_TEAM_ID",
 			"MAESTRO_EVALOPS_TEAM_ID",
 			"MAESTRO_LLM_GATEWAY_TEAM_ID",
@@ -182,6 +204,28 @@ function buildRemoteMemoryTags(
 			tags,
 		) ?? []
 	);
+}
+
+function buildSourceReferences(
+	topic: string,
+	scope: RemoteMemoryScope,
+): MemorySourceReference[] {
+	return [
+		{
+			uri: scope.repository
+				? `repo:${scope.repository}`
+				: "maestro://durable-memory",
+			title: `Maestro durable memory: ${normalizeTopic(topic)}`,
+			type: "maestro-durable-memory",
+			metadata: {
+				source: "maestro",
+				topic: normalizeTopic(topic),
+				...(scope.projectId ? { projectId: scope.projectId } : {}),
+				...(scope.projectName ? { projectName: scope.projectName } : {}),
+				...(scope.repository ? { repository: scope.repository } : {}),
+			},
+		},
+	];
 }
 
 function extractTopicFromTags(tags?: readonly string[]): string | undefined {
@@ -273,12 +317,15 @@ async function listRemoteRecordsForScope(
 	config: RemoteMemoryConfig,
 	scope: RemoteMemoryScope,
 ): Promise<ClientMemory[]> {
-	const response = await config.client.list({
+	const request: RemoteListRequest = {
 		type: MemoryType.PROJECT,
 		teamId: config.teamId,
 		repository: scope.repository,
 		agent: MAESTRO_AGENT,
-	});
+		agentId: config.agentId,
+		reviewStatus: "approved",
+	};
+	const response = await config.client.list(request);
 	return (response.memories ?? []).filter(isManagedDurableMemory);
 }
 
@@ -322,17 +369,19 @@ async function upsertRemoteDurableMemoryWithConfig(
 	);
 
 	if (!existing) {
+		const request: RemoteStoreRequest = {
+			type: MemoryType.PROJECT,
+			content: nextContent,
+			teamId: config.teamId,
+			repository: scope.repository,
+			agent: MAESTRO_AGENT,
+			agentId: config.agentId,
+			tags: nextTags,
+			reviewStatus: "approved",
+			sourceReferences: buildSourceReferences(topic, scope),
+		};
 		const created = requireMemory(
-			(
-				await config.client.store({
-					type: MemoryType.PROJECT,
-					content: nextContent,
-					teamId: config.teamId,
-					repository: scope.repository,
-					agent: MAESTRO_AGENT,
-					tags: nextTags,
-				})
-			).memory,
+			(await config.client.store(request)).memory,
 			"store memory",
 		);
 		return {
@@ -361,6 +410,8 @@ async function upsertRemoteDurableMemoryWithConfig(
 			await config.client.update({
 				id: existing.id,
 				content: nextContent,
+				reviewStatus: "approved",
+				sourceReferences: buildSourceReferences(topic, scope),
 				tags: mergedTags ?? [],
 			})
 		).memory,
@@ -411,14 +462,17 @@ export async function recallRemoteDurableMemories(
 
 	const scope = resolveRemoteScope(options);
 	try {
-		const response = await config.client.recall({
+		const request: RemoteRecallRequest = {
 			query,
 			limit: options?.limit ?? 10,
 			type: MemoryType.PROJECT,
 			teamId: config.teamId,
 			repository: scope.repository,
 			agent: MAESTRO_AGENT,
-		});
+			agentId: config.agentId,
+			reviewStatus: "approved",
+		};
+		const response = await config.client.recall(request);
 		return (response.memories ?? [])
 			.filter(isManagedDurableMemory)
 			.map((memory) => ({

--- a/src/oauth/evalops.ts
+++ b/src/oauth/evalops.ts
@@ -283,13 +283,21 @@ export function buildEvalOpsDelegationEnvironment(
 	result: Pick<
 		EvalOpsDelegationTokenResult,
 		"organizationId" | "providerRef" | "token"
-	>,
+	> &
+		Partial<Pick<EvalOpsDelegationTokenResult, "agentId" | "runId">>,
 ): Record<string, string> {
 	return {
 		MAESTRO_EVALOPS_ACCESS_TOKEN: result.token,
 		MAESTRO_EVALOPS_ORG_ID: result.organizationId,
 		MAESTRO_EVALOPS_PROVIDER: result.providerRef.provider,
 		MAESTRO_EVALOPS_ENVIRONMENT: result.providerRef.environment,
+		...(result.agentId
+			? {
+					MAESTRO_AGENT_ID: result.agentId,
+					MAESTRO_EVALOPS_AGENT_ID: result.agentId,
+				}
+			: {}),
+		...(result.runId ? { MAESTRO_EVALOPS_RUN_ID: result.runId } : {}),
 		...(result.providerRef.credential_name
 			? {
 					MAESTRO_EVALOPS_CREDENTIAL_NAME: result.providerRef.credential_name,

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -156,7 +156,7 @@ export async function resolvePlatformServiceConfig(
 	}
 
 	const token = await resolvePlatformToken(options.tokenEnvVars);
-	if (!token && options.requireToken === true) {
+	if (!token && options.requireToken !== false) {
 		return null;
 	}
 
@@ -237,24 +237,6 @@ async function fetchWithRetry(
 	throw lastError instanceof Error
 		? lastError
 		: new Error(`${options.serviceName} request failed`);
-}
-
-export async function postPlatformJson(
-	config: PlatformServiceConfig,
-	path: string,
-	body: Record<string, unknown>,
-	options: PlatformRequestOptions,
-	headers?: Record<string, string | undefined>,
-): Promise<Response> {
-	return fetchWithRetry(
-		`${config.baseUrl}${path}`,
-		{
-			method: "POST",
-			headers: buildPlatformJsonHeaders(config, headers),
-			body: JSON.stringify(body),
-		},
-		options,
-	);
 }
 
 export async function postPlatformConnect(

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -5,8 +5,6 @@ export const CONNECT_PROTOCOL_VERSION = "1";
 export const DEFAULT_PLATFORM_TIMEOUT_MS = 2_000;
 export const DEFAULT_PLATFORM_MAX_ATTEMPTS = 2;
 
-export type DownstreamFailureMode = "optional" | "required";
-
 export interface PlatformServiceConfig {
 	baseUrl: string;
 	token?: string;
@@ -35,7 +33,6 @@ export interface ResolvePlatformServiceConfigOptions {
 
 export interface PlatformRequestOptions {
 	serviceName: string;
-	failureMode: DownstreamFailureMode;
 	timeoutMs: number;
 	maxAttempts?: number;
 	signal?: AbortSignal;
@@ -210,7 +207,7 @@ export function buildPlatformConnectHeaders(
 	});
 }
 
-async function fetchWithRetry(
+export async function fetchWithRetry(
 	url: string,
 	init: RequestInit,
 	options: PlatformRequestOptions,

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -178,7 +178,7 @@ export async function resolvePlatformServiceConfig(
 	};
 }
 
-export function buildPlatformJsonHeaders(
+function buildPlatformJsonHeaders(
 	config: Pick<PlatformServiceConfig, "organizationId" | "token">,
 	extraHeaders?: Record<string, string | undefined>,
 ): Record<string, string> {

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -1,0 +1,276 @@
+import { getOAuthToken } from "../oauth/index.js";
+import { loadOAuthCredentials } from "../oauth/storage.js";
+
+export const CONNECT_PROTOCOL_VERSION = "1";
+export const DEFAULT_PLATFORM_TIMEOUT_MS = 2_000;
+export const DEFAULT_PLATFORM_MAX_ATTEMPTS = 2;
+
+export type DownstreamFailureMode = "optional" | "required";
+
+export interface PlatformServiceConfig {
+	baseUrl: string;
+	token?: string;
+	organizationId?: string;
+	teamId?: string;
+	workspaceId?: string;
+	timeoutMs: number;
+	maxAttempts: number;
+}
+
+export interface ResolvePlatformServiceConfigOptions {
+	baseUrlEnvVars: readonly string[];
+	tokenEnvVars?: readonly string[];
+	organizationEnvVars?: readonly string[];
+	teamEnvVars?: readonly string[];
+	workspaceEnvVars?: readonly string[];
+	timeoutEnvVars?: readonly string[];
+	maxAttemptsEnvVars?: readonly string[];
+	baseUrlSuffixes?: readonly string[];
+	defaultTimeoutMs?: number;
+	defaultMaxAttempts?: number;
+	requireBaseUrl?: boolean;
+	requireOrganizationId?: boolean;
+	requireToken?: boolean;
+}
+
+export interface PlatformRequestOptions {
+	serviceName: string;
+	failureMode: DownstreamFailureMode;
+	timeoutMs: number;
+	maxAttempts?: number;
+	signal?: AbortSignal;
+}
+
+const SHARED_PLATFORM_BASE_URL_ENV_VARS = [
+	"MAESTRO_PLATFORM_BASE_URL",
+	"MAESTRO_EVALOPS_BASE_URL",
+	"EVALOPS_BASE_URL",
+] as const;
+
+const DEFAULT_TOKEN_ENV_VARS = [
+	"MAESTRO_EVALOPS_ACCESS_TOKEN",
+	"EVALOPS_TOKEN",
+] as const;
+
+const DEFAULT_ORGANIZATION_ENV_VARS = [
+	"MAESTRO_EVALOPS_ORG_ID",
+	"EVALOPS_ORGANIZATION_ID",
+	"MAESTRO_ENTERPRISE_ORG_ID",
+] as const;
+
+const DEFAULT_TEAM_ENV_VARS = [
+	"MAESTRO_EVALOPS_TEAM_ID",
+	"MAESTRO_LLM_GATEWAY_TEAM_ID",
+] as const;
+
+export function trimString(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+export function getEnvValue(names: readonly string[]): string | undefined {
+	for (const name of names) {
+		const value = trimString(process.env[name]);
+		if (value) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+export function parsePositiveInt(
+	value: string | undefined,
+	fallback: number,
+): number {
+	const parsed = Number.parseInt(value ?? "", 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function normalizeBaseUrl(
+	baseUrl: string,
+	suffixes: readonly string[] = [],
+): string {
+	let normalized = baseUrl.trim().replace(/\/+$/u, "");
+	for (const suffix of suffixes) {
+		if (normalized.endsWith(suffix)) {
+			normalized = normalized.slice(0, -suffix.length).replace(/\/+$/u, "");
+		}
+	}
+	return normalized;
+}
+
+export function resolveOrganizationId(
+	envVars: readonly string[] = DEFAULT_ORGANIZATION_ENV_VARS,
+): string | undefined {
+	const envOrgId = getEnvValue(envVars);
+	if (envOrgId) {
+		return envOrgId;
+	}
+	const stored = loadOAuthCredentials("evalops")?.metadata?.organizationId;
+	return typeof stored === "string" ? trimString(stored) : undefined;
+}
+
+export function resolveTeamId(
+	envVars: readonly string[] = DEFAULT_TEAM_ENV_VARS,
+): string | undefined {
+	return getEnvValue(envVars);
+}
+
+export function resolveWorkspaceId(
+	envVars: readonly string[] = DEFAULT_ORGANIZATION_ENV_VARS,
+): string | undefined {
+	return getEnvValue(envVars) ?? resolveOrganizationId();
+}
+
+export function resolveConfiguredToken(
+	envVars: readonly string[] = DEFAULT_TOKEN_ENV_VARS,
+): string | undefined {
+	const envToken = getEnvValue(envVars);
+	if (envToken) {
+		return envToken;
+	}
+	const stored = loadOAuthCredentials("evalops")?.access;
+	return typeof stored === "string" ? trimString(stored) : undefined;
+}
+
+export async function resolvePlatformToken(
+	envVars: readonly string[] = DEFAULT_TOKEN_ENV_VARS,
+): Promise<string | undefined> {
+	return getEnvValue(envVars) ?? (await getOAuthToken("evalops")) ?? undefined;
+}
+
+export async function resolvePlatformServiceConfig(
+	options: ResolvePlatformServiceConfigOptions,
+): Promise<PlatformServiceConfig | null> {
+	const baseUrl = getEnvValue([
+		...options.baseUrlEnvVars,
+		...SHARED_PLATFORM_BASE_URL_ENV_VARS,
+	]);
+	if (!baseUrl && options.requireBaseUrl !== false) {
+		return null;
+	}
+
+	const organizationId = resolveOrganizationId(options.organizationEnvVars);
+	if (!organizationId && options.requireOrganizationId !== false) {
+		return null;
+	}
+
+	const token = await resolvePlatformToken(options.tokenEnvVars);
+	if (!token && options.requireToken === true) {
+		return null;
+	}
+
+	const workspaceId = options.workspaceEnvVars
+		? resolveWorkspaceId(options.workspaceEnvVars)
+		: organizationId;
+
+	return {
+		baseUrl: normalizeBaseUrl(baseUrl ?? "", options.baseUrlSuffixes),
+		...(token ? { token } : {}),
+		...(organizationId ? { organizationId } : {}),
+		teamId: resolveTeamId(options.teamEnvVars),
+		...(workspaceId ? { workspaceId } : {}),
+		timeoutMs: parsePositiveInt(
+			getEnvValue(options.timeoutEnvVars ?? []),
+			options.defaultTimeoutMs ?? DEFAULT_PLATFORM_TIMEOUT_MS,
+		),
+		maxAttempts: parsePositiveInt(
+			getEnvValue(options.maxAttemptsEnvVars ?? []),
+			options.defaultMaxAttempts ?? DEFAULT_PLATFORM_MAX_ATTEMPTS,
+		),
+	};
+}
+
+export function buildPlatformJsonHeaders(
+	config: Pick<PlatformServiceConfig, "organizationId" | "token">,
+	extraHeaders?: Record<string, string | undefined>,
+): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries({
+			...(config.token ? { Authorization: `Bearer ${config.token}` } : {}),
+			"Content-Type": "application/json",
+			...(config.organizationId
+				? { "X-Organization-ID": config.organizationId }
+				: {}),
+			...(extraHeaders ?? {}),
+		}).filter(
+			(entry): entry is [string, string] =>
+				typeof entry[1] === "string" && entry[1].trim().length > 0,
+		),
+	);
+}
+
+export function buildPlatformConnectHeaders(
+	config: Pick<PlatformServiceConfig, "organizationId" | "token">,
+	extraHeaders?: Record<string, string | undefined>,
+): Record<string, string> {
+	return buildPlatformJsonHeaders(config, {
+		"Connect-Protocol-Version": CONNECT_PROTOCOL_VERSION,
+		...(extraHeaders ?? {}),
+	});
+}
+
+async function fetchWithRetry(
+	url: string,
+	init: RequestInit,
+	options: PlatformRequestOptions,
+): Promise<Response> {
+	const maxAttempts = Math.max(1, options.maxAttempts ?? 1);
+	let lastError: unknown;
+	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+		try {
+			const response = await fetch(url, {
+				...init,
+				signal:
+					options.signal ?? AbortSignal.timeout(Math.max(1, options.timeoutMs)),
+			});
+			if (response.status < 500 || attempt === maxAttempts) {
+				return response;
+			}
+		} catch (error) {
+			lastError = error;
+			if (attempt === maxAttempts) {
+				break;
+			}
+		}
+	}
+	throw lastError instanceof Error
+		? lastError
+		: new Error(`${options.serviceName} request failed`);
+}
+
+export async function postPlatformJson(
+	config: PlatformServiceConfig,
+	path: string,
+	body: Record<string, unknown>,
+	options: PlatformRequestOptions,
+	headers?: Record<string, string | undefined>,
+): Promise<Response> {
+	return fetchWithRetry(
+		`${config.baseUrl}${path}`,
+		{
+			method: "POST",
+			headers: buildPlatformJsonHeaders(config, headers),
+			body: JSON.stringify(body),
+		},
+		options,
+	);
+}
+
+export async function postPlatformConnect(
+	config: PlatformServiceConfig,
+	path: string,
+	body: Record<string, unknown>,
+	options: PlatformRequestOptions,
+	headers?: Record<string, string | undefined>,
+): Promise<Response> {
+	return fetchWithRetry(
+		`${config.baseUrl}${path}`,
+		{
+			method: "POST",
+			headers: buildPlatformConnectHeaders(config, headers),
+			body: JSON.stringify(body),
+		},
+		options,
+	);
+}

--- a/src/prompts/service-client.ts
+++ b/src/prompts/service-client.ts
@@ -1,6 +1,7 @@
 import {
 	type PlatformServiceConfig,
 	buildPlatformJsonHeaders,
+	fetchWithRetry,
 	getEnvValue,
 	postPlatformConnect,
 	resolvePlatformServiceConfig,
@@ -131,7 +132,6 @@ async function resolveViaPlatformConnect(
 		},
 		{
 			serviceName: "prompts service",
-			failureMode: "optional",
 			timeoutMs: config.timeoutMs,
 			maxAttempts: config.maxAttempts,
 		},
@@ -160,11 +160,18 @@ async function resolveViaLegacyRest(
 		url.searchParams.set("surface", trimString(input.surface)!);
 	}
 
-	const response = await fetch(url, {
-		method: "GET",
-		headers: buildPlatformJsonHeaders(config),
-		signal: AbortSignal.timeout(config.timeoutMs),
-	});
+	const response = await fetchWithRetry(
+		url.toString(),
+		{
+			method: "GET",
+			headers: buildPlatformJsonHeaders(config),
+		},
+		{
+			serviceName: "prompts service",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
 	if (response.status === 404) {
 		return null;
 	}

--- a/src/prompts/service-client.ts
+++ b/src/prompts/service-client.ts
@@ -3,7 +3,6 @@ import {
 	fetchWithRetry,
 	getEnvValue,
 	postPlatformConnect,
-	resolveConfiguredToken,
 	resolveOrganizationId,
 	resolvePlatformServiceConfig,
 	trimString,
@@ -88,11 +87,9 @@ function warnPromptsServiceMisconfiguration(): void {
 		);
 		return;
 	}
-	if (!resolveConfiguredToken(PROMPTS_TOKEN_ENV_VARS)) {
-		logger.warn(
-			"Prompts service configured without access token; retaining bundled prompts",
-		);
-	}
+	logger.warn(
+		"Prompts service configured without access token; retaining bundled prompts",
+	);
 }
 
 async function resolvePromptsServiceConfig(): Promise<PromptsServiceConfig | null> {

--- a/src/prompts/service-client.ts
+++ b/src/prompts/service-client.ts
@@ -1,9 +1,10 @@
 import {
 	type PlatformServiceConfig,
-	buildPlatformJsonHeaders,
 	fetchWithRetry,
 	getEnvValue,
 	postPlatformConnect,
+	resolveConfiguredToken,
+	resolveOrganizationId,
 	resolvePlatformServiceConfig,
 	trimString,
 } from "../platform/client.js";
@@ -18,6 +19,23 @@ const DEFAULT_TIMEOUT_MS = 2_000;
 const DEFAULT_MAX_ATTEMPTS = 2;
 const RESOLVE_PROMPT_PATH = "/prompts.v1.PromptService/Resolve";
 const LEGACY_RESOLVE_PROMPT_PATH = "/v1/resolve";
+const PROMPTS_BASE_URL_ENV_VARS = [
+	"PROMPTS_SERVICE_URL",
+	"MAESTRO_PROMPTS_SERVICE_URL",
+] as const;
+const PROMPTS_TOKEN_ENV_VARS = [
+	"PROMPTS_SERVICE_TOKEN",
+	"MAESTRO_PROMPTS_SERVICE_TOKEN",
+	"MAESTRO_EVALOPS_ACCESS_TOKEN",
+	"EVALOPS_TOKEN",
+] as const;
+const PROMPTS_ORGANIZATION_ENV_VARS = [
+	"PROMPTS_SERVICE_ORGANIZATION_ID",
+	"MAESTRO_PROMPTS_ORGANIZATION_ID",
+	"MAESTRO_EVALOPS_ORG_ID",
+	"EVALOPS_ORGANIZATION_ID",
+	"MAESTRO_ENTERPRISE_ORG_ID",
+] as const;
 
 type PromptsTransport = "connect" | "legacy-rest";
 
@@ -45,29 +63,43 @@ function resolvePromptsTransport(): PromptsTransport {
 	if (configured === "legacy" || configured === "legacy-rest") {
 		return "legacy-rest";
 	}
-	const serviceSpecificBase = getEnvValue([
-		"PROMPTS_SERVICE_URL",
-		"MAESTRO_PROMPTS_SERVICE_URL",
-	]);
+	const serviceSpecificBase = getEnvValue(PROMPTS_BASE_URL_ENV_VARS);
 	return serviceSpecificBase ? "legacy-rest" : "connect";
+}
+
+function hasConfiguredPromptsBaseUrl(): boolean {
+	return Boolean(
+		getEnvValue([
+			...PROMPTS_BASE_URL_ENV_VARS,
+			"MAESTRO_PLATFORM_BASE_URL",
+			"MAESTRO_EVALOPS_BASE_URL",
+			"EVALOPS_BASE_URL",
+		]),
+	);
+}
+
+function warnPromptsServiceMisconfiguration(): void {
+	if (!hasConfiguredPromptsBaseUrl()) {
+		return;
+	}
+	if (!resolveOrganizationId(PROMPTS_ORGANIZATION_ENV_VARS)) {
+		logger.warn(
+			"Prompts service configured without organization id; retaining bundled prompts",
+		);
+		return;
+	}
+	if (!resolveConfiguredToken(PROMPTS_TOKEN_ENV_VARS)) {
+		logger.warn(
+			"Prompts service configured without access token; retaining bundled prompts",
+		);
+	}
 }
 
 async function resolvePromptsServiceConfig(): Promise<PromptsServiceConfig | null> {
 	const config = await resolvePlatformServiceConfig({
-		baseUrlEnvVars: ["PROMPTS_SERVICE_URL", "MAESTRO_PROMPTS_SERVICE_URL"],
-		tokenEnvVars: [
-			"PROMPTS_SERVICE_TOKEN",
-			"MAESTRO_PROMPTS_SERVICE_TOKEN",
-			"MAESTRO_EVALOPS_ACCESS_TOKEN",
-			"EVALOPS_TOKEN",
-		],
-		organizationEnvVars: [
-			"PROMPTS_SERVICE_ORGANIZATION_ID",
-			"MAESTRO_PROMPTS_ORGANIZATION_ID",
-			"MAESTRO_EVALOPS_ORG_ID",
-			"EVALOPS_ORGANIZATION_ID",
-			"MAESTRO_ENTERPRISE_ORG_ID",
-		],
+		baseUrlEnvVars: PROMPTS_BASE_URL_ENV_VARS,
+		tokenEnvVars: PROMPTS_TOKEN_ENV_VARS,
+		organizationEnvVars: PROMPTS_ORGANIZATION_ENV_VARS,
 		timeoutEnvVars: [
 			"PROMPTS_SERVICE_TIMEOUT_MS",
 			"MAESTRO_PROMPTS_TIMEOUT_MS",
@@ -87,12 +119,22 @@ async function resolvePromptsServiceConfig(): Promise<PromptsServiceConfig | nul
 		requireToken: true,
 	});
 	if (!config) {
+		warnPromptsServiceMisconfiguration();
 		return null;
 	}
 
 	return {
 		...config,
 		transport: resolvePromptsTransport(),
+	};
+}
+
+function buildHeaders(config: PromptsServiceConfig): Record<string, string> {
+	return {
+		...(config.token ? { Authorization: `Bearer ${config.token}` } : {}),
+		...(config.organizationId
+			? { "X-Organization-ID": config.organizationId }
+			: {}),
 	};
 }
 
@@ -164,7 +206,7 @@ async function resolveViaLegacyRest(
 		url.toString(),
 		{
 			method: "GET",
-			headers: buildPlatformJsonHeaders(config),
+			headers: buildHeaders(config),
 		},
 		{
 			serviceName: "prompts service",

--- a/src/prompts/service-client.ts
+++ b/src/prompts/service-client.ts
@@ -1,5 +1,11 @@
-import { getOAuthToken } from "../oauth/index.js";
-import { loadOAuthCredentials } from "../oauth/storage.js";
+import {
+	type PlatformServiceConfig,
+	buildPlatformJsonHeaders,
+	getEnvValue,
+	postPlatformConnect,
+	resolvePlatformServiceConfig,
+	trimString,
+} from "../platform/client.js";
 import { createLogger } from "../utils/logger.js";
 import type {
 	ResolvePromptTemplateInput,
@@ -8,13 +14,15 @@ import type {
 
 const logger = createLogger("prompts:service");
 const DEFAULT_TIMEOUT_MS = 2_000;
+const DEFAULT_MAX_ATTEMPTS = 2;
+const RESOLVE_PROMPT_PATH = "/prompts.v1.PromptService/Resolve";
+const LEGACY_RESOLVE_PROMPT_PATH = "/v1/resolve";
 
-interface PromptsServiceConfig {
-	serviceUrl: string;
-	serviceToken?: string;
-	organizationId: string;
-	timeoutMs: number;
-}
+type PromptsTransport = "connect" | "legacy-rest";
+
+type PromptsServiceConfig = PlatformServiceConfig & {
+	transport: PromptsTransport;
+};
 
 interface ResolveVersionPayload {
 	id?: string;
@@ -26,75 +34,64 @@ interface ResolveResponse {
 	version?: ResolveVersionPayload;
 }
 
-function trimString(value: string | undefined): string | undefined {
-	const trimmed = value?.trim();
-	return trimmed ? trimmed : undefined;
-}
-
-function normalizeBaseUrl(baseUrl: string): string {
-	return baseUrl.replace(/\/+$/, "");
-}
-
-function resolveOrganizationId(): string | undefined {
-	const envOrgId =
-		trimString(process.env.PROMPTS_SERVICE_ORGANIZATION_ID) ??
-		trimString(process.env.MAESTRO_EVALOPS_ORG_ID) ??
-		trimString(process.env.EVALOPS_ORGANIZATION_ID) ??
-		trimString(process.env.MAESTRO_ENTERPRISE_ORG_ID);
-	if (envOrgId) {
-		return envOrgId;
+function resolvePromptsTransport(): PromptsTransport {
+	const configured = trimString(
+		process.env.PROMPTS_SERVICE_TRANSPORT,
+	)?.toLowerCase();
+	if (configured === "connect" || configured === "platform") {
+		return "connect";
 	}
-	const stored = loadOAuthCredentials("evalops")?.metadata?.organizationId;
-	return typeof stored === "string" && stored.trim().length > 0
-		? stored.trim()
-		: undefined;
+	if (configured === "legacy" || configured === "legacy-rest") {
+		return "legacy-rest";
+	}
+	const serviceSpecificBase = getEnvValue([
+		"PROMPTS_SERVICE_URL",
+		"MAESTRO_PROMPTS_SERVICE_URL",
+	]);
+	return serviceSpecificBase ? "legacy-rest" : "connect";
 }
 
 async function resolvePromptsServiceConfig(): Promise<PromptsServiceConfig | null> {
-	const serviceUrl = trimString(process.env.PROMPTS_SERVICE_URL);
-	if (!serviceUrl) {
+	const config = await resolvePlatformServiceConfig({
+		baseUrlEnvVars: ["PROMPTS_SERVICE_URL", "MAESTRO_PROMPTS_SERVICE_URL"],
+		tokenEnvVars: [
+			"PROMPTS_SERVICE_TOKEN",
+			"MAESTRO_PROMPTS_SERVICE_TOKEN",
+			"MAESTRO_EVALOPS_ACCESS_TOKEN",
+			"EVALOPS_TOKEN",
+		],
+		organizationEnvVars: [
+			"PROMPTS_SERVICE_ORGANIZATION_ID",
+			"MAESTRO_PROMPTS_ORGANIZATION_ID",
+			"MAESTRO_EVALOPS_ORG_ID",
+			"EVALOPS_ORGANIZATION_ID",
+			"MAESTRO_ENTERPRISE_ORG_ID",
+		],
+		timeoutEnvVars: [
+			"PROMPTS_SERVICE_TIMEOUT_MS",
+			"MAESTRO_PROMPTS_TIMEOUT_MS",
+		],
+		maxAttemptsEnvVars: [
+			"PROMPTS_SERVICE_MAX_ATTEMPTS",
+			"MAESTRO_PROMPTS_MAX_ATTEMPTS",
+		],
+		baseUrlSuffixes: [
+			RESOLVE_PROMPT_PATH,
+			LEGACY_RESOLVE_PROMPT_PATH,
+			"/prompts.v1.PromptService",
+		],
+		defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+		defaultMaxAttempts: DEFAULT_MAX_ATTEMPTS,
+		requireOrganizationId: true,
+		requireToken: true,
+	});
+	if (!config) {
 		return null;
 	}
-
-	const organizationId = resolveOrganizationId();
-	if (!organizationId) {
-		logger.warn(
-			"Prompts service configured without organization id; retaining bundled system prompt",
-		);
-		return null;
-	}
-
-	const serviceToken =
-		trimString(process.env.PROMPTS_SERVICE_TOKEN) ??
-		trimString(process.env.MAESTRO_EVALOPS_ACCESS_TOKEN) ??
-		(await getOAuthToken("evalops"));
-	if (!serviceToken) {
-		logger.warn(
-			"Prompts service configured without access token; retaining bundled system prompt",
-		);
-		return null;
-	}
-
-	const timeoutMs = Number.parseInt(
-		process.env.PROMPTS_SERVICE_TIMEOUT_MS ?? "",
-		10,
-	);
 
 	return {
-		serviceUrl: normalizeBaseUrl(serviceUrl),
-		serviceToken,
-		organizationId,
-		timeoutMs:
-			Number.isFinite(timeoutMs) && timeoutMs > 0
-				? timeoutMs
-				: DEFAULT_TIMEOUT_MS,
-	};
-}
-
-function buildHeaders(config: PromptsServiceConfig): Record<string, string> {
-	return {
-		Authorization: `Bearer ${config.serviceToken}`,
-		"X-Organization-ID": config.organizationId,
+		...config,
+		transport: resolvePromptsTransport(),
 	};
 }
 
@@ -120,6 +117,66 @@ function normalizeResolvedPrompt(
 	};
 }
 
+async function resolveViaPlatformConnect(
+	config: PromptsServiceConfig,
+	input: ResolvePromptTemplateInput,
+	name: string,
+): Promise<ResolveResponse | null> {
+	const response = await postPlatformConnect(
+		config,
+		RESOLVE_PROMPT_PATH,
+		{
+			name,
+			label: trimString(input.label) ?? "production",
+		},
+		{
+			serviceName: "prompts service",
+			failureMode: "optional",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	if (response.status === 404) {
+		return null;
+	}
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`prompts service returned ${response.status}: ${text || response.statusText}`,
+		);
+	}
+	return (await response.json()) as ResolveResponse;
+}
+
+async function resolveViaLegacyRest(
+	config: PromptsServiceConfig,
+	input: ResolvePromptTemplateInput,
+	name: string,
+): Promise<ResolveResponse | null> {
+	const url = new URL(LEGACY_RESOLVE_PROMPT_PATH, config.baseUrl);
+	url.searchParams.set("name", name);
+	url.searchParams.set("env", trimString(input.label) ?? "production");
+	if (trimString(input.surface)) {
+		url.searchParams.set("surface", trimString(input.surface)!);
+	}
+
+	const response = await fetch(url, {
+		method: "GET",
+		headers: buildPlatformJsonHeaders(config),
+		signal: AbortSignal.timeout(config.timeoutMs),
+	});
+	if (response.status === 404) {
+		return null;
+	}
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`prompts service returned ${response.status}: ${text || response.statusText}`,
+		);
+	}
+	return (await response.json()) as ResolveResponse;
+}
+
 export async function resolvePromptTemplate(
 	input: ResolvePromptTemplateInput,
 ): Promise<ResolvedPromptTemplate | null> {
@@ -134,32 +191,15 @@ export async function resolvePromptTemplate(
 			return null;
 		}
 
-		const url = new URL("/v1/resolve", config.serviceUrl);
-		url.searchParams.set("name", name);
-		url.searchParams.set("env", trimString(input.label) ?? "production");
-		if (trimString(input.surface)) {
-			url.searchParams.set("surface", trimString(input.surface)!);
-		}
-
-		const response = await fetch(url, {
-			method: "GET",
-			headers: buildHeaders(config),
-			signal: AbortSignal.timeout(config.timeoutMs),
-		});
-		if (response.status === 404) {
+		const payload =
+			config.transport === "connect"
+				? await resolveViaPlatformConnect(config, input, name)
+				: await resolveViaLegacyRest(config, input, name);
+		if (!payload) {
 			return null;
 		}
-		if (!response.ok) {
-			const text = await response.text();
-			throw new Error(
-				`prompts service returned ${response.status}: ${text || response.statusText}`,
-			);
-		}
 
-		return normalizeResolvedPrompt(
-			input,
-			(await response.json()) as ResolveResponse,
-		);
+		return normalizeResolvedPrompt(input, payload);
 	} catch (error) {
 		logger.warn("Failed to resolve prompt template; retaining bundled prompt", {
 			error: error instanceof Error ? error.message : String(error),

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -198,6 +198,36 @@ function resolveEvalOpsProviderRef(
 	};
 }
 
+function resolveEvalOpsRequestMetadata(
+	metadata?: Record<string, unknown>,
+): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries({
+			agent_id:
+				getNonEmptyString(metadata?.agentId) ??
+				getNonEmptyString(metadata?.agent_id) ??
+				process.env.MAESTRO_EVALOPS_AGENT_ID?.trim() ??
+				process.env.MAESTRO_AGENT_ID?.trim(),
+			run_id:
+				getNonEmptyString(metadata?.runId) ??
+				getNonEmptyString(metadata?.run_id) ??
+				process.env.MAESTRO_EVALOPS_RUN_ID?.trim(),
+			session_id:
+				getNonEmptyString(metadata?.sessionId) ??
+				getNonEmptyString(metadata?.session_id) ??
+				process.env.MAESTRO_SESSION_ID?.trim(),
+			surface:
+				getNonEmptyString(metadata?.surface) ??
+				process.env.MAESTRO_EVALOPS_SURFACE?.trim() ??
+				process.env.MAESTRO_SURFACE?.trim() ??
+				"maestro",
+		}).filter(
+			(entry): entry is [string, string] =>
+				typeof entry[1] === "string" && entry[1].trim().length > 0,
+		),
+	);
+}
+
 function buildEvalOpsCredential(
 	provider: string,
 	token: string,
@@ -220,6 +250,7 @@ function buildEvalOpsCredential(
 		},
 		metadata,
 		requestBody: {
+			metadata: resolveEvalOpsRequestMetadata(metadata),
 			provider_ref: resolveEvalOpsProviderRef(provider, metadata),
 		},
 	};

--- a/src/telemetry/meter-service-client.ts
+++ b/src/telemetry/meter-service-client.ts
@@ -214,6 +214,7 @@ async function postMeter<T>(
 	config: RemoteMeterConfig,
 	path: string,
 	body: Record<string, unknown>,
+	emptyResponseValue?: T,
 ): Promise<T> {
 	const response = await postPlatformConnect(
 		config,
@@ -231,7 +232,28 @@ async function postMeter<T>(
 			`meter service returned ${response.status}: ${text || response.statusText}`,
 		);
 	}
-	return (await response.json()) as T;
+	const text = await response.text();
+	if (!text.trim()) {
+		if (emptyResponseValue !== undefined) {
+			return emptyResponseValue;
+		}
+		throw new Error("meter service returned empty response");
+	}
+	const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+	if (contentType && !contentType.includes("application/json")) {
+		if (emptyResponseValue !== undefined) {
+			return emptyResponseValue;
+		}
+		throw new Error(`meter service returned non-JSON response: ${contentType}`);
+	}
+	try {
+		return JSON.parse(text) as T;
+	} catch (error) {
+		if (emptyResponseValue !== undefined) {
+			return emptyResponseValue;
+		}
+		throw error;
+	}
 }
 
 export async function queryRemoteMeterWideEvents(
@@ -295,6 +317,7 @@ export async function mirrorCanonicalTurnEventToMeter(
 			config,
 			INGEST_WIDE_EVENT_PATH,
 			buildWideEventBody(config, event),
+			null,
 		);
 		return true;
 	} catch (error) {

--- a/src/telemetry/meter-service-client.ts
+++ b/src/telemetry/meter-service-client.ts
@@ -1,136 +1,102 @@
-import { getOAuthToken } from "../oauth/index.js";
-import { loadOAuthCredentials } from "../oauth/storage.js";
+import {
+	type PlatformServiceConfig,
+	getEnvValue,
+	postPlatformConnect,
+	resolveConfiguredToken,
+	resolveOrganizationId,
+	resolvePlatformServiceConfig,
+} from "../platform/client.js";
 import { createLogger } from "../utils/logger.js";
 import type { CanonicalTurnEvent } from "./wide-events.js";
 
 const logger = createLogger("telemetry:meter");
 
-const CONNECT_PROTOCOL_VERSION = "1";
 const DEFAULT_TIMEOUT_MS = 2_000;
+const DEFAULT_MAX_ATTEMPTS = 2;
 const INGEST_WIDE_EVENT_PATH = "/meter.v1.MeterService/IngestWideEvent";
+const QUERY_WIDE_EVENTS_PATH = "/meter.v1.MeterService/QueryWideEvents";
+const GET_EVENT_DASHBOARD_PATH = "/meter.v1.MeterService/GetEventDashboard";
 const MAESTRO_AGENT_ID = "maestro";
 const MAESTRO_SURFACE = "maestro";
 
-type RemoteMeterConfig = {
-	baseUrl: string;
+type RemoteMeterConfig = PlatformServiceConfig & {
 	organizationId: string;
-	teamId?: string;
-	timeoutMs: number;
 	token: string;
 };
 
-function getEnvValue(names: string[]): string | undefined {
-	for (const name of names) {
-		const value = process.env[name]?.trim();
-		if (value) {
-			return value;
-		}
-	}
-	return undefined;
+export interface RemoteMeterWideEventQuery {
+	agentId?: string;
+	endTime?: string;
+	eventType?: string;
+	limit?: number;
+	metadataKey?: string;
+	metadataValue?: string;
+	model?: string;
+	offset?: number;
+	provider?: string;
+	startTime?: string;
+	surface?: string;
+	teamId?: string;
 }
 
-function normalizeBaseUrl(value: string): string {
-	let normalized = value.trim();
-	for (const suffix of [
-		"/meter.v1.MeterService/IngestWideEvent",
-		"/meter.v1.MeterService/QueryWideEvents",
-		"/meter.v1.MeterService/GetEventDashboard",
-		"/meter.v1.MeterService",
-	]) {
-		if (normalized.endsWith(suffix)) {
-			normalized = normalized.slice(0, -suffix.length);
-		}
-	}
-	return normalized.replace(/\/+$/, "");
+export interface RemoteMeterWideEventQueryResult {
+	events: Array<Record<string, unknown>>;
+	total: number;
+	hasMore: boolean;
 }
 
-function parseTimeoutMs(): number {
-	const raw = getEnvValue(["MAESTRO_METER_TIMEOUT_MS"]);
-	if (!raw) {
-		return DEFAULT_TIMEOUT_MS;
-	}
-	const value = Number.parseInt(raw, 10);
-	if (!Number.isFinite(value) || value <= 0) {
-		return DEFAULT_TIMEOUT_MS;
-	}
-	return value;
-}
-
-function resolveOrganizationId(): string | undefined {
-	const envOrgId = getEnvValue([
-		"MAESTRO_METER_ORGANIZATION_ID",
-		"MAESTRO_EVALOPS_ORG_ID",
-		"EVALOPS_ORGANIZATION_ID",
-		"MAESTRO_ENTERPRISE_ORG_ID",
-	]);
-	if (envOrgId) {
-		return envOrgId;
-	}
-	const stored = loadOAuthCredentials("evalops")?.metadata?.organizationId;
-	return typeof stored === "string" && stored.trim().length > 0
-		? stored.trim()
-		: undefined;
-}
-
-function resolveTeamId(): string | undefined {
-	return getEnvValue([
-		"MAESTRO_METER_TEAM_ID",
-		"MAESTRO_EVALOPS_TEAM_ID",
-		"MAESTRO_LLM_GATEWAY_TEAM_ID",
-	]);
-}
-
-function hasStoredEvalopsToken(): boolean {
-	const stored = loadOAuthCredentials("evalops")?.access;
-	return typeof stored === "string" && stored.trim().length > 0;
-}
-
-function resolveConfiguredToken(): string | undefined {
-	return (
-		getEnvValue([
-			"MAESTRO_METER_ACCESS_TOKEN",
-			"MAESTRO_EVALOPS_ACCESS_TOKEN",
-		]) ??
-		(hasStoredEvalopsToken()
-			? loadOAuthCredentials("evalops")?.access?.trim()
-			: undefined)
-	);
+export interface RemoteMeterEventDashboardResult {
+	totalEvents?: number;
+	totalInputTokens?: number;
+	totalOutputTokens?: number;
+	totalCacheReadTokens?: number;
+	totalCacheWriteTokens?: number;
+	totalCostUsd?: number;
+	byEventType?: Array<Record<string, unknown>>;
+	bySurface?: Array<Record<string, unknown>>;
+	byModel?: Array<Record<string, unknown>>;
+	byProvider?: Array<Record<string, unknown>>;
 }
 
 async function resolveRemoteMeterConfig(): Promise<RemoteMeterConfig | null> {
-	const baseUrl = getEnvValue([
-		"MAESTRO_METER_BASE",
-		"MAESTRO_METER_SERVICE_URL",
-	]);
-	const organizationId = resolveOrganizationId();
-	if (!baseUrl || !organizationId) {
-		return null;
-	}
-
-	const token =
-		getEnvValue([
+	const config = await resolvePlatformServiceConfig({
+		baseUrlEnvVars: ["MAESTRO_METER_BASE", "MAESTRO_METER_SERVICE_URL"],
+		tokenEnvVars: [
 			"MAESTRO_METER_ACCESS_TOKEN",
 			"MAESTRO_EVALOPS_ACCESS_TOKEN",
-		]) ?? (await getOAuthToken("evalops"));
-	if (!token) {
+			"EVALOPS_TOKEN",
+		],
+		organizationEnvVars: [
+			"MAESTRO_METER_ORGANIZATION_ID",
+			"MAESTRO_EVALOPS_ORG_ID",
+			"EVALOPS_ORGANIZATION_ID",
+			"MAESTRO_ENTERPRISE_ORG_ID",
+		],
+		teamEnvVars: [
+			"MAESTRO_METER_TEAM_ID",
+			"MAESTRO_EVALOPS_TEAM_ID",
+			"MAESTRO_LLM_GATEWAY_TEAM_ID",
+		],
+		timeoutEnvVars: ["MAESTRO_METER_TIMEOUT_MS"],
+		maxAttemptsEnvVars: ["MAESTRO_METER_MAX_ATTEMPTS"],
+		baseUrlSuffixes: [
+			INGEST_WIDE_EVENT_PATH,
+			QUERY_WIDE_EVENTS_PATH,
+			GET_EVENT_DASHBOARD_PATH,
+			"/meter.v1.MeterService",
+		],
+		defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+		defaultMaxAttempts: DEFAULT_MAX_ATTEMPTS,
+		requireOrganizationId: true,
+		requireToken: true,
+	});
+	if (!config?.organizationId || !config.token) {
 		return null;
 	}
-
 	return {
-		baseUrl: normalizeBaseUrl(baseUrl),
-		organizationId,
-		teamId: resolveTeamId(),
-		timeoutMs: parseTimeoutMs(),
-		token,
-	};
-}
-
-function buildHeaders(config: RemoteMeterConfig): Record<string, string> {
-	return {
-		Authorization: `Bearer ${config.token}`,
-		"Connect-Protocol-Version": CONNECT_PROTOCOL_VERSION,
-		"Content-Type": "application/json",
-		"X-Organization-ID": config.organizationId,
+		...config,
+		organizationId: config.organizationId,
+		token: config.token,
 	};
 }
 
@@ -169,10 +135,152 @@ export function hasRemoteMeterDestination(): boolean {
 	const baseUrl = getEnvValue([
 		"MAESTRO_METER_BASE",
 		"MAESTRO_METER_SERVICE_URL",
+		"MAESTRO_PLATFORM_BASE_URL",
+		"MAESTRO_EVALOPS_BASE_URL",
+		"EVALOPS_BASE_URL",
 	]);
-	return Boolean(
-		baseUrl && resolveOrganizationId() && resolveConfiguredToken(),
+	const organizationId = resolveOrganizationId([
+		"MAESTRO_METER_ORGANIZATION_ID",
+		"MAESTRO_EVALOPS_ORG_ID",
+		"EVALOPS_ORGANIZATION_ID",
+		"MAESTRO_ENTERPRISE_ORG_ID",
+	]);
+	const token = resolveConfiguredToken([
+		"MAESTRO_METER_ACCESS_TOKEN",
+		"MAESTRO_EVALOPS_ACCESS_TOKEN",
+		"EVALOPS_TOKEN",
+	]);
+	return Boolean(baseUrl && organizationId && token);
+}
+
+function buildWideEventBody(
+	config: RemoteMeterConfig,
+	event: CanonicalTurnEvent,
+): Record<string, unknown> {
+	return {
+		timestamp: event.timestamp,
+		teamId: config.teamId,
+		agentId: getEnvValue(["MAESTRO_AGENT_ID"]) ?? MAESTRO_AGENT_ID,
+		surface: getEnvValue(["MAESTRO_SURFACE"]) ?? MAESTRO_SURFACE,
+		eventType: event.type,
+		model: event.model.id,
+		provider: event.model.provider,
+		requestId: event.turnId,
+		metadata: buildMetadata(event),
+		data: event,
+		metrics: {
+			inputTokens: toNonNegativeInt(event.tokens.input),
+			outputTokens: toNonNegativeInt(event.tokens.output),
+			cacheReadTokens: toNonNegativeInt(event.tokens.cacheRead),
+			cacheWriteTokens: toNonNegativeInt(event.tokens.cacheWrite),
+			totalCostUsd: event.costUsd,
+			durationMs: toNonNegativeInt(event.totalDurationMs),
+			toolCallsCount: toNonNegativeInt(event.toolCount),
+		},
+	};
+}
+
+function buildWideEventQueryBody(
+	config: RemoteMeterConfig,
+	query: RemoteMeterWideEventQuery,
+): Record<string, unknown> {
+	return {
+		teamId: query.teamId ?? config.teamId,
+		agentId: query.agentId,
+		surface: query.surface,
+		eventType: query.eventType,
+		model: query.model,
+		provider: query.provider,
+		metadataKey: query.metadataKey,
+		metadataValue: query.metadataValue,
+		startTime: query.startTime,
+		endTime: query.endTime,
+		limit: query.limit,
+		offset: query.offset,
+	};
+}
+
+function stripUndefinedValues(
+	value: Record<string, unknown>,
+): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(value).filter((entry): entry is [string, unknown] => {
+			return entry[1] !== undefined;
+		}),
 	);
+}
+
+async function postMeter<T>(
+	config: RemoteMeterConfig,
+	path: string,
+	body: Record<string, unknown>,
+): Promise<T> {
+	const response = await postPlatformConnect(
+		config,
+		path,
+		stripUndefinedValues(body),
+		{
+			serviceName: "meter service",
+			failureMode: "optional",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`meter service returned ${response.status}: ${text || response.statusText}`,
+		);
+	}
+	return (await response.json()) as T;
+}
+
+export async function queryRemoteMeterWideEvents(
+	query: RemoteMeterWideEventQuery = {},
+): Promise<RemoteMeterWideEventQueryResult | null> {
+	const config = await resolveRemoteMeterConfig();
+	if (!config) {
+		return null;
+	}
+
+	try {
+		return await postMeter<RemoteMeterWideEventQueryResult>(
+			config,
+			QUERY_WIDE_EVENTS_PATH,
+			buildWideEventQueryBody(config, query),
+		);
+	} catch (error) {
+		logger.debug("Failed to query meter wide events", {
+			error: error instanceof Error ? error.message : String(error),
+			agentId: query.agentId,
+			surface: query.surface,
+		});
+		return null;
+	}
+}
+
+export async function getRemoteMeterEventDashboard(
+	query: RemoteMeterWideEventQuery = {},
+): Promise<RemoteMeterEventDashboardResult | null> {
+	const config = await resolveRemoteMeterConfig();
+	if (!config) {
+		return null;
+	}
+
+	try {
+		return await postMeter<RemoteMeterEventDashboardResult>(
+			config,
+			GET_EVENT_DASHBOARD_PATH,
+			buildWideEventQueryBody(config, query),
+		);
+	} catch (error) {
+		logger.debug("Failed to fetch meter event dashboard", {
+			error: error instanceof Error ? error.message : String(error),
+			agentId: query.agentId,
+			surface: query.surface,
+		});
+		return null;
+	}
 }
 
 export async function mirrorCanonicalTurnEventToMeter(
@@ -184,38 +292,11 @@ export async function mirrorCanonicalTurnEventToMeter(
 	}
 
 	try {
-		const response = await fetch(`${config.baseUrl}${INGEST_WIDE_EVENT_PATH}`, {
-			method: "POST",
-			headers: buildHeaders(config),
-			body: JSON.stringify({
-				timestamp: event.timestamp,
-				teamId: config.teamId,
-				agentId: MAESTRO_AGENT_ID,
-				surface: MAESTRO_SURFACE,
-				eventType: event.type,
-				model: event.model.id,
-				provider: event.model.provider,
-				requestId: event.turnId,
-				metadata: buildMetadata(event),
-				data: event,
-				metrics: {
-					inputTokens: toNonNegativeInt(event.tokens.input),
-					outputTokens: toNonNegativeInt(event.tokens.output),
-					cacheReadTokens: toNonNegativeInt(event.tokens.cacheRead),
-					cacheWriteTokens: toNonNegativeInt(event.tokens.cacheWrite),
-					totalCostUsd: event.costUsd,
-					durationMs: toNonNegativeInt(event.totalDurationMs),
-					toolCallsCount: toNonNegativeInt(event.toolCount),
-				},
-			}),
-			signal: AbortSignal.timeout(config.timeoutMs),
-		});
-		if (!response.ok) {
-			const text = await response.text();
-			throw new Error(
-				`meter service returned ${response.status}: ${text || response.statusText}`,
-			);
-		}
+		await postMeter(
+			config,
+			INGEST_WIDE_EVENT_PATH,
+			buildWideEventBody(config, event),
+		);
 		return true;
 	} catch (error) {
 		logger.debug(

--- a/src/telemetry/meter-service-client.ts
+++ b/src/telemetry/meter-service-client.ts
@@ -221,7 +221,6 @@ async function postMeter<T>(
 		stripUndefinedValues(body),
 		{
 			serviceName: "meter service",
-			failureMode: "optional",
 			timeoutMs: config.timeoutMs,
 			maxAttempts: config.maxAttempts,
 		},

--- a/test/auth/auth-resolver.test.ts
+++ b/test/auth/auth-resolver.test.ts
@@ -55,6 +55,12 @@ describe("auth resolver", () => {
 			process.env.CODEX_API_KEY = originalCodex;
 		}
 		Reflect.deleteProperty(process.env, "EVALOPS_FEATURE_FLAGS_PATH");
+		Reflect.deleteProperty(process.env, "MAESTRO_AGENT_ID");
+		Reflect.deleteProperty(process.env, "MAESTRO_EVALOPS_AGENT_ID");
+		Reflect.deleteProperty(process.env, "MAESTRO_EVALOPS_RUN_ID");
+		Reflect.deleteProperty(process.env, "MAESTRO_EVALOPS_SURFACE");
+		Reflect.deleteProperty(process.env, "MAESTRO_SESSION_ID");
+		Reflect.deleteProperty(process.env, "MAESTRO_SURFACE");
 		resetFeatureFlagCacheForTests();
 		vi.clearAllMocks();
 	});
@@ -177,6 +183,9 @@ describe("auth resolver", () => {
 			"X-Organization-ID": "org_evalops",
 		});
 		expect(credential?.requestBody).toEqual({
+			metadata: {
+				surface: "maestro",
+			},
 			provider_ref: {
 				provider: "openai",
 				environment: "prod",
@@ -223,6 +232,9 @@ describe("auth resolver", () => {
 				definition.usesAnthropicOAuth ? "anthropic-oauth" : "api-key",
 			);
 			expect(credential?.requestBody).toEqual({
+				metadata: {
+					surface: "maestro",
+				},
 				provider_ref: {
 					provider: definition.providerRefProvider,
 					environment: "prod",
@@ -253,6 +265,9 @@ describe("auth resolver", () => {
 		const resolver = createAuthResolver({ mode: "auto" });
 		const credential = await resolver("evalops-openrouter");
 		expect(credential?.requestBody).toEqual({
+			metadata: {
+				surface: "maestro",
+			},
 			provider_ref: {
 				provider: "openrouter",
 				environment: "prod",
@@ -262,6 +277,47 @@ describe("auth resolver", () => {
 		});
 		Reflect.deleteProperty(process.env, "MAESTRO_EVALOPS_CREDENTIAL_NAME");
 		Reflect.deleteProperty(process.env, "MAESTRO_EVALOPS_TEAM_ID");
+		mockedGetToken.mockReset();
+		mockedLoadCreds.mockReset();
+	});
+
+	it("passes EvalOps managed request metadata for LLM gateway attribution", async () => {
+		const mockedGetToken = vi.mocked(getOAuthToken);
+		const mockedLoadCreds = vi.mocked(loadOAuthCredentials);
+		process.env.MAESTRO_AGENT_ID = "agent_cli";
+		process.env.MAESTRO_EVALOPS_RUN_ID = "run_123";
+		process.env.MAESTRO_SESSION_ID = "session_456";
+		process.env.MAESTRO_SURFACE = "cli";
+		mockedGetToken.mockResolvedValue("evalops-token");
+		mockedLoadCreds.mockReturnValue({
+			type: "oauth",
+			access: "evalops-token",
+			refresh: "",
+			expires: Date.now() + 60_000,
+			metadata: {
+				organizationId: "org_evalops",
+				providerRef: {
+					provider: "openai",
+					environment: "prod",
+				},
+			},
+		});
+
+		const resolver = createAuthResolver({ mode: "auto" });
+		const credential = await resolver("evalops");
+
+		expect(credential?.requestBody).toEqual({
+			metadata: {
+				agent_id: "agent_cli",
+				run_id: "run_123",
+				session_id: "session_456",
+				surface: "cli",
+			},
+			provider_ref: {
+				provider: "openai",
+				environment: "prod",
+			},
+		});
 		mockedGetToken.mockReset();
 		mockedLoadCreds.mockReset();
 	});

--- a/test/memory/service-client.test.ts
+++ b/test/memory/service-client.test.ts
@@ -22,6 +22,7 @@ describe("memory service client", () => {
 	afterEach(() => {
 		Reflect.deleteProperty(process.env, "MAESTRO_MEMORY_BASE");
 		Reflect.deleteProperty(process.env, "MAESTRO_MEMORY_ACCESS_TOKEN");
+		Reflect.deleteProperty(process.env, "MAESTRO_MEMORY_AGENT_ID");
 		Reflect.deleteProperty(process.env, "MAESTRO_EVALOPS_ORG_ID");
 		Reflect.deleteProperty(process.env, "MAESTRO_MEMORY_TEAM_ID");
 		vi.unstubAllGlobals();
@@ -79,10 +80,23 @@ describe("memory service client", () => {
 		);
 
 		expect(requests[0]?.url).toContain("/v1/memories?");
+		expect(requests[0]?.url).toContain("agent_id=maestro");
+		expect(requests[0]?.url).toContain("review_status=approved");
 		expect(requests[1]?.method).toBe("POST");
 		const createBody = JSON.parse(String(requests[1]?.body));
 		expect(createBody.repository).toBeTruthy();
 		expect(createBody.agent).toBe("maestro");
+		expect(createBody.agent_id).toBe("maestro");
+		expect(createBody.review_status).toBe("approved");
+		expect(createBody.source_references).toEqual([
+			expect.objectContaining({
+				type: "maestro-durable-memory",
+				metadata: expect.objectContaining({
+					source: "maestro",
+					topic: "team-preferences",
+				}),
+			}),
+		]);
 		expect(createBody.tags).toEqual(
 			expect.arrayContaining([
 				"auto",
@@ -105,9 +119,15 @@ describe("memory service client", () => {
 	});
 
 	it("updates matching remote durable memories when metadata changes", async () => {
+		const requests: Array<{ body?: string; method?: string; url: string }> = [];
 		const fetchMock = vi.fn(
 			async (input: RequestInfo | URL, init?: RequestInit) => {
 				const url = typeof input === "string" ? input : input.toString();
+				requests.push({
+					url,
+					method: init?.method,
+					body: typeof init?.body === "string" ? init.body : undefined,
+				});
 				if (url.includes("/v1/memories?")) {
 					return new Response(
 						JSON.stringify({
@@ -170,6 +190,19 @@ describe("memory service client", () => {
 		);
 
 		expect(fetchMock).toHaveBeenCalledTimes(2);
+		const updateBody = JSON.parse(String(requests[1]?.body));
+		expect(updateBody.review_status).toBe("approved");
+		expect(updateBody.source_references).toEqual([
+			expect.objectContaining({
+				type: "maestro-durable-memory",
+				metadata: expect.objectContaining({
+					projectId: "repo_123",
+					projectName: "maestro",
+					source: "maestro",
+					topic: "team-preferences",
+				}),
+			}),
+		]);
 		expect(result).toMatchObject({
 			created: false,
 			updated: true,
@@ -183,9 +216,15 @@ describe("memory service client", () => {
 	});
 
 	it("recalls remote durable memories for the current repository scope", async () => {
+		const requests: Array<{ body?: string; method?: string; url: string }> = [];
 		const fetchMock = vi.fn(
 			async (input: RequestInfo | URL, init?: RequestInit) => {
 				const url = typeof input === "string" ? input : input.toString();
+				requests.push({
+					url,
+					method: init?.method,
+					body: typeof init?.body === "string" ? init.body : undefined,
+				});
 				if (url.endsWith("/v1/memories/recall")) {
 					const body = JSON.parse(String(init?.body));
 					return new Response(
@@ -235,6 +274,9 @@ describe("memory service client", () => {
 		);
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const recallBody = JSON.parse(String(requests[0]?.body));
+		expect(recallBody.agent_id).toBe("maestro");
+		expect(recallBody.review_status).toBe("approved");
 		expect(results).toEqual([
 			expect.objectContaining({
 				score: 0.73,

--- a/test/prompts/service-client.test.ts
+++ b/test/prompts/service-client.test.ts
@@ -16,6 +16,13 @@ describe("prompts service client", () => {
 		delete process.env.PROMPTS_SERVICE_TOKEN;
 		delete process.env.PROMPTS_SERVICE_ORGANIZATION_ID;
 		delete process.env.PROMPTS_SERVICE_TIMEOUT_MS;
+		delete process.env.PROMPTS_SERVICE_TRANSPORT;
+		delete process.env.MAESTRO_PLATFORM_BASE_URL;
+		delete process.env.MAESTRO_PROMPTS_SERVICE_URL;
+		delete process.env.MAESTRO_PROMPTS_SERVICE_TOKEN;
+		delete process.env.MAESTRO_PROMPTS_ORGANIZATION_ID;
+		delete process.env.MAESTRO_EVALOPS_ACCESS_TOKEN;
+		delete process.env.MAESTRO_EVALOPS_ORG_ID;
 		vi.unstubAllGlobals();
 	});
 
@@ -25,10 +32,12 @@ describe("prompts service client", () => {
 				"http://prompts.test/v1/resolve?name=maestro-system&env=production&surface=maestro",
 			);
 			expect(init?.method).toBe("GET");
-			expect(init?.headers).toEqual({
-				Authorization: "Bearer prompts-token",
-				"X-Organization-ID": "org_123",
-			});
+			expect(init?.headers).toEqual(
+				expect.objectContaining({
+					Authorization: "Bearer prompts-token",
+					"X-Organization-ID": "org_123",
+				}),
+			);
 			return new Response(
 				JSON.stringify({
 					version: {
@@ -58,6 +67,64 @@ describe("prompts service client", () => {
 			version: 7,
 			versionId: "ver_7",
 			content: "Resolved system instructions",
+		});
+	});
+
+	it("resolves prompt versions through the shared Platform Connect endpoint", async () => {
+		delete process.env.PROMPTS_SERVICE_URL;
+		delete process.env.PROMPTS_SERVICE_TOKEN;
+		delete process.env.PROMPTS_SERVICE_ORGANIZATION_ID;
+		process.env.PROMPTS_SERVICE_TRANSPORT = "connect";
+		process.env.MAESTRO_PLATFORM_BASE_URL = "http://platform.test/";
+		process.env.MAESTRO_EVALOPS_ACCESS_TOKEN = "platform-token";
+		process.env.MAESTRO_EVALOPS_ORG_ID = "org_platform";
+
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+			expect(String(input)).toBe(
+				"http://platform.test/prompts.v1.PromptService/Resolve",
+			);
+			expect(init?.method).toBe("POST");
+			expect(init?.headers).toEqual(
+				expect.objectContaining({
+					Authorization: "Bearer platform-token",
+					"Connect-Protocol-Version": "1",
+					"Content-Type": "application/json",
+					"X-Organization-ID": "org_platform",
+				}),
+			);
+			expect(JSON.parse(String(init?.body ?? "{}"))).toEqual({
+				name: "maestro-system",
+				label: "production",
+			});
+			return new Response(
+				JSON.stringify({
+					version: {
+						id: "ver_platform_9",
+						version: 9,
+						content: "Platform resolved system instructions",
+					},
+				}),
+				{
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await resolvePromptTemplate({
+			name: "maestro-system",
+			label: "production",
+			surface: "maestro",
+		});
+
+		expect(result).toEqual({
+			name: "maestro-system",
+			label: "production",
+			surface: "maestro",
+			version: 9,
+			versionId: "ver_platform_9",
+			content: "Platform resolved system instructions",
 		});
 	});
 

--- a/test/prompts/service-client.test.ts
+++ b/test/prompts/service-client.test.ts
@@ -243,7 +243,9 @@ describe("prompts service client", () => {
 
 		expect(fetchMock).not.toHaveBeenCalled();
 		expect(logSpy).toHaveBeenCalledWith(
-			expect.stringContaining("Prompts service configured without access token"),
+			expect.stringContaining(
+				"Prompts service configured without access token",
+			),
 		);
 	});
 });

--- a/test/prompts/service-client.test.ts
+++ b/test/prompts/service-client.test.ts
@@ -25,6 +25,9 @@ describe("prompts service client", () => {
 		delete process.env.MAESTRO_PROMPTS_ORGANIZATION_ID;
 		delete process.env.MAESTRO_EVALOPS_ACCESS_TOKEN;
 		delete process.env.MAESTRO_EVALOPS_ORG_ID;
+		delete process.env.MAESTRO_HOME;
+		delete process.env.EVALOPS_TOKEN;
+		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
 	});
 
@@ -39,6 +42,9 @@ describe("prompts service client", () => {
 					Authorization: "Bearer prompts-token",
 					"X-Organization-ID": "org_123",
 				}),
+			);
+			expect(init?.headers).not.toEqual(
+				expect.objectContaining({ "Content-Type": "application/json" }),
 			);
 			return new Response(
 				JSON.stringify({
@@ -196,5 +202,48 @@ describe("prompts service client", () => {
 			}),
 		).resolves.toBeNull();
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("warns when configured prompt service is missing an organization id", async () => {
+		delete process.env.PROMPTS_SERVICE_ORGANIZATION_ID;
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			resolvePromptTemplate({
+				name: "maestro-system",
+				label: "production",
+				surface: "maestro",
+			}),
+		).resolves.toBeNull();
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(logSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				"Prompts service configured without organization id",
+			),
+		);
+	});
+
+	it("warns when configured prompt service is missing an access token", async () => {
+		delete process.env.PROMPTS_SERVICE_TOKEN;
+		process.env.MAESTRO_HOME = "/tmp/maestro-prompts-test-no-oauth";
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			resolvePromptTemplate({
+				name: "maestro-system",
+				label: "production",
+				surface: "maestro",
+			}),
+		).resolves.toBeNull();
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(logSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Prompts service configured without access token"),
+		);
 	});
 });

--- a/test/prompts/service-client.test.ts
+++ b/test/prompts/service-client.test.ts
@@ -8,6 +8,7 @@ describe("prompts service client", () => {
 		process.env.PROMPTS_SERVICE_TOKEN = "prompts-token";
 		process.env.PROMPTS_SERVICE_ORGANIZATION_ID = "org_123";
 		process.env.PROMPTS_SERVICE_TIMEOUT_MS = "2400";
+		process.env.PROMPTS_SERVICE_MAX_ATTEMPTS = "2";
 		vi.unstubAllGlobals();
 	});
 
@@ -16,6 +17,7 @@ describe("prompts service client", () => {
 		delete process.env.PROMPTS_SERVICE_TOKEN;
 		delete process.env.PROMPTS_SERVICE_ORGANIZATION_ID;
 		delete process.env.PROMPTS_SERVICE_TIMEOUT_MS;
+		delete process.env.PROMPTS_SERVICE_MAX_ATTEMPTS;
 		delete process.env.PROMPTS_SERVICE_TRANSPORT;
 		delete process.env.MAESTRO_PLATFORM_BASE_URL;
 		delete process.env.MAESTRO_PROMPTS_SERVICE_URL;
@@ -67,6 +69,44 @@ describe("prompts service client", () => {
 			version: 7,
 			versionId: "ver_7",
 			content: "Resolved system instructions",
+		});
+	});
+
+	it("retries legacy REST prompt resolution based on configured attempts", async () => {
+		const fetchMock = vi
+			.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>()
+			.mockRejectedValueOnce(new Error("temporary network failure"))
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						version: {
+							id: "ver_retry_8",
+							version: 8,
+							content: "Resolved after retry",
+						},
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await resolvePromptTemplate({
+			name: "maestro-system",
+			label: "production",
+			surface: "maestro",
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result).toEqual({
+			name: "maestro-system",
+			label: "production",
+			surface: "maestro",
+			version: 8,
+			versionId: "ver_retry_8",
+			content: "Resolved after retry",
 		});
 	});
 

--- a/test/telemetry/meter-service-client.test.ts
+++ b/test/telemetry/meter-service-client.test.ts
@@ -106,9 +106,7 @@ describe("meter telemetry client", () => {
 	});
 
 	it("treats empty successful ingest responses as mirrored", async () => {
-		const fetchMock = vi.fn(
-			async () => new Response(null, { status: 204 }),
-		);
+		const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
 		vi.stubGlobal("fetch", fetchMock);
 
 		const result = await mirrorCanonicalTurnEventToMeter(

--- a/test/telemetry/meter-service-client.test.ts
+++ b/test/telemetry/meter-service-client.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	getRemoteMeterEventDashboard,
 	hasRemoteMeterDestination,
 	mirrorCanonicalTurnEventToMeter,
+	queryRemoteMeterWideEvents,
 } from "../../src/telemetry/meter-service-client.js";
 import { TurnCollector } from "../../src/telemetry/wide-events.js";
 
@@ -101,6 +103,75 @@ describe("meter telemetry client", () => {
 
 		expect(result).toBe(true);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("queries wide events through the shared meter service", async () => {
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+			expect(String(input)).toBe(
+				"http://meter.test/meter.v1.MeterService/QueryWideEvents",
+			);
+			expect(init?.headers).toEqual(
+				expect.objectContaining({
+					Authorization: "Bearer meter-token",
+					"Connect-Protocol-Version": "1",
+					"X-Organization-ID": "org_evalops",
+				}),
+			);
+			expect(JSON.parse(String(init?.body ?? "{}"))).toEqual({
+				teamId: "team_ops",
+				agentId: "maestro",
+				eventType: "canonical-turn",
+				limit: 10,
+			});
+			return new Response(
+				JSON.stringify({
+					events: [{ id: "wide_event_1" }],
+					total: 1,
+					hasMore: false,
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			queryRemoteMeterWideEvents({
+				agentId: "maestro",
+				eventType: "canonical-turn",
+				limit: 10,
+			}),
+		).resolves.toEqual({
+			events: [{ id: "wide_event_1" }],
+			total: 1,
+			hasMore: false,
+		});
+	});
+
+	it("fetches the meter dashboard through the shared meter service", async () => {
+		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+			expect(String(input)).toBe(
+				"http://meter.test/meter.v1.MeterService/GetEventDashboard",
+			);
+			expect(JSON.parse(String(init?.body ?? "{}"))).toEqual({
+				teamId: "team_ops",
+				surface: "maestro",
+			});
+			return new Response(
+				JSON.stringify({
+					totalEvents: 2,
+					bySurface: [{ surface: "maestro", count: 2 }],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			getRemoteMeterEventDashboard({ surface: "maestro" }),
+		).resolves.toEqual({
+			totalEvents: 2,
+			bySurface: [{ surface: "maestro", count: 2 }],
+		});
 	});
 
 	it("skips remote mirroring when required meter config is missing", async () => {

--- a/test/telemetry/meter-service-client.test.ts
+++ b/test/telemetry/meter-service-client.test.ts
@@ -105,6 +105,38 @@ describe("meter telemetry client", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
+	it("treats empty successful ingest responses as mirrored", async () => {
+		const fetchMock = vi.fn(
+			async () => new Response(null, { status: 204 }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await mirrorCanonicalTurnEventToMeter(
+			createCanonicalTurnEvent(),
+		);
+
+		expect(result).toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("treats non-JSON successful ingest responses as mirrored", async () => {
+		const fetchMock = vi.fn(
+			async () =>
+				new Response("accepted", {
+					status: 202,
+					headers: { "Content-Type": "text/plain" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await mirrorCanonicalTurnEventToMeter(
+			createCanonicalTurnEvent(),
+		);
+
+		expect(result).toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("queries wide events through the shared meter service", async () => {
 		const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
 			expect(String(input)).toBe(


### PR DESCRIPTION
## Summary
- add a shared Platform service client for base URL/token/org/team resolution and Connect JSON calls
- route prompts through the Platform PromptService when configured, while preserving the legacy REST endpoint
- enrich remote memory calls with Maestro agent attribution, approved review status, and source references
- extend meter integration with Platform query/dashboard calls and configurable agent/surface metadata
- attach delegated EvalOps agent/run metadata to managed LLM gateway requests

## Validation
- `npm test -- test/prompts/service-client.test.ts test/telemetry/meter-service-client.test.ts test/memory/service-client.test.ts test/auth/auth-resolver.test.ts`
- `bun run --filter @evalops/contracts build && bun run --filter @evalops/tui build && npx tsc -p tsconfig.build.json --noEmit`
- `npx biome check --write <touched files>`
- `git diff --check`

## Platform note
No Platform repository patch was required for this slice: the reviewed PromptService, MeterService, Memory REST fields, identity delegation metadata, and LLM gateway metadata path already support the Maestro-side integration.
