### PR TITLE
Add Platform core services smoke test

### DIFF
--- a/test/platform/core-services-smoke.test.ts
+++ b/test/platform/core-services-smoke.test.ts
@@ -1,0 +1,258 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { recallRemoteDurableMemories } from "../../src/memory/service-client.js";
+import { resolvePromptTemplate } from "../../src/prompts/service-client.js";
+import {
+	hasRemoteMeterDestination,
+	mirrorCanonicalTurnEventToMeter,
+} from "../../src/telemetry/meter-service-client.js";
+import { TurnCollector } from "../../src/telemetry/wide-events.js";
+
+type CapturedRequest = {
+	body?: Record<string, unknown>;
+	headers: Record<string, string>;
+	method?: string;
+	pathname: string;
+	url: string;
+};
+
+function headersToRecord(
+	headers: HeadersInit | undefined,
+): Record<string, string> {
+	return Object.fromEntries(new Headers(headers).entries());
+}
+
+function parseRequestBody(
+	body: BodyInit | null | undefined,
+): Record<string, unknown> | undefined {
+	return typeof body === "string"
+		? (JSON.parse(body) as Record<string, unknown>)
+		: undefined;
+}
+
+function createCanonicalTurnEvent() {
+	return new TurnCollector("session-platform-smoke", 1)
+		.setModel({
+			id: "gpt-5.4",
+			provider: "openai",
+			thinkingLevel: "medium",
+		})
+		.setSandboxMode("workspace-write")
+		.setApprovalMode("on-request")
+		.complete(
+			"success",
+			{
+				input: 42,
+				output: 21,
+				cacheRead: 2,
+				cacheWrite: 1,
+			},
+			0.04,
+		);
+}
+
+describe("Platform core service integration smoke", () => {
+	let repoRoot: string;
+
+	beforeEach(() => {
+		repoRoot = mkdtempSync(join(tmpdir(), "maestro-platform-smoke-"));
+		execSync("git init -b main", {
+			cwd: repoRoot,
+			stdio: "ignore",
+		});
+
+		for (const name of [
+			"PROMPTS_SERVICE_URL",
+			"PROMPTS_SERVICE_TOKEN",
+			"PROMPTS_SERVICE_ORGANIZATION_ID",
+			"MAESTRO_PROMPTS_SERVICE_URL",
+			"MAESTRO_PROMPTS_SERVICE_TOKEN",
+			"MAESTRO_PROMPTS_ORGANIZATION_ID",
+			"MAESTRO_MEMORY_BASE",
+			"MAESTRO_MEMORY_ACCESS_TOKEN",
+			"MAESTRO_MEMORY_ORGANIZATION_ID",
+			"MAESTRO_METER_BASE",
+			"MAESTRO_METER_ACCESS_TOKEN",
+			"MAESTRO_METER_ORGANIZATION_ID",
+		]) {
+			vi.stubEnv(name, "");
+		}
+
+		vi.stubEnv("PROMPTS_SERVICE_TRANSPORT", "connect");
+		vi.stubEnv("MAESTRO_PLATFORM_BASE_URL", "http://platform-smoke.test/");
+		vi.stubEnv("MAESTRO_EVALOPS_ACCESS_TOKEN", "platform-token");
+		vi.stubEnv("MAESTRO_EVALOPS_ORG_ID", "org_platform");
+		vi.stubEnv("MAESTRO_EVALOPS_TEAM_ID", "team_platform");
+		vi.stubEnv("MAESTRO_AGENT_ID", "maestro-smoke");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+		rmSync(repoRoot, { recursive: true, force: true });
+	});
+
+	it("drives prompts, memory, and meter from shared Platform configuration", async () => {
+		const requests: CapturedRequest[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				const request = {
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				};
+				requests.push(request);
+
+				if (parsed.pathname === "/prompts.v1.PromptService/Resolve") {
+					return new Response(
+						JSON.stringify({
+							version: {
+								id: "ver_smoke_1",
+								version: 1,
+								content: "Platform smoke prompt",
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (parsed.pathname === "/v1/memories/recall") {
+					return new Response(
+						JSON.stringify({
+							query: request.body?.query,
+							total: 1,
+							memories: [
+								{
+									id: "mem_smoke_1",
+									organization_id: "org_platform",
+									type: "project",
+									content: "Use Platform core services for Maestro.",
+									repository: request.body?.repository,
+									agent: "maestro",
+									score: 0.82,
+									tags: [
+										"source:maestro",
+										"maestro-kind:durable-memory",
+										"maestro-topic:platform-core",
+									],
+									created_at: "2026-04-21T00:00:00.000Z",
+									updated_at: "2026-04-21T00:00:00.000Z",
+								},
+							],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (parsed.pathname === "/meter.v1.MeterService/IngestWideEvent") {
+					return new Response(null, { status: 204 });
+				}
+
+				throw new Error(`Unexpected Platform smoke request: ${url}`);
+			}),
+		);
+
+		await expect(
+			resolvePromptTemplate({
+				name: "maestro-system",
+				label: "production",
+				surface: "maestro",
+			}),
+		).resolves.toEqual({
+			name: "maestro-system",
+			label: "production",
+			surface: "maestro",
+			version: 1,
+			versionId: "ver_smoke_1",
+			content: "Platform smoke prompt",
+		});
+
+		await expect(
+			recallRemoteDurableMemories("platform core services", {
+				cwd: repoRoot,
+				limit: 2,
+			}),
+		).resolves.toEqual([
+			expect.objectContaining({
+				score: 0.82,
+				entry: expect.objectContaining({
+					content: "Use Platform core services for Maestro.",
+					topic: "platform-core",
+				}),
+			}),
+		]);
+
+		expect(hasRemoteMeterDestination()).toBe(true);
+		await expect(
+			mirrorCanonicalTurnEventToMeter(createCanonicalTurnEvent()),
+		).resolves.toBe(true);
+
+		const promptRequest = requests.find(
+			(request) => request.pathname === "/prompts.v1.PromptService/Resolve",
+		);
+		const memoryRequest = requests.find(
+			(request) => request.pathname === "/v1/memories/recall",
+		);
+		const meterRequest = requests.find(
+			(request) =>
+				request.pathname === "/meter.v1.MeterService/IngestWideEvent",
+		);
+
+		expect(promptRequest).toMatchObject({
+			method: "POST",
+			headers: expect.objectContaining({
+				authorization: "Bearer platform-token",
+				"connect-protocol-version": "1",
+				"content-type": "application/json",
+				"x-organization-id": "org_platform",
+			}),
+			body: {
+				name: "maestro-system",
+				label: "production",
+			},
+		});
+		expect(memoryRequest).toMatchObject({
+			method: "POST",
+			headers: expect.objectContaining({
+				authorization: "Bearer platform-token",
+				"content-type": "application/json",
+				"x-organization-id": "org_platform",
+			}),
+			body: expect.objectContaining({
+				agent: "maestro",
+				agent_id: "maestro-smoke",
+				limit: 2,
+				query: "platform core services",
+				review_status: "approved",
+				team_id: "team_platform",
+				type: "project",
+			}),
+		});
+		expect(memoryRequest?.headers).not.toHaveProperty(
+			"connect-protocol-version",
+		);
+		expect(meterRequest).toMatchObject({
+			method: "POST",
+			headers: expect.objectContaining({
+				authorization: "Bearer platform-token",
+				"connect-protocol-version": "1",
+				"content-type": "application/json",
+				"x-organization-id": "org_platform",
+			}),
+			body: expect.objectContaining({
+				agentId: "maestro-smoke",
+				eventType: "canonical-turn",
+				surface: "maestro",
+				teamId: "team_platform",
+			}),
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add a single smoke test proving shared Platform env config drives prompt resolution, memory recall, and meter mirroring together
- assert Connect headers for prompts/meter and the existing HTTP JSON memory boundary with shared auth/org/team metadata

## Validation
- npm test -- test/platform/core-services-smoke.test.ts test/prompts/service-client.test.ts test/telemetry/meter-service-client.test.ts test/memory/service-client.test.ts
- npm exec --yes --package=bun@1.3.6 -- sh -lc 'bun run --filter @evalops/contracts build && bun run --filter @evalops/tui build && bun run --filter @evalops/ai build'
- npx tsc -p tsconfig.build.json --noEmit
- git diff --check