### PR TITLE
Centralize Platform core service paths

### DIFF
--- a/src/platform/core-services.ts
+++ b/src/platform/core-services.ts
@@ -1,0 +1,128 @@
+export interface PlatformConnectMethodDescriptor {
+	readonly service: string;
+	readonly method: string;
+}
+
+export const PLATFORM_CONNECT_SERVICES = {
+	approvals: "approvals.v1.ApprovalService",
+	connectors: "connectors.v1.ConnectorService",
+	governance: "governance.v1.GovernanceService",
+	llmGateway: "llmgateway.v1.GatewayService",
+	meter: "meter.v1.MeterService",
+	prompts: "prompts.v1.PromptService",
+} as const;
+
+export const PLATFORM_CONNECT_METHODS = {
+	approvals: {
+		requestApproval: {
+			service: PLATFORM_CONNECT_SERVICES.approvals,
+			method: "RequestApproval",
+		},
+		resolveApproval: {
+			service: PLATFORM_CONNECT_SERVICES.approvals,
+			method: "ResolveApproval",
+		},
+	},
+	connectors: {
+		getCapabilities: {
+			service: PLATFORM_CONNECT_SERVICES.connectors,
+			method: "GetCapabilities",
+		},
+		getConnection: {
+			service: PLATFORM_CONNECT_SERVICES.connectors,
+			method: "GetConnection",
+		},
+		getDegradedReadPolicy: {
+			service: PLATFORM_CONNECT_SERVICES.connectors,
+			method: "GetDegradedReadPolicy",
+		},
+		getHealth: {
+			service: PLATFORM_CONNECT_SERVICES.connectors,
+			method: "GetHealth",
+		},
+		listConnections: {
+			service: PLATFORM_CONNECT_SERVICES.connectors,
+			method: "ListConnections",
+		},
+		refreshConnection: {
+			service: PLATFORM_CONNECT_SERVICES.connectors,
+			method: "RefreshConnection",
+		},
+		registerConnection: {
+			service: PLATFORM_CONNECT_SERVICES.connectors,
+			method: "RegisterConnection",
+		},
+		resolveSourceOfTruth: {
+			service: PLATFORM_CONNECT_SERVICES.connectors,
+			method: "ResolveSourceOfTruth",
+		},
+		revokeConnection: {
+			service: PLATFORM_CONNECT_SERVICES.connectors,
+			method: "RevokeConnection",
+		},
+	},
+	governance: {
+		evaluateAction: {
+			service: PLATFORM_CONNECT_SERVICES.governance,
+			method: "EvaluateAction",
+		},
+	},
+	llmGateway: {
+		createChatCompletion: {
+			service: PLATFORM_CONNECT_SERVICES.llmGateway,
+			method: "CreateChatCompletion",
+		},
+		createEmbedding: {
+			service: PLATFORM_CONNECT_SERVICES.llmGateway,
+			method: "CreateEmbedding",
+		},
+		createMessage: {
+			service: PLATFORM_CONNECT_SERVICES.llmGateway,
+			method: "CreateMessage",
+		},
+		createResponse: {
+			service: PLATFORM_CONNECT_SERVICES.llmGateway,
+			method: "CreateResponse",
+		},
+		getInfo: {
+			service: PLATFORM_CONNECT_SERVICES.llmGateway,
+			method: "GetInfo",
+		},
+	},
+	meter: {
+		getEventDashboard: {
+			service: PLATFORM_CONNECT_SERVICES.meter,
+			method: "GetEventDashboard",
+		},
+		ingestWideEvent: {
+			service: PLATFORM_CONNECT_SERVICES.meter,
+			method: "IngestWideEvent",
+		},
+		queryWideEvents: {
+			service: PLATFORM_CONNECT_SERVICES.meter,
+			method: "QueryWideEvents",
+		},
+	},
+	prompts: {
+		resolve: {
+			service: PLATFORM_CONNECT_SERVICES.prompts,
+			method: "Resolve",
+		},
+	},
+} as const;
+
+export const PLATFORM_HTTP_ROUTES = {
+	memory: {
+		recall: "/v1/memories/recall",
+	},
+} as const;
+
+export function platformConnectServicePath(service: string): string {
+	return `/${service}`;
+}
+
+export function platformConnectMethodPath(
+	descriptor: PlatformConnectMethodDescriptor,
+): string {
+	return `${platformConnectServicePath(descriptor.service)}/${descriptor.method}`;
+}

--- a/src/prompts/service-client.ts
+++ b/src/prompts/service-client.ts
@@ -7,6 +7,12 @@ import {
 	resolvePlatformServiceConfig,
 	trimString,
 } from "../platform/client.js";
+import {
+	PLATFORM_CONNECT_METHODS,
+	PLATFORM_CONNECT_SERVICES,
+	platformConnectMethodPath,
+	platformConnectServicePath,
+} from "../platform/core-services.js";
 import { createLogger } from "../utils/logger.js";
 import type {
 	ResolvePromptTemplateInput,
@@ -16,7 +22,9 @@ import type {
 const logger = createLogger("prompts:service");
 const DEFAULT_TIMEOUT_MS = 2_000;
 const DEFAULT_MAX_ATTEMPTS = 2;
-const RESOLVE_PROMPT_PATH = "/prompts.v1.PromptService/Resolve";
+const RESOLVE_PROMPT_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.prompts.resolve,
+);
 const LEGACY_RESOLVE_PROMPT_PATH = "/v1/resolve";
 const PROMPTS_BASE_URL_ENV_VARS = [
 	"PROMPTS_SERVICE_URL",
@@ -108,7 +116,7 @@ async function resolvePromptsServiceConfig(): Promise<PromptsServiceConfig | nul
 		baseUrlSuffixes: [
 			RESOLVE_PROMPT_PATH,
 			LEGACY_RESOLVE_PROMPT_PATH,
-			"/prompts.v1.PromptService",
+			platformConnectServicePath(PLATFORM_CONNECT_SERVICES.prompts),
 		],
 		defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
 		defaultMaxAttempts: DEFAULT_MAX_ATTEMPTS,

--- a/src/telemetry/meter-service-client.ts
+++ b/src/telemetry/meter-service-client.ts
@@ -6,6 +6,12 @@ import {
 	resolveOrganizationId,
 	resolvePlatformServiceConfig,
 } from "../platform/client.js";
+import {
+	PLATFORM_CONNECT_METHODS,
+	PLATFORM_CONNECT_SERVICES,
+	platformConnectMethodPath,
+	platformConnectServicePath,
+} from "../platform/core-services.js";
 import { createLogger } from "../utils/logger.js";
 import type { CanonicalTurnEvent } from "./wide-events.js";
 
@@ -13,9 +19,15 @@ const logger = createLogger("telemetry:meter");
 
 const DEFAULT_TIMEOUT_MS = 2_000;
 const DEFAULT_MAX_ATTEMPTS = 2;
-const INGEST_WIDE_EVENT_PATH = "/meter.v1.MeterService/IngestWideEvent";
-const QUERY_WIDE_EVENTS_PATH = "/meter.v1.MeterService/QueryWideEvents";
-const GET_EVENT_DASHBOARD_PATH = "/meter.v1.MeterService/GetEventDashboard";
+const INGEST_WIDE_EVENT_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.meter.ingestWideEvent,
+);
+const QUERY_WIDE_EVENTS_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.meter.queryWideEvents,
+);
+const GET_EVENT_DASHBOARD_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.meter.getEventDashboard,
+);
 const MAESTRO_AGENT_ID = "maestro";
 const MAESTRO_SURFACE = "maestro";
 
@@ -83,7 +95,7 @@ async function resolveRemoteMeterConfig(): Promise<RemoteMeterConfig | null> {
 			INGEST_WIDE_EVENT_PATH,
 			QUERY_WIDE_EVENTS_PATH,
 			GET_EVENT_DASHBOARD_PATH,
-			"/meter.v1.MeterService",
+			platformConnectServicePath(PLATFORM_CONNECT_SERVICES.meter),
 		],
 		defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
 		defaultMaxAttempts: DEFAULT_MAX_ATTEMPTS,

--- a/test/platform/core-services-smoke.test.ts
+++ b/test/platform/core-services-smoke.test.ts
@@ -4,12 +4,25 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { recallRemoteDurableMemories } from "../../src/memory/service-client.js";
+import {
+	PLATFORM_CONNECT_METHODS,
+	PLATFORM_HTTP_ROUTES,
+	platformConnectMethodPath,
+} from "../../src/platform/core-services.js";
 import { resolvePromptTemplate } from "../../src/prompts/service-client.js";
 import {
 	hasRemoteMeterDestination,
 	mirrorCanonicalTurnEventToMeter,
 } from "../../src/telemetry/meter-service-client.js";
 import { TurnCollector } from "../../src/telemetry/wide-events.js";
+
+const PROMPTS_RESOLVE_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.prompts.resolve,
+);
+const METER_INGEST_WIDE_EVENT_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.meter.ingestWideEvent,
+);
+const MEMORY_RECALL_PATH = PLATFORM_HTTP_ROUTES.memory.recall;
 
 type CapturedRequest = {
 	body?: Record<string, unknown>;
@@ -111,7 +124,7 @@ describe("Platform core service integration smoke", () => {
 				};
 				requests.push(request);
 
-				if (parsed.pathname === "/prompts.v1.PromptService/Resolve") {
+				if (parsed.pathname === PROMPTS_RESOLVE_PATH) {
 					return new Response(
 						JSON.stringify({
 							version: {
@@ -124,7 +137,7 @@ describe("Platform core service integration smoke", () => {
 					);
 				}
 
-				if (parsed.pathname === "/v1/memories/recall") {
+				if (parsed.pathname === MEMORY_RECALL_PATH) {
 					return new Response(
 						JSON.stringify({
 							query: request.body?.query,
@@ -152,7 +165,7 @@ describe("Platform core service integration smoke", () => {
 					);
 				}
 
-				if (parsed.pathname === "/meter.v1.MeterService/IngestWideEvent") {
+				if (parsed.pathname === METER_INGEST_WIDE_EVENT_PATH) {
 					return new Response(null, { status: 204 });
 				}
 
@@ -196,14 +209,13 @@ describe("Platform core service integration smoke", () => {
 		).resolves.toBe(true);
 
 		const promptRequest = requests.find(
-			(request) => request.pathname === "/prompts.v1.PromptService/Resolve",
+			(request) => request.pathname === PROMPTS_RESOLVE_PATH,
 		);
 		const memoryRequest = requests.find(
-			(request) => request.pathname === "/v1/memories/recall",
+			(request) => request.pathname === MEMORY_RECALL_PATH,
 		);
 		const meterRequest = requests.find(
-			(request) =>
-				request.pathname === "/meter.v1.MeterService/IngestWideEvent",
+			(request) => request.pathname === METER_INGEST_WIDE_EVENT_PATH,
 		);
 
 		expect(promptRequest).toMatchObject({

--- a/test/platform/core-services.test.ts
+++ b/test/platform/core-services.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+	PLATFORM_CONNECT_METHODS,
+	PLATFORM_CONNECT_SERVICES,
+	PLATFORM_HTTP_ROUTES,
+	platformConnectMethodPath,
+	platformConnectServicePath,
+} from "../../src/platform/core-services.js";
+
+describe("Platform core service contract names", () => {
+	it("pins Connect service and method paths used by Maestro clients", () => {
+		expect(platformConnectServicePath(PLATFORM_CONNECT_SERVICES.prompts)).toBe(
+			"/prompts.v1.PromptService",
+		);
+		expect(
+			platformConnectMethodPath(PLATFORM_CONNECT_METHODS.prompts.resolve),
+		).toBe("/prompts.v1.PromptService/Resolve");
+		expect(
+			platformConnectMethodPath(PLATFORM_CONNECT_METHODS.meter.ingestWideEvent),
+		).toBe("/meter.v1.MeterService/IngestWideEvent");
+		expect(
+			platformConnectMethodPath(PLATFORM_CONNECT_METHODS.meter.queryWideEvents),
+		).toBe("/meter.v1.MeterService/QueryWideEvents");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.meter.getEventDashboard,
+			),
+		).toBe("/meter.v1.MeterService/GetEventDashboard");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.approvals.requestApproval,
+			),
+		).toBe("/approvals.v1.ApprovalService/RequestApproval");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.governance.evaluateAction,
+			),
+		).toBe("/governance.v1.GovernanceService/EvaluateAction");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.connectors.listConnections,
+			),
+		).toBe("/connectors.v1.ConnectorService/ListConnections");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.llmGateway.createMessage,
+			),
+		).toBe("/llmgateway.v1.GatewayService/CreateMessage");
+	});
+
+	it("keeps durable memory on the existing HTTP JSON route", () => {
+		expect(PLATFORM_HTTP_ROUTES.memory.recall).toBe("/v1/memories/recall");
+	});
+});


### PR DESCRIPTION
## Summary
- add a shared Platform core service method/path contract for Maestro
- route prompt and meter clients through the shared Connect descriptors
- pin the durable memory HTTP JSON route in the Platform smoke coverage

## Validation
- npm test -- test/platform/core-services.test.ts test/platform/core-services-smoke.test.ts test/prompts/service-client.test.ts test/telemetry/meter-service-client.test.ts test/telemetry/telemetry-meter.test.ts
- bun run --filter @evalops/contracts build && bun run --filter @evalops/tui build && bun run --filter @evalops/ai build
- npx tsc -p tsconfig.build.json --noEmit
- git diff --check
- pre-commit hook with bun 1.3.6