### PR TITLE
Add Platform SDK contract smoke

### DIFF
--- a/docs/BUILD_TESTING.md
+++ b/docs/BUILD_TESTING.md
@@ -78,6 +78,15 @@ Comprehensive build verification script that runs all checks:
 - `VERIFY_PACKAGES=1 bun run verify-build` (includes package verification)
 - `npx nx run maestro:verify-build` (Nx target wrapper)
 
+### 6. Platform SDK Contract Smoke (`scripts/check-platform-sdk-contract.ts`)
+
+Cross-repo smoke test for the generated Platform TypeScript SDK before
+`@evalops/sdk-ts` is available from npm. The script packs `gen/ts` from a
+Platform checkout, runs Platform's SDK package smoke test, installs the tarball,
+and verifies Maestro's core service paths against the generated descriptors.
+
+**Run:** `MAESTRO_PLATFORM_REPO=/path/to/platform npm run platform:sdk-smoke`
+
 ## Usage
 
 ### Local Development

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "verify:headless-proto:sync": "node scripts/verify-headless-proto-sync.mjs",
     "lint:headless-proto": "buf lint && bun run verify:headless-proto:sync && bun run check:headless-proto:generated",
     "lint:evals": "bun run lint:headless-proto && node scripts/verify-evals.js && node scripts/verify-tool-versions.js && node scripts/validate-system-paths.js && node scripts/validate-package-boundaries.js && node scripts/sync-package-metadata.js --check && node scripts/headless-protocol-codegen.mjs --check",
+    "platform:sdk-smoke": "tsx scripts/check-platform-sdk-contract.ts",
     "format": "biome format .",
     "check": "npm run lint && npm run check --workspaces --if-present && tsc -p tsconfig.build.json --noEmit",
     "evals": "npm run build && node scripts/run-evals.js",

--- a/scripts/check-platform-sdk-contract.ts
+++ b/scripts/check-platform-sdk-contract.ts
@@ -1,0 +1,270 @@
+import { execFileSync } from "node:child_process";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+	PLATFORM_CONNECT_METHODS,
+	PLATFORM_CONNECT_SERVICES,
+	PLATFORM_HTTP_ROUTES,
+	platformConnectMethodPath,
+} from "../src/platform/core-services.js";
+
+const EXPECTED_PACKAGE_NAME = "@evalops/sdk-ts";
+
+const serviceModules = {
+	approvals: {
+		specifier: "approvals/v1/approvals_pb",
+		exportName: "ApprovalService",
+	},
+	connectors: {
+		specifier: "connectors/v1/connectors_pb",
+		exportName: "ConnectorService",
+	},
+	governance: {
+		specifier: "governance/v1/governance_pb",
+		exportName: "GovernanceService",
+	},
+	llmGateway: {
+		specifier: "llmgateway/v1/gateway_pb",
+		exportName: "GatewayService",
+	},
+	meter: {
+		specifier: "meter/v1/meter_pb",
+		exportName: "MeterService",
+	},
+	prompts: {
+		specifier: "prompts/v1/prompts_pb",
+		exportName: "PromptService",
+	},
+} as const;
+
+type PlatformServiceKey = keyof typeof serviceModules;
+type SdkService = {
+	typeName: string;
+	methods?: Array<{ name: string }>;
+};
+
+function npmCommand(): string {
+	return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+function nodeCommand(): string {
+	return process.execPath;
+}
+
+function resolvePlatformRepo(): string {
+	const configured =
+		process.env.MAESTRO_PLATFORM_REPO?.trim() ||
+		process.env.PLATFORM_REPO?.trim();
+	if (configured) {
+		return resolve(configured);
+	}
+
+	return resolve(process.cwd(), "..", "platform");
+}
+
+function readJson(path: string): unknown {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function packPlatformSdk(sdkDir: string, tempDir: string): string {
+	execFileSync(npmCommand(), ["ci"], {
+		cwd: sdkDir,
+		stdio: "inherit",
+	});
+	const raw = execFileSync(
+		npmCommand(),
+		["pack", "--json", "--pack-destination", tempDir],
+		{
+			cwd: sdkDir,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "inherit"],
+		},
+	);
+	const packed = JSON.parse(raw) as Array<{ filename?: string }>;
+	const filename = packed[0]?.filename;
+	if (!filename) {
+		throw new Error("npm pack did not return a tarball filename");
+	}
+	return join(tempDir, filename);
+}
+
+function installPackedSdk(tempDir: string, tarball: string): {
+	importPackageModule: (specifier: string) => Promise<Record<string, unknown>>;
+} {
+	const projectDir = join(tempDir, "maestro-platform-sdk-smoke");
+	mkdirSync(projectDir);
+	writeFileSync(
+		join(projectDir, "package.json"),
+		JSON.stringify(
+			{ name: "maestro-platform-sdk-smoke", private: true, type: "module" },
+			null,
+			2,
+		),
+	);
+	execFileSync(npmCommand(), ["install", tarball], {
+		cwd: projectDir,
+		stdio: "inherit",
+	});
+	const packageRoot = join(
+		projectDir,
+		"node_modules",
+		...EXPECTED_PACKAGE_NAME.split("/"),
+	);
+	const packageJson = readJson(join(packageRoot, "package.json")) as {
+		exports?: Record<string, string | { import?: string }>;
+	};
+	return {
+		importPackageModule: async (specifier) => {
+			const entry = packageJson.exports?.[`./${specifier}`];
+			const importPath = typeof entry === "string" ? entry : entry?.import;
+			if (!importPath) {
+				throw new Error(
+					`${EXPECTED_PACKAGE_NAME} does not export import target ./${specifier}`,
+				);
+			}
+			const resolved = join(packageRoot, importPath);
+			return import(pathToFileURL(resolved).href) as Promise<
+				Record<string, unknown>
+			>;
+		},
+	};
+}
+
+async function loadService(
+	importPackageModule: (specifier: string) => Promise<Record<string, unknown>>,
+	serviceKey: PlatformServiceKey,
+): Promise<SdkService> {
+	const moduleInfo = serviceModules[serviceKey];
+	const imported = await importPackageModule(moduleInfo.specifier);
+	const service = imported[moduleInfo.exportName] as SdkService | undefined;
+	if (!service) {
+		throw new Error(
+			`${moduleInfo.specifier} is missing ${moduleInfo.exportName}`,
+		);
+	}
+	return service;
+}
+
+async function assertConnectContracts(
+	importPackageModule: (specifier: string) => Promise<Record<string, unknown>>,
+): Promise<void> {
+	const services = PLATFORM_CONNECT_SERVICES as Record<
+		PlatformServiceKey,
+		string
+	>;
+	const serviceDescriptors = new Map<PlatformServiceKey, SdkService>();
+
+	for (const serviceKey of Object.keys(serviceModules) as PlatformServiceKey[]) {
+		const service = await loadService(importPackageModule, serviceKey);
+		serviceDescriptors.set(serviceKey, service);
+		if (services[serviceKey] !== service.typeName) {
+			throw new Error(
+				`${serviceKey} service drifted: Maestro uses ${services[serviceKey]}, SDK exposes ${service.typeName}`,
+			);
+		}
+	}
+
+	const methodGroups = PLATFORM_CONNECT_METHODS as Record<
+		PlatformServiceKey,
+		Record<string, { service: string; method: string }>
+	>;
+	for (const [serviceKey, methods] of Object.entries(methodGroups) as Array<
+		[PlatformServiceKey, Record<string, { service: string; method: string }>]
+	>) {
+		const service = serviceDescriptors.get(serviceKey);
+		if (!service) {
+			throw new Error(`No SDK descriptor mapped for ${serviceKey}`);
+		}
+		const sdkMethodNames = new Set(
+			(service.methods || []).map((method) => method.name),
+		);
+		for (const [localName, descriptor] of Object.entries(methods)) {
+			if (!sdkMethodNames.has(descriptor.method)) {
+				throw new Error(
+					`${serviceKey}.${localName} drifted: SDK does not expose ${descriptor.method}`,
+				);
+			}
+			const path = platformConnectMethodPath(descriptor);
+			const expectedPath = `/${service.typeName}/${descriptor.method}`;
+			if (path !== expectedPath) {
+				throw new Error(
+					`${serviceKey}.${localName} path drifted: got ${path}, want ${expectedPath}`,
+				);
+			}
+		}
+	}
+}
+
+async function assertMemoryContract(
+	importPackageModule: (specifier: string) => Promise<Record<string, unknown>>,
+): Promise<void> {
+	const imported = await importPackageModule("memory/v1/memory_pb");
+	const service = imported.MemoryService as SdkService | undefined;
+	if (!service) {
+		throw new Error("memory/v1/memory_pb is missing MemoryService");
+	}
+	if (service.typeName !== "memory.v1.MemoryService") {
+		throw new Error(`memory service drifted: SDK exposes ${service.typeName}`);
+	}
+	const methodNames = new Set(
+		(service.methods || []).map((method) => method.name),
+	);
+	if (!methodNames.has("Recall")) {
+		throw new Error("memory service drifted: SDK does not expose Recall");
+	}
+	if (PLATFORM_HTTP_ROUTES.memory.recall !== "/v1/memories/recall") {
+		throw new Error(
+			`memory HTTP route drifted: ${PLATFORM_HTTP_ROUTES.memory.recall}`,
+		);
+	}
+}
+
+async function main(): Promise<void> {
+	const platformRepo = resolvePlatformRepo();
+	const sdkDir = join(platformRepo, "gen", "ts");
+	const packageJsonPath = join(sdkDir, "package.json");
+	const packageJson = readJson(packageJsonPath) as { name?: string };
+	if (packageJson.name !== EXPECTED_PACKAGE_NAME) {
+		throw new Error(
+			`Expected ${packageJsonPath} to define ${EXPECTED_PACKAGE_NAME}, got ${packageJson.name}`,
+		);
+	}
+
+	const tempDir = mkdtempSync(join(tmpdir(), "maestro-platform-sdk-contract-"));
+	try {
+		const tarball = packPlatformSdk(sdkDir, tempDir);
+		execFileSync(
+			nodeCommand(),
+			[
+				join(sdkDir, "scripts", "smoke-core-service-package.mjs"),
+				"--package-spec",
+				tarball,
+				"--package-name",
+				EXPECTED_PACKAGE_NAME,
+			],
+			{ stdio: "inherit" },
+		);
+
+		const { importPackageModule } = installPackedSdk(tempDir, tarball);
+		await assertConnectContracts(importPackageModule);
+		await assertMemoryContract(importPackageModule);
+		console.log(
+			`Validated Maestro Platform SDK contract against ${platformRepo}`,
+		);
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : error);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a cross-repo Platform SDK contract smoke script for the generated @evalops/sdk-ts tarball
- compare Maestro's centralized Platform service/method paths against generated SDK descriptors
- document the interim MAESTRO_PLATFORM_REPO bridge while npm publishing is still gated

## Validation
- npm run platform:sdk-smoke
- npm run test:fast -- test/platform/core-services.test.ts
- git diff --check

Note: npm ci in this fresh worktree hit repeated npm tarball integrity errors, so local dependencies were installed via the existing bun.lockb with Bun 1.3.6 for validation.