### PR TITLE
Fix production runtime database migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN apk add --no-cache tini git && \
     adduser --system --uid 1001 appuser
 
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src/db/migrations ./dist/db/migrations
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/skills ./skills

--- a/src/db/migrations/0003_ensure_runtime_identity_tables.sql
+++ b/src/db/migrations/0003_ensure_runtime_identity_tables.sql
@@ -1,0 +1,95 @@
+CREATE TABLE IF NOT EXISTS "revoked_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"token_hash" varchar(64) NOT NULL,
+	"token_type" varchar(20) NOT NULL,
+	"user_id" uuid,
+	"org_id" uuid,
+	"reason" varchar(100),
+	"expires_at" timestamp with time zone NOT NULL,
+	"revoked_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"revoked_by" uuid,
+	CONSTRAINT "revoked_tokens_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "user_revocation_timestamps" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"revoked_before" timestamp with time zone NOT NULL,
+	"reason" varchar(100) NOT NULL,
+	"revoked_by" uuid,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_revocation_timestamps_user_id_unique" UNIQUE("user_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "totp_rate_limits" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"window_start" timestamp with time zone NOT NULL,
+	"locked_until" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "totp_rate_limits_user_id_unique" UNIQUE("user_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "totp_used_codes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"code_hash" varchar(64) NOT NULL,
+	"window_start" timestamp with time zone NOT NULL,
+	"used_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "distributed_locks" (
+	"id" varchar(100) PRIMARY KEY NOT NULL,
+	"holder_id" varchar(100) NOT NULL,
+	"acquired_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "revoked_token_hash_idx" ON "revoked_tokens" USING btree ("token_hash");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "revoked_token_user_idx" ON "revoked_tokens" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "revoked_token_expires_idx" ON "revoked_tokens" USING btree ("expires_at");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "user_revocation_user_idx" ON "user_revocation_timestamps" USING btree ("user_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "totp_rate_limit_user_idx" ON "totp_rate_limits" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "totp_rate_limit_locked_idx" ON "totp_rate_limits" USING btree ("locked_until");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "totp_used_code_user_idx" ON "totp_used_codes" USING btree ("user_id","code_hash","window_start");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "totp_used_code_window_idx" ON "totp_used_codes" USING btree ("window_start");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "distributed_lock_expires_idx" ON "distributed_locks" USING btree ("expires_at");
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users') THEN
+		IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'revoked_tokens_user_id_users_id_fk') THEN
+			ALTER TABLE "revoked_tokens" ADD CONSTRAINT "revoked_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+		END IF;
+		IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'revoked_tokens_revoked_by_users_id_fk') THEN
+			ALTER TABLE "revoked_tokens" ADD CONSTRAINT "revoked_tokens_revoked_by_users_id_fk" FOREIGN KEY ("revoked_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+		END IF;
+		IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_revocation_timestamps_user_id_users_id_fk') THEN
+			ALTER TABLE "user_revocation_timestamps" ADD CONSTRAINT "user_revocation_timestamps_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+		END IF;
+		IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'user_revocation_timestamps_revoked_by_users_id_fk') THEN
+			ALTER TABLE "user_revocation_timestamps" ADD CONSTRAINT "user_revocation_timestamps_revoked_by_users_id_fk" FOREIGN KEY ("revoked_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+		END IF;
+		IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'totp_rate_limits_user_id_users_id_fk') THEN
+			ALTER TABLE "totp_rate_limits" ADD CONSTRAINT "totp_rate_limits_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+		END IF;
+		IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'totp_used_codes_user_id_users_id_fk') THEN
+			ALTER TABLE "totp_used_codes" ADD CONSTRAINT "totp_used_codes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+		END IF;
+	END IF;
+
+	IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'organizations') THEN
+		IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'revoked_tokens_org_id_organizations_id_fk') THEN
+			ALTER TABLE "revoked_tokens" ADD CONSTRAINT "revoked_tokens_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+		END IF;
+	END IF;
+END $$;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
 			"when": 1776800458000,
 			"tag": "0002_ensure_distributed_locks",
 			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1776800459000,
+			"tag": "0003_ensure_runtime_identity_tables",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -10,7 +10,7 @@ import {
 	warmUserRevocationCache,
 } from "./auth/token-revocation.js";
 import { cleanupRateLimits, cleanupUsedCodes } from "./auth/totp.js";
-import { isDbAvailable } from "./db/client.js";
+import { isDatabaseConfigured, isDbAvailable } from "./db/client.js";
 import { initEncryption, isEncryptionEnabled } from "./db/encryption.js";
 import { migrate } from "./db/migrate.js";
 import { registerGauge } from "./server/logger.js";
@@ -211,7 +211,7 @@ export async function initLifecycle(): Promise<void> {
 	}
 
 	// Run database migrations
-	if (isDbAvailable()) {
+	if (isDatabaseConfigured()) {
 		try {
 			const migrationsApplied = await migrate();
 			if (migrationsApplied > 0) {

--- a/test/agent/lifecycle.test.ts
+++ b/test/agent/lifecycle.test.ts
@@ -7,6 +7,10 @@ vi.mock("../../src/db/client.js", () => ({
 	getDb: vi.fn(),
 }));
 
+vi.mock("../../src/db/migrate.js", () => ({
+	migrate: vi.fn(() => Promise.resolve(0)),
+}));
+
 vi.mock("../../src/audit/integrity.js", () => ({
 	warmHashCache: vi.fn(() => Promise.resolve(0)),
 }));
@@ -33,7 +37,8 @@ import {
 	warmUserRevocationCache,
 } from "../../src/auth/token-revocation.js";
 import { cleanupRateLimits, cleanupUsedCodes } from "../../src/auth/totp.js";
-import { isDbAvailable } from "../../src/db/client.js";
+import { isDatabaseConfigured, isDbAvailable } from "../../src/db/client.js";
+import { migrate } from "../../src/db/migrate.js";
 import {
 	initLifecycle,
 	shutdownLifecycle,
@@ -91,6 +96,15 @@ describe("Lifecycle", () => {
 	});
 
 	describe("initLifecycle", () => {
+		it("runs migrations when the database is configured", async () => {
+			vi.mocked(isDatabaseConfigured).mockReturnValue(true);
+			vi.mocked(isDbAvailable).mockReturnValue(false);
+
+			await initLifecycle();
+
+			expect(migrate).toHaveBeenCalledOnce();
+		});
+
 		it("should initialize all services", async () => {
 			vi.mocked(isDbAvailable).mockReturnValue(true);
 

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -10,6 +10,7 @@ interface MigrationJournal {
 }
 
 const migrationsDir = join(process.cwd(), "src/db/migrations");
+const dockerfilePath = join(process.cwd(), "Dockerfile");
 
 describe("database migration files", () => {
 	it("includes an idempotent repair migration for distributed_locks", () => {
@@ -37,5 +38,43 @@ describe("database migration files", () => {
 		expect(repairSql).toContain("--> statement-breakpoint");
 		expect(repairSql).not.toMatch(/\bDROP\b/i);
 		expect(repairSql).not.toMatch(/\bDELETE\b/i);
+	});
+
+	it("includes an idempotent repair migration for runtime identity tables", () => {
+		const journal = JSON.parse(
+			readFileSync(join(migrationsDir, "meta", "_journal.json"), "utf-8"),
+		) as MigrationJournal;
+		const tags = journal.entries.map((entry) => entry.tag);
+
+		expect(tags).toContain("0003_ensure_runtime_identity_tables");
+		expect(tags.indexOf("0003_ensure_runtime_identity_tables")).toBeGreaterThan(
+			tags.indexOf("0002_ensure_distributed_locks"),
+		);
+
+		const repairSql = readFileSync(
+			join(migrationsDir, "0003_ensure_runtime_identity_tables.sql"),
+			"utf-8",
+		);
+
+		for (const tableName of [
+			"revoked_tokens",
+			"user_revocation_timestamps",
+			"totp_rate_limits",
+			"totp_used_codes",
+			"distributed_locks",
+		]) {
+			expect(repairSql).toContain(`CREATE TABLE IF NOT EXISTS "${tableName}"`);
+		}
+		expect(repairSql).toContain("--> statement-breakpoint");
+		expect(repairSql).not.toMatch(/\bDROP\b/i);
+		expect(repairSql).not.toMatch(/\bDELETE\s+FROM\b/i);
+	});
+
+	it("copies SQL migrations into the runtime Docker image", () => {
+		const dockerfile = readFileSync(dockerfilePath, "utf-8");
+
+		expect(dockerfile).toContain(
+			"COPY --from=builder /app/src/db/migrations ./dist/db/migrations",
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- run database migrations when a database is configured instead of waiting for an existing connection
- copy SQL migration files into the runtime Docker image at dist/db/migrations
- add an idempotent repair migration for missing production runtime identity tables used by webhook locks, token revocation, and TOTP cleanup

## Verification
- bun run test -- test/db/migration-files.test.ts test/agent/lifecycle.test.ts
- ./node_modules/.bin/biome check --write src/lifecycle.ts test/agent/lifecycle.test.ts test/db/migration-files.test.ts
- git diff --check

Note: repo-wide `tsc -p tsconfig.build.json --noEmit` is blocked in this local worktree by existing dependency/workspace resolution issues (`otplib` OTP export, `@evalops/memory`, `exceljs`), unrelated to these touched files.