### PR TITLE
Extend npm release canary window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,9 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Verify published package from npm
+        env:
+          MAESTRO_REGISTRY_POLL_ATTEMPTS: "120"
+          MAESTRO_REGISTRY_POLL_DELAY_MS: "5000"
         run: node scripts/smoke-registry-install.js
 
   notify:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
       - prepare
       - publish
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:

--- a/scripts/smoke-registry-install.js
+++ b/scripts/smoke-registry-install.js
@@ -49,7 +49,7 @@ const packageSpec = `${name}@${version}`;
 const npmCommand = getNpmCommand();
 const npxCommand = getNpxCommand();
 const maxAttempts = Number.parseInt(
-	process.env.MAESTRO_REGISTRY_POLL_ATTEMPTS ?? "24",
+	process.env.MAESTRO_REGISTRY_POLL_ATTEMPTS ?? "120",
 	10,
 );
 const pollDelayMs = Number.parseInt(


### PR DESCRIPTION
## Summary
- increase npm registry polling for release canaries to handle delayed packument visibility
- set explicit canary polling env in the release workflow

## Test plan
- actionlint .github/workflows/release.yml
- git diff --check
- node --check scripts/smoke-registry-install.js
- npm run release:verify:published -- --package @evalops/maestro --version 0.10.8