### PR TITLE
Make npm publish auth mode explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,12 +167,47 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_PUBLISH_AUTH_MODE: ${{ vars.NPM_PUBLISH_AUTH_MODE || 'auto' }}
         run: |
           set -euo pipefail
-          if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+          publish_with_token() {
+            if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+              echo "::error::NPM_PUBLISH_AUTH_MODE=token requires the NPM_TOKEN secret."
+              exit 1
+            fi
+
+            echo "Publishing with NPM_TOKEN fallback."
             printf "//registry.npmjs.org/:_authToken=%s\n" "$NODE_AUTH_TOKEN" > ~/.npmrc
-          fi
-          npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
+            npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
+          }
+
+          publish_with_trusted_publisher() {
+            echo "Publishing with npm trusted publishing."
+            unset NODE_AUTH_TOKEN
+            rm -f ~/.npmrc
+            npm publish "${{ steps.pack.outputs.tarball }}" --access public
+          }
+
+          case "${NPM_PUBLISH_AUTH_MODE}" in
+            auto|"")
+              if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+                echo "NPM_TOKEN is present; using token fallback. Set NPM_PUBLISH_AUTH_MODE=trusted after npm trust is configured."
+                publish_with_token
+              else
+                publish_with_trusted_publisher
+              fi
+              ;;
+            token)
+              publish_with_token
+              ;;
+            trusted)
+              publish_with_trusted_publisher
+              ;;
+            *)
+              echo "::error::Unsupported NPM_PUBLISH_AUTH_MODE '${NPM_PUBLISH_AUTH_MODE}'. Use auto, token, or trusted."
+              exit 1
+              ;;
+          esac
 
       - name: Sync Hopper version metadata
         env:

--- a/docs/release-ops.md
+++ b/docs/release-ops.md
@@ -39,6 +39,14 @@
 - npm publishing uses GitHub OIDC trusted publishing when npm has the
   `evalops/maestro` release workflow configured; the EvalOps org `NPM_TOKEN`
   secret remains a temporary fallback during the scope cutover.
+- `NPM_PUBLISH_AUTH_MODE` controls the release publish path:
+  - `auto` keeps the migration fallback, using `NPM_TOKEN` when present and
+    trusted publishing otherwise.
+  - `trusted` ignores `NPM_TOKEN` and forces npm trusted publishing.
+  - `token` requires `NPM_TOKEN` and keeps the legacy fallback explicit.
+- After `npm trust github @evalops/maestro --repo evalops/maestro --file release.yml --env npm-release --yes` succeeds and one release verifies, set
+  `NPM_PUBLISH_AUTH_MODE=trusted` in the `npm-release` environment and remove
+  the release-scoped `NPM_TOKEN`.
 
 ## Rollback And Deprecation
 


### PR DESCRIPTION
## Summary
- add an explicit `NPM_PUBLISH_AUTH_MODE` switch for release publishing
- preserve the current token fallback while allowing `trusted` mode to ignore `NPM_TOKEN`
- document the cutover step after npm trusted publishing is configured

## Test plan
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- `npm run metadata:check`