### PR TITLE
Handle legacy Maestro migration baselines

### DIFF
--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -35,6 +35,15 @@ interface MigrationRecord {
 	applied_at: Date;
 }
 
+function firstRow(results: unknown): Record<string, unknown> | null {
+	const rows = Array.from(results as Iterable<Record<string, unknown>>);
+	return rows[0] ?? null;
+}
+
+function sqlBoolean(value: unknown): boolean {
+	return value === true || value === "true" || value === 1 || value === "1";
+}
+
 /**
  * Get the list of migrations from the journal
  */
@@ -129,6 +138,68 @@ async function markMigrationApplied(tag: string): Promise<void> {
 	`);
 }
 
+async function tableExists(tableName: string): Promise<boolean> {
+	const db = getDb();
+
+	const result = await db.execute(sql`
+		SELECT to_regclass(${`public.${tableName}`}) IS NOT NULL AS exists
+	`);
+
+	return sqlBoolean(firstRow(result)?.exists);
+}
+
+async function enumTypeExists(typeName: string): Promise<boolean> {
+	const db = getDb();
+
+	const result = await db.execute(sql`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_type t
+			JOIN pg_namespace n ON n.oid = t.typnamespace
+			WHERE n.nspname = 'public' AND t.typname = ${typeName}
+		) AS exists
+	`);
+
+	return sqlBoolean(firstRow(result)?.exists);
+}
+
+async function initialSchemaExists(): Promise<boolean> {
+	return (
+		(await enumTypeExists("alert_severity")) ||
+		(await tableExists("organizations")) ||
+		(await tableExists("users"))
+	);
+}
+
+async function reconcileLegacyMigrationRecords(
+	migrationEntries: MigrationJournal["entries"],
+	appliedMigrations: Set<string>,
+): Promise<void> {
+	for (const entry of migrationEntries) {
+		if (appliedMigrations.has(entry.tag)) {
+			continue;
+		}
+
+		let alreadyPresent = false;
+		if (entry.tag === "0000_initial") {
+			alreadyPresent = await initialSchemaExists();
+		} else if (entry.tag === "0001_shared_sessions") {
+			alreadyPresent = await tableExists("shared_sessions");
+		}
+
+		if (!alreadyPresent) {
+			continue;
+		}
+
+		logger.warn(
+			"Detected existing schema for untracked migration; marking as applied",
+			{ tag: entry.tag },
+		);
+		await markMigrationApplied(entry.tag);
+		appliedMigrations.add(entry.tag);
+	}
+}
+
 /**
  * Remove a migration from the applied list (for rollback)
  */
@@ -175,6 +246,7 @@ export async function migrate(): Promise<number> {
 	await ensureMigrationsTable();
 	const appliedMigrations = await getAppliedMigrations();
 	const migrationEntries = getMigrationEntries();
+	await reconcileLegacyMigrationRecords(migrationEntries, appliedMigrations);
 
 	let applied = 0;
 

--- a/test/db/migrate.test.ts
+++ b/test/db/migrate.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	execute: vi.fn(),
+	queries: [] as string[],
+	tableState: new Map<string, boolean>(),
+}));
+
+vi.mock("../../src/db/client.js", () => ({
+	isDatabaseConfigured: vi.fn(() => true),
+	getDb: vi.fn(() => ({ execute: mocks.execute })),
+}));
+
+import { migrate } from "../../src/db/migrate.js";
+
+function sqlText(query: unknown): string {
+	const chunks =
+		(query as { queryChunks?: Array<string | { value?: string[] }> })
+			.queryChunks ?? [];
+
+	return chunks
+		.map((chunk) => {
+			if (typeof chunk === "string") {
+				return chunk;
+			}
+			return chunk.value?.join("") ?? "";
+		})
+		.join("");
+}
+
+describe("migrate", () => {
+	beforeEach(() => {
+		mocks.queries.length = 0;
+		mocks.tableState.clear();
+		mocks.execute.mockReset();
+		mocks.execute.mockImplementation(async (query: unknown) => {
+			const text = sqlText(query);
+			mocks.queries.push(text);
+
+			if (text.includes("SELECT tag FROM _composer_migrations")) {
+				return [];
+			}
+			if (text.includes("pg_type") && text.includes("alert_severity")) {
+				return [{ exists: true }];
+			}
+			if (text.includes("to_regclass(")) {
+				const tableName = Array.from(mocks.tableState.keys()).find((name) =>
+					text.includes(`public.${name}`),
+				);
+				return [
+					{ exists: tableName ? mocks.tableState.get(tableName) : false },
+				];
+			}
+
+			return [];
+		});
+	});
+
+	it("marks the initial migration applied instead of replaying existing schema", async () => {
+		const applied = await migrate();
+
+		expect(applied).toBe(3);
+		expect(
+			mocks.queries.some((query) =>
+				query.includes('CREATE TYPE "public"."alert_severity"'),
+			),
+		).toBe(false);
+		expect(
+			mocks.queries.some(
+				(query) =>
+					query.includes("INSERT INTO _composer_migrations") &&
+					query.includes("0000_initial"),
+			),
+		).toBe(true);
+		expect(
+			mocks.queries.some((query) =>
+				query.includes('CREATE TABLE IF NOT EXISTS "shared_sessions"'),
+			),
+		).toBe(true);
+	});
+
+	it("also backfills the shared session migration when that table already exists", async () => {
+		mocks.tableState.set("shared_sessions", true);
+
+		const applied = await migrate();
+
+		expect(applied).toBe(2);
+		expect(
+			mocks.queries.some((query) =>
+				query.includes('CREATE TABLE IF NOT EXISTS "shared_sessions"'),
+			),
+		).toBe(false);
+		expect(
+			mocks.queries.some(
+				(query) =>
+					query.includes("INSERT INTO _composer_migrations") &&
+					query.includes("0001_shared_sessions"),
+			),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- detect existing legacy Maestro schema artifacts before replaying historical migrations
- backfill `_composer_migrations` rows for `0000_initial` and `0001_shared_sessions` only when their schema objects already exist
- keep idempotent repair migrations runnable so missing runtime tables are still repaired

## Why
The production/staging migration hook for the runtime-table repair image hit existing databases with an empty or incomplete migration ledger and tried to replay `0000_initial`, failing on existing enum types like `alert_severity`.

## Validation
- `bun run test -- test/db/migrate.test.ts test/db/migration-files.test.ts test/agent/lifecycle.test.ts`
- `./node_modules/.bin/biome check src/db/migrate.ts test/db/migrate.test.ts test/db/migration-files.test.ts test/agent/lifecycle.test.ts`
- `git diff --check`
