### PR TITLE
Reconcile legacy RBAC migration schema

### DIFF
--- a/src/db/migrations/0004_reconcile_legacy_rbac_tables.sql
+++ b/src/db/migrations/0004_reconcile_legacy_rbac_tables.sql
@@ -1,0 +1,95 @@
+ALTER TABLE "permissions" ADD COLUMN IF NOT EXISTS "action" varchar(50);
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND table_name = 'permissions'
+			AND column_name = 'permission_type'
+	) THEN
+		UPDATE "permissions"
+		SET "action" = "permission_type"
+		WHERE "action" IS NULL
+			AND "permission_type" IS NOT NULL;
+	END IF;
+END $$;
+--> statement-breakpoint
+UPDATE "permissions"
+SET "action" = 'read'
+WHERE "action" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "permissions" ALTER COLUMN "action" SET NOT NULL;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND table_name = 'permissions'
+			AND column_name = 'name'
+	) THEN
+		ALTER TABLE "permissions" ALTER COLUMN "name" DROP NOT NULL;
+	END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND table_name = 'permissions'
+			AND column_name = 'permission_type'
+	) THEN
+		ALTER TABLE "permissions" ALTER COLUMN "permission_type" DROP NOT NULL;
+	END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "permission_resource_action_idx" ON "permissions" USING btree ("resource", "action");
+--> statement-breakpoint
+ALTER TABLE "roles" ADD COLUMN IF NOT EXISTS "org_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "roles" ADD COLUMN IF NOT EXISTS "is_system" boolean DEFAULT false;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND table_name = 'roles'
+			AND column_name = 'is_system_role'
+	) THEN
+		UPDATE "roles"
+		SET "is_system" = "is_system_role"
+		WHERE "is_system" IS DISTINCT FROM "is_system_role";
+	END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "roles" ALTER COLUMN "is_system" SET DEFAULT false;
+--> statement-breakpoint
+UPDATE "roles" SET "is_system" = false WHERE "is_system" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "roles" ALTER COLUMN "is_system" SET NOT NULL;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND table_name = 'roles'
+			AND column_name = 'role_type'
+	) THEN
+		ALTER TABLE "roles" ALTER COLUMN "role_type" DROP NOT NULL;
+	END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "role_org_name_idx" ON "roles" USING btree ("org_id", "name");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "role_system_name_idx" ON "roles" USING btree ("name") WHERE "org_id" IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "role_permission_pk" ON "role_permissions" USING btree ("role_id", "permission_id");

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1776800459000,
 			"tag": "0003_ensure_runtime_identity_tables",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1776800460000,
+			"tag": "0004_reconcile_legacy_rbac_tables",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/rbac/permissions.ts
+++ b/src/rbac/permissions.ts
@@ -3,7 +3,7 @@
  * Defines resources, actions, and permission checking logic
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { getDb } from "../db/client.js";
 import {
 	orgMemberships,
@@ -315,40 +315,64 @@ export async function seedPermissions(): Promise<void> {
 		}
 
 		for (const roleData of Object.values(SYSTEM_ROLES)) {
-			const [role] = await db
-				.insert(roles)
-				.values({
-					orgId: null,
-					name: roleData.name,
-					description: roleData.description,
-					isSystem: true,
-				})
-				.onConflictDoNothing()
-				.returning();
+			let role = await db.query.roles.findFirst({
+				where: and(
+					eq(roles.name, roleData.name),
+					eq(roles.isSystem, true),
+					isNull(roles.orgId),
+				),
+			});
 
-			if (role) {
-				// For each permission defined in the role, find the exact matching permission record
-				for (const rolePerm of roleData.permissions) {
-					const perm = await db.query.permissions.findFirst({
+			if (!role) {
+				const [createdRole] = await db
+					.insert(roles)
+					.values({
+						orgId: null,
+						name: roleData.name,
+						description: roleData.description,
+						isSystem: true,
+					})
+					.onConflictDoNothing()
+					.returning();
+
+				role =
+					createdRole ??
+					(await db.query.roles.findFirst({
 						where: and(
-							eq(permissions.resource, rolePerm.resource),
-							eq(permissions.action, rolePerm.action),
+							eq(roles.name, roleData.name),
+							eq(roles.isSystem, true),
+							isNull(roles.orgId),
 						),
-					});
-
-					if (perm) {
-						await db
-							.insert(rolePermissions)
-							.values({
-								roleId: role.id,
-								permissionId: perm.id,
-							})
-							.onConflictDoNothing();
-					}
-				}
-
-				logger.info(`Created system role: ${roleData.name}`);
+					}));
 			}
+
+			if (!role) {
+				throw new Error(
+					`Failed to create or load system role: ${roleData.name}`,
+				);
+			}
+
+			// For each permission defined in the role, find the exact matching permission record.
+			for (const rolePerm of roleData.permissions) {
+				const perm = await db.query.permissions.findFirst({
+					where: and(
+						eq(permissions.resource, rolePerm.resource),
+						eq(permissions.action, rolePerm.action),
+					),
+				});
+
+				if (perm) {
+					await db
+						.insert(rolePermissions)
+						.values({
+							roleId: role.id,
+							permissionId: perm.id,
+						})
+						.onConflictDoNothing();
+				}
+			}
+
+			logger.info(`System role ready: ${roleData.name}`);
 		}
 
 		logger.info("Permission seeding completed");

--- a/test/db/migrate.test.ts
+++ b/test/db/migrate.test.ts
@@ -59,7 +59,7 @@ describe("migrate", () => {
 	it("marks the initial migration applied instead of replaying existing schema", async () => {
 		const applied = await migrate();
 
-		expect(applied).toBe(3);
+		expect(applied).toBe(4);
 		expect(
 			mocks.queries.some((query) =>
 				query.includes('CREATE TYPE "public"."alert_severity"'),
@@ -77,6 +77,13 @@ describe("migrate", () => {
 				query.includes('CREATE TABLE IF NOT EXISTS "shared_sessions"'),
 			),
 		).toBe(true);
+		expect(
+			mocks.queries.some((query) =>
+				query.includes(
+					'ALTER TABLE "permissions" ADD COLUMN IF NOT EXISTS "action"',
+				),
+			),
+		).toBe(true);
 	});
 
 	it("also backfills the shared session migration when that table already exists", async () => {
@@ -84,7 +91,7 @@ describe("migrate", () => {
 
 		const applied = await migrate();
 
-		expect(applied).toBe(2);
+		expect(applied).toBe(3);
 		expect(
 			mocks.queries.some((query) =>
 				query.includes('CREATE TABLE IF NOT EXISTS "shared_sessions"'),

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -70,6 +70,42 @@ describe("database migration files", () => {
 		expect(repairSql).not.toMatch(/\bDELETE\s+FROM\b/i);
 	});
 
+	it("includes an idempotent repair migration for legacy RBAC table shape", () => {
+		const journal = JSON.parse(
+			readFileSync(join(migrationsDir, "meta", "_journal.json"), "utf-8"),
+		) as MigrationJournal;
+		const tags = journal.entries.map((entry) => entry.tag);
+
+		expect(tags).toContain("0004_reconcile_legacy_rbac_tables");
+		expect(tags.indexOf("0004_reconcile_legacy_rbac_tables")).toBeGreaterThan(
+			tags.indexOf("0003_ensure_runtime_identity_tables"),
+		);
+
+		const repairSql = readFileSync(
+			join(migrationsDir, "0004_reconcile_legacy_rbac_tables.sql"),
+			"utf-8",
+		);
+
+		expect(repairSql).toContain(
+			'ALTER TABLE "permissions" ADD COLUMN IF NOT EXISTS "action"',
+		);
+		expect(repairSql).toContain(
+			'CREATE UNIQUE INDEX IF NOT EXISTS "permission_resource_action_idx"',
+		);
+		expect(repairSql).toContain(
+			'ALTER TABLE "roles" ADD COLUMN IF NOT EXISTS "org_id"',
+		);
+		expect(repairSql).toContain(
+			'CREATE UNIQUE INDEX IF NOT EXISTS "role_system_name_idx"',
+		);
+		expect(repairSql).toContain(
+			'CREATE UNIQUE INDEX IF NOT EXISTS "role_permission_pk"',
+		);
+		expect(repairSql).toContain("--> statement-breakpoint");
+		expect(repairSql).not.toMatch(/\bDROP\s+TABLE\b/i);
+		expect(repairSql).not.toMatch(/\bDELETE\s+FROM\b/i);
+	});
+
 	it("copies SQL migrations into the runtime Docker image", () => {
 		const dockerfile = readFileSync(dockerfilePath, "utf-8");
 


### PR DESCRIPTION
## Summary
- Add an idempotent RBAC repair migration for the legacy live permissions/roles table shape.
- Add current permissions.action, roles.org_id, and roles.is_system compatibility while relaxing legacy-only NOT NULL columns so current seed inserts work.
- Make system role seeding load existing roles before/after insert so startup is idempotent with nullable org_id.

## Validation
- bun run test -- test/db/migrate.test.ts test/db/migration-files.test.ts test/enterprise/rbac-permissions.test.ts
- biome check src/rbac/permissions.ts test/db/migrate.test.ts test/db/migration-files.test.ts
- git diff --check
- validated src/db/migrations/0004_reconcile_legacy_rbac_tables.sql against live staging inside a rolled-back transaction

## Context
Live staging/production Maestro pods on sha-08630d1 no longer report the distributed_locks/runtime identity table errors, but both report Failed to seed permissions because the live RBAC tables still use the older name/permission_type and role_type/is_system_role shape.