### PR TITLE
Cover connector source-of-truth policy method

### DIFF
--- a/src/platform/core-services.ts
+++ b/src/platform/core-services.ts
@@ -60,6 +60,10 @@ export const PLATFORM_CONNECT_METHODS = {
 			service: PLATFORM_CONNECT_SERVICES.connectors,
 			method: "RevokeConnection",
 		},
+		setSourceOfTruthPolicy: {
+			service: PLATFORM_CONNECT_SERVICES.connectors,
+			method: "SetSourceOfTruthPolicy",
+		},
 	},
 	governance: {
 		evaluateAction: {

--- a/test/platform/core-services.test.ts
+++ b/test/platform/core-services.test.ts
@@ -43,6 +43,11 @@ describe("Platform core service contract names", () => {
 		).toBe("/connectors.v1.ConnectorService/ListConnections");
 		expect(
 			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.connectors.setSourceOfTruthPolicy,
+			),
+		).toBe("/connectors.v1.ConnectorService/SetSourceOfTruthPolicy");
+		expect(
+			platformConnectMethodPath(
 				PLATFORM_CONNECT_METHODS.llmGateway.createMessage,
 			),
 		).toBe("/llmgateway.v1.GatewayService/CreateMessage");


### PR DESCRIPTION
## Summary
- add the Platform Connect descriptor for ConnectorService.SetSourceOfTruthPolicy
- cover the generated Connect path in the core-service contract test

## Verification
- node ./scripts/run-vitest.js --run test/platform/core-services.test.ts
- MAESTRO_PLATFORM_REPO=/Users/jonathanhaas/.codex-worktrees/platform-sdk-connectors-smoke-20260422 npm run platform:sdk-smoke
- npx -y -p bun@1.3.6 npm run build
- commit hook: guardian, lint/evals checks, generated proto check, build, binary compile