### PR TITLE
Add auth command for connector source-of-truth metadata

### DIFF
--- a/src/cli-tui/commands/grouped-command-handlers.ts
+++ b/src/cli-tui/commands/grouped-command-handlers.ts
@@ -75,6 +75,9 @@ export type GroupedCommandDeps = {
 	auth: {
 		handleLogin: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleLogout: (ctx: CommandExecutionContext) => void | Promise<void>;
+		handleSourceOfTruthPolicy: (
+			ctx: CommandExecutionContext,
+		) => void | Promise<void>;
 		getAuthState: () => {
 			authenticated: boolean;
 			provider?: string;
@@ -230,6 +233,8 @@ export function createGroupedCommandHandlers(
 					deps.auth.handleLogin(ctx),
 				handleLogout: async (ctx: CommandExecutionContext) =>
 					deps.auth.handleLogout(ctx),
+				handleSourceOfTruthPolicy: async (ctx: CommandExecutionContext) =>
+					deps.auth.handleSourceOfTruthPolicy(ctx),
 				showInfo: (msg: string) => context.showInfo(msg),
 				getAuthState: () => deps.auth.getAuthState(),
 			});

--- a/src/cli-tui/commands/grouped/auth-commands.ts
+++ b/src/cli-tui/commands/grouped/auth-commands.ts
@@ -7,6 +7,7 @@
  *   /auth                 - Show auth status
  *   /auth login [mode]    - Authenticate (pro|console|provider:mode)
  *   /auth logout [provider] - Remove credentials
+ *   /auth source-of-truth <provider> <area> [fallbackConnectionId] - Set connector policy
  *   /auth status          - Show current auth state
  */
 
@@ -16,6 +17,9 @@ import { createGroupedCommandHandler } from "./utils.js";
 export interface AuthCommandDeps {
 	handleLogin: (ctx: CommandExecutionContext) => Promise<void> | void;
 	handleLogout: (ctx: CommandExecutionContext) => Promise<void> | void;
+	handleSourceOfTruthPolicy?: (
+		ctx: CommandExecutionContext,
+	) => Promise<void> | void;
 	showInfo: (message: string) => void;
 	getAuthState: () => {
 		authenticated: boolean;
@@ -42,6 +46,23 @@ export function createAuthCommandHandler(deps: AuthCommandDeps) {
 				match: ["logout", "signout"],
 				execute: ({ rewriteContext }) =>
 					deps.handleLogout(rewriteContext("logout")),
+			},
+			{
+				match: ["source-of-truth", "sot", "policy"],
+				execute: ({ ctx, customContext, restArgumentText }) => {
+					if (!deps.handleSourceOfTruthPolicy) {
+						ctx.showError(
+							"Source-of-truth policy management is not available in this session.",
+						);
+						return;
+					}
+					return deps.handleSourceOfTruthPolicy(
+						customContext(
+							`/auth source-of-truth ${restArgumentText}`.trim(),
+							restArgumentText,
+						),
+					);
+				},
 			},
 		],
 		onUnknown: async ({ ctx, subcommand, customContext }) => {
@@ -85,6 +106,11 @@ function showAuthHelp(ctx: CommandExecutionContext): void {
                          - console: Anthropic Console
                          - provider:mode (e.g., anthropic:pro)
   /auth logout [provider] Remove credentials
+  /auth source-of-truth <provider> <area> [fallbackConnectionId]
+                         Set connector source-of-truth policy metadata
+                         Areas: analytics, billing, crm, hris, support
+  /auth source-of-truth clear <provider>
+                         Remove local policy metadata
   /auth status           Show current auth state
 
 Direct shortcuts still work: /login, /logout`);

--- a/src/cli-tui/commands/grouped/utils.ts
+++ b/src/cli-tui/commands/grouped/utils.ts
@@ -399,6 +399,11 @@ export const AUTH_SUBCOMMANDS: SubcommandDef[] = [
 	},
 	{ name: "login", description: "Authenticate", aliases: ["signin"] },
 	{ name: "logout", description: "Remove credentials", aliases: ["signout"] },
+	{
+		name: "source-of-truth",
+		description: "Set connector source-of-truth policy",
+		aliases: ["sot", "policy"],
+	},
 ];
 
 export const USAGE_SUBCOMMANDS: SubcommandDef[] = [

--- a/src/cli-tui/commands/registry.ts
+++ b/src/cli-tui/commands/registry.ts
@@ -135,10 +135,15 @@ const GROUPED_COMMAND_DEFINITIONS: readonly GroupedCommandDefinition[] = [
 	{
 		command: {
 			name: "auth",
-			description: "Authentication: login, logout, status",
-			usage: "/auth [login|logout|status] [mode]",
+			description: "Authentication: login, logout, status, source-of-truth",
+			usage: "/auth [login|logout|status|source-of-truth] [provider] [area]",
 			tags: ["auth"],
-			examples: ["/auth", "/auth login pro", "/auth logout"],
+			examples: [
+				"/auth",
+				"/auth login pro",
+				"/auth logout",
+				"/auth source-of-truth openai analytics",
+			],
 		},
 		subcommands: AUTH_SUBCOMMANDS,
 		handlerKey: "auth",

--- a/src/cli-tui/oauth/oauth-flow-controller.ts
+++ b/src/cli-tui/oauth/oauth-flow-controller.ts
@@ -255,6 +255,86 @@ export class OAuthFlowController {
 		this.oauthLogoutView.show();
 	}
 
+	/**
+	 * Handle the /auth source-of-truth command.
+	 */
+	async handleSourceOfTruthPolicyCommand(
+		argumentText: string,
+		showError: (msg: string) => void,
+		showInfo: (msg: string) => void,
+	): Promise<void> {
+		const args = argumentText.trim().split(/\s+/).filter(Boolean);
+		const usage =
+			"Usage: /auth source-of-truth <provider> <area> [fallbackConnectionId]\n" +
+			"       /auth source-of-truth clear <provider>\n" +
+			"Areas: analytics, billing, crm, hris, support";
+		if (
+			args.length === 0 ||
+			["help", "?", "-h", "--help"].includes(args[0]?.toLowerCase() ?? "")
+		) {
+			showInfo(usage);
+			return;
+		}
+
+		const subcommand = args[0]?.toLowerCase();
+		try {
+			if (["clear", "unset", "remove"].includes(subcommand ?? "")) {
+				const provider = args[1];
+				if (!provider || args.length > 2) {
+					showError(usage);
+					return;
+				}
+				const { clearOAuthProviderSourceOfTruthPolicy } = await import(
+					"../../oauth/connectors.js"
+				);
+				const cleared = clearOAuthProviderSourceOfTruthPolicy(provider);
+				showInfo(
+					cleared
+						? `Source-of-truth policy metadata cleared for ${provider}.`
+						: `No source-of-truth policy metadata was set for ${provider}.`,
+				);
+				return;
+			}
+
+			const provider = args[0];
+			const area = args[1];
+			const fallbackConnectionId = args[2];
+			if (!provider || !area || args.length > 3) {
+				showError(usage);
+				return;
+			}
+
+			const { configureOAuthProviderSourceOfTruthPolicy } = await import(
+				"../../oauth/connectors.js"
+			);
+			const configured = await configureOAuthProviderSourceOfTruthPolicy(
+				provider,
+				{ area, fallbackConnectionId },
+			);
+			const details = [
+				`Source-of-truth policy metadata configured for ${configured.provider}.`,
+				`Area: ${configured.area}`,
+				...(configured.fallbackConnectionId
+					? [`Fallback connection: ${configured.fallbackConnectionId}`]
+					: []),
+				...(configured.connectorConnectionId
+					? [`Connector connection: ${configured.connectorConnectionId}`]
+					: []),
+				...(configured.primaryConnectionId
+					? [`Platform primary connection: ${configured.primaryConnectionId}`]
+					: [
+							"Platform policy will sync when the connector service integration is configured and reachable.",
+						]),
+				...(configured.workspaceId
+					? [`Workspace: ${configured.workspaceId}`]
+					: []),
+			];
+			showInfo(details.join("\n"));
+		} catch (error) {
+			showError(error instanceof Error ? error.message : String(error));
+		}
+	}
+
 	private async performOAuthLogin(
 		providerId: SupportedOAuthProvider,
 		mode: string,

--- a/src/cli-tui/tui-renderer.ts
+++ b/src/cli-tui/tui-renderer.ts
@@ -2634,6 +2634,12 @@ export class TuiRenderer {
 						showError,
 						showInfo,
 					),
+				handleAuthSourceOfTruthCommand: (argumentText, showError, showInfo) =>
+					this.oauthFlowController.handleSourceOfTruthPolicyCommand(
+						argumentText,
+						showError,
+						showInfo,
+					),
 				getAuthState: () => this.getActualAuthState(),
 				handleCostCommand: (ctx) => this.getCostView().handleCostCommand(ctx),
 				handleQuotaCommand: (ctx) =>

--- a/src/cli-tui/tui-renderer/grouped-handlers-wiring.ts
+++ b/src/cli-tui/tui-renderer/grouped-handlers-wiring.ts
@@ -99,6 +99,11 @@ export interface GroupedWiringDeps {
 		showError: (msg: string) => void,
 		showInfo: (msg: string) => void,
 	) => void | Promise<void>;
+	handleAuthSourceOfTruthCommand: (
+		argumentText: string,
+		showError: (msg: string) => void,
+		showInfo: (msg: string) => void,
+	) => void | Promise<void>;
 	getAuthState: () => {
 		authenticated: boolean;
 		provider?: string;
@@ -207,6 +212,12 @@ export function buildGroupedCommandHandlers(
 				deps.handleLoginCommand(ctx.argumentText, (msg) => ctx.showError(msg)),
 			handleLogout: (ctx) =>
 				deps.handleLogoutCommand(
+					ctx.argumentText,
+					(msg) => ctx.showError(msg),
+					(msg) => ctx.showInfo(msg),
+				),
+			handleSourceOfTruthPolicy: (ctx) =>
+				deps.handleAuthSourceOfTruthCommand(
 					ctx.argumentText,
 					(msg) => ctx.showError(msg),
 					(msg) => ctx.showInfo(msg),

--- a/src/oauth/connectors.ts
+++ b/src/oauth/connectors.ts
@@ -1,0 +1,189 @@
+import type { SupportedOAuthProvider } from "./index.js";
+import {
+	type OAuthCredentials,
+	loadOAuthCredentials,
+	saveOAuthCredentials,
+} from "./storage.js";
+
+type ConnectorOAuthProvider = Exclude<SupportedOAuthProvider, "evalops">;
+
+const CONNECTOR_PROVIDER_BY_OAUTH_PROVIDER: Record<
+	ConnectorOAuthProvider,
+	string
+> = {
+	anthropic: "x-evalops:anthropic",
+	"github-copilot": "github",
+	"google-antigravity": "google",
+	"google-gemini-cli": "google",
+	openai: "x-evalops:openai",
+};
+
+export const CONNECTOR_SOURCE_OF_TRUTH_AREAS = [
+	"analytics",
+	"billing",
+	"crm",
+	"hris",
+	"support",
+] as const;
+
+export type ConnectorSourceOfTruthArea =
+	(typeof CONNECTOR_SOURCE_OF_TRUTH_AREAS)[number];
+
+export interface ConfigureOAuthProviderSourceOfTruthPolicyInput {
+	area: string;
+	fallbackConnectionId?: string;
+}
+
+export interface ConfiguredOAuthProviderSourceOfTruthPolicy {
+	provider: ConnectorOAuthProvider;
+	area: ConnectorSourceOfTruthArea;
+	fallbackConnectionId?: string;
+	connectorConnectionId?: string;
+	primaryConnectionId?: string;
+	workspaceId?: string;
+}
+
+const SOURCE_OF_TRUTH_METADATA_KEYS = [
+	"connectorSourceOfTruthArea",
+	"connectorSourceOfTruthFallbackConnectionId",
+	"connectorSourceOfTruthPrimaryConnectionId",
+	"connectorSourceOfTruthWorkspaceId",
+	"sourceOfTruthArea",
+	"sourceOfTruthFallbackConnectionId",
+] as const;
+
+function isConnectorOAuthProvider(
+	provider: string,
+): provider is ConnectorOAuthProvider {
+	return Object.prototype.hasOwnProperty.call(
+		CONNECTOR_PROVIDER_BY_OAUTH_PROVIDER,
+		provider,
+	);
+}
+
+function supportedConnectorOAuthProviders(): string {
+	return Object.keys(CONNECTOR_PROVIDER_BY_OAUTH_PROVIDER).sort().join(", ");
+}
+
+function trimString(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function getMetadataString(
+	metadata: Record<string, unknown> | undefined,
+	key: string,
+): string | undefined {
+	const value = metadata?.[key];
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+export function normalizeConnectorSourceOfTruthArea(
+	area: string,
+): ConnectorSourceOfTruthArea | null {
+	const normalized = area
+		.trim()
+		.toLowerCase()
+		.replace(/^source_of_truth_area_/u, "")
+		.replace(/^source-of-truth-area-/u, "")
+		.replaceAll("_", "-");
+	for (const candidate of CONNECTOR_SOURCE_OF_TRUTH_AREAS) {
+		if (
+			candidate === normalized ||
+			candidate.replaceAll("_", "-") === normalized
+		) {
+			return candidate;
+		}
+	}
+	return null;
+}
+
+export async function configureOAuthProviderSourceOfTruthPolicy(
+	provider: string,
+	input: ConfigureOAuthProviderSourceOfTruthPolicyInput,
+): Promise<ConfiguredOAuthProviderSourceOfTruthPolicy> {
+	if (!isConnectorOAuthProvider(provider)) {
+		throw new Error(
+			`Unsupported OAuth connector provider: ${provider}. Supported providers: ${supportedConnectorOAuthProviders()}`,
+		);
+	}
+	const credentials = loadOAuthCredentials(provider);
+	if (!credentials) {
+		throw new Error(`No OAuth credentials found for ${provider}`);
+	}
+	const area = normalizeConnectorSourceOfTruthArea(input.area);
+	if (!area) {
+		throw new Error(
+			`Unsupported source-of-truth area: ${input.area}. Valid areas: ${CONNECTOR_SOURCE_OF_TRUTH_AREAS.join(", ")}`,
+		);
+	}
+
+	const metadata: Record<string, unknown> = { ...credentials.metadata };
+	metadata.connectorSourceOfTruthArea = area;
+	delete metadata.sourceOfTruthArea;
+	delete metadata.sourceOfTruthFallbackConnectionId;
+	delete metadata.connectorSourceOfTruthPrimaryConnectionId;
+	delete metadata.connectorSourceOfTruthWorkspaceId;
+
+	const fallbackConnectionId = trimString(input.fallbackConnectionId);
+	if (fallbackConnectionId) {
+		metadata.connectorSourceOfTruthFallbackConnectionId = fallbackConnectionId;
+	} else {
+		delete metadata.connectorSourceOfTruthFallbackConnectionId;
+	}
+
+	saveOAuthCredentials(provider, { ...credentials, metadata });
+	const saved =
+		loadOAuthCredentials(provider) ??
+		({ ...credentials, metadata } satisfies OAuthCredentials);
+	const savedMetadata = saved.metadata ?? {};
+	const connectorConnectionId = getMetadataString(
+		savedMetadata,
+		"connectorConnectionId",
+	);
+	const primaryConnectionId = getMetadataString(
+		savedMetadata,
+		"connectorSourceOfTruthPrimaryConnectionId",
+	);
+	const workspaceId = getMetadataString(
+		savedMetadata,
+		"connectorSourceOfTruthWorkspaceId",
+	);
+	return {
+		provider,
+		area,
+		...(fallbackConnectionId ? { fallbackConnectionId } : {}),
+		...(connectorConnectionId ? { connectorConnectionId } : {}),
+		...(primaryConnectionId ? { primaryConnectionId } : {}),
+		...(workspaceId ? { workspaceId } : {}),
+	};
+}
+
+export function clearOAuthProviderSourceOfTruthPolicy(
+	provider: string,
+): boolean {
+	if (!isConnectorOAuthProvider(provider)) {
+		throw new Error(
+			`Unsupported OAuth connector provider: ${provider}. Supported providers: ${supportedConnectorOAuthProviders()}`,
+		);
+	}
+	const credentials = loadOAuthCredentials(provider);
+	if (!credentials) {
+		throw new Error(`No OAuth credentials found for ${provider}`);
+	}
+
+	const metadata: Record<string, unknown> = { ...credentials.metadata };
+	const hadPolicyMetadata = SOURCE_OF_TRUTH_METADATA_KEYS.some(
+		(key) => key in metadata,
+	);
+	if (!hadPolicyMetadata) {
+		return false;
+	}
+	for (const key of SOURCE_OF_TRUTH_METADATA_KEYS) {
+		delete metadata[key];
+	}
+	saveOAuthCredentials(provider, { ...credentials, metadata });
+	return true;
+}

--- a/test/oauth-connectors.test.ts
+++ b/test/oauth-connectors.test.ts
@@ -1,0 +1,113 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const testDir = join(tmpdir(), `maestro-oauth-connectors-${Date.now()}`);
+
+import {
+	clearOAuthProviderSourceOfTruthPolicy,
+	configureOAuthProviderSourceOfTruthPolicy,
+	normalizeConnectorSourceOfTruthArea,
+} from "../src/oauth/connectors.js";
+import {
+	loadOAuthCredentials,
+	saveOAuthCredentials,
+} from "../src/oauth/storage.js";
+
+describe("OAuth connector source-of-truth metadata", () => {
+	beforeEach(() => {
+		process.env.MAESTRO_AGENT_DIR = join(testDir, "agent");
+		mkdirSync(testDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(testDir)) {
+			rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
+	it("normalizes local and enum source-of-truth area names", () => {
+		expect(normalizeConnectorSourceOfTruthArea("crm")).toBe("crm");
+		expect(
+			normalizeConnectorSourceOfTruthArea("SOURCE_OF_TRUTH_AREA_ANALYTICS"),
+		).toBe("analytics");
+		expect(normalizeConnectorSourceOfTruthArea("finance")).toBeNull();
+	});
+
+	it("configures source-of-truth metadata for a stored provider", async () => {
+		saveOAuthCredentials("openai", {
+			type: "oauth",
+			access: "openai-access",
+			refresh: "openai-refresh",
+			expires: Date.now() + 3_600_000,
+			metadata: {
+				scopes: ["model.read"],
+				sourceOfTruthArea: "analytics",
+			},
+		});
+
+		const configured = await configureOAuthProviderSourceOfTruthPolicy(
+			"openai",
+			{
+				area: "crm",
+				fallbackConnectionId: "conn_crm_fallback",
+			},
+		);
+
+		expect(configured).toMatchObject({
+			provider: "openai",
+			area: "crm",
+			fallbackConnectionId: "conn_crm_fallback",
+		});
+		expect(loadOAuthCredentials("openai")?.metadata).toMatchObject({
+			scopes: ["model.read"],
+			connectorSourceOfTruthArea: "crm",
+			connectorSourceOfTruthFallbackConnectionId: "conn_crm_fallback",
+		});
+		expect(loadOAuthCredentials("openai")?.metadata).not.toHaveProperty(
+			"sourceOfTruthArea",
+		);
+	});
+
+	it("rejects unsupported source-of-truth areas before changing credentials", async () => {
+		saveOAuthCredentials("openai", {
+			type: "oauth",
+			access: "openai-access",
+			refresh: "openai-refresh",
+			expires: Date.now() + 3_600_000,
+			metadata: { connectorSourceOfTruthArea: "analytics" },
+		});
+
+		await expect(
+			configureOAuthProviderSourceOfTruthPolicy("openai", {
+				area: "finance",
+			}),
+		).rejects.toThrow("Unsupported source-of-truth area");
+		expect(loadOAuthCredentials("openai")?.metadata).toMatchObject({
+			connectorSourceOfTruthArea: "analytics",
+		});
+	});
+
+	it("clears local source-of-truth policy metadata", () => {
+		saveOAuthCredentials("openai", {
+			type: "oauth",
+			access: "openai-access",
+			refresh: "openai-refresh",
+			expires: Date.now() + 3_600_000,
+			metadata: {
+				connectorConnectionId: "conn_openai",
+				connectorSourceOfTruthArea: "crm",
+				connectorSourceOfTruthFallbackConnectionId: "conn_fallback",
+				connectorSourceOfTruthPrimaryConnectionId: "conn_openai",
+				connectorSourceOfTruthWorkspaceId: "org_123",
+			},
+		});
+
+		expect(clearOAuthProviderSourceOfTruthPolicy("openai")).toBe(true);
+		expect(loadOAuthCredentials("openai")?.metadata).toEqual({
+			connectorConnectionId: "conn_openai",
+		});
+		expect(clearOAuthProviderSourceOfTruthPolicy("openai")).toBe(false);
+	});
+});

--- a/test/tui/tui-grouped-commands.test.ts
+++ b/test/tui/tui-grouped-commands.test.ts
@@ -518,6 +518,7 @@ describe("Grouped Command Handlers", () => {
 		const createAuthDeps = () => ({
 			handleLogin: vi.fn(),
 			handleLogout: vi.fn(),
+			handleSourceOfTruthPolicy: vi.fn(),
 			showInfo: vi.fn(),
 			getAuthState: vi.fn().mockReturnValue({
 				authenticated: false,
@@ -591,6 +592,28 @@ describe("Grouped Command Handlers", () => {
 
 			expect(deps.showInfo).toHaveBeenCalledWith(
 				expect.stringContaining("Authenticated: no"),
+			);
+		});
+
+		it("routes 'source-of-truth' to connector policy handler", async () => {
+			const { createAuthCommandHandler } = await import(
+				"../../src/cli-tui/commands/grouped/auth-commands.js"
+			);
+
+			const deps = createAuthDeps();
+			const handler = createAuthCommandHandler(deps);
+			const ctx = createMockContext(
+				"/auth source-of-truth openai analytics",
+				"source-of-truth openai analytics",
+			);
+
+			await handler(ctx);
+
+			expect(deps.handleSourceOfTruthPolicy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					rawInput: "/auth source-of-truth openai analytics",
+					argumentText: "openai analytics",
+				}),
 			);
 		});
 	});


### PR DESCRIPTION
## Summary
- add a public-side OAuth connector metadata helper for source-of-truth policy intent
- wire /auth source-of-truth <provider> <area> [fallbackConnectionId] and clear support through the grouped TUI auth command
- persist the same connectorSourceOfTruth* metadata keys used by maestro-internal so public/internal can converge cleanly when remote connector sync is present

## Notes
- The public repo currently does not include the internal connector service client, so this PR stores local desired policy metadata and leaves remote sync to the internal implementation/future public connector client.

## Verification
- npm run test -- test/oauth-connectors.test.ts test/tui/tui-grouped-commands.test.ts
- npx --yes bun@1.3.6 run build:all
- git diff --check
- commit hooks: guardian, biome/lint:evals, package metadata check, build, bun compile