### PR TITLE
Store hosted web sessions in Postgres

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,4 +75,4 @@ jobs:
         run: |
           # Run web tests plus production-schema database regressions with
           # Redis and PostgreSQL available.
-          bunx vitest run test/web/ test/db/legacy-rbac-migration.integration.test.ts --reporter=verbose
+          bunx vitest run test/web/ test/db/legacy-rbac-migration.integration.test.ts test/db/hosted-session-storage.integration.test.ts --reporter=verbose

--- a/src/db/migrations/0005_hosted_session_storage.sql
+++ b/src/db/migrations/0005_hosted_session_storage.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS "hosted_sessions" (
+	"session_id" varchar(128) PRIMARY KEY NOT NULL,
+	"scope" text NOT NULL,
+	"subject" text,
+	"title" varchar(255),
+	"summary" text,
+	"resume_summary" text,
+	"memory_extraction_hash" varchar(64),
+	"favorite" boolean DEFAULT false NOT NULL,
+	"tags" jsonb,
+	"cwd" text,
+	"model" varchar(255),
+	"thinking_level" varchar(50),
+	"system_prompt" text,
+	"prompt_metadata" jsonb,
+	"model_metadata" jsonb,
+	"tools" jsonb,
+	"message_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "hosted_session_entries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"session_id" varchar(128) NOT NULL,
+	"sequence" bigserial NOT NULL,
+	"entry_type" varchar(64) NOT NULL,
+	"entry_id" varchar(128),
+	"entry" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "hosted_session_entries_session_id_hosted_sessions_session_id_fk"
+		FOREIGN KEY ("session_id")
+		REFERENCES "public"."hosted_sessions"("session_id")
+		ON DELETE cascade
+		ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "hosted_session_scope_updated_idx" ON "hosted_sessions" USING btree ("scope", "updated_at");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "hosted_session_scope_id_idx" ON "hosted_sessions" USING btree ("scope", "session_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "hosted_session_subject_updated_idx" ON "hosted_sessions" USING btree ("subject", "updated_at");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "hosted_session_entry_session_sequence_idx" ON "hosted_session_entries" USING btree ("session_id", "sequence");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "hosted_session_entry_type_idx" ON "hosted_session_entries" USING btree ("session_id", "entry_type");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "hosted_session_entry_session_entry_idx"
+	ON "hosted_session_entries" USING btree ("session_id", "entry_id")
+	WHERE "entry_id" IS NOT NULL;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1776800460000,
 			"tag": "0004_reconcile_legacy_rbac_tables",
 			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1776800461000,
+			"tag": "0005_hosted_session_storage",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,6 +5,7 @@
 
 import { relations } from "drizzle-orm";
 import {
+	bigserial,
 	boolean,
 	index,
 	integer,
@@ -17,6 +18,7 @@ import {
 	uuid,
 	varchar,
 } from "drizzle-orm/pg-core";
+import type { SessionModelMetadata } from "../session/types.js";
 
 // ============================================================================
 // ENUMS
@@ -328,6 +330,80 @@ export type MessageMetadata = {
 	piiRedacted?: boolean;
 	redactedFields?: string[];
 };
+
+// ============================================================================
+// HOSTED WEB SESSIONS
+// ============================================================================
+
+export const hostedSessions = pgTable(
+	"hosted_sessions",
+	{
+		sessionId: varchar("session_id", { length: 128 }).primaryKey(),
+		scope: text("scope").notNull(),
+		subject: text("subject"),
+		title: varchar("title", { length: 255 }),
+		summary: text("summary"),
+		resumeSummary: text("resume_summary"),
+		memoryExtractionHash: varchar("memory_extraction_hash", { length: 64 }),
+		favorite: boolean("favorite").default(false).notNull(),
+		tags: jsonb("tags").$type<string[]>(),
+		cwd: text("cwd"),
+		model: varchar("model", { length: 255 }),
+		thinkingLevel: varchar("thinking_level", { length: 50 }),
+		systemPrompt: text("system_prompt"),
+		promptMetadata: jsonb("prompt_metadata").$type<unknown>(),
+		modelMetadata: jsonb("model_metadata").$type<SessionModelMetadata>(),
+		tools: jsonb("tools").$type<unknown[]>(),
+		messageCount: integer("message_count").default(0).notNull(),
+		createdAt: timestamp("created_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+		deletedAt: timestamp("deleted_at", { withTimezone: true }),
+	},
+	(table) => ({
+		scopeUpdatedIdx: index("hosted_session_scope_updated_idx").on(
+			table.scope,
+			table.updatedAt,
+		),
+		scopeSessionIdx: uniqueIndex("hosted_session_scope_id_idx").on(
+			table.scope,
+			table.sessionId,
+		),
+		subjectUpdatedIdx: index("hosted_session_subject_updated_idx").on(
+			table.subject,
+			table.updatedAt,
+		),
+	}),
+);
+
+export const hostedSessionEntries = pgTable(
+	"hosted_session_entries",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+		sessionId: varchar("session_id", { length: 128 })
+			.notNull()
+			.references(() => hostedSessions.sessionId, { onDelete: "cascade" }),
+		sequence: bigserial("sequence", { mode: "number" }).notNull(),
+		entryType: varchar("entry_type", { length: 64 }).notNull(),
+		entryId: varchar("entry_id", { length: 128 }),
+		entry: jsonb("entry").$type<unknown>().notNull(),
+		createdAt: timestamp("created_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+	},
+	(table) => ({
+		sessionSequenceIdx: uniqueIndex(
+			"hosted_session_entry_session_sequence_idx",
+		).on(table.sessionId, table.sequence),
+		sessionEntryTypeIdx: index("hosted_session_entry_type_idx").on(
+			table.sessionId,
+			table.entryType,
+		),
+	}),
+);
 
 // ============================================================================
 // AUDIT LOGS

--- a/src/server/handlers/approvals.ts
+++ b/src/server/handlers/approvals.ts
@@ -8,7 +8,7 @@ import {
 } from "../approval-mode-store.js";
 import { getAuthSubject } from "../authz.js";
 import { ApiError, sendJson } from "../server-utils.js";
-import { createSessionManagerForRequest } from "../session-scope.js";
+import { createWebSessionManagerForRequest } from "../session-scope.js";
 import {
 	type ApprovalsUpdateRequestInput,
 	ApprovalsUpdateRequestSchema,
@@ -46,18 +46,10 @@ async function ensureApprovalSessionAccess(
 		return null;
 	}
 
-	const sessionManager = createSessionManagerForRequest(req, false);
-	const sessionFile = sessionManager.getSessionFileById(sessionId);
-	if (!sessionFile) {
-		return null;
-	}
-
+	const sessionManager = createWebSessionManagerForRequest(req, false);
 	const session = await sessionManager.loadSession(sessionId);
 	if (!session) {
-		return {
-			statusCode: 404,
-			error: "Session file exists but could not be loaded",
-		};
+		return null;
 	}
 
 	if (!verifySessionOwnership(session, subject)) {

--- a/src/server/handlers/branch.ts
+++ b/src/server/handlers/branch.ts
@@ -3,8 +3,9 @@ import { type Static, Type } from "@sinclair/typebox";
 import { isUserMessage } from "../../agent/type-guards.js";
 import type { UserMessageWithAttachments } from "../../agent/types.js";
 import { getAuthSubject, requireApiAuth, requireCsrf } from "../authz.js";
+import { isHostedSessionManager } from "../hosted-session-manager.js";
 import { respondWithApiError, sendJson } from "../server-utils.js";
-import { createSessionManagerForRequest } from "../session-scope.js";
+import { createWebSessionManagerForRequest } from "../session-scope.js";
 import { checkSessionRateLimitAsync } from "../utils/session-rate-limit.js";
 import { parseAndValidateJson } from "../validation.js";
 
@@ -82,24 +83,13 @@ export async function handleBranch(
 					return;
 				}
 
-				const sessionManager = createSessionManagerForRequest(req, false);
-				const sessionFile = sessionManager.getSessionFileById(sessionId);
-				if (!sessionFile) {
-					sendJson(
-						res,
-						404,
-						{ error: `Session not found: ${sessionId}` },
-						corsHeaders,
-					);
-					return;
-				}
-
+				const sessionManager = createWebSessionManagerForRequest(req, false);
 				const session = await sessionManager.loadSession(sessionId);
 				if (!session) {
 					sendJson(
 						res,
 						404,
-						{ error: "Session file exists but could not be loaded" },
+						{ error: `Session not found: ${sessionId}` },
 						corsHeaders,
 					);
 					return;
@@ -152,24 +142,13 @@ export async function handleBranch(
 				return;
 			}
 
-			const sessionManager = createSessionManagerForRequest(req, false);
-			const sessionFile = sessionManager.getSessionFileById(data.sessionId);
-			if (!sessionFile) {
-				sendJson(
-					res,
-					404,
-					{ error: `Session not found: ${data.sessionId}` },
-					corsHeaders,
-				);
-				return;
-			}
-
+			const sessionManager = createWebSessionManagerForRequest(req, false);
 			const session = await sessionManager.loadSession(data.sessionId);
 			if (!session) {
 				sendJson(
 					res,
 					404,
-					{ error: "Session file exists but could not be loaded" },
+					{ error: `Session not found: ${data.sessionId}` },
 					corsHeaders,
 				);
 				return;
@@ -241,7 +220,21 @@ export async function handleBranch(
 				return;
 			}
 
-			sessionManager.setSessionFile(sessionFile);
+			if (isHostedSessionManager(sessionManager)) {
+				await sessionManager.resumeSession(data.sessionId);
+			} else {
+				const sessionFile = sessionManager.getSessionFileById(data.sessionId);
+				if (!sessionFile) {
+					sendJson(
+						res,
+						404,
+						{ error: `Session not found: ${data.sessionId}` },
+						corsHeaders,
+					);
+					return;
+				}
+				sessionManager.setSessionFile(sessionFile);
+			}
 			const modelKey = sessionManager.loadModel();
 			const thinkingLevel = sessionManager.loadThinkingLevel();
 			const messages = session.messages.slice(0, targetIndex);
@@ -293,14 +286,23 @@ export async function handleBranch(
 				pendingToolCalls: Map<string, { toolName: string }>;
 			};
 
-			const newSessionFile = sessionManager.createBranchedSession(
-				agentState,
-				targetIndex,
-			);
-
-			const sessionManager2 = createSessionManagerForRequest(req, false);
-			sessionManager2.setSessionFile(newSessionFile);
-			const newSessionId = sessionManager2.getSessionId();
+			let newSessionId: string;
+			let newSessionFile: string;
+			if (isHostedSessionManager(sessionManager)) {
+				newSessionId = await sessionManager.createBranchedSessionFromState(
+					agentState,
+					targetIndex,
+				);
+				newSessionFile = `db:${newSessionId}`;
+			} else {
+				newSessionFile = sessionManager.createBranchedSession(
+					agentState,
+					targetIndex,
+				);
+				const sessionManager2 = createWebSessionManagerForRequest(req, false);
+				sessionManager2.setSessionFile(newSessionFile);
+				newSessionId = sessionManager2.getSessionId();
+			}
 
 			sendJson(
 				res,

--- a/src/server/handlers/chat-ws.ts
+++ b/src/server/handlers/chat-ws.ts
@@ -767,29 +767,6 @@ export function handleChatWebSocket(
 					if (event.message.role === "assistant") {
 						automaticMemoryExtraction.schedule(sessionManager.getSessionFile());
 					}
-					if (sessionManager.shouldInitializeSession(agent.state.messages)) {
-						void initializeSessionIfNeeded()
-							.then((initializationError) => {
-								if (initializationError) {
-									wsSession.sendEvent({
-										type: "error",
-										message: `[Policy] ${initializationError}`,
-									});
-									wsSession.end();
-								}
-							})
-							.catch((error) => {
-								logger.warn("Failed to initialize session", {
-									error: error instanceof Error ? error.message : String(error),
-								});
-								wsSession.sendEvent({
-									type: "error",
-									message: "[Policy] Failed to initialize session",
-								});
-								wsSession.end();
-							});
-					}
-
 					sessionManager.updateSnapshot(
 						agent.state,
 						toSessionModelMetadata(registeredModel),

--- a/src/server/handlers/chat-ws.ts
+++ b/src/server/handlers/chat-ws.ts
@@ -729,7 +729,7 @@ export function handleChatWebSocket(
 				},
 			);
 
-			const unsubscribe = agent.subscribe(async (event: AgentEvent) => {
+			const unsubscribe = agent.subscribe((event: AgentEvent) => {
 				updateSessionSummary(event);
 
 				wsSession.sendEvent(maybeSlimEvent(event));
@@ -767,21 +767,27 @@ export function handleChatWebSocket(
 					if (event.message.role === "assistant") {
 						automaticMemoryExtraction.schedule(sessionManager.getSessionFile());
 					}
-					let initializationError: string | null = null;
-
 					if (sessionManager.shouldInitializeSession(agent.state.messages)) {
-						initializationError = await startSessionWithPolicy({
-							agent,
-							enterpriseContext,
-							logger,
-							modelId: registeredModel.id,
-							onSessionReady: (sessionId) => {
-								wsSession.sendSessionUpdate(sessionId);
-								wsSession.setContext({ sessionId });
-							},
-							sessionManager,
-							subject,
-						});
+						void initializeSessionIfNeeded()
+							.then((initializationError) => {
+								if (initializationError) {
+									wsSession.sendEvent({
+										type: "error",
+										message: `[Policy] ${initializationError}`,
+									});
+									wsSession.end();
+								}
+							})
+							.catch((error) => {
+								logger.warn("Failed to initialize session", {
+									error: error instanceof Error ? error.message : String(error),
+								});
+								wsSession.sendEvent({
+									type: "error",
+									message: "[Policy] Failed to initialize session",
+								});
+								wsSession.end();
+							});
 					}
 
 					sessionManager.updateSnapshot(
@@ -801,13 +807,6 @@ export function handleChatWebSocket(
 						},
 					);
 
-					if (initializationError) {
-						wsSession.sendEvent({
-							type: "error",
-							message: `[Policy] ${initializationError}`,
-						});
-						wsSession.end();
-					}
 					return;
 				}
 

--- a/src/server/handlers/chat-ws.ts
+++ b/src/server/handlers/chat-ws.ts
@@ -34,10 +34,11 @@ import { publishArtifactUpdate } from "../artifacts-live-reload.js";
 import { getAuthSubject } from "../authz.js";
 import { getAgentCircuitBreaker } from "../circuit-breaker.js";
 import { clientToolService } from "../client-tools-service.js";
+import { isHostedSessionManager } from "../hosted-session-manager.js";
 import { serverRequestManager } from "../server-request-manager.js";
 import { getRequestHeader } from "../server-utils.js";
 import { startSessionWithPolicy } from "../session-initialization.js";
-import { createSessionManagerForRequest } from "../session-scope.js";
+import { createWebSessionManagerForRequest } from "../session-scope.js";
 import { convertComposerMessagesToApp } from "../session-serialization.js";
 import type { SseContext, SseSkipListener } from "../sse-session.js";
 import { ServerRequestToolRetryService } from "../tool-retry-service.js";
@@ -396,16 +397,22 @@ export function handleChatWebSocket(
 				}
 			}
 
-			const sessionManager = createSessionManagerForRequest(req, false);
+			const sessionManager = createWebSessionManagerForRequest(req, false);
 			const subject = getAuthSubject(req);
 			let existingSessionLoaded = false;
 			if (chatReq.sessionId) {
-				const sessionFile = sessionManager.getSessionFileById(
-					chatReq.sessionId,
-				);
-				if (sessionFile) {
-					sessionManager.setSessionFile(sessionFile);
-					existingSessionLoaded = true;
+				if (isHostedSessionManager(sessionManager)) {
+					existingSessionLoaded = await sessionManager.resumeSession(
+						chatReq.sessionId,
+					);
+				} else {
+					const sessionFile = sessionManager.getSessionFileById(
+						chatReq.sessionId,
+					);
+					if (sessionFile) {
+						sessionManager.setSessionFile(sessionFile);
+						existingSessionLoaded = true;
+					}
 				}
 			}
 
@@ -501,11 +508,11 @@ export function handleChatWebSocket(
 			const wsSession = new WsSession(ws, undefined, { requestId, modelKey });
 			const { enterpriseContext } = await import("../../enterprise/context.js");
 
-			const initializeSessionIfNeeded = (): string | null => {
+			const initializeSessionIfNeeded = async (): Promise<string | null> => {
 				if (existingSessionLoaded || sessionManager.isInitialized()) {
 					return null;
 				}
-				const initializationError = startSessionWithPolicy({
+				const initializationError = await startSessionWithPolicy({
 					agent,
 					enterpriseContext,
 					logger,
@@ -524,7 +531,7 @@ export function handleChatWebSocket(
 				return null;
 			};
 
-			const initializationError = initializeSessionIfNeeded();
+			const initializationError = await initializeSessionIfNeeded();
 			if (initializationError) {
 				wsSession.sendEvent({
 					type: "error",
@@ -722,7 +729,7 @@ export function handleChatWebSocket(
 				},
 			);
 
-			const unsubscribe = agent.subscribe((event: AgentEvent) => {
+			const unsubscribe = agent.subscribe(async (event: AgentEvent) => {
 				updateSessionSummary(event);
 
 				wsSession.sendEvent(maybeSlimEvent(event));
@@ -763,7 +770,7 @@ export function handleChatWebSocket(
 					let initializationError: string | null = null;
 
 					if (sessionManager.shouldInitializeSession(agent.state.messages)) {
-						initializationError = startSessionWithPolicy({
+						initializationError = await startSessionWithPolicy({
 							agent,
 							enterpriseContext,
 							logger,

--- a/src/server/handlers/chat.ts
+++ b/src/server/handlers/chat.ts
@@ -50,8 +50,6 @@ function getComposerTextContent(content: ComposerMessage["content"]): string {
 		.join("");
 }
 
-// SessionManager type import for annotations, value import for instantiation
-import type { SessionManager } from "../../session/manager.js";
 import { toSessionModelMetadata } from "../../session/manager.js";
 import { createRuntimeSessionSummaryUpdater } from "../../session/runtime-summary-updater.js";
 import { recordSseSkip } from "../../telemetry.js";
@@ -65,6 +63,7 @@ import { publishArtifactUpdate } from "../artifacts-live-reload.js";
 import { getAuthSubject } from "../authz.js";
 import { getAgentCircuitBreaker } from "../circuit-breaker.js";
 import { clientToolService } from "../client-tools-service.js";
+import { isHostedSessionManager } from "../hosted-session-manager.js";
 import { serverRequestManager } from "../server-request-manager.js";
 import {
 	ApiError,
@@ -73,7 +72,7 @@ import {
 	sendJson,
 } from "../server-utils.js";
 import { startSessionWithPolicy } from "../session-initialization.js";
-import { createSessionManagerForRequest } from "../session-scope.js";
+import { createWebSessionManagerForRequest } from "../session-scope.js";
 import { convertComposerMessagesToApp } from "../session-serialization.js";
 import { SseSession, sendSSE, sendSessionUpdate } from "../sse-session.js";
 import { ServerRequestToolRetryService } from "../tool-retry-service.js";
@@ -255,16 +254,24 @@ export async function handleChat(
 
 		// ===== Phase 3: Session and Agent Setup =====
 		// Create session manager (false = don't auto-initialize from disk)
-		const sessionManager = createSessionManagerForRequest(req, false);
+		const sessionManager = createWebSessionManagerForRequest(req, false);
 		const subject = getAuthSubject(req);
 
 		// Resume existing session if sessionId provided
 		let existingSessionLoaded = false;
 		if (chatReq.sessionId) {
-			const sessionFile = sessionManager.getSessionFileById(chatReq.sessionId);
-			if (sessionFile) {
-				sessionManager.setSessionFile(sessionFile);
-				existingSessionLoaded = true;
+			if (isHostedSessionManager(sessionManager)) {
+				existingSessionLoaded = await sessionManager.resumeSession(
+					chatReq.sessionId,
+				);
+			} else {
+				const sessionFile = sessionManager.getSessionFileById(
+					chatReq.sessionId,
+				);
+				if (sessionFile) {
+					sessionManager.setSessionFile(sessionFile);
+					existingSessionLoaded = true;
+				}
 			}
 		}
 
@@ -380,11 +387,11 @@ export async function handleChat(
 		// Pre-load enterprise context for session tracking
 		const { enterpriseContext } = await import("../../enterprise/context.js");
 
-		const initializeSessionIfNeeded = (): string | null => {
+		const initializeSessionIfNeeded = async (): Promise<string | null> => {
 			if (existingSessionLoaded || sessionManager.isInitialized()) {
 				return null;
 			}
-			const initializationError = startSessionWithPolicy({
+			const initializationError = await startSessionWithPolicy({
 				agent,
 				enterpriseContext,
 				logger,
@@ -403,7 +410,7 @@ export async function handleChat(
 			return null;
 		};
 
-		const initializationError = initializeSessionIfNeeded();
+		const initializationError = await initializeSessionIfNeeded();
 		if (initializationError) {
 			sendSSE(sseSession, {
 				type: "error",
@@ -594,7 +601,7 @@ export async function handleChat(
 			},
 		);
 
-		const unsubscribe = agent.subscribe((event: AgentEvent) => {
+		const unsubscribe = agent.subscribe(async (event: AgentEvent) => {
 			updateSessionSummary(event);
 
 			// Forward event to client
@@ -639,7 +646,7 @@ export async function handleChat(
 
 				// Auto-initialize session on first user message
 				if (sessionManager.shouldInitializeSession(agent.state.messages)) {
-					initializationError = startSessionWithPolicy({
+					initializationError = await startSessionWithPolicy({
 						agent,
 						enterpriseContext,
 						logger,

--- a/src/server/handlers/chat.ts
+++ b/src/server/handlers/chat.ts
@@ -601,7 +601,7 @@ export async function handleChat(
 			},
 		);
 
-		const unsubscribe = agent.subscribe(async (event: AgentEvent) => {
+		const unsubscribe = agent.subscribe((event: AgentEvent) => {
 			updateSessionSummary(event);
 
 			// Forward event to client
@@ -642,22 +642,28 @@ export async function handleChat(
 				if (event.message.role === "assistant") {
 					automaticMemoryExtraction.schedule(sessionManager.getSessionFile());
 				}
-				let initializationError: string | null = null;
-
 				// Auto-initialize session on first user message
 				if (sessionManager.shouldInitializeSession(agent.state.messages)) {
-					initializationError = await startSessionWithPolicy({
-						agent,
-						enterpriseContext,
-						logger,
-						modelId: registeredModel.id,
-						onSessionReady: (sessionId) => {
-							sendSessionUpdate(sseSession, sessionId);
-							sseSession.setContext({ sessionId });
-						},
-						sessionManager,
-						subject,
-					});
+					void initializeSessionIfNeeded()
+						.then((initializationError) => {
+							if (initializationError) {
+								sendSSE(sseSession, {
+									type: "error",
+									message: `[Policy] ${initializationError}`,
+								});
+								sseSession.end();
+							}
+						})
+						.catch((error) => {
+							logger.warn("Failed to initialize session", {
+								error: error instanceof Error ? error.message : String(error),
+							});
+							sendSSE(sseSession, {
+								type: "error",
+								message: "[Policy] Failed to initialize session",
+							});
+							sseSession.end();
+						});
 				}
 
 				// Update session snapshot on every event
@@ -678,13 +684,6 @@ export async function handleChat(
 					},
 				);
 
-				if (initializationError) {
-					sendSSE(sseSession, {
-						type: "error",
-						message: `[Policy] ${initializationError}`,
-					});
-					sseSession.end();
-				}
 				return;
 			}
 

--- a/src/server/handlers/chat.ts
+++ b/src/server/handlers/chat.ts
@@ -642,30 +642,6 @@ export async function handleChat(
 				if (event.message.role === "assistant") {
 					automaticMemoryExtraction.schedule(sessionManager.getSessionFile());
 				}
-				// Auto-initialize session on first user message
-				if (sessionManager.shouldInitializeSession(agent.state.messages)) {
-					void initializeSessionIfNeeded()
-						.then((initializationError) => {
-							if (initializationError) {
-								sendSSE(sseSession, {
-									type: "error",
-									message: `[Policy] ${initializationError}`,
-								});
-								sseSession.end();
-							}
-						})
-						.catch((error) => {
-							logger.warn("Failed to initialize session", {
-								error: error instanceof Error ? error.message : String(error),
-							});
-							sendSSE(sseSession, {
-								type: "error",
-								message: "[Policy] Failed to initialize session",
-							});
-							sseSession.end();
-						});
-				}
-
 				// Update session snapshot on every event
 				sessionManager.updateSnapshot(
 					agent.state,

--- a/src/server/handlers/context.ts
+++ b/src/server/handlers/context.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { getAuthSubject, requireApiAuth } from "../authz.js";
 import { respondWithApiError, sendJson } from "../server-utils.js";
-import { createSessionManagerForRequest } from "../session-scope.js";
+import { createWebSessionManagerForRequest } from "../session-scope.js";
 import { redactPii } from "../utils/redact.js";
 import { checkSessionRateLimitAsync } from "../utils/session-rate-limit.js";
 import {
@@ -86,24 +86,13 @@ export async function handleContext(
 			sendJson(res, 429, { error: "Too many context requests" }, corsHeaders);
 			return;
 		}
-		const sessionManager = createSessionManagerForRequest(req, false);
-		const sessionFile = sessionManager.getSessionFileById(sessionId);
-		if (!sessionFile) {
-			sendJson(
-				res,
-				404,
-				{ error: `Session not found: ${sessionId}` },
-				corsHeaders,
-			);
-			return;
-		}
-
+		const sessionManager = createWebSessionManagerForRequest(req, false);
 		const session = await sessionManager.loadSession(sessionId);
 		if (!session) {
 			sendJson(
 				res,
 				404,
-				{ error: "Session file exists but could not be loaded" },
+				{ error: `Session not found: ${sessionId}` },
 				corsHeaders,
 			);
 			return;

--- a/src/server/handlers/session-artifacts.ts
+++ b/src/server/handlers/session-artifacts.ts
@@ -16,7 +16,7 @@ import {
 	sendJson,
 } from "../server-utils.js";
 import {
-	createSessionManagerForRequest,
+	createWebSessionManagerForRequest,
 	resolveSessionScope,
 } from "../session-scope.js";
 import { convertAppMessagesToComposer } from "../session-serialization.js";
@@ -236,7 +236,7 @@ async function loadComposerMessages(
 	req: IncomingMessage,
 	sessionId: string,
 ): Promise<ComposerMessage[]> {
-	const sessionManager = createSessionManagerForRequest(req, true);
+	const sessionManager = createWebSessionManagerForRequest(req, true);
 	const session = await sessionManager.loadSession(sessionId);
 	if (!session) {
 		throw new ApiError(404, "Session not found");

--- a/src/server/handlers/session-attachments.ts
+++ b/src/server/handlers/session-attachments.ts
@@ -5,7 +5,7 @@ import {
 	respondWithApiError,
 	sendJson,
 } from "../server-utils.js";
-import { createSessionManagerForRequest } from "../session-scope.js";
+import { createWebSessionManagerForRequest } from "../session-scope.js";
 
 const sessionIdPattern = /^[a-zA-Z0-9._-]+$/;
 const attachmentIdPattern = /^[a-zA-Z0-9._-]+$/;
@@ -64,7 +64,7 @@ export async function handleSessionAttachment(
 	params: { id: string; attachmentId: string },
 	cors: Record<string, string>,
 ) {
-	const sessionManager = createSessionManagerForRequest(req, true);
+	const sessionManager = createWebSessionManagerForRequest(req, true);
 
 	try {
 		if (req.method !== "GET") {
@@ -125,7 +125,7 @@ export async function handleSessionAttachmentExtract(
 	params: { id: string; attachmentId: string },
 	cors: Record<string, string>,
 ) {
-	const sessionManager = createSessionManagerForRequest(req, true);
+	const sessionManager = createWebSessionManagerForRequest(req, true);
 
 	try {
 		if (req.method !== "POST") {

--- a/src/server/handlers/sessions.ts
+++ b/src/server/handlers/sessions.ts
@@ -46,8 +46,10 @@ import {
 	summarizeOutboundSensitiveFindings,
 } from "../../safety/outbound-secret-preflight.js";
 import { safeReadSessionEntries } from "../../session/session-context.js";
+import type { SessionEntry } from "../../session/types.js";
 import { createLogger } from "../../utils/logger.js";
 import { getAuthSubject } from "../authz.js";
+import { isHostedSessionManager } from "../hosted-session-manager.js";
 import { serverRequestManager } from "../server-request-manager.js";
 import {
 	buildContentDisposition,
@@ -56,8 +58,8 @@ import {
 	sendJson,
 } from "../server-utils.js";
 import {
-	createSessionManagerForRequest,
-	createSessionManagerForScope,
+	createWebSessionManagerForRequest,
+	createWebSessionManagerForScope,
 	decodeScopedSessionId,
 	encodeScopedSessionId,
 	resolveSessionScope,
@@ -337,7 +339,7 @@ export async function handleSessions(
 	params: { id?: string },
 	cors: Record<string, string>,
 ) {
-	const sessionManager = createSessionManagerForRequest(req, true);
+	const sessionManager = createWebSessionManagerForRequest(req, true);
 	const sessionId = params.id;
 	const url = new URL(req.url || "/api/sessions", "http://localhost");
 	const limitParam = url.searchParams.get("limit");
@@ -470,21 +472,25 @@ export async function handleSessions(
 				return;
 			}
 
-			const sessionPath = sessionManager.getSessionFileById(sessionId);
-			if (!sessionPath) {
-				sendJson(res, 404, { error: "Session file not found" }, cors, req);
-				return;
-			}
+			if (isHostedSessionManager(sessionManager)) {
+				await sessionManager.updateSessionMetadata(sessionId, updates);
+			} else {
+				const sessionPath = sessionManager.getSessionFileById(sessionId);
+				if (!sessionPath) {
+					sendJson(res, 404, { error: "Session file not found" }, cors, req);
+					return;
+				}
 
-			// Apply updates - SessionManager supports favorite, title, and tags via meta entries
-			if (updates.favorite !== undefined) {
-				sessionManager.setSessionFavorite(sessionPath, updates.favorite);
-			}
-			if (updates.title !== undefined) {
-				sessionManager.setSessionTitle(sessionPath, updates.title);
-			}
-			if (updates.tags !== undefined) {
-				sessionManager.setSessionTags(sessionPath, updates.tags);
+				// Apply updates - SessionManager supports favorite, title, and tags via meta entries
+				if (updates.favorite !== undefined) {
+					sessionManager.setSessionFavorite(sessionPath, updates.favorite);
+				}
+				if (updates.title !== undefined) {
+					sessionManager.setSessionTitle(sessionPath, updates.title);
+				}
+				if (updates.tags !== undefined) {
+					sessionManager.setSessionTags(sessionPath, updates.tags);
+				}
 			}
 
 			// Return the updated values directly (writes are applied synchronously to the file)
@@ -554,7 +560,7 @@ export async function handleSessionShare(
 	params: { id: string },
 	cors: Record<string, string>,
 ) {
-	const sessionManager = createSessionManagerForRequest(req, true);
+	const sessionManager = createWebSessionManagerForRequest(req, true);
 	const sessionId = params.id;
 
 	try {
@@ -679,7 +685,7 @@ export async function handleSharedSession(
 		}
 
 		const { scope, sessionId } = decodeScopedSessionId(resolvedSessionId);
-		const sessionManager = createSessionManagerForScope(scope, true);
+		const sessionManager = createWebSessionManagerForScope(scope, true);
 		const session = await sessionManager.loadSession(sessionId);
 		if (!session) {
 			sendJson(res, 404, { error: "Session not found" }, cors, req);
@@ -744,7 +750,7 @@ export async function handleSharedSessionAttachment(
 		}
 
 		const { scope, sessionId } = decodeScopedSessionId(resolvedSessionId);
-		const sessionManager = createSessionManagerForScope(scope, true);
+		const sessionManager = createWebSessionManagerForScope(scope, true);
 		const session = await sessionManager.loadSession(sessionId);
 		if (!session) {
 			sendJson(res, 404, { error: "Session not found" }, cors, req);
@@ -788,7 +794,7 @@ export async function handleSessionExport(
 	params: { id: string },
 	cors: Record<string, string>,
 ) {
-	const sessionManager = createSessionManagerForRequest(req, true);
+	const sessionManager = createWebSessionManagerForRequest(req, true);
 	const sessionId = params.id;
 
 	try {
@@ -826,31 +832,32 @@ export async function handleSessionExport(
 		>(req);
 		const format = options.format || "json";
 		const messages = session.messages || [];
-		const jsonlEntries =
-			format === "jsonl"
-				? (() => {
-						const sessionFile = sessionManager.getSessionFileById(sessionId);
-						if (!sessionFile) {
-							sendJson(
-								res,
-								404,
-								{ error: "Session file not found" },
-								cors,
-								req,
-							);
-							return null;
-						}
-						return safeReadSessionEntries(sessionFile);
-					})()
-				: undefined;
-		if (format === "jsonl" && !jsonlEntries) {
-			return;
+		let jsonlEntries: SessionEntry[] | null | undefined = undefined;
+		let jsonlSessionFile: string | null = null;
+		if (format === "jsonl") {
+			if (isHostedSessionManager(sessionManager)) {
+				jsonlEntries = await sessionManager.loadEntries(sessionId);
+				if (!jsonlEntries) {
+					sendJson(res, 404, { error: "Session not found" }, cors, req);
+					return;
+				}
+			} else {
+				jsonlSessionFile = sessionManager.getSessionFileById(sessionId);
+				if (!jsonlSessionFile) {
+					sendJson(res, 404, { error: "Session file not found" }, cors, req);
+					return;
+				}
+				jsonlEntries = safeReadSessionEntries(jsonlSessionFile);
+				if (!jsonlEntries) {
+					return;
+				}
+			}
 		}
 
 		if (!options.allowSensitiveContent) {
 			const scan = scanOutboundSensitiveContent({
 				title: session.title,
-				messages: format === "jsonl" ? jsonlEntries : messages,
+				messages: format === "jsonl" ? (jsonlEntries ?? []) : messages,
 			});
 			if (scan.blockingFindings.length > 0) {
 				sendSensitiveContentBlockedResponse(
@@ -870,12 +877,15 @@ export async function handleSessionExport(
 
 		switch (format) {
 			case "jsonl": {
-				const sessionFile = sessionManager.getSessionFileById(sessionId);
-				if (!sessionFile) {
-					sendJson(res, 404, { error: "Session file not found" }, cors, req);
-					return;
+				if (isHostedSessionManager(sessionManager)) {
+					content = `${(jsonlEntries ?? []).map((entry) => JSON.stringify(entry)).join("\n")}\n`;
+				} else {
+					if (!jsonlSessionFile) {
+						sendJson(res, 404, { error: "Session file not found" }, cors, req);
+						return;
+					}
+					content = readFileSync(jsonlSessionFile, "utf8");
 				}
-				content = readFileSync(sessionFile, "utf8");
 				contentType = "application/x-ndjson";
 				filename = `session-${sessionId}.jsonl`;
 				break;

--- a/src/server/hosted-session-manager.ts
+++ b/src/server/hosted-session-manager.ts
@@ -1,0 +1,787 @@
+import { randomUUID } from "node:crypto";
+import { and, asc, desc, eq, gte, isNull, sql } from "drizzle-orm";
+import type { AgentState, AppMessage } from "../agent/types.js";
+import { getDb } from "../db/client.js";
+import { hostedSessionEntries, hostedSessions } from "../db/schema.js";
+import {
+	type SessionContextSnapshot,
+	buildSessionContextFromEntries,
+	generateEntryId,
+} from "../session/session-context.js";
+import {
+	applyAttachmentExtracts,
+	sanitizeMessageForSession,
+} from "../session/session-sanitize.js";
+import type { SessionMetadata } from "../session/types.js";
+import {
+	type AttachmentExtractedEntry,
+	CURRENT_SESSION_VERSION,
+	type CompactionEntry,
+	type SessionEntry,
+	type SessionHeaderEntry,
+	type SessionMetaEntry,
+	type SessionModelMetadata,
+	type SessionSummary,
+	type SessionTreeEntry,
+	isSessionHeaderEntry,
+	isSessionTreeEntry,
+	tryParseSessionEntry,
+} from "../session/types.js";
+import { queueSharedMemoryUpdate } from "../shared-memory/client.js";
+
+type SessionRow = typeof hostedSessions.$inferSelect;
+
+export interface HostedSessionMetadataUpdate {
+	title?: string;
+	favorite?: boolean;
+	tags?: string[];
+}
+
+export class HostedSessionManager {
+	readonly storageKind = "database" as const;
+
+	private readonly scope: string;
+	private readonly subject?: string;
+	private sessionId: string = randomUUID();
+	private entries: SessionEntry[] = [];
+	private byId: Map<string, SessionTreeEntry> = new Map();
+	private leafId: string | null = null;
+	private sessionInitialized = false;
+	private writeChain: Promise<unknown> = Promise.resolve();
+	private snapshot?: AgentState;
+	private lastModelMetadata?: SessionModelMetadata;
+
+	constructor(options: { scope: string; subject?: string }) {
+		this.scope = options.scope;
+		this.subject = options.subject;
+	}
+
+	private toModelMetadata(model: AgentState["model"]): SessionModelMetadata {
+		const optional = model as AgentState["model"] &
+			Partial<Pick<SessionModelMetadata, "providerName" | "source">>;
+		return {
+			provider: model.provider,
+			modelId: model.id,
+			providerName: optional.providerName,
+			name: model.name,
+			baseUrl: model.baseUrl,
+			reasoning: model.reasoning,
+			contextWindow: model.contextWindow,
+			maxTokens: model.maxTokens,
+			source: optional.source,
+		};
+	}
+
+	private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+		const result = this.writeChain.then(operation, operation);
+		this.writeChain = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
+	}
+
+	private rebuildIndex(entries: SessionEntry[]): void {
+		this.byId.clear();
+		this.leafId = null;
+		for (const entry of entries) {
+			if (!isSessionTreeEntry(entry)) {
+				continue;
+			}
+			this.byId.set(entry.id, entry);
+			this.leafId = entry.id;
+		}
+		this.sessionInitialized = entries.some(isSessionHeaderEntry);
+	}
+
+	private currentMessageCount(): number {
+		return this.buildSessionContext().messages.length;
+	}
+
+	private async ensureSessionRow(
+		sessionId: string,
+		values: Partial<typeof hostedSessions.$inferInsert> = {},
+	): Promise<void> {
+		const now = new Date();
+		await getDb()
+			.insert(hostedSessions)
+			.values({
+				sessionId,
+				scope: this.scope,
+				subject: this.subject ?? null,
+				cwd: process.cwd(),
+				messageCount: this.currentMessageCount(),
+				createdAt: now,
+				updatedAt: now,
+				...values,
+			})
+			.onConflictDoUpdate({
+				target: hostedSessions.sessionId,
+				set: {
+					scope: this.scope,
+					subject: values.subject ?? this.subject ?? null,
+					cwd: values.cwd ?? process.cwd(),
+					updatedAt: now,
+					deletedAt: null,
+					...values,
+				},
+			});
+	}
+
+	private appendEntry(entry: SessionEntry): void {
+		this.entries.push(entry);
+		if (isSessionTreeEntry(entry)) {
+			this.byId.set(entry.id, entry);
+			this.leafId = entry.id;
+		}
+		const sessionId = this.sessionId;
+		const entryId =
+			"id" in entry && typeof entry.id === "string" ? entry.id : undefined;
+		const messageCount = this.currentMessageCount();
+
+		void this.enqueue(async () => {
+			await this.ensureSessionRow(sessionId, { messageCount });
+			await getDb().insert(hostedSessionEntries).values({
+				sessionId,
+				entryType: entry.type,
+				entryId,
+				entry,
+			});
+			await getDb()
+				.update(hostedSessions)
+				.set({
+					messageCount,
+					updatedAt: new Date(),
+				})
+				.where(eq(hostedSessions.sessionId, sessionId));
+		});
+	}
+
+	private async loadRow(sessionId: string): Promise<SessionRow | null> {
+		const [row] = await getDb()
+			.select()
+			.from(hostedSessions)
+			.where(
+				and(
+					eq(hostedSessions.sessionId, sessionId),
+					eq(hostedSessions.scope, this.scope),
+					isNull(hostedSessions.deletedAt),
+				),
+			)
+			.limit(1);
+		return row ?? null;
+	}
+
+	async loadEntries(sessionId: string): Promise<SessionEntry[] | null> {
+		const row = await this.loadRow(sessionId);
+		if (!row) {
+			return null;
+		}
+		const rows = await getDb()
+			.select({ entry: hostedSessionEntries.entry })
+			.from(hostedSessionEntries)
+			.where(eq(hostedSessionEntries.sessionId, sessionId))
+			.orderBy(asc(hostedSessionEntries.sequence));
+
+		const entries: SessionEntry[] = [];
+		for (const row of rows) {
+			const entry = tryParseSessionEntry(JSON.stringify(row.entry));
+			if (entry) {
+				entries.push(entry);
+			}
+		}
+		return entries;
+	}
+
+	async resumeSession(sessionId: string): Promise<boolean> {
+		await this.flush();
+		const row = await this.loadRow(sessionId);
+		if (!row) {
+			return false;
+		}
+		const entries = (await this.loadEntries(sessionId)) ?? [];
+		this.sessionId = row.sessionId;
+		this.entries = entries;
+		this.rebuildIndex(entries);
+		return true;
+	}
+
+	loadAllSessions(): SessionMetadata[] {
+		return [];
+	}
+
+	async countActiveSessions(since: Date): Promise<number> {
+		await this.flush();
+		const [row] = await getDb()
+			.select({ count: sql<number>`count(*)::int` })
+			.from(hostedSessions)
+			.where(
+				and(
+					eq(hostedSessions.scope, this.scope),
+					gte(hostedSessions.updatedAt, since),
+					isNull(hostedSessions.deletedAt),
+				),
+			);
+		return Number(row?.count ?? 0);
+	}
+
+	async listSessions(options?: {
+		limit?: number;
+		offset?: number;
+	}): Promise<SessionSummary[]> {
+		await this.flush();
+		const rows = await getDb()
+			.select()
+			.from(hostedSessions)
+			.where(
+				and(
+					eq(hostedSessions.scope, this.scope),
+					isNull(hostedSessions.deletedAt),
+				),
+			)
+			.orderBy(desc(hostedSessions.updatedAt))
+			.limit(options?.limit ?? 500)
+			.offset(options?.offset ?? 0);
+
+		return rows.map((row) => ({
+			id: row.sessionId,
+			subject: row.subject ?? undefined,
+			title: row.title ?? undefined,
+			resumeSummary: row.resumeSummary ?? undefined,
+			createdAt: row.createdAt.toISOString(),
+			updatedAt: row.updatedAt.toISOString(),
+			messageCount: row.messageCount,
+			favorite: row.favorite,
+			tags: row.tags ?? undefined,
+		}));
+	}
+
+	async loadSession(sessionId: string): Promise<{
+		id: string;
+		subject?: string;
+		title?: string;
+		resumeSummary?: string;
+		messages: AppMessage[];
+		createdAt: string;
+		updatedAt: string;
+		messageCount: number;
+		favorite: boolean;
+		tags?: string[];
+	} | null> {
+		await this.flush();
+		const row = await this.loadRow(sessionId);
+		if (!row) {
+			return null;
+		}
+		const entries = (await this.loadEntries(sessionId)) ?? [];
+		const context = buildSessionContextFromEntries(entries);
+		const extractedById = new Map<string, string>();
+		for (const entry of entries) {
+			if (
+				entry.type === "attachment_extract" &&
+				entry.attachmentId &&
+				entry.extractedText
+			) {
+				extractedById.set(entry.attachmentId, entry.extractedText);
+			}
+		}
+		const messages =
+			extractedById.size === 0
+				? context.messages
+				: context.messages.map((message) =>
+						applyAttachmentExtracts(message, extractedById),
+					);
+
+		return {
+			id: row.sessionId,
+			subject: row.subject ?? undefined,
+			title: row.title ?? undefined,
+			resumeSummary: row.resumeSummary ?? undefined,
+			messages,
+			createdAt: row.createdAt.toISOString(),
+			updatedAt: row.updatedAt.toISOString(),
+			messageCount: messages.length,
+			favorite: row.favorite,
+			tags: row.tags ?? undefined,
+		};
+	}
+
+	async createSession(options?: { title?: string }): Promise<{
+		id: string;
+		title?: string;
+		resumeSummary?: string;
+		messages: AppMessage[];
+		createdAt: string;
+		updatedAt: string;
+		messageCount: number;
+		favorite: boolean;
+		tags?: string[];
+	}> {
+		await this.flush();
+		this.sessionId = randomUUID();
+		this.entries = [];
+		this.rebuildIndex([]);
+		const now = new Date();
+		await this.enqueue(() =>
+			this.ensureSessionRow(this.sessionId, {
+				title: options?.title,
+				favorite: false,
+				messageCount: 0,
+				createdAt: now,
+				updatedAt: now,
+			}),
+		);
+		await this.flush();
+		return {
+			id: this.sessionId,
+			title: options?.title,
+			messages: [],
+			createdAt: now.toISOString(),
+			updatedAt: now.toISOString(),
+			messageCount: 0,
+			favorite: false,
+		};
+	}
+
+	async deleteSession(sessionId: string): Promise<void> {
+		await this.flush();
+		await getDb()
+			.update(hostedSessions)
+			.set({ deletedAt: new Date(), updatedAt: new Date() })
+			.where(
+				and(
+					eq(hostedSessions.sessionId, sessionId),
+					eq(hostedSessions.scope, this.scope),
+				),
+			);
+	}
+
+	async createBranchedSessionFromState(
+		state: AgentState,
+		branchFromIndex: number,
+	): Promise<string> {
+		await this.flush();
+		const newSessionId = randomUUID();
+		const timestamp = new Date().toISOString();
+		const modelKey = `${state.model.provider}/${state.model.id}`;
+		const branchEntries: SessionEntry[] = [
+			{
+				type: "session",
+				version: CURRENT_SESSION_VERSION,
+				id: newSessionId,
+				timestamp,
+				cwd: process.cwd(),
+				subject: this.subject,
+				model: modelKey,
+				modelMetadata: this.toModelMetadata(state.model),
+				thinkingLevel: state.thinkingLevel,
+				systemPrompt: state.systemPrompt,
+				promptMetadata: state.promptMetadata,
+				tools: state.tools.map((tool) => ({
+					name: tool.name,
+					label: tool.label,
+					description: tool.description,
+				})),
+				branchedFrom: this.sessionId,
+				parentSession: this.sessionId,
+			} satisfies SessionHeaderEntry,
+		];
+		const branchIds = new Map<string, SessionTreeEntry>();
+		let parentId: string | null = null;
+		for (const message of state.messages.slice(0, branchFromIndex)) {
+			const entry: SessionTreeEntry = {
+				type: "message",
+				id: generateEntryId(branchIds),
+				parentId,
+				timestamp: new Date().toISOString(),
+				message: sanitizeMessageForSession(message),
+			};
+			branchIds.set(entry.id, entry);
+			parentId = entry.id;
+			branchEntries.push(entry);
+		}
+		const now = new Date();
+		await getDb()
+			.insert(hostedSessions)
+			.values({
+				sessionId: newSessionId,
+				scope: this.scope,
+				subject: this.subject,
+				cwd: process.cwd(),
+				model: modelKey,
+				modelMetadata: this.toModelMetadata(state.model),
+				thinkingLevel: state.thinkingLevel,
+				systemPrompt: state.systemPrompt,
+				promptMetadata: state.promptMetadata,
+				tools: state.tools,
+				messageCount: branchEntries.filter((entry) => entry.type === "message")
+					.length,
+				createdAt: now,
+				updatedAt: now,
+			});
+		for (const entry of branchEntries) {
+			await getDb()
+				.insert(hostedSessionEntries)
+				.values({
+					sessionId: newSessionId,
+					entryType: entry.type,
+					entryId:
+						"id" in entry && typeof entry.id === "string"
+							? entry.id
+							: undefined,
+					entry,
+				});
+		}
+		return newSessionId;
+	}
+
+	async updateSessionMetadata(
+		sessionId: string,
+		updates: HostedSessionMetadataUpdate,
+	): Promise<void> {
+		await this.flush();
+		const set: Partial<typeof hostedSessions.$inferInsert> = {
+			updatedAt: new Date(),
+		};
+		if (updates.title !== undefined) set.title = updates.title;
+		if (updates.favorite !== undefined) set.favorite = updates.favorite;
+		if (updates.tags !== undefined) set.tags = updates.tags;
+		await getDb()
+			.update(hostedSessions)
+			.set(set)
+			.where(
+				and(
+					eq(hostedSessions.sessionId, sessionId),
+					eq(hostedSessions.scope, this.scope),
+					isNull(hostedSessions.deletedAt),
+				),
+			);
+		const meta: SessionMetaEntry = {
+			type: "session_meta",
+			timestamp: new Date().toISOString(),
+			...(updates.title !== undefined ? { title: updates.title } : {}),
+			...(updates.favorite !== undefined ? { favorite: updates.favorite } : {}),
+			...(updates.tags !== undefined ? { tags: updates.tags } : {}),
+		};
+		if (sessionId === this.sessionId) {
+			this.appendEntry(meta);
+		} else {
+			await getDb().insert(hostedSessionEntries).values({
+				sessionId,
+				entryType: meta.type,
+				entry: meta,
+			});
+		}
+	}
+
+	startSession(state: AgentState, options?: { subject?: string }): void {
+		if (this.sessionInitialized) return;
+
+		const modelKey = `${state.model.provider}/${state.model.id}`;
+		const entry: SessionHeaderEntry = {
+			type: "session",
+			version: CURRENT_SESSION_VERSION,
+			id: this.sessionId,
+			timestamp: new Date().toISOString(),
+			cwd: process.cwd(),
+			subject: options?.subject ?? this.subject,
+			model: modelKey,
+			modelMetadata: this.toModelMetadata(state.model),
+			thinkingLevel: state.thinkingLevel,
+			systemPrompt: state.systemPrompt,
+			promptMetadata: state.promptMetadata,
+			tools: state.tools.map((tool) => ({
+				name: tool.name,
+				label: tool.label,
+				description: tool.description,
+			})),
+		};
+		this.sessionInitialized = true;
+		this.appendEntry(entry);
+
+		queueSharedMemoryUpdate({
+			sessionId: this.sessionId,
+			state: {
+				sessionId: this.sessionId,
+				cwd: process.cwd(),
+				model: modelKey,
+				updatedAt: entry.timestamp,
+				source: "maestro",
+			},
+			event: {
+				type: "maestro.session.started",
+				payload: {
+					sessionId: this.sessionId,
+					model: modelKey,
+					timestamp: entry.timestamp,
+				},
+			},
+		});
+	}
+
+	saveMessage(message: AppMessage): void {
+		const sanitizedMessage = sanitizeMessageForSession(message);
+		const entry: SessionTreeEntry = {
+			type: "message",
+			id: this.createTreeEntryId(),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+			message: sanitizedMessage,
+		};
+		this.appendEntry(entry);
+
+		queueSharedMemoryUpdate({
+			sessionId: this.sessionId,
+			state: {
+				sessionId: this.sessionId,
+				updatedAt: entry.timestamp,
+				lastMessageId: entry.id,
+				lastMessageRole: message.role,
+				source: "maestro",
+			},
+			event: {
+				type: "maestro.message.saved",
+				payload: {
+					sessionId: this.sessionId,
+					messageId: entry.id,
+					role: message.role,
+					timestamp: entry.timestamp,
+				},
+			},
+		});
+	}
+
+	saveCompaction(
+		summary: string,
+		firstKeptEntryIndex: number,
+		tokensBefore: number,
+		options?: {
+			auto?: boolean;
+			customInstructions?: string;
+			firstKeptEntryId?: string;
+		},
+	): void {
+		const context = this.buildSessionContext();
+		const fallbackEntry = context.messageEntries[firstKeptEntryIndex];
+		const firstKeptEntryId =
+			options?.firstKeptEntryId ?? fallbackEntry?.id ?? this.leafId;
+		if (!firstKeptEntryId) {
+			return;
+		}
+		const entry: CompactionEntry = {
+			type: "compaction",
+			id: this.createTreeEntryId(),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+			summary,
+			firstKeptEntryId,
+			tokensBefore,
+			auto: options?.auto,
+			customInstructions: options?.customInstructions,
+		};
+		this.appendEntry(entry);
+	}
+
+	saveAttachmentExtraction(
+		sessionRef: string,
+		attachmentId: string,
+		text: string,
+	): void {
+		if (!attachmentId || !text) return;
+		const entry: AttachmentExtractedEntry = {
+			type: "attachment_extract",
+			timestamp: new Date().toISOString(),
+			attachmentId,
+			extractedText: text,
+		};
+		const targetSessionId = sessionRef.startsWith("db:")
+			? sessionRef.slice("db:".length)
+			: sessionRef;
+		if (targetSessionId && targetSessionId !== this.sessionId) {
+			void this.enqueue(async () => {
+				await getDb().insert(hostedSessionEntries).values({
+					sessionId: targetSessionId,
+					entryType: entry.type,
+					entry,
+				});
+				await getDb()
+					.update(hostedSessions)
+					.set({ updatedAt: new Date() })
+					.where(
+						and(
+							eq(hostedSessions.sessionId, targetSessionId),
+							eq(hostedSessions.scope, this.scope),
+							isNull(hostedSessions.deletedAt),
+						),
+					);
+			});
+			return;
+		}
+		this.appendEntry(entry);
+	}
+
+	saveSessionSummary(summary: string, _sessionRef?: string): void {
+		const trimmed = summary.trim();
+		if (!trimmed) return;
+		const sessionId = this.sessionId;
+		const entry: SessionMetaEntry = {
+			type: "session_meta",
+			timestamp: new Date().toISOString(),
+			summary: trimmed,
+		};
+		this.appendEntry(entry);
+		void this.enqueue(async () => {
+			await getDb()
+				.update(hostedSessions)
+				.set({ summary: trimmed, updatedAt: new Date() })
+				.where(
+					and(
+						eq(hostedSessions.sessionId, sessionId),
+						eq(hostedSessions.scope, this.scope),
+					),
+				);
+		});
+	}
+
+	saveSessionResumeSummary(summary: string, _sessionRef?: string): void {
+		const trimmed = summary.trim();
+		if (!trimmed) return;
+		const sessionId = this.sessionId;
+		const entry: SessionMetaEntry = {
+			type: "session_meta",
+			timestamp: new Date().toISOString(),
+			resumeSummary: trimmed,
+		};
+		this.appendEntry(entry);
+		void this.enqueue(async () => {
+			await getDb()
+				.update(hostedSessions)
+				.set({ resumeSummary: trimmed, updatedAt: new Date() })
+				.where(
+					and(
+						eq(hostedSessions.sessionId, sessionId),
+						eq(hostedSessions.scope, this.scope),
+					),
+				);
+		});
+	}
+
+	saveSessionMemoryExtractionHash(hash: string, _sessionRef?: string): void {
+		const trimmed = hash.trim();
+		if (!trimmed) return;
+		const sessionId = this.sessionId;
+		const entry: SessionMetaEntry = {
+			type: "session_meta",
+			timestamp: new Date().toISOString(),
+			memoryExtractionHash: trimmed,
+		};
+		this.appendEntry(entry);
+		void this.enqueue(async () => {
+			await getDb()
+				.update(hostedSessions)
+				.set({ memoryExtractionHash: trimmed, updatedAt: new Date() })
+				.where(
+					and(
+						eq(hostedSessions.sessionId, sessionId),
+						eq(hostedSessions.scope, this.scope),
+					),
+				);
+		});
+	}
+
+	setSessionFavorite(_sessionRef: string, favorite: boolean): void {
+		void this.updateSessionMetadata(this.sessionId, { favorite });
+	}
+
+	setSessionTitle(_sessionRef: string, title: string): void {
+		void this.updateSessionMetadata(this.sessionId, { title });
+	}
+
+	setSessionTags(_sessionRef: string, tags: string[]): void {
+		void this.updateSessionMetadata(this.sessionId, { tags });
+	}
+
+	getSessionId(): string {
+		return this.sessionId;
+	}
+
+	getSessionFile(): string {
+		return `db:${this.sessionId}`;
+	}
+
+	getSessionFileById(sessionId: string): string | null {
+		return `db:${sessionId}`;
+	}
+
+	setSessionFile(sessionRef: string): void {
+		const sessionId = sessionRef.startsWith("db:")
+			? sessionRef.slice("db:".length)
+			: sessionRef;
+		if (sessionId) {
+			this.sessionId = sessionId;
+		}
+	}
+
+	isInitialized(): boolean {
+		return this.sessionInitialized;
+	}
+
+	shouldInitializeSession(messages: AppMessage[]): boolean {
+		return (
+			!this.sessionInitialized &&
+			messages.some((message) => message.role === "user")
+		);
+	}
+
+	updateSnapshot(state: AgentState, metadata?: SessionModelMetadata): void {
+		this.snapshot = state;
+		if (metadata) {
+			this.lastModelMetadata = metadata;
+		}
+	}
+
+	buildSessionContext(
+		leafId: string | null = this.leafId,
+	): SessionContextSnapshot {
+		return buildSessionContextFromEntries(this.entries, {
+			leafId,
+			byId: this.byId,
+			header: this.getHeader(),
+		});
+	}
+
+	loadModel(): string | null {
+		return this.buildSessionContext().model;
+	}
+
+	loadThinkingLevel(): string {
+		return this.buildSessionContext().thinkingLevel;
+	}
+
+	getHeader(): SessionHeaderEntry | null {
+		return (
+			(this.entries.find((entry) => entry.type === "session") as
+				| SessionHeaderEntry
+				| undefined) ?? null
+		);
+	}
+
+	private createTreeEntryId(): string {
+		return generateEntryId(this.byId);
+	}
+
+	async flush(): Promise<void> {
+		await this.writeChain;
+	}
+}
+
+export function isHostedSessionManager(
+	manager: unknown,
+): manager is HostedSessionManager {
+	return (
+		typeof manager === "object" &&
+		manager !== null &&
+		"storageKind" in manager &&
+		(manager as { storageKind?: unknown }).storageKind === "database"
+	);
+}

--- a/src/server/session-initialization.ts
+++ b/src/server/session-initialization.ts
@@ -1,8 +1,27 @@
 import type { EnterpriseSession } from "../enterprise/context.js";
 import { checkSessionLimits } from "../safety/policy.js";
-import type { SessionManager } from "../session/manager.js";
 
-type SessionState = Parameters<SessionManager["startSession"]>[0];
+type SessionState = Parameters<SessionInitializationManager["startSession"]>[0];
+
+export interface SessionInitializationManager {
+	loadAllSessions(): Array<{ modified: Date }>;
+	countActiveSessions?(since: Date): Promise<number>;
+	startSession(state: AgentSessionState, options?: { subject?: string }): void;
+	getSessionId(): string;
+}
+
+type AgentSessionState = {
+	messages: unknown[];
+	model: unknown;
+	thinkingLevel: unknown;
+	systemPrompt: string;
+	promptMetadata?: unknown;
+	tools: Array<{
+		name: string;
+		label?: string;
+		description?: string;
+	}>;
+};
 
 export interface SessionInitializationAgent {
 	state: SessionState;
@@ -19,15 +38,15 @@ export interface SessionInitializationLogger {
 	warn(message: string, context: Record<string, unknown>): void;
 }
 
-export function startSessionWithPolicy(params: {
+export async function startSessionWithPolicy(params: {
 	agent: SessionInitializationAgent;
 	enterpriseContext: SessionInitializationEnterpriseContext;
 	logger: SessionInitializationLogger;
 	modelId: string;
 	onSessionReady: (sessionId: string) => void;
-	sessionManager: SessionManager;
+	sessionManager: SessionInitializationManager;
 	subject?: string;
-}): string | null {
+}): Promise<string | null> {
 	const {
 		agent,
 		enterpriseContext,
@@ -40,10 +59,15 @@ export function startSessionWithPolicy(params: {
 
 	let activeCount: number | undefined;
 	try {
-		const sessions = sessionManager.loadAllSessions();
-		activeCount = sessions.filter(
-			(session) => Date.now() - session.modified.getTime() < 60 * 60 * 1000,
-		).length;
+		const activeSince = new Date(Date.now() - 60 * 60 * 1000);
+		if (sessionManager.countActiveSessions) {
+			activeCount = await sessionManager.countActiveSessions(activeSince);
+		} else {
+			const sessions = sessionManager.loadAllSessions();
+			activeCount = sessions.filter(
+				(session) => session.modified.getTime() >= activeSince.getTime(),
+			).length;
+		}
 	} catch (error) {
 		logger.warn("Failed to count active sessions", {
 			error: error instanceof Error ? error.message : String(error),

--- a/src/server/session-scope.ts
+++ b/src/server/session-scope.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage } from "node:http";
+import { isDatabaseConfigured } from "../db/client.js";
 import { SessionManager } from "../session/manager.js";
 import {
 	decodeScopedSessionId,
@@ -7,6 +8,7 @@ import {
 } from "../session/scope.js";
 import { getArtifactAccessGrantFromRequest } from "./artifact-access.js";
 import { getAuthSubject } from "./authz.js";
+import { HostedSessionManager } from "./hosted-session-manager.js";
 import { getRequestToken } from "./server-utils.js";
 
 const SESSION_SCOPE_MODE = (
@@ -59,4 +61,67 @@ export function createSessionManagerForScope(
 		});
 	}
 	return new SessionManager(continueSession, customSessionPath);
+}
+
+export type WebSessionManager = SessionManager | HostedSessionManager;
+
+function getHostedSessionStorageMode(): string {
+	return (
+		process.env.MAESTRO_HOSTED_SESSION_STORAGE ??
+		process.env.MAESTRO_SESSION_STORAGE ??
+		""
+	)
+		.trim()
+		.toLowerCase();
+}
+
+function shouldUseHostedDatabaseSessions(scope: string | null): boolean {
+	if (!scope) return false;
+	const mode = getHostedSessionStorageMode();
+	if (mode === "file" || mode === "jsonl" || mode === "filesystem") {
+		return false;
+	}
+	if (mode === "database" || mode === "db" || mode === "postgres") {
+		if (!isDatabaseConfigured()) {
+			throw new Error(
+				"MAESTRO_HOSTED_SESSION_STORAGE=database requires MAESTRO_DATABASE_URL or DATABASE_URL",
+			);
+		}
+		return true;
+	}
+	return isDatabaseConfigured();
+}
+
+export function createWebSessionManagerForRequest(
+	req: IncomingMessage,
+	continueSession = true,
+	customSessionPath?: string,
+): WebSessionManager {
+	const scope = resolveSessionScope(req);
+	if (!customSessionPath && shouldUseHostedDatabaseSessions(scope)) {
+		return new HostedSessionManager({
+			scope: scope!,
+			subject: getAuthSubject(req) || undefined,
+		});
+	}
+	return createSessionManagerForScope(
+		scope,
+		continueSession,
+		customSessionPath,
+	);
+}
+
+export function createWebSessionManagerForScope(
+	scope: string | null,
+	continueSession = true,
+	customSessionPath?: string,
+): WebSessionManager {
+	if (!customSessionPath && shouldUseHostedDatabaseSessions(scope)) {
+		return new HostedSessionManager({ scope: scope! });
+	}
+	return createSessionManagerForScope(
+		scope,
+		continueSession,
+		customSessionPath,
+	);
 }

--- a/test/db/hosted-session-storage.integration.test.ts
+++ b/test/db/hosted-session-storage.integration.test.ts
@@ -1,0 +1,258 @@
+/**
+ * @vitest-environment node
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import type { IncomingMessage } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import postgres from "postgres";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentState, AppMessage } from "../../src/agent/types.js";
+
+vi.mock("../../src/session/session-memory.js", () => ({
+	syncSessionMemory: vi.fn(),
+}));
+
+const BASE_DB_URL =
+	process.env.MAESTRO_DATABASE_URL || process.env.DATABASE_URL;
+const describeDb = BASE_DB_URL ? describe : describe.skip;
+
+const originalEnv = { ...process.env };
+
+function quoteIdent(identifier: string): string {
+	return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function databaseUrlFor(baseUrl: string, databaseName: string): string {
+	const url = new URL(baseUrl);
+	url.pathname = `/${databaseName}`;
+	return url.toString();
+}
+
+function createMockState(messages: AppMessage[] = []): AgentState {
+	return {
+		steeringMode: "all",
+		followUpMode: "all",
+		queueMode: "all",
+		messages,
+		systemPrompt: "hosted session test",
+		model: {
+			provider: "anthropic",
+			id: "claude-sonnet-4",
+			contextWindow: 200000,
+			name: "Claude Sonnet 4",
+			api: "anthropic-messages",
+			baseUrl: "https://api.anthropic.com/v1/messages",
+			reasoning: false,
+			input: ["text", "image"],
+			cost: {
+				input: 0.003,
+				output: 0.015,
+				cacheRead: 0.0003,
+				cacheWrite: 0.00375,
+			},
+			maxTokens: 8192,
+		},
+		tools: [],
+		thinkingLevel: "off",
+		isStreaming: false,
+		streamMessage: null,
+		pendingToolCalls: new Map(),
+	};
+}
+
+function userMessage(text: string): AppMessage {
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+	};
+}
+
+function assistantMessage(text: string): AppMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4",
+		stopReason: "stop",
+		timestamp: Date.now(),
+		usage: {
+			input: 10,
+			output: 5,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	};
+}
+
+function createScopedRequest(token: string): IncomingMessage {
+	return {
+		headers: { authorization: `Bearer ${token}` },
+		socket: { remoteAddress: "127.0.0.1" },
+	} as unknown as IncomingMessage;
+}
+
+function countJsonlFiles(root: string): number {
+	if (!existsSync(root)) return 0;
+	let count = 0;
+	for (const entry of readdirSync(root, { recursive: true })) {
+		if (String(entry).endsWith(".jsonl")) {
+			count += 1;
+		}
+	}
+	return count;
+}
+
+describeDb("hosted session database storage", () => {
+	let admin: postgres.Sql | null = null;
+	let databaseName = "";
+	let databaseUrl = "";
+	let sessionDir = "";
+
+	beforeEach(async () => {
+		vi.resetModules();
+		process.env = { ...originalEnv };
+
+		databaseName = `maestro_hosted_sessions_${randomUUID().replaceAll("-", "").slice(0, 16)}`;
+		databaseUrl = databaseUrlFor(BASE_DB_URL!, databaseName);
+		admin = postgres(BASE_DB_URL!, { max: 1 });
+		await admin.unsafe(`CREATE DATABASE ${quoteIdent(databaseName)}`);
+
+		const setup = postgres(databaseUrl, { max: 1 });
+		try {
+			await setup`CREATE EXTENSION IF NOT EXISTS pgcrypto`;
+		} finally {
+			await setup.end();
+		}
+
+		sessionDir = mkdtempSync(join(tmpdir(), "maestro-hosted-sessions-"));
+		process.env.MAESTRO_DATABASE_URL = databaseUrl;
+		process.env.MAESTRO_DB_MAX_CONNECTIONS = "1";
+		process.env.MAESTRO_SESSION_SCOPE = "auth";
+		process.env.MAESTRO_HOSTED_SESSION_STORAGE = "database";
+		process.env.MAESTRO_SESSION_DIR = sessionDir;
+	});
+
+	afterEach(async () => {
+		try {
+			const client = await import("../../src/db/client.js");
+			await client.closeDb();
+		} catch {
+			// The test may fail before the app client is imported.
+		}
+
+		if (admin) {
+			await admin.unsafe(
+				`
+				SELECT pg_terminate_backend(pid)
+				FROM pg_stat_activity
+				WHERE datname = '${databaseName.replaceAll("'", "''")}'
+					AND pid <> pg_backend_pid()
+				`,
+			);
+			await admin.unsafe(`DROP DATABASE IF EXISTS ${quoteIdent(databaseName)}`);
+			await admin.end();
+			admin = null;
+		}
+
+		if (sessionDir) {
+			rmSync(sessionDir, { recursive: true, force: true });
+			sessionDir = "";
+		}
+
+		process.env = originalEnv;
+		vi.resetModules();
+	});
+
+	it("persists scoped web sessions in Postgres instead of JSONL files", async () => {
+		const { migrate } = await import("../../src/db/migrate.js");
+		await expect(migrate()).resolves.toBe(6);
+
+		const { createWebSessionManagerForRequest } = await import(
+			"../../src/server/session-scope.js"
+		);
+		const { isHostedSessionManager } = await import(
+			"../../src/server/hosted-session-manager.js"
+		);
+
+		const req = createScopedRequest("production-identity-token");
+		const manager = createWebSessionManagerForRequest(req, false);
+		expect(isHostedSessionManager(manager)).toBe(true);
+
+		const firstUser = userMessage("Store this in the hosted session database.");
+		const firstAssistant = assistantMessage("Stored in Postgres.");
+		const state = createMockState([firstUser, firstAssistant]);
+		manager.startSession(state, { subject: "key:test-subject" });
+		manager.saveMessage(firstUser);
+		manager.saveMessage(firstAssistant);
+		manager.saveSessionSummary("The session is backed by Postgres.");
+		manager.saveSessionResumeSummary(
+			"Continue from the database-backed state.",
+		);
+		await manager.flush();
+		await expect(
+			manager.countActiveSessions(new Date(Date.now() - 60 * 60 * 1000)),
+		).resolves.toBe(1);
+
+		const sessionId = manager.getSessionId();
+		const loaded = await manager.loadSession(sessionId);
+		expect(loaded).toMatchObject({
+			id: sessionId,
+			messageCount: 2,
+			resumeSummary: "Continue from the database-backed state.",
+		});
+		expect(loaded?.messages.map((message) => message.role)).toEqual([
+			"user",
+			"assistant",
+		]);
+
+		const resumed = createWebSessionManagerForRequest(req, false);
+		expect(isHostedSessionManager(resumed)).toBe(true);
+		if (!isHostedSessionManager(resumed)) {
+			throw new Error("expected hosted session manager");
+		}
+		await expect(resumed.resumeSession(sessionId)).resolves.toBe(true);
+		const followUp = userMessage("Resume without touching JSONL.");
+		resumed.saveMessage(followUp);
+		await resumed.updateSessionMetadata(sessionId, {
+			title: "Database session",
+			favorite: true,
+			tags: ["hosted", "identity"],
+		});
+		await resumed.flush();
+
+		const reloaded = await resumed.loadSession(sessionId);
+		expect(reloaded).toMatchObject({
+			title: "Database session",
+			favorite: true,
+			tags: ["hosted", "identity"],
+			messageCount: 3,
+		});
+
+		const entries = await resumed.loadEntries(sessionId);
+		expect(entries?.some((entry) => entry.type === "session")).toBe(true);
+		expect(entries?.filter((entry) => entry.type === "message")).toHaveLength(
+			3,
+		);
+		expect(countJsonlFiles(sessionDir)).toBe(0);
+
+		const verify = postgres(databaseUrl, { max: 1 });
+		try {
+			const rows = await verify<
+				Array<{ session_count: string; entry_count: string }>
+			>`
+				SELECT
+					(SELECT count(*)::text FROM hosted_sessions) AS session_count,
+					(SELECT count(*)::text FROM hosted_session_entries) AS entry_count
+			`;
+			expect(rows[0]).toEqual({ session_count: "1", entry_count: "7" });
+		} finally {
+			await verify.end();
+		}
+	});
+});

--- a/test/db/legacy-rbac-migration.integration.test.ts
+++ b/test/db/legacy-rbac-migration.integration.test.ts
@@ -132,7 +132,7 @@ describeDb("legacy RBAC migration integration", () => {
 			"../../src/rbac/permissions.js"
 		);
 
-		await expect(migrate()).resolves.toBe(1);
+		await expect(migrate()).resolves.toBe(2);
 		await expect(seedPermissions()).resolves.toBeUndefined();
 		await expect(seedPermissions()).resolves.toBeUndefined();
 
@@ -143,6 +143,9 @@ describeDb("legacy RBAC migration integration", () => {
 			`;
 			expect(applied.map((row) => row.tag)).toContain(
 				"0004_reconcile_legacy_rbac_tables",
+			);
+			expect(applied.map((row) => row.tag)).toContain(
+				"0005_hosted_session_storage",
 			);
 
 			const columnState = await verify<

--- a/test/db/migrate.test.ts
+++ b/test/db/migrate.test.ts
@@ -59,7 +59,7 @@ describe("migrate", () => {
 	it("marks the initial migration applied instead of replaying existing schema", async () => {
 		const applied = await migrate();
 
-		expect(applied).toBe(4);
+		expect(applied).toBe(5);
 		expect(
 			mocks.queries.some((query) =>
 				query.includes('CREATE TYPE "public"."alert_severity"'),
@@ -91,7 +91,7 @@ describe("migrate", () => {
 
 		const applied = await migrate();
 
-		expect(applied).toBe(3);
+		expect(applied).toBe(4);
 		expect(
 			mocks.queries.some((query) =>
 				query.includes('CREATE TABLE IF NOT EXISTS "shared_sessions"'),

--- a/test/server/hosted-session-export.test.ts
+++ b/test/server/hosted-session-export.test.ts
@@ -1,0 +1,97 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function createMockRequest(method: string, body?: unknown): IncomingMessage {
+	return {
+		method,
+		headers: {},
+		socket: { remoteAddress: "127.0.0.1" },
+		on: vi.fn((event: string, callback: (chunk?: Buffer) => void) => {
+			if (event === "data" && body) {
+				callback(Buffer.from(JSON.stringify(body)));
+			}
+			if (event === "end") {
+				setTimeout(() => callback(), 0);
+			}
+		}),
+	} as unknown as IncomingMessage;
+}
+
+function createMockResponse(): {
+	res: ServerResponse;
+	getStatus: () => number;
+	getBody: () => unknown;
+} {
+	let status = 200;
+	let body = "";
+	const res = {
+		writeHead: vi.fn((value: number) => {
+			status = value;
+		}),
+		end: vi.fn((value?: string) => {
+			if (value) body = value;
+		}),
+		setHeader: vi.fn(),
+	} as unknown as ServerResponse;
+	return {
+		res,
+		getStatus: () => status,
+		getBody: () => {
+			try {
+				return JSON.parse(body);
+			} catch {
+				return body;
+			}
+		},
+	};
+}
+
+describe("hosted session export", () => {
+	afterEach(() => {
+		vi.doUnmock("../../src/server/session-scope.js");
+		vi.doUnmock("../../src/server/hosted-session-manager.js");
+		vi.resetModules();
+	});
+
+	it("sends 404 when hosted JSONL entries disappear before export", async () => {
+		const hostedManager = {
+			storageKind: "database",
+			loadSession: vi.fn(async () => ({
+				id: "hosted-session",
+				owner: "anon",
+				createdAt: "2024-01-01T00:00:00Z",
+				updatedAt: "2024-01-01T00:00:00Z",
+				messageCount: 1,
+				messages: [{ role: "user", content: "hello" }],
+			})),
+			loadEntries: vi.fn(async () => null),
+			getSessionFileById: vi.fn(() => "db:hosted-session"),
+		};
+		vi.doMock("../../src/server/session-scope.js", () => ({
+			createWebSessionManagerForRequest: vi.fn(() => hostedManager),
+			createWebSessionManagerForScope: vi.fn(() => hostedManager),
+		}));
+		vi.doMock("../../src/server/hosted-session-manager.js", () => ({
+			isHostedSessionManager: (manager: unknown) =>
+				typeof manager === "object" &&
+				manager !== null &&
+				(manager as { storageKind?: unknown }).storageKind === "database",
+		}));
+
+		const { handleSessionExport } = await import(
+			"../../src/server/handlers/sessions.js"
+		);
+		const req = createMockRequest("POST", { format: "jsonl" });
+		const { res, getStatus, getBody } = createMockResponse();
+
+		await handleSessionExport(
+			req,
+			res,
+			{ id: "hosted-session" },
+			{ "Access-Control-Allow-Origin": "*" },
+		);
+
+		expect(getStatus()).toBe(404);
+		expect(getBody()).toEqual({ error: "Session not found" });
+	});
+});

--- a/test/server/session-initialization.test.ts
+++ b/test/server/session-initialization.test.ts
@@ -1,0 +1,117 @@
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadPolicy } from "../../src/safety/policy.js";
+import { startSessionWithPolicy } from "../../src/server/session-initialization.js";
+
+const MOCK_POLICY_PATH = join(homedir(), ".maestro", "policy.json");
+
+function createAgent() {
+	return {
+		state: {
+			messages: [],
+			model: {},
+			thinkingLevel: "off",
+			systemPrompt: "test",
+			tools: [],
+		},
+		setSession: vi.fn(),
+	};
+}
+
+function createEnterpriseContext() {
+	return {
+		isEnterprise: vi.fn(() => false),
+		startSession: vi.fn(),
+		getSession: vi.fn(() => null),
+	};
+}
+
+describe("startSessionWithPolicy", () => {
+	let originalPolicy: string | null = null;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mkdirSync(dirname(MOCK_POLICY_PATH), { recursive: true });
+		originalPolicy = existsSync(MOCK_POLICY_PATH)
+			? readFileSync(MOCK_POLICY_PATH, "utf8")
+			: null;
+	});
+
+	afterEach(() => {
+		if (originalPolicy === null) {
+			if (existsSync(MOCK_POLICY_PATH)) {
+				unlinkSync(MOCK_POLICY_PATH);
+			}
+		} else {
+			writeFileSync(MOCK_POLICY_PATH, originalPolicy);
+		}
+		loadPolicy(true);
+	});
+
+	it("uses async manager active-session counts for concurrent session policy", async () => {
+		writeFileSync(
+			MOCK_POLICY_PATH,
+			JSON.stringify({ limits: { maxConcurrentSessions: 1 } }),
+		);
+		loadPolicy(true);
+		const startSession = vi.fn();
+		const countActiveSessions = vi.fn(async () => 1);
+		const manager = {
+			loadAllSessions: vi.fn(() => []),
+			countActiveSessions,
+			startSession,
+			getSessionId: vi.fn(() => "session-id"),
+		};
+
+		const result = await startSessionWithPolicy({
+			agent: createAgent(),
+			enterpriseContext: createEnterpriseContext(),
+			logger: { warn: vi.fn() },
+			modelId: "test-model",
+			onSessionReady: vi.fn(),
+			sessionManager: manager,
+		});
+
+		expect(result).toContain("Concurrent session limit exceeded");
+		expect(countActiveSessions).toHaveBeenCalledWith(expect.any(Date));
+		expect(manager.loadAllSessions).not.toHaveBeenCalled();
+		expect(startSession).not.toHaveBeenCalled();
+	});
+
+	it("starts a session when async active-session count is within policy", async () => {
+		writeFileSync(
+			MOCK_POLICY_PATH,
+			JSON.stringify({ limits: { maxConcurrentSessions: 1 } }),
+		);
+		loadPolicy(true);
+		const startSession = vi.fn();
+		const onSessionReady = vi.fn();
+		const manager = {
+			loadAllSessions: vi.fn(() => []),
+			countActiveSessions: vi.fn(async () => 0),
+			startSession,
+			getSessionId: vi.fn(() => "session-id"),
+		};
+
+		const result = await startSessionWithPolicy({
+			agent: createAgent(),
+			enterpriseContext: createEnterpriseContext(),
+			logger: { warn: vi.fn() },
+			modelId: "test-model",
+			onSessionReady,
+			sessionManager: manager,
+		});
+
+		expect(result).toBeNull();
+		expect(startSession).toHaveBeenCalledTimes(1);
+		expect(onSessionReady).toHaveBeenCalledWith("session-id");
+	});
+});

--- a/test/web/session-artifact-viewer.test.ts
+++ b/test/web/session-artifact-viewer.test.ts
@@ -8,6 +8,9 @@ vi.mock("../../src/server/session-scope.js", () => ({
 	createSessionManagerForRequest: vi.fn(() => ({
 		loadSession: mockLoadSession,
 	})),
+	createWebSessionManagerForRequest: vi.fn(() => ({
+		loadSession: mockLoadSession,
+	})),
 	resolveSessionScope: vi.fn(() => "scope-1"),
 }));
 


### PR DESCRIPTION
## Summary
- add Postgres-backed hosted session and session-entry tables with migration metadata
- route scoped web/chat/session endpoints to a DB-backed hosted session manager when database storage is configured
- preserve JSONL export behavior from DB entries and keep file-backed sessions available for explicit file/jsonl mode
- add Postgres integration coverage proving hosted web sessions persist/resume/update without creating JSONL files

Fixes #58.

## Verification
- `./node_modules/.bin/biome check .github/workflows/integration.yml src/db/schema.ts src/server/hosted-session-manager.ts src/server/session-scope.ts src/server/session-initialization.ts src/server/handlers/approvals.ts src/server/handlers/branch.ts src/server/handlers/chat.ts src/server/handlers/chat-ws.ts src/server/handlers/context.ts src/server/handlers/session-artifacts.ts src/server/handlers/session-attachments.ts src/server/handlers/sessions.ts test/db/hosted-session-storage.integration.test.ts test/db/legacy-rbac-migration.integration.test.ts test/db/migrate.test.ts`
- `node ./scripts/run-vitest.js --run test/db/migrate.test.ts test/db/hosted-session-storage.integration.test.ts test/session-endpoints.test.ts test/shared-session-attachments-endpoints.test.ts`
- `MAESTRO_DATABASE_URL=postgresql://maestro:maestro@127.0.0.1:$PORT/maestro node ./scripts/run-vitest.js --run test/db/hosted-session-storage.integration.test.ts test/db/legacy-rbac-migration.integration.test.ts`
- `git diff --cached --check`

## Local caveat
- Full `tsc -p tsconfig.build.json --noEmit` and `test/web/chat-handler.test.ts` are blocked in this disposable worktree because `npm ci` hits an npm rollup tarball integrity mismatch, and the fallback borrowed dependency tree does not resolve `@evalops/memory`/`exceljs` workspace package imports. The new hosted-session manager type errors were cleared before those unrelated dependency-resolution errors remained.