### PR TITLE
Pass prompt surface through Platform resolve

### DIFF
--- a/src/prompts/service-client.ts
+++ b/src/prompts/service-client.ts
@@ -5,6 +5,7 @@ import {
 	postPlatformConnect,
 	resolveOrganizationId,
 	resolvePlatformServiceConfig,
+	resolvePlatformToken,
 	trimString,
 } from "../platform/client.js";
 import {
@@ -85,7 +86,7 @@ function hasConfiguredPromptsBaseUrl(): boolean {
 	);
 }
 
-function warnPromptsServiceMisconfiguration(): void {
+async function warnPromptsServiceMisconfiguration(): Promise<void> {
 	if (!hasConfiguredPromptsBaseUrl()) {
 		return;
 	}
@@ -95,9 +96,11 @@ function warnPromptsServiceMisconfiguration(): void {
 		);
 		return;
 	}
-	logger.warn(
-		"Prompts service configured without access token; retaining bundled prompts",
-	);
+	if (!(await resolvePlatformToken(PROMPTS_TOKEN_ENV_VARS))) {
+		logger.warn(
+			"Prompts service configured without access token; retaining bundled prompts",
+		);
+	}
 }
 
 async function resolvePromptsServiceConfig(): Promise<PromptsServiceConfig | null> {
@@ -124,7 +127,7 @@ async function resolvePromptsServiceConfig(): Promise<PromptsServiceConfig | nul
 		requireToken: true,
 	});
 	if (!config) {
-		warnPromptsServiceMisconfiguration();
+		await warnPromptsServiceMisconfiguration();
 		return null;
 	}
 
@@ -176,6 +179,7 @@ async function resolveViaPlatformConnect(
 		{
 			name,
 			label: trimString(input.label) ?? "production",
+			surface: trimString(input.surface),
 		},
 		{
 			serviceName: "prompts service",

--- a/test/prompts/service-client.test.ts
+++ b/test/prompts/service-client.test.ts
@@ -141,6 +141,7 @@ describe("prompts service client", () => {
 			expect(JSON.parse(String(init?.body ?? "{}"))).toEqual({
 				name: "maestro-system",
 				label: "production",
+				surface: "maestro",
 			});
 			return new Response(
 				JSON.stringify({


### PR DESCRIPTION
## Summary
- pass the Maestro prompt surface through Platform Connect prompt resolution
- let prompts service fallback warning consult the same runtime token resolution path used by the Platform client
- keep the stale platform-core branch triage as a focused forward-port instead of reintroducing already-merged code

## Test plan
- node ./scripts/run-vitest.js --run test/prompts/service-client.test.ts
- npx --yes bun@1.3.6 run build:all
- git diff --check
- bash scripts/guardian.sh --all --trigger ci