### PR TITLE
Prefer trusted npm publishing in release auto mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,15 +170,17 @@ jobs:
           NPM_PUBLISH_AUTH_MODE: ${{ vars.NPM_PUBLISH_AUTH_MODE || 'auto' }}
         run: |
           set -euo pipefail
+          NPM_TOKEN_FALLBACK="${NODE_AUTH_TOKEN:-}"
+
           publish_with_token() {
-            if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            if [ -z "${NPM_TOKEN_FALLBACK:-}" ]; then
               echo "::error::NPM_PUBLISH_AUTH_MODE=token requires the NPM_TOKEN secret."
               exit 1
             fi
 
             echo "Publishing with NPM_TOKEN fallback."
-            printf "//registry.npmjs.org/:_authToken=%s\n" "$NODE_AUTH_TOKEN" > ~/.npmrc
-            npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
+            printf "//registry.npmjs.org/:_authToken=%s\n" "$NPM_TOKEN_FALLBACK" > ~/.npmrc
+            NODE_AUTH_TOKEN="$NPM_TOKEN_FALLBACK" npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
           }
 
           publish_with_trusted_publisher() {
@@ -190,12 +192,20 @@ jobs:
 
           case "${NPM_PUBLISH_AUTH_MODE}" in
             auto|"")
-              if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
-                echo "NPM_TOKEN is present; using token fallback. Set NPM_PUBLISH_AUTH_MODE=trusted after npm trust is configured."
-                publish_with_token
-              else
-                publish_with_trusted_publisher
+              echo "Attempting npm trusted publishing first; NPM_TOKEN is only a fallback."
+              trusted_status=0
+              publish_with_trusted_publisher || trusted_status=$?
+              if [ "$trusted_status" -eq 0 ]; then
+                exit 0
               fi
+
+              if [ -z "${NPM_TOKEN_FALLBACK:-}" ]; then
+                echo "::error::Trusted publishing failed and no NPM_TOKEN fallback is configured."
+                exit "$trusted_status"
+              fi
+
+              echo "::warning::Trusted publishing failed; falling back to NPM_TOKEN. Set NPM_PUBLISH_AUTH_MODE=trusted after npm trust is verified."
+              publish_with_token
               ;;
             token)
               publish_with_token

--- a/docs/release-ops.md
+++ b/docs/release-ops.md
@@ -40,8 +40,8 @@
   `evalops/maestro` release workflow configured; the EvalOps org `NPM_TOKEN`
   secret remains a temporary fallback during the scope cutover.
 - `NPM_PUBLISH_AUTH_MODE` controls the release publish path:
-  - `auto` keeps the migration fallback, using `NPM_TOKEN` when present and
-    trusted publishing otherwise.
+  - `auto` tries npm trusted publishing first, then falls back to `NPM_TOKEN`
+    if the npm-side trusted publisher is not configured yet.
   - `trusted` ignores `NPM_TOKEN` and forces npm trusted publishing.
   - `token` requires `NPM_TOKEN` and keeps the legacy fallback explicit.
 - After `npm trust github @evalops/maestro --repo evalops/maestro --file release.yml --env npm-release --yes` succeeds and one release verifies, set


### PR DESCRIPTION
## Summary
- make release auto mode attempt npm trusted publishing before using NPM_TOKEN
- keep the EvalOps org token as an explicit fallback while npm trust is being verified
- update release ops docs so the operator path matches the workflow behavior

## Test plan
- actionlint -shellcheck= -pyflakes= .github/workflows/release.yml
- npm run metadata:check
- git diff --check
- bash scripts/guardian.sh --all --trigger ci