### PR TITLE
Add npm trusted publisher bootstrap

### DIFF
--- a/docs/release-ops.md
+++ b/docs/release-ops.md
@@ -44,7 +44,11 @@
     if the npm-side trusted publisher is not configured yet.
   - `trusted` ignores `NPM_TOKEN` and forces npm trusted publishing.
   - `token` requires `NPM_TOKEN` and keeps the legacy fallback explicit.
-- After `npm trust github @evalops/maestro --repo evalops/maestro --file release.yml --env npm-release --yes` succeeds and one release verifies, set
+- Run `npm run release:trust` for a dry run of the npm trusted-publisher
+  configuration. Use `npm run release:trust -- --apply --otp=<code>` to write
+  the `@evalops/maestro` trusted publisher for `evalops/maestro`,
+  `.github/workflows/release.yml`, and the `npm-release` environment.
+- After the trusted-publisher write succeeds and one release verifies, set
   `NPM_PUBLISH_AUTH_MODE=trusted` in the `npm-release` environment and remove
   the release-scoped `NPM_TOKEN`.
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "verify:runtime-deps": "node scripts/check-runtime-deps.js",
     "release:verify:published": "node scripts/smoke-registry-install.js",
     "release:deprecate": "node scripts/deprecate-release.js",
+    "release:trust": "node scripts/configure-npm-trusted-publisher.mjs",
     "factory:import": "npm run build && node dist/scripts/import-factory-config.js",
     "factory:export": "npm run build && node dist/scripts/export-factory-config.js",
     "version:patch": "node scripts/version.js patch",

--- a/scripts/configure-npm-trusted-publisher.mjs
+++ b/scripts/configure-npm-trusted-publisher.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+const config = {
+	packageName: "@evalops/maestro",
+	repository: "evalops/maestro",
+	workflowFile: "release.yml",
+	environment: "npm-release",
+	npmPackage: "npm@11.10.0",
+};
+
+const args = process.argv.slice(2);
+const allowedFlags = new Set(["--apply", "--dry-run", "--json", "--list"]);
+
+function readValueFlag(name) {
+	const prefix = `${name}=`;
+	const match = args.find((arg) => arg.startsWith(prefix));
+	return match ? match.slice(prefix.length) : null;
+}
+
+const unknown = args.filter((arg) => {
+	if (allowedFlags.has(arg)) {
+		return false;
+	}
+	return !arg.startsWith("--otp=");
+});
+
+if (unknown.length > 0) {
+	console.error(`Unsupported option(s): ${unknown.join(", ")}`);
+	console.error(
+		"Usage: node scripts/configure-npm-trusted-publisher.mjs [--list] [--apply] [--otp=<code>]",
+	);
+	process.exit(2);
+}
+
+const apply = args.includes("--apply");
+const list = args.includes("--list");
+const otp = readValueFlag("--otp") ?? process.env.NPM_OTP ?? null;
+
+const npmArgs = ["--yes", config.npmPackage, "trust"];
+
+if (list) {
+	npmArgs.push("list", config.packageName, "--json");
+} else {
+	npmArgs.push(
+		"github",
+		config.packageName,
+		"--repo",
+		config.repository,
+		"--file",
+		config.workflowFile,
+		"--env",
+		config.environment,
+		"--json",
+	);
+	if (!apply) {
+		npmArgs.push("--dry-run");
+	} else {
+		npmArgs.push("--yes");
+	}
+}
+
+if (otp) {
+	npmArgs.push(`--otp=${otp}`);
+}
+
+const shownArgs = npmArgs.filter((arg) => !arg.startsWith("--otp="));
+console.error(`Running: npx ${shownArgs.join(" ")}`);
+if (!apply && !list) {
+	console.error("Dry run only. Add --apply --otp=<code> to write npm trust config.");
+}
+
+const result = spawnSync("npx", npmArgs, { stdio: "inherit" });
+if (result.error) {
+	console.error(result.error.message);
+	process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/scripts/configure-npm-trusted-publisher.mjs
+++ b/scripts/configure-npm-trusted-publisher.mjs
@@ -34,8 +34,14 @@ if (unknown.length > 0) {
 }
 
 const apply = args.includes("--apply");
+const dryRun = args.includes("--dry-run");
 const list = args.includes("--list");
 const otp = readValueFlag("--otp") ?? process.env.NPM_OTP ?? null;
+
+if (apply && dryRun) {
+	console.error("Cannot combine --apply with --dry-run. Omit --apply to preview only.");
+	process.exit(2);
+}
 
 const npmArgs = ["--yes", config.npmPackage, "trust"];
 

--- a/scripts/configure-npm-trusted-publisher.mjs
+++ b/scripts/configure-npm-trusted-publisher.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { getPackageMetadata } from "./package-metadata.js";
+
+const { name: packageName } = getPackageMetadata();
 
 const config = {
-	packageName: "@evalops/maestro",
+	packageName,
 	repository: "evalops/maestro",
 	workflowFile: "release.yml",
 	environment: "npm-release",


### PR DESCRIPTION
## Summary
- add a release:trust helper for dry-running or applying the npm trusted publisher config
- document the OTP-backed apply path for @evalops/maestro and the npm-release environment

## Validation
- npm run release:trust
- npm run metadata:check
- node --check scripts/configure-npm-trusted-publisher.mjs
- git diff --check