### PR TITLE
Use enum-backed command suite adapter

### DIFF
--- a/src/cli-tui/commands/command-suite-handlers.ts
+++ b/src/cli-tui/commands/command-suite-handlers.ts
@@ -13,17 +13,18 @@ import {
 } from "./subcommands/index.js";
 import type { CommandExecutionContext } from "./types.js";
 
-export type CommandSuiteKey =
-	| "session"
-	| "diag"
-	| "ui"
-	| "safety"
-	| "git"
-	| "auth"
-	| "usage"
-	| "undo"
-	| "config"
-	| "tools";
+export enum CommandSuiteKey {
+	Session = "session",
+	Diag = "diag",
+	Ui = "ui",
+	Safety = "safety",
+	Git = "git",
+	Auth = "auth",
+	Usage = "usage",
+	Undo = "undo",
+	Config = "config",
+	Tools = "tools",
+}
 
 export type CommandSuiteHandlers = Record<
 	CommandSuiteKey,
@@ -31,7 +32,7 @@ export type CommandSuiteHandlers = Record<
 >;
 
 export type CommandSuiteDeps = {
-	session: {
+	[CommandSuiteKey.Session]: {
 		handleNewChat: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleClear: () => void | Promise<void>;
 		handleSessionInfo: (ctx: CommandExecutionContext) => void | Promise<void>;
@@ -44,7 +45,7 @@ export type CommandSuiteDeps = {
 		handleRecover: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleCleanup: (ctx: CommandExecutionContext) => void | Promise<void>;
 	};
-	diag: {
+	[CommandSuiteKey.Diag]: {
 		handleStatus: () => void | Promise<void>;
 		handleAbout: () => void | Promise<void>;
 		handleContext: (ctx: CommandExecutionContext) => void | Promise<void>;
@@ -60,7 +61,7 @@ export type CommandSuiteDeps = {
 		handleSources: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handlePerf: () => void | Promise<void>;
 	};
-	ui: {
+	[CommandSuiteKey.Ui]: {
 		showTheme: () => void | Promise<void>;
 		handleClean: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleFooter: (ctx: CommandExecutionContext) => void | Promise<void>;
@@ -73,7 +74,7 @@ export type CommandSuiteDeps = {
 			compactTools: boolean;
 		};
 	};
-	safety: {
+	[CommandSuiteKey.Safety]: {
 		handleApprovals: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handlePlanMode: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleGuardian: (ctx: CommandExecutionContext) => void | Promise<void>;
@@ -83,12 +84,11 @@ export type CommandSuiteDeps = {
 			guardianEnabled: boolean;
 		};
 	};
-	git: {
+	[CommandSuiteKey.Git]: {
 		handleDiff: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleReview: (ctx: CommandExecutionContext) => void | Promise<void>;
-		runGitCommand: (cmd: string) => Promise<string>;
 	};
-	auth: {
+	[CommandSuiteKey.Auth]: {
 		handleLogin: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleLogout: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleSourceOfTruthPolicy: (
@@ -100,12 +100,12 @@ export type CommandSuiteDeps = {
 			mode?: string;
 		};
 	};
-	usage: {
+	[CommandSuiteKey.Usage]: {
 		handleCost: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleQuota: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleStats: (ctx: CommandExecutionContext) => void | Promise<void>;
 	};
-	undo: {
+	[CommandSuiteKey.Undo]: {
 		handleUndo: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleCheckpoint: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleChanges: (ctx: CommandExecutionContext) => void | Promise<void>;
@@ -115,14 +115,14 @@ export type CommandSuiteDeps = {
 			checkpoints: string[];
 		};
 	};
-	config: {
+	[CommandSuiteKey.Config]: {
 		handleConfig: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleImport: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleFramework: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleComposer: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleInit: (ctx: CommandExecutionContext) => void | Promise<void>;
 	};
-	tools: {
+	[CommandSuiteKey.Tools]: {
 		handleTools: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleMcp: (ctx: CommandExecutionContext) => void | Promise<void>;
 		handleLsp: (ctx: CommandExecutionContext) => void | Promise<void>;
@@ -135,88 +135,97 @@ export type CommandSuiteDeps = {
 export function createCommandSuiteHandlers(
 	deps: CommandSuiteDeps,
 ): CommandSuiteHandlers {
+	const session = deps[CommandSuiteKey.Session];
+	const diag = deps[CommandSuiteKey.Diag];
+	const ui = deps[CommandSuiteKey.Ui];
+	const safety = deps[CommandSuiteKey.Safety];
+	const git = deps[CommandSuiteKey.Git];
+	const auth = deps[CommandSuiteKey.Auth];
+	const usage = deps[CommandSuiteKey.Usage];
+	const undo = deps[CommandSuiteKey.Undo];
+	const config = deps[CommandSuiteKey.Config];
+	const tools = deps[CommandSuiteKey.Tools];
+
 	return {
-		session: createSessionCommandHandler({
-			handleNewChat: (ctx) => deps.session.handleNewChat(ctx),
-			handleClear: () => deps.session.handleClear(),
-			handleSessionInfo: (ctx) => deps.session.handleSessionInfo(ctx),
-			handleSessionsList: (ctx) => deps.session.handleSessionsList(ctx),
-			handleBranch: (ctx) => deps.session.handleBranch(ctx),
-			handleTree: (ctx) => deps.session.handleTree(ctx),
-			handleQueue: (ctx) => deps.session.handleQueue(ctx),
-			handleExport: (ctx) => deps.session.handleExport(ctx),
-			handleShare: (ctx) => deps.session.handleShare(ctx),
-			handleRecover: (ctx) => deps.session.handleRecover(ctx),
-			handleCleanup: (ctx) => deps.session.handleCleanup(ctx),
+		[CommandSuiteKey.Session]: createSessionCommandHandler({
+			handleNewChat: (ctx) => session.handleNewChat(ctx),
+			handleClear: () => session.handleClear(),
+			handleSessionInfo: (ctx) => session.handleSessionInfo(ctx),
+			handleSessionsList: (ctx) => session.handleSessionsList(ctx),
+			handleBranch: (ctx) => session.handleBranch(ctx),
+			handleTree: (ctx) => session.handleTree(ctx),
+			handleQueue: (ctx) => session.handleQueue(ctx),
+			handleExport: (ctx) => session.handleExport(ctx),
+			handleShare: (ctx) => session.handleShare(ctx),
+			handleRecover: (ctx) => session.handleRecover(ctx),
+			handleCleanup: (ctx) => session.handleCleanup(ctx),
 		}),
-		diag: createDiagCommandHandler({
-			handleStatus: () => deps.diag.handleStatus(),
-			handleAbout: () => deps.diag.handleAbout(),
-			handleContext: (ctx) => deps.diag.handleContext(ctx),
-			handleStats: (ctx) => deps.diag.handleStats(ctx),
-			handleBackground: (ctx) => deps.diag.handleBackground(ctx),
-			handleDiagnostics: (ctx) => deps.diag.handleDiagnostics(ctx),
-			handleTelemetry: (ctx) => deps.diag.handleTelemetry(ctx),
-			handleTraining: (ctx) => deps.diag.handleTraining(ctx),
-			handleOtel: (ctx) => deps.diag.handleOtel(ctx),
-			handleConfig: (ctx) => deps.diag.handleConfig(ctx),
-			handleLsp: (ctx) => deps.diag.handleLsp(ctx),
-			handleMcp: (ctx) => deps.diag.handleMcp(ctx),
-			handleSources: (ctx) => deps.diag.handleSources(ctx),
-			handlePerf: () => deps.diag.handlePerf(),
+		[CommandSuiteKey.Diag]: createDiagCommandHandler({
+			handleStatus: () => diag.handleStatus(),
+			handleAbout: () => diag.handleAbout(),
+			handleContext: (ctx) => diag.handleContext(ctx),
+			handleStats: (ctx) => diag.handleStats(ctx),
+			handleBackground: (ctx) => diag.handleBackground(ctx),
+			handleDiagnostics: (ctx) => diag.handleDiagnostics(ctx),
+			handleTelemetry: (ctx) => diag.handleTelemetry(ctx),
+			handleTraining: (ctx) => diag.handleTraining(ctx),
+			handleOtel: (ctx) => diag.handleOtel(ctx),
+			handleConfig: (ctx) => diag.handleConfig(ctx),
+			handleLsp: (ctx) => diag.handleLsp(ctx),
+			handleMcp: (ctx) => diag.handleMcp(ctx),
+			handleSources: (ctx) => diag.handleSources(ctx),
+			handlePerf: () => diag.handlePerf(),
 			isDatabaseConfigured: () => isDatabaseConfigured(),
 		}),
-		ui: createUiCommandHandler({
-			handleTheme: () => deps.ui.showTheme(),
-			handleClean: (ctx) => deps.ui.handleClean(ctx),
-			handleFooter: (ctx) => deps.ui.handleFooter(ctx),
-			handleZen: (ctx) => deps.ui.handleZen(ctx),
-			handleCompactTools: (ctx) => deps.ui.handleCompactTools(ctx),
-			getUiState: () => deps.ui.getUiState(),
+		[CommandSuiteKey.Ui]: createUiCommandHandler({
+			handleTheme: () => ui.showTheme(),
+			handleClean: (ctx) => ui.handleClean(ctx),
+			handleFooter: (ctx) => ui.handleFooter(ctx),
+			handleZen: (ctx) => ui.handleZen(ctx),
+			handleCompactTools: (ctx) => ui.handleCompactTools(ctx),
+			getUiState: () => ui.getUiState(),
 		}),
-		safety: createSafetyCommandHandler({
-			handleApprovals: (ctx) => deps.safety.handleApprovals(ctx),
-			handlePlanMode: (ctx) => deps.safety.handlePlanMode(ctx),
-			handleGuardian: (ctx) => deps.safety.handleGuardian(ctx),
-			getSafetyState: () => deps.safety.getSafetyState(),
+		[CommandSuiteKey.Safety]: createSafetyCommandHandler({
+			handleApprovals: (ctx) => safety.handleApprovals(ctx),
+			handlePlanMode: (ctx) => safety.handlePlanMode(ctx),
+			handleGuardian: (ctx) => safety.handleGuardian(ctx),
+			getSafetyState: () => safety.getSafetyState(),
 		}),
-		git: createGitCommandHandler({
-			handleDiff: (ctx) => deps.git.handleDiff(ctx),
-			handleReview: (ctx) => deps.git.handleReview(ctx),
-			runGitCommand: (cmd) => deps.git.runGitCommand(cmd),
+		[CommandSuiteKey.Git]: createGitCommandHandler({
+			handleDiff: (ctx) => git.handleDiff(ctx),
+			handleReview: (ctx) => git.handleReview(ctx),
 		}),
-		auth: createAuthCommandHandler({
-			handleLogin: (ctx) => deps.auth.handleLogin(ctx),
-			handleLogout: (ctx) => deps.auth.handleLogout(ctx),
-			handleSourceOfTruthPolicy: (ctx) =>
-				deps.auth.handleSourceOfTruthPolicy(ctx),
-			getAuthState: () => deps.auth.getAuthState(),
+		[CommandSuiteKey.Auth]: createAuthCommandHandler({
+			handleLogin: (ctx) => auth.handleLogin(ctx),
+			handleLogout: (ctx) => auth.handleLogout(ctx),
+			handleSourceOfTruthPolicy: (ctx) => auth.handleSourceOfTruthPolicy(ctx),
+			getAuthState: () => auth.getAuthState(),
 		}),
-		usage: createUsageCommandHandler({
-			handleCost: (ctx) => deps.usage.handleCost(ctx),
-			handleQuota: (ctx) => deps.usage.handleQuota(ctx),
-			handleStats: (ctx) => deps.usage.handleStats(ctx),
+		[CommandSuiteKey.Usage]: createUsageCommandHandler({
+			handleCost: (ctx) => usage.handleCost(ctx),
+			handleQuota: (ctx) => usage.handleQuota(ctx),
+			handleStats: (ctx) => usage.handleStats(ctx),
 		}),
-		undo: createUndoCommandHandler({
-			handleUndo: (ctx) => deps.undo.handleUndo(ctx),
-			handleCheckpoint: (ctx) => deps.undo.handleCheckpoint(ctx),
-			handleChanges: (ctx) => deps.undo.handleChanges(ctx),
-			getUndoState: () => deps.undo.getUndoState(),
+		[CommandSuiteKey.Undo]: createUndoCommandHandler({
+			handleUndo: (ctx) => undo.handleUndo(ctx),
+			handleCheckpoint: (ctx) => undo.handleCheckpoint(ctx),
+			handleChanges: (ctx) => undo.handleChanges(ctx),
+			getUndoState: () => undo.getUndoState(),
 		}),
-		config: createConfigCommandHandler({
-			handleConfig: (ctx) => deps.config.handleConfig(ctx),
-			handleImport: (ctx) => deps.config.handleImport(ctx),
-			handleFramework: (ctx) => deps.config.handleFramework(ctx),
-			handleComposer: (ctx) => deps.config.handleComposer(ctx),
-			handleInit: (ctx) => deps.config.handleInit(ctx),
+		[CommandSuiteKey.Config]: createConfigCommandHandler({
+			handleConfig: (ctx) => config.handleConfig(ctx),
+			handleImport: (ctx) => config.handleImport(ctx),
+			handleFramework: (ctx) => config.handleFramework(ctx),
+			handleComposer: (ctx) => config.handleComposer(ctx),
+			handleInit: (ctx) => config.handleInit(ctx),
 		}),
-		tools: createToolsCommandHandler({
-			handleTools: (ctx) => deps.tools.handleTools(ctx),
-			handleMcp: (ctx) => deps.tools.handleMcp(ctx),
-			handleLsp: (ctx) => deps.tools.handleLsp(ctx),
-			handleWorkflow: (ctx) => deps.tools.handleWorkflow(ctx),
-			handleRun: (ctx) => deps.tools.handleRun(ctx),
-			handleCommands: (ctx) => deps.tools.handleCommands(ctx),
+		[CommandSuiteKey.Tools]: createToolsCommandHandler({
+			handleTools: (ctx) => tools.handleTools(ctx),
+			handleMcp: (ctx) => tools.handleMcp(ctx),
+			handleLsp: (ctx) => tools.handleLsp(ctx),
+			handleWorkflow: (ctx) => tools.handleWorkflow(ctx),
+			handleRun: (ctx) => tools.handleRun(ctx),
+			handleCommands: (ctx) => tools.handleCommands(ctx),
 		}),
 	};
 }

--- a/src/cli-tui/commands/registry.ts
+++ b/src/cli-tui/commands/registry.ts
@@ -1,6 +1,9 @@
 import type { SlashCommand } from "@evalops/tui";
 import { parseCommandArguments, shouldShowHelp } from "./argument-parser.js";
-import type { CommandSuiteHandlers } from "./command-suite-handlers.js";
+import {
+	type CommandSuiteHandlers,
+	CommandSuiteKey,
+} from "./command-suite-handlers.js";
 import { HOTKEYS_SUBCOMMANDS } from "./hotkeys-command.js";
 import { PACKAGE_SUBCOMMANDS } from "./package-handlers.js";
 import {
@@ -27,7 +30,7 @@ import type {
 type CommandSuiteDefinition = {
 	command: SlashCommand;
 	subcommands: readonly SubcommandDef[];
-	handlerKey: keyof CommandSuiteHandlers;
+	handlerKey: CommandSuiteKey;
 };
 
 const equals =
@@ -71,7 +74,7 @@ const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
 			],
 		},
 		subcommands: SESSION_SUBCOMMANDS,
-		handlerKey: "session",
+		handlerKey: CommandSuiteKey.Session,
 	},
 	{
 		command: {
@@ -91,7 +94,7 @@ const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
 			],
 		},
 		subcommands: DIAG_SUBCOMMANDS,
-		handlerKey: "diag",
+		handlerKey: CommandSuiteKey.Diag,
 	},
 	{
 		command: {
@@ -103,7 +106,7 @@ const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
 			examples: ["/ui", "/ui theme", "/ui zen on", "/ui compact off"],
 		},
 		subcommands: UI_SUBCOMMANDS,
-		handlerKey: "ui",
+		handlerKey: CommandSuiteKey.Ui,
 	},
 	{
 		command: {
@@ -119,7 +122,7 @@ const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
 			],
 		},
 		subcommands: SAFETY_SUBCOMMANDS,
-		handlerKey: "safety",
+		handlerKey: CommandSuiteKey.Safety,
 	},
 	{
 		command: {
@@ -130,7 +133,7 @@ const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
 			examples: ["/git", "/git diff src/index.ts", "/git review"],
 		},
 		subcommands: GIT_SUBCOMMANDS,
-		handlerKey: "git",
+		handlerKey: CommandSuiteKey.Git,
 	},
 	{
 		command: {
@@ -146,7 +149,7 @@ const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
 			],
 		},
 		subcommands: AUTH_SUBCOMMANDS,
-		handlerKey: "auth",
+		handlerKey: CommandSuiteKey.Auth,
 	},
 	{
 		command: {
@@ -161,7 +164,7 @@ const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
 			],
 		},
 		subcommands: USAGE_SUBCOMMANDS,
-		handlerKey: "usage",
+		handlerKey: CommandSuiteKey.Usage,
 	},
 	{
 		command: {
@@ -177,7 +180,7 @@ const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
 			],
 		},
 		subcommands: UNDO_SUBCOMMANDS,
-		handlerKey: "undo",
+		handlerKey: CommandSuiteKey.Undo,
 	},
 	{
 		command: {
@@ -194,7 +197,7 @@ const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
 			],
 		},
 		subcommands: CONFIG_SUBCOMMANDS,
-		handlerKey: "config",
+		handlerKey: CommandSuiteKey.Config,
 	},
 	{
 		command: {
@@ -212,7 +215,7 @@ const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
 			],
 		},
 		subcommands: TOOLS_SUBCOMMANDS,
-		handlerKey: "tools",
+		handlerKey: CommandSuiteKey.Tools,
 	},
 ];
 

--- a/src/cli-tui/commands/subcommands/git-commands.ts
+++ b/src/cli-tui/commands/subcommands/git-commands.ts
@@ -16,7 +16,6 @@ import { createSubcommandHandler } from "./utils.js";
 export interface GitCommandDeps {
 	handleDiff: (ctx: CommandExecutionContext) => Promise<void> | void;
 	handleReview: (ctx: CommandExecutionContext) => void;
-	runGitCommand: (cmd: string) => Promise<string>;
 }
 
 export function createGitCommandHandler(deps: GitCommandDeps) {

--- a/src/cli-tui/tui-renderer.ts
+++ b/src/cli-tui/tui-renderer.ts
@@ -72,7 +72,6 @@ import type { BackgroundTasksController } from "./background/background-tasks-co
 import { BashModeView } from "./bash-mode-view.js";
 import { ChangelogView } from "./changelog-view.js";
 import { formatCommandHelp } from "./commands/argument-parser.js";
-import type { CommandSuiteHandlers } from "./commands/command-suite-handlers.js";
 import type {
 	CommandEntry,
 	CommandExecutionContext,
@@ -148,7 +147,6 @@ import {
 } from "./tui-renderer/attachment-controller.js";
 import { buildTuiCommandRegistryOptions } from "./tui-renderer/command-registry-options.js";
 import { buildTuiCommandRegistry } from "./tui-renderer/command-registry.js";
-import { buildCommandSuiteHandlers } from "./tui-renderer/command-suite-wiring.js";
 import {
 	type DelegatingCommandHandlerMap,
 	createDelegatingCommandHandlers,
@@ -448,7 +446,6 @@ export class TuiRenderer {
 	private interruptController!: InterruptController;
 	private pasteHandler!: PasteHandler;
 	private miscHandlers!: MiscHandlers;
-	private commandSuiteHandlers?: CommandSuiteHandlers;
 	private uiStateController!: UiStateController;
 	private quickSettingsController!: QuickSettingsController;
 	private branchController?: BranchController;
@@ -1175,7 +1172,34 @@ export class TuiRenderer {
 					this.delegatingHandlers.handleMemoryCommand(context),
 				handleModeCommand: (context) =>
 					this.delegatingHandlers.handleModeCommand(context),
-				getCommandSuiteHandlers: () => this.getCommandSuiteHandlers(),
+				commandSuite: {
+					getUiState: () => ({
+						...this.uiStateController.getState(),
+						compactTools: this.toolOutputView?.isCompact() ?? false,
+					}),
+					getAuthState: () => this.getActualAuthState(),
+					handleSessionRecoverCommand: (context) =>
+						this.sessionStateController.handleSessionRecoverCommand(context),
+					handleSessionCleanupCommand: (context) => {
+						const result = this.sessionManager.pruneSessions();
+						if (result.removed === 0) {
+							context.showInfo("No sessions to prune.");
+							return;
+						}
+						context.showInfo(
+							`Pruned ${result.removed} session(s).${result.errors > 0 ? ` ${result.errors} error(s).` : ""}`,
+						);
+					},
+					handleSourcesCommand: (context) =>
+						this.delegatingHandlers.handleSourcesCommand(context),
+					handlePerfCommand: () => this.showPerfReport(),
+					handleAuthSourceOfTruthCommand: (argumentText, showError, showInfo) =>
+						this.oauthFlowController.handleSourceOfTruthPolicyCommand(
+							argumentText,
+							showError,
+							showInfo,
+						),
+				},
 				refreshFooterHint: () => this.refreshFooterHint(),
 				onQuit: () => {
 					this.stop();
@@ -2545,116 +2569,6 @@ export class TuiRenderer {
 	private showPerfReport(): void {
 		const snap = this.perfCollector.snapshot();
 		this.notificationView.showInfo(formatPerfReport(snap));
-	}
-
-	private getCommandSuiteHandlers(): CommandSuiteHandlers {
-		if (!this.commandSuiteHandlers) {
-			this.commandSuiteHandlers = buildCommandSuiteHandlers({
-				delegatingHandlers: this.delegatingHandlers,
-				notificationView: this.notificationView,
-				approvalService: this.approvalService,
-				requestRender: () => this.ui.requestRender(),
-				refreshFooterHint: () => this.refreshFooterHint(),
-				addSpacedText: (text) => {
-					this.chatContainer.addChild(new Spacer(1));
-					this.chatContainer.addChild(new Text(text, 1, 0));
-				},
-				handleNewChatCommand: (ctx) =>
-					this.sessionStateController.handleNewChatCommand(ctx),
-				handleClearCommand: () =>
-					this.getClearController().handleClearCommand(),
-				handleSessionCommand: (rawInput) =>
-					this.sessionView.handleSessionCommand(rawInput),
-				handleSessionsCommand: (rawInput) =>
-					this.sessionView.handleSessionsCommand(rawInput),
-				handleBranchCommand: (ctx) =>
-					this.getBranchController().handleBranchCommand(ctx),
-				showTree: () => this.getTreeSelectorView().show(),
-				handleQueueCommand: (ctx) => {
-					const queuePanelController = this.getQueuePanelController();
-					if (queuePanelController) {
-						queuePanelController.handleQueueCommand(ctx);
-						return;
-					}
-					ctx.showInfo("Prompt queue is not available.");
-				},
-				handleExportCommand: (rawInput) =>
-					this.getImportExportView().handleExportCommand(rawInput),
-				handleShareCommand: (rawInput) =>
-					this.getImportExportView().handleShareCommand(rawInput),
-				handleSessionRecoverCommand: (ctx) =>
-					this.sessionStateController.handleSessionRecoverCommand(ctx),
-				handleSessionCleanupCommand: (ctx) => {
-					const result = this.sessionManager.pruneSessions();
-					if (result.removed === 0) {
-						ctx.showInfo("No sessions to prune.");
-					} else {
-						ctx.showInfo(
-							`Pruned ${result.removed} session(s).${result.errors > 0 ? ` ${result.errors} error(s).` : ""}`,
-						);
-					}
-				},
-				handleStatusCommand: () =>
-					this.getDiagnosticsView().handleStatusCommand(),
-				handleAboutCommand: () => this.getAboutView().handleAboutCommand(),
-				handleContextCommand: (ctx) => this.handleContextCommand(ctx),
-				handleStatsCommand: (ctx) => this.handleStatsCommand(ctx),
-				handleBackgroundCommand: (ctx) =>
-					this.backgroundTasksController.handleBackgroundCommand(ctx),
-				handleDiagnosticsCommand: (rawInput) =>
-					this.getDiagnosticsView().handleDiagnosticsCommand(rawInput),
-				handleTelemetryCommand: (ctx) =>
-					this.getTelemetryView().handleTelemetryCommand(ctx),
-				handleTrainingCommand: (ctx) =>
-					this.getTrainingView().handleTrainingCommand(ctx),
-				handleConfigCommand: (ctx) =>
-					this.getConfigView().handleConfigCommand(ctx),
-				handleLspCommand: (rawInput) =>
-					this.getLspView().handleLspCommand(rawInput),
-				handlePerfCommand: () => this.showPerfReport(),
-				showTheme: () => this.getThemeSelectorView().show(),
-				handleCleanCommand: (ctx) =>
-					this.uiStateController.handleCleanCommand(ctx),
-				handleFooterCommand: (ctx) => this.handleFooterCommand(ctx),
-				handleZenCommand: (ctx) => this.uiStateController.handleZenCommand(ctx),
-				handleCompactToolsCommand: (ctx) =>
-					this.handleCompactToolsCommand(ctx.rawInput),
-				getUiState: () => ({
-					...this.uiStateController.getState(),
-					compactTools: this.toolOutputView?.isCompact() ?? false,
-				}),
-				handleDiffCommand: (rawInput) =>
-					this.gitView.handlePreviewCommand(rawInput),
-				handleReviewCommand: (ctx) => this.handleReviewCommand(ctx),
-				handleLoginCommand: (argumentText, showError) =>
-					this.oauthFlowController.handleLoginCommand(argumentText, showError),
-				handleLogoutCommand: (argumentText, showError, showInfo) =>
-					this.oauthFlowController.handleLogoutCommand(
-						argumentText,
-						showError,
-						showInfo,
-					),
-				handleAuthSourceOfTruthCommand: (argumentText, showError, showInfo) =>
-					this.oauthFlowController.handleSourceOfTruthPolicyCommand(
-						argumentText,
-						showError,
-						showInfo,
-					),
-				getAuthState: () => this.getActualAuthState(),
-				handleCostCommand: (ctx) => this.getCostView().handleCostCommand(ctx),
-				handleQuotaCommand: (ctx) =>
-					this.getQuotaView().handleQuotaCommand(ctx),
-				handleImportCommand: (rawInput) =>
-					this.getImportExportView().handleImportCommand(rawInput),
-				handleToolsCommand: (rawInput) =>
-					this.getToolStatusView().handleToolsCommand(rawInput),
-				handleRunCommand: (rawInput) =>
-					this.getRunCommandView().handleRunCommand(rawInput),
-				handleCommandsCommand: (ctx) =>
-					this.getCustomCommandsController().handleCommandsCommand(ctx),
-			});
-		}
-		return this.commandSuiteHandlers;
 	}
 
 	stop(): void {

--- a/src/cli-tui/tui-renderer/command-registry-options.ts
+++ b/src/cli-tui/tui-renderer/command-registry-options.ts
@@ -12,7 +12,6 @@ import type { BackgroundTasksController } from "../background/background-tasks-c
 import type { ChangelogView } from "../changelog-view.js";
 import { handleAccessCommand } from "../commands/access-command.js";
 import { handleAuditCommand } from "../commands/audit-command.js";
-import type { CommandSuiteHandlers } from "../commands/command-suite-handlers.js";
 import { createHotkeysCommandHandler } from "../commands/hotkeys-command.js";
 import { handleLimitsCommand } from "../commands/limits-command.js";
 import { handleOtelCommand as otelHandler } from "../commands/otel-handlers.js";
@@ -60,6 +59,10 @@ import type { ToolStatusView } from "../tool-status-view.js";
 import type { UpdateView } from "../update-view.js";
 import type { BranchController } from "./branch-controller.js";
 import type { ClearController } from "./clear-controller.js";
+import {
+	type CommandSuiteRuntimeDeps,
+	buildCommandSuiteHandlers,
+} from "./command-suite-wiring.js";
 import type { CompactionController } from "./compaction-controller.js";
 import type { CustomCommandsController } from "./custom-commands-controller.js";
 import type { UiStateController } from "./ui-state-controller.js";
@@ -132,7 +135,7 @@ export interface TuiCommandRegistryDeps {
 	handleCheckpointCommand: (context: CommandExecutionContext) => void;
 	handleMemoryCommand: (context: CommandExecutionContext) => void;
 	handleModeCommand: (context: CommandExecutionContext) => void;
-	getCommandSuiteHandlers: () => CommandSuiteHandlers;
+	commandSuite: CommandSuiteRuntimeDeps;
 	refreshFooterHint: () => void;
 	onQuit: () => void;
 }
@@ -311,12 +314,21 @@ export function buildTuiCommandRegistryOptions(
 				},
 			),
 	};
+	let commandSuiteHandlers: ReturnType<
+		typeof buildCommandSuiteHandlers
+	> | null = null;
 
 	return {
 		getRunScriptCompletions: (prefix) =>
 			deps.getRunCommandView().getRunScriptCompletions(prefix),
 		createContext: (ctx) => deps.createCommandContext(ctx),
 		handlers,
-		getCommandSuiteHandlers: deps.getCommandSuiteHandlers,
+		getCommandSuiteHandlers: () => {
+			commandSuiteHandlers ??= buildCommandSuiteHandlers({
+				handlers,
+				...deps.commandSuite,
+			});
+			return commandSuiteHandlers;
+		},
 	};
 }

--- a/src/cli-tui/tui-renderer/command-suite-wiring.ts
+++ b/src/cli-tui/tui-renderer/command-suite-wiring.ts
@@ -1,221 +1,159 @@
 /**
- * CommandSuiteWiring — Builds the command suite dependency map that wires
- * TuiRenderer's sub-controllers/views to parent command handlers.
- *
- * No own state. Pure mapping from TuiRenderer-level refs to CommandSuiteDeps.
+ * CommandSuiteWiring adapts top-level command handlers into parent command
+ * suites such as /ss, /diag, /cfg, and /tools.
  */
 
 import {
 	type CommandSuiteHandlers,
+	CommandSuiteKey,
 	createCommandSuiteHandlers,
 } from "../commands/command-suite-handlers.js";
-import { handleOtelCommand as otelHandler } from "../commands/otel-handlers.js";
-import {
-	type ApprovalService,
-	handleApprovalsCommand,
-	handlePlanModeCommand,
-} from "../commands/safety-handlers.js";
-import type { CommandExecutionContext } from "../commands/types.js";
-import { handleInitCommand } from "../commands/utility-handlers.js";
-import type { NotificationView } from "../notification-view.js";
-import type { DelegatingCommandHandlerMap } from "./delegating-command-handlers.js";
+import type {
+	CommandExecutionContext,
+	CommandHandlers,
+} from "../commands/types.js";
 
-// ─── Dependency Interface ────────────────────────────────────────────────────
+type SuiteHandlerKey =
+	| "about"
+	| "approvals"
+	| "background"
+	| "branch"
+	| "changes"
+	| "checkpoint"
+	| "clean"
+	| "clear"
+	| "commands"
+	| "compactTools"
+	| "composer"
+	| "config"
+	| "context"
+	| "cost"
+	| "diagnostics"
+	| "exportSession"
+	| "footer"
+	| "framework"
+	| "guardian"
+	| "importConfig"
+	| "initAgents"
+	| "login"
+	| "logout"
+	| "lsp"
+	| "mcp"
+	| "newChat"
+	| "otel"
+	| "planMode"
+	| "preview"
+	| "quota"
+	| "queue"
+	| "review"
+	| "run"
+	| "session"
+	| "sessions"
+	| "shareSession"
+	| "stats"
+	| "status"
+	| "telemetry"
+	| "theme"
+	| "training"
+	| "tree"
+	| "tools"
+	| "undoChanges"
+	| "workflow"
+	| "zen";
 
-export interface CommandSuiteWiringDeps {
-	/** Delegating command handler map (guardian, workflow, undo, etc.). */
-	delegatingHandlers: DelegatingCommandHandlerMap;
-	/** Notification view for toasts and errors. */
-	notificationView: NotificationView;
-	/** Approval service for safety commands. */
-	approvalService: ApprovalService;
-	/** Request a TUI render cycle. */
-	requestRender: () => void;
-	/** Refresh footer hints. */
-	refreshFooterHint: () => void;
-	/** Add a spaced text component to the chat container. */
-	addSpacedText: (text: string) => void;
+export type CommandSuiteBaseHandlers = Pick<CommandHandlers, SuiteHandlerKey>;
 
-	// ── Session ──
-	handleNewChatCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-	handleClearCommand: () => void | Promise<void>;
-	handleSessionCommand: (rawInput: string) => void | Promise<void>;
-	handleSessionsCommand: (rawInput: string) => void | Promise<void>;
-	handleBranchCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-	showTree: () => void;
-	handleQueueCommand: ((ctx: CommandExecutionContext) => void) | null;
-	handleExportCommand: (rawInput: string) => void | Promise<void>;
-	handleShareCommand: (rawInput: string) => void | Promise<void>;
-	handleSessionRecoverCommand: (
-		ctx: CommandExecutionContext,
-	) => void | Promise<void>;
-	handleSessionCleanupCommand: (
-		ctx: CommandExecutionContext,
-	) => void | Promise<void>;
-
-	// ── Diag ──
-	handleStatusCommand: () => void | Promise<void>;
-	handleAboutCommand: () => void | Promise<void>;
-	handleContextCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-	handleStatsCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-	handleBackgroundCommand: (
-		ctx: CommandExecutionContext,
-	) => void | Promise<void>;
-	handleDiagnosticsCommand: (rawInput: string) => void | Promise<void>;
-	handleTelemetryCommand: (
-		ctx: CommandExecutionContext,
-	) => void | Promise<void>;
-	handleTrainingCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-	handleConfigCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-	handleLspCommand: (rawInput: string) => void | Promise<void>;
-	handlePerfCommand: () => void;
-
-	// ── UI ──
-	showTheme: () => void;
-	handleCleanCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-	handleFooterCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-	handleZenCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-	handleCompactToolsCommand: (
-		ctx: CommandExecutionContext,
-	) => void | Promise<void>;
+export interface CommandSuiteRuntimeDeps {
 	getUiState: () => {
 		zenMode: boolean;
 		cleanMode: string;
 		footerMode: string;
 		compactTools: boolean;
 	};
-
-	// ── Git ──
-	handleDiffCommand: (rawInput: string) => void | Promise<void>;
-	handleReviewCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-
-	// ── Auth ──
-	handleLoginCommand: (
-		argumentText: string,
-		showError: (msg: string) => void,
-	) => void | Promise<void>;
-	handleLogoutCommand: (
-		argumentText: string,
-		showError: (msg: string) => void,
-		showInfo: (msg: string) => void,
-	) => void | Promise<void>;
-	handleAuthSourceOfTruthCommand: (
-		argumentText: string,
-		showError: (msg: string) => void,
-		showInfo: (msg: string) => void,
-	) => void | Promise<void>;
 	getAuthState: () => {
 		authenticated: boolean;
 		provider?: string;
 		mode?: string;
 	};
-
-	// ── Usage ──
-	handleCostCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-	handleQuotaCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
-
-	// ── Config ──
-	handleImportCommand: (rawInput: string) => void | Promise<void>;
-
-	// ── Tools ──
-	handleToolsCommand: (rawInput: string) => void | Promise<void>;
-	handleRunCommand: (rawInput: string) => void | Promise<void>;
-	handleCommandsCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
+	handleSessionRecoverCommand: (
+		ctx: CommandExecutionContext,
+	) => void | Promise<void>;
+	handleSessionCleanupCommand: (
+		ctx: CommandExecutionContext,
+	) => void | Promise<void>;
+	handleSourcesCommand: (ctx: CommandExecutionContext) => void | Promise<void>;
+	handlePerfCommand: () => void | Promise<void>;
+	handleAuthSourceOfTruthCommand: (
+		argumentText: string,
+		showError: (msg: string) => void,
+		showInfo: (msg: string) => void,
+	) => void | Promise<void>;
 }
 
-// ─── Factory ─────────────────────────────────────────────────────────────────
+export interface CommandSuiteWiringDeps extends CommandSuiteRuntimeDeps {
+	handlers: CommandSuiteBaseHandlers;
+}
 
-/**
- * Build command suite handlers from TuiRenderer-level references.
- */
 export function buildCommandSuiteHandlers(
 	deps: CommandSuiteWiringDeps,
 ): CommandSuiteHandlers {
-	/** Shared rendering callbacks for safety commands. */
-	const safetyCallbacks = () => ({
-		showToast: (msg: string, type: "success" | "info") =>
-			deps.notificationView.showToast(msg, type),
-		refreshFooterHint: () => deps.refreshFooterHint(),
-		addContent: (text: string) => deps.addSpacedText(text),
-		requestRender: () => deps.requestRender(),
-	});
+	const { handlers } = deps;
 
 	return createCommandSuiteHandlers({
-		session: {
-			handleNewChat: (ctx) => deps.handleNewChatCommand(ctx),
-			handleClear: () => deps.handleClearCommand(),
-			handleSessionInfo: (ctx) => deps.handleSessionCommand(ctx.rawInput),
-			handleSessionsList: (ctx) => deps.handleSessionsCommand(ctx.rawInput),
-			handleBranch: (ctx) => deps.handleBranchCommand(ctx),
-			handleTree: () => deps.showTree(),
-			handleQueue: (ctx) => {
-				if (deps.handleQueueCommand) {
-					deps.handleQueueCommand(ctx);
-					return;
-				}
-				ctx.showInfo("Prompt queue is not available.");
-			},
-			handleExport: (ctx) => deps.handleExportCommand(ctx.rawInput),
-			handleShare: (ctx) => deps.handleShareCommand(ctx.rawInput),
+		[CommandSuiteKey.Session]: {
+			handleNewChat: (ctx) => handlers.newChat(ctx),
+			handleClear: () => handlers.clear(commandContext("/clear")),
+			handleSessionInfo: (ctx) => handlers.session(ctx),
+			handleSessionsList: (ctx) => handlers.sessions(ctx),
+			handleBranch: (ctx) => handlers.branch(ctx),
+			handleTree: (ctx) => handlers.tree(ctx),
+			handleQueue: (ctx) => handlers.queue(ctx),
+			handleExport: (ctx) => handlers.exportSession(ctx),
+			handleShare: (ctx) => handlers.shareSession(ctx),
 			handleRecover: (ctx) => deps.handleSessionRecoverCommand(ctx),
 			handleCleanup: (ctx) => deps.handleSessionCleanupCommand(ctx),
 		},
-		diag: {
-			handleStatus: () => deps.handleStatusCommand(),
-			handleAbout: () => deps.handleAboutCommand(),
-			handleContext: (ctx) => deps.handleContextCommand(ctx),
-			handleStats: (ctx) => deps.handleStatsCommand(ctx),
-			handleBackground: (ctx) => deps.handleBackgroundCommand(ctx),
-			handleDiagnostics: (ctx) => deps.handleDiagnosticsCommand(ctx.rawInput),
-			handleTelemetry: (ctx) => deps.handleTelemetryCommand(ctx),
-			handleTraining: (ctx) => deps.handleTrainingCommand(ctx),
-			handleOtel: () =>
-				otelHandler({
-					showInfo: (msg) => deps.notificationView.showInfo(msg),
-				}),
-			handleConfig: (ctx) => deps.handleConfigCommand(ctx),
-			handleLsp: (ctx) => deps.handleLspCommand(ctx.rawInput),
-			handleMcp: (ctx) => deps.delegatingHandlers.handleMcpCommand(ctx),
-			handleSources: (ctx) => deps.delegatingHandlers.handleSourcesCommand(ctx),
+		[CommandSuiteKey.Diag]: {
+			handleStatus: () => handlers.status(commandContext("/status")),
+			handleAbout: () => handlers.about(commandContext("/about")),
+			handleContext: (ctx) => handlers.context(ctx),
+			handleStats: (ctx) => handlers.stats(ctx),
+			handleBackground: (ctx) => handlers.background(ctx),
+			handleDiagnostics: (ctx) => handlers.diagnostics(ctx),
+			handleTelemetry: (ctx) => handlers.telemetry(ctx),
+			handleTraining: (ctx) => handlers.training(ctx),
+			handleOtel: (ctx) => handlers.otel(ctx),
+			handleConfig: (ctx) => handlers.config(ctx),
+			handleLsp: (ctx) => handlers.lsp(ctx),
+			handleMcp: (ctx) => handlers.mcp(ctx),
+			handleSources: (ctx) => deps.handleSourcesCommand(ctx),
 			handlePerf: () => deps.handlePerfCommand(),
 		},
-		ui: {
-			showTheme: () => deps.showTheme(),
-			handleClean: (ctx) => deps.handleCleanCommand(ctx),
-			handleFooter: (ctx) => deps.handleFooterCommand(ctx),
-			handleZen: (ctx) => deps.handleZenCommand(ctx),
-			handleCompactTools: (ctx) => deps.handleCompactToolsCommand(ctx),
+		[CommandSuiteKey.Ui]: {
+			showTheme: () => handlers.theme(commandContext("/theme")),
+			handleClean: (ctx) => handlers.clean(ctx),
+			handleFooter: (ctx) => handlers.footer(ctx),
+			handleZen: (ctx) => handlers.zen(ctx),
+			handleCompactTools: (ctx) => handlers.compactTools(ctx),
 			getUiState: () => deps.getUiState(),
 		},
-		safety: {
-			handleApprovals: (ctx) =>
-				handleApprovalsCommand(ctx, deps.approvalService, safetyCallbacks()),
-			handlePlanMode: (ctx) => handlePlanModeCommand(ctx, safetyCallbacks()),
-			handleGuardian: (ctx) =>
-				deps.delegatingHandlers.handleGuardianCommand(ctx),
+		[CommandSuiteKey.Safety]: {
+			handleApprovals: (ctx) => handlers.approvals(ctx),
+			handlePlanMode: (ctx) => handlers.planMode(ctx),
+			handleGuardian: (ctx) => handlers.guardian(ctx),
 			getSafetyState: () => ({
 				approvalMode: process.env.MAESTRO_APPROVALS ?? "prompt",
 				planMode: process.env.MAESTRO_PLAN_MODE === "1",
 				guardianEnabled: true,
 			}),
 		},
-		git: {
-			handleDiff: (ctx) => deps.handleDiffCommand(ctx.rawInput),
-			handleReview: (ctx) => deps.handleReviewCommand(ctx),
-			runGitCommand: async (cmd: string) => {
-				const { execSync } = await import("node:child_process");
-				return execSync(cmd, { encoding: "utf-8" });
-			},
+		[CommandSuiteKey.Git]: {
+			handleDiff: (ctx) => handlers.preview(ctx),
+			handleReview: (ctx) => handlers.review(ctx),
 		},
-		auth: {
-			handleLogin: (ctx) =>
-				deps.handleLoginCommand(ctx.argumentText, (msg) => ctx.showError(msg)),
-			handleLogout: (ctx) =>
-				deps.handleLogoutCommand(
-					ctx.argumentText,
-					(msg) => ctx.showError(msg),
-					(msg) => ctx.showInfo(msg),
-				),
+		[CommandSuiteKey.Auth]: {
+			handleLogin: (ctx) => handlers.login(ctx),
+			handleLogout: (ctx) => handlers.logout(ctx),
 			handleSourceOfTruthPolicy: (ctx) =>
 				deps.handleAuthSourceOfTruthCommand(
 					ctx.argumentText,
@@ -224,46 +162,46 @@ export function buildCommandSuiteHandlers(
 				),
 			getAuthState: () => deps.getAuthState(),
 		},
-		usage: {
-			handleCost: (ctx) => deps.handleCostCommand(ctx),
-			handleQuota: (ctx) => deps.handleQuotaCommand(ctx),
-			handleStats: (ctx) => deps.handleStatsCommand(ctx),
+		[CommandSuiteKey.Usage]: {
+			handleCost: (ctx) => handlers.cost(ctx),
+			handleQuota: (ctx) => handlers.quota(ctx),
+			handleStats: (ctx) => handlers.stats(ctx),
 		},
-		undo: {
-			handleUndo: (ctx) =>
-				deps.delegatingHandlers.handleEnhancedUndoCommand(ctx),
-			handleCheckpoint: (ctx) =>
-				deps.delegatingHandlers.handleCheckpointCommand(ctx),
-			handleChanges: (ctx) => deps.delegatingHandlers.handleChangesCommand(ctx),
+		[CommandSuiteKey.Undo]: {
+			handleUndo: (ctx) => handlers.undoChanges(ctx),
+			handleCheckpoint: (ctx) => handlers.checkpoint(ctx),
+			handleChanges: (ctx) => handlers.changes(ctx),
 			getUndoState: () => ({
 				canUndo: true,
 				undoCount: 0,
 				checkpoints: [],
 			}),
 		},
-		config: {
-			handleConfig: (ctx) => deps.handleConfigCommand(ctx),
-			handleImport: (ctx) => deps.handleImportCommand(ctx.rawInput),
-			handleFramework: (ctx) =>
-				deps.delegatingHandlers.handleFrameworkCommand(ctx),
-			handleComposer: (ctx) =>
-				deps.delegatingHandlers.handleComposerCommand(ctx),
-			handleInit: (ctx) =>
-				handleInitCommand(ctx, {
-					showSuccess: (msg) => deps.notificationView.showToast(msg, "success"),
-					showError: (msg) => ctx.showError(msg),
-					addContent: (text) => deps.addSpacedText(text),
-					requestRender: () => deps.requestRender(),
-				}),
+		[CommandSuiteKey.Config]: {
+			handleConfig: (ctx) => handlers.config(ctx),
+			handleImport: (ctx) => handlers.importConfig(ctx),
+			handleFramework: (ctx) => handlers.framework(ctx),
+			handleComposer: (ctx) => handlers.composer(ctx),
+			handleInit: (ctx) => handlers.initAgents(ctx),
 		},
-		tools: {
-			handleTools: (ctx) => deps.handleToolsCommand(ctx.rawInput),
-			handleMcp: (ctx) => deps.delegatingHandlers.handleMcpCommand(ctx),
-			handleLsp: (ctx) => deps.handleLspCommand(ctx.rawInput),
-			handleWorkflow: (ctx) =>
-				deps.delegatingHandlers.handleWorkflowCommand(ctx),
-			handleRun: (ctx) => deps.handleRunCommand(ctx.rawInput),
-			handleCommands: (ctx) => deps.handleCommandsCommand(ctx),
+		[CommandSuiteKey.Tools]: {
+			handleTools: (ctx) => handlers.tools(ctx),
+			handleMcp: (ctx) => handlers.mcp(ctx),
+			handleLsp: (ctx) => handlers.lsp(ctx),
+			handleWorkflow: (ctx) => handlers.workflow(ctx),
+			handleRun: (ctx) => handlers.run(ctx),
+			handleCommands: (ctx) => handlers.commands(ctx),
 		},
 	});
+}
+
+function commandContext(rawInput: string): CommandExecutionContext {
+	return {
+		command: { name: rawInput.replace(/^\//, ""), description: "" },
+		rawInput,
+		argumentText: "",
+		showInfo: () => undefined,
+		showError: () => undefined,
+		renderHelp: () => undefined,
+	};
 }

--- a/test/cli-tui/commands/command-registry-integration.test.ts
+++ b/test/cli-tui/commands/command-registry-integration.test.ts
@@ -1,6 +1,9 @@
 import type { SlashCommand } from "@evalops/tui";
 import { describe, expect, it, vi } from "vitest";
-import type { CommandSuiteHandlers } from "../../../src/cli-tui/commands/command-suite-handlers.js";
+import {
+	type CommandSuiteHandlers,
+	CommandSuiteKey,
+} from "../../../src/cli-tui/commands/command-suite-handlers.js";
 import type {
 	CommandExecutionContext,
 	CommandHandlers,
@@ -101,16 +104,16 @@ function createMockOptions(): CommandRegistryOptions & {
 		package: noop,
 	};
 	const commandSuiteHandlers: CommandSuiteHandlers = {
-		session: vi.fn(),
-		diag: vi.fn(),
-		ui: vi.fn(),
-		safety: vi.fn(),
-		git: vi.fn(),
-		auth: vi.fn(),
-		usage: vi.fn(),
-		undo: vi.fn(),
-		config: vi.fn(),
-		tools: vi.fn(),
+		[CommandSuiteKey.Session]: vi.fn(),
+		[CommandSuiteKey.Diag]: vi.fn(),
+		[CommandSuiteKey.Ui]: vi.fn(),
+		[CommandSuiteKey.Safety]: vi.fn(),
+		[CommandSuiteKey.Git]: vi.fn(),
+		[CommandSuiteKey.Auth]: vi.fn(),
+		[CommandSuiteKey.Usage]: vi.fn(),
+		[CommandSuiteKey.Undo]: vi.fn(),
+		[CommandSuiteKey.Config]: vi.fn(),
+		[CommandSuiteKey.Tools]: vi.fn(),
 	};
 	return {
 		getRunScriptCompletions: vi.fn(() => null),
@@ -374,7 +377,9 @@ describe("command-registry-integration", () => {
 			safeEntry!.execute("/safe");
 
 			expect(opts.getCommandSuiteHandlers).toHaveBeenCalledTimes(1);
-			expect(opts.commandSuiteHandlers.safety).toHaveBeenCalled();
+			expect(
+				opts.commandSuiteHandlers[CommandSuiteKey.Safety],
+			).toHaveBeenCalled();
 		});
 
 		it("dispatches /cfg to the command suite config handler", () => {
@@ -384,7 +389,9 @@ describe("command-registry-integration", () => {
 
 			configEntry!.execute("/cfg");
 
-			expect(opts.commandSuiteHandlers.config).toHaveBeenCalled();
+			expect(
+				opts.commandSuiteHandlers[CommandSuiteKey.Config],
+			).toHaveBeenCalled();
 		});
 
 		it("passes --help flag through to renderHelp", () => {

--- a/test/tui/command-registry-options.test.ts
+++ b/test/tui/command-registry-options.test.ts
@@ -75,6 +75,7 @@ function createDeps() {
 		oauthFlowController: {
 			handleLoginCommand: vi.fn(),
 			handleLogoutCommand: vi.fn(),
+			handleSourceOfTruthPolicyCommand: vi.fn(),
 		},
 		approvalService: {} as TuiCommandRegistryDeps["approvalService"],
 		notificationView: {
@@ -144,23 +145,20 @@ function createDeps() {
 		handleCheckpointCommand: vi.fn(),
 		handleMemoryCommand: vi.fn(),
 		handleModeCommand: vi.fn(),
-		getCommandSuiteHandlers: vi.fn(
-			() =>
-				({
-					session: vi.fn(),
-					diag: vi.fn(),
-					ui: vi.fn(),
-					safety: vi.fn(),
-					git: vi.fn(),
-					auth: vi.fn(),
-					usage: vi.fn(),
-					undo: vi.fn(),
-					config: vi.fn(),
-					tools: vi.fn(),
-				}) as TuiCommandRegistryDeps["getCommandSuiteHandlers"] extends () => infer T
-					? T
-					: never,
-		),
+		commandSuite: {
+			getUiState: vi.fn(() => ({
+				zenMode: false,
+				cleanMode: "off",
+				footerMode: "auto",
+				compactTools: false,
+			})),
+			getAuthState: vi.fn(() => ({ authenticated: false })),
+			handleSessionRecoverCommand: vi.fn(),
+			handleSessionCleanupCommand: vi.fn(),
+			handleSourcesCommand: vi.fn(),
+			handlePerfCommand: vi.fn(),
+			handleAuthSourceOfTruthCommand: vi.fn(),
+		},
 		refreshFooterHint: vi.fn(),
 		onQuit: vi.fn(),
 	} as unknown as TuiCommandRegistryDeps;
@@ -205,7 +203,8 @@ describe("buildTuiCommandRegistryOptions", () => {
 		expect(deps.getClearController).not.toHaveBeenCalled();
 		expect(deps.getCustomCommandsController).not.toHaveBeenCalled();
 		expect(deps.getBranchController).not.toHaveBeenCalled();
-		expect(deps.getCommandSuiteHandlers).not.toHaveBeenCalled();
+		expect(deps.commandSuite.getUiState).not.toHaveBeenCalled();
+		expect(deps.commandSuite.getAuthState).not.toHaveBeenCalled();
 	});
 
 	it("resolves lazy views only when the matching command runs", async () => {
@@ -310,7 +309,8 @@ describe("buildTuiCommandRegistryOptions", () => {
 		expect(deps.getThinkingSelectorView).toHaveBeenCalledTimes(1);
 		expect(thinkingSelectorView.show).toHaveBeenCalledTimes(1);
 
-		expect(options.getCommandSuiteHandlers()).toBeDefined();
-		expect(deps.getCommandSuiteHandlers).toHaveBeenCalledTimes(1);
+		const commandSuiteHandlers = options.getCommandSuiteHandlers();
+		expect(commandSuiteHandlers).toBeDefined();
+		expect(options.getCommandSuiteHandlers()).toBe(commandSuiteHandlers);
 	});
 });

--- a/test/tui/tui-subcommands.test.ts
+++ b/test/tui/tui-subcommands.test.ts
@@ -465,7 +465,6 @@ describe("Subcommand Suite Handlers", () => {
 			handleDiff: vi.fn(),
 			handleReview: vi.fn(),
 			showInfo: vi.fn(),
-			runGitCommand: vi.fn().mockResolvedValue(""),
 		});
 
 		it("routes 'diff' to handleDiff", async () => {
@@ -1114,7 +1113,6 @@ describe("Subcommand Suite Handlers", () => {
 				handleDiff: vi.fn(),
 				handleReview: vi.fn(),
 				showInfo: vi.fn(),
-				runGitCommand: vi.fn().mockResolvedValue(""),
 			};
 
 			const handler = createGitCommandHandler(deps);
@@ -1715,7 +1713,6 @@ describe("Subcommand Suite Handlers", () => {
 				handleDiff: vi.fn(),
 				handleReview: vi.fn(),
 				showInfo: vi.fn(),
-				runGitCommand: vi.fn(),
 			};
 
 			const handler = createGitCommandHandler(deps);


### PR DESCRIPTION
## Summary
- replace stringly command suite keys with a shared CommandSuiteKey enum
- move command suite construction into the registry-options adapter so TuiRenderer only supplies true suite-specific runtime hooks
- reuse the top-level command handlers for suite routing and remove the old renderer-owned callback bag / unused git command dep

## Validation
- npx biome check --write --unsafe src/cli-tui/commands/command-suite-handlers.ts src/cli-tui/commands/registry.ts src/cli-tui/commands/subcommands/git-commands.ts src/cli-tui/tui-renderer/command-suite-wiring.ts src/cli-tui/tui-renderer/command-registry-options.ts src/cli-tui/tui-renderer.ts test/cli-tui/commands/command-registry-integration.test.ts test/tui/command-registry-options.test.ts test/tui/tui-subcommands.test.ts
- node ./scripts/run-vitest.js --run test/cli-tui/commands/command-registry-integration.test.ts test/tui/command-registry-options.test.ts test/tui/tui-subcommands.test.ts
- npx --yes bun@1.3.6 run --filter @evalops/tui build
- npx --yes bun@1.3.6 run --filter @evalops/contracts build
- npx tsc -p tsconfig.build.json --noEmit
- npx --yes bun@1.3.6 run build
- npx --yes bun@1.3.6 run --filter @evalops/ai build
- npx --yes bun@1.3.6 run --filter @evalops/maestro-web build
- node ./scripts/run-vitest.js --run test/slack-agent/api-server.test.ts test/build/package-builds.test.ts
- node ./scripts/run-vitest.js --run
- git diff --check

Full Vitest result after workspace package builds: 531 files passed, 6541 tests passed, 34 skipped.