### PR TITLE
Refactor command registry around catalogs

### DIFF
--- a/src/cli-tui/commands/command-catalog.ts
+++ b/src/cli-tui/commands/command-catalog.ts
@@ -1,0 +1,1034 @@
+import type { SlashCommand } from "@evalops/tui";
+import type { CommandHandlers } from "./types.js";
+
+export enum CommandMatchKind {
+	Exact = "exact",
+	WithArgs = "with-args",
+	Diagnostics = "diagnostics",
+	Quit = "quit",
+}
+
+export enum CommandCompletionKind {
+	Access = "access",
+	Hotkeys = "hotkeys",
+	Package = "package",
+	RunScripts = "run-scripts",
+}
+
+export type CommandCatalogEntry = {
+	command: SlashCommand;
+	handlerKey: keyof CommandHandlers;
+	match: {
+		kind: CommandMatchKind;
+		aliases?: string[];
+	};
+	completions?: CommandCompletionKind;
+	rewriteTo?: string;
+};
+
+export const PRIMARY_COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
+	{
+		command: {
+			name: "zen",
+			description: "Toggle Zen Mode (hides header, ensures minimal footer)",
+			usage: "/zen [on|off]",
+			tags: ["ui"],
+			examples: ["/zen", "/zen on", "/zen off"],
+		},
+		handlerKey: "zen",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "context",
+			description: "Visualize context usage (tokens per message/file)",
+			usage: "/context",
+			tags: ["diagnostics", "usage"],
+		},
+		handlerKey: "context",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "access",
+			description: "Directory access rules and path testing",
+			usage: "/access [safe|restricted|test <path>]",
+			tags: ["diagnostics", "safety"],
+			examples: ["/access", "/access safe", "/access test ./logs/output.txt"],
+		},
+		handlerKey: "access",
+		match: { kind: CommandMatchKind.WithArgs },
+		completions: CommandCompletionKind.Access,
+	},
+	{
+		command: {
+			name: "pii",
+			description: "PII detection patterns and testing",
+			usage: "/pii [patterns|test <text>]",
+			tags: ["diagnostics", "security"],
+			examples: ["/pii", "/pii patterns", "/pii test jane.doe@example.com"],
+		},
+		handlerKey: "pii",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "audit",
+			description: "Audit log status (enterprise)",
+			usage: "/audit [status]",
+			tags: ["diagnostics", "security"],
+			examples: ["/audit", "/audit status"],
+		},
+		handlerKey: "audit",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "limits",
+			description: "Show configurable runtime limits",
+			usage: "/limits [all|tool|tui|api|session|runtime|help]",
+			tags: ["config", "diagnostics"],
+			examples: ["/limits", "/limits tool", "/limits runtime"],
+		},
+		handlerKey: "limits",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "approvals",
+			description:
+				"Show approval status or switch between auto/prompt/fail modes",
+			usage: "/approvals [auto|prompt|fail]",
+			tags: ["safety"],
+		},
+		handlerKey: "approvals",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "plan-mode",
+			description: "Toggle plan mode (ask before write/edit/bash)",
+			usage: "/plan-mode [on|off]",
+			tags: ["safety"],
+		},
+		handlerKey: "planMode",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "guardian",
+			description:
+				"Run Maestro Guardian (Semgrep + secrets) or toggle enforcement",
+			usage: "/guardian [run|status|enable|disable|all]",
+			tags: ["safety", "git"],
+			examples: ["/guardian", "/guardian status", "/guardian disable"],
+		},
+		handlerKey: "guardian",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "workflow",
+			description: "Run declarative multi-step tool workflows",
+			usage: "/workflow [list|run|validate|show] [name]",
+			tags: ["tools", "automation"],
+			arguments: [
+				{
+					name: "subcommand",
+					type: "enum",
+					required: false,
+					description: "Workflow subcommand",
+					choices: ["list", "run", "validate", "show"],
+				},
+				{
+					name: "name",
+					type: "string",
+					required: false,
+					description: "Workflow name",
+				},
+			],
+			examples: [
+				"/workflow",
+				"/workflow list",
+				"/workflow run setup-project",
+				"/workflow validate my-workflow",
+				"/workflow show my-workflow",
+			],
+		},
+		handlerKey: "workflow",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "framework",
+			description:
+				"Set or show default framework (supports --workspace and list)",
+			usage: "/framework [id|none|list] [--workspace]",
+			tags: ["session"],
+		},
+		handlerKey: "framework",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "commands",
+			description: "List or run user commands from .maestro/commands",
+			usage: "/commands list | /commands run <name> [k=v]...",
+			tags: ["session", "automation"],
+		},
+		handlerKey: "commands",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "report",
+			description: "Collect info for bug reports or general feedback",
+			usage: "/report [bug|feedback]",
+			tags: ["support"],
+			arguments: [
+				{
+					name: "type",
+					type: "enum",
+					required: false,
+					description: "Select report type",
+					choices: ["bug", "feedback"],
+				},
+			],
+			examples: ["/report", "/report bug", "/report feedback"],
+		},
+		handlerKey: "report",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "thinking",
+			description: "Adjust reasoning level for supported models",
+			usage: "/thinking [off|minimal|low|medium|high]",
+			tags: ["session"],
+			arguments: [
+				{
+					name: "level",
+					type: "enum",
+					required: false,
+					description: "Thinking level to set",
+					choices: ["off", "minimal", "low", "medium", "high"],
+				},
+			],
+			examples: ["/thinking", "/thinking medium", "/thinking off"],
+		},
+		handlerKey: "thinking",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "model",
+			description: "Select model (opens selector UI)",
+			usage: "/model",
+			tags: ["session"],
+		},
+		handlerKey: "model",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "mode",
+			description: "Switch agent mode (smart/rush/free)",
+			usage: "/mode [smart|rush|free|list|suggest]",
+			tags: ["session", "model"],
+			examples: ["/mode", "/mode smart", "/mode rush", "/mode free"],
+		},
+		handlerKey: "mode",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "theme",
+			description: "Select color theme (opens selector with live preview)",
+			usage: "/theme",
+			tags: ["ui"],
+		},
+		handlerKey: "theme",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "clean",
+			description:
+				"Toggle assistant text deduplication during live streaming only",
+			usage: "/clean [off|soft|aggressive]",
+			tags: ["ui"],
+			examples: ["/clean", "/clean soft", "/clean off"],
+		},
+		handlerKey: "clean",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "new",
+			description: "Start a fresh chat session",
+			usage: "/new",
+			tags: ["session"],
+		},
+		handlerKey: "newChat",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "export",
+			description: "Export session to HTML, text, JSON, or JSONL",
+			usage: "/export [path] [html|text|json|jsonl]",
+			tags: ["session", "sharing"],
+			aliases: ["e"],
+		},
+		handlerKey: "exportSession",
+		match: { kind: CommandMatchKind.WithArgs, aliases: ["e"] },
+	},
+	{
+		command: {
+			name: "share",
+			description: "Generate a self-contained HTML share link",
+			usage: "/share [output.html]",
+			tags: ["session", "sharing"],
+		},
+		handlerKey: "shareSession",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "import",
+			description: "Import configuration or portable session files",
+			usage: "/import factory | /import session <file.json|file.jsonl>",
+			tags: ["config"],
+		},
+		handlerKey: "importConfig",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "session",
+			description: "Show session info, mark favorite, or add a manual summary",
+			usage:
+				'/session [info|favorite|unfavorite|summary "text"] (defaults: info)',
+			tags: ["session"],
+			aliases: ["s"],
+		},
+		handlerKey: "session",
+		match: { kind: CommandMatchKind.WithArgs, aliases: ["s"] },
+	},
+	{
+		command: {
+			name: "sessions",
+			description:
+				"List, load, favorite, or summarize recent sessions by index",
+			usage:
+				"/sessions [list|load <id>|favorite <id>|unfavorite <id>|summarize <id>]",
+			tags: ["session"],
+		},
+		handlerKey: "sessions",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "history",
+			description: "Show or search prompt history",
+			usage: "/history [count|search query|clear]",
+			tags: ["session"],
+			aliases: ["hist"],
+			examples: ["/history", "/history 25", "/history clear"],
+		},
+		handlerKey: "history",
+		match: { kind: CommandMatchKind.WithArgs, aliases: ["hist"] },
+	},
+	{
+		command: {
+			name: "branch",
+			description:
+				"Create a new session from an earlier user message (keeps history up to that point)",
+			usage: "/branch [list|<user-message-number>]",
+			tags: ["session"],
+		},
+		handlerKey: "branch",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "tree",
+			description: "Navigate the session tree and switch branches",
+			usage: "/tree",
+			tags: ["session"],
+		},
+		handlerKey: "tree",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "queue",
+			description: "List, cancel, or change queue mode",
+			usage: "/queue [list|cancel <id>|mode [steer|followup] <one|all>]",
+			tags: ["session"],
+		},
+		handlerKey: "queue",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "steer",
+			description: "Interrupt current run and run a prompt next",
+			usage: "/steer <message>",
+			tags: ["session"],
+			examples: ["/steer focus on tests next"],
+		},
+		handlerKey: "steer",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "about",
+			description: "Show Maestro build, env, and git info",
+			usage: "/about",
+			tags: ["system", "diagnostics"],
+		},
+		handlerKey: "about",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "clear",
+			description: "Clear context and start a fresh session",
+			usage: "/clear",
+			tags: ["session"],
+		},
+		handlerKey: "clear",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "plan",
+			description: "Show saved plans/checklists",
+			usage: "/plan [id]",
+			tags: ["planning"],
+			aliases: ["p"],
+		},
+		handlerKey: "plan",
+		match: { kind: CommandMatchKind.WithArgs, aliases: ["p"] },
+	},
+	{
+		command: {
+			name: "init",
+			description: "Create or overwrite AGENTS.md scaffolding for this repo",
+			usage: "/init [path]",
+			tags: ["config"],
+		},
+		handlerKey: "initAgents",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "diff",
+			description: "Show git diff for a file",
+			usage: "/diff <path>",
+			tags: ["git"],
+		},
+		handlerKey: "preview",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "status",
+			description:
+				"Show health snapshot (model, git, plan, telemetry, training)",
+			usage: "/status",
+			tags: ["diagnostics"],
+		},
+		handlerKey: "status",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "background",
+			description:
+				"Configure background task notifications and status redaction",
+			usage:
+				"/background [status|notify <on|off>|details <on|off>|history|path]",
+			tags: ["diagnostics"],
+			examples: [
+				"/background",
+				"/background notify on",
+				"/background details on",
+				"/background history",
+				"/background path",
+			],
+		},
+		handlerKey: "background",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "review",
+			description: "Summarize git status and diff stats",
+			usage: "/review",
+			tags: ["git"],
+		},
+		handlerKey: "review",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "undo",
+			description: "Undo last N file changes (beyond git) with preview",
+			usage: "/undo [N] [--preview] [--force]",
+			tags: ["undo", "safety"],
+			arguments: [
+				{
+					name: "count",
+					type: "number",
+					required: false,
+					description: "Number of changes to undo (default: 1)",
+				},
+			],
+			examples: ["/undo", "/undo 3", "/undo --preview", "/undo 2 --force"],
+		},
+		handlerKey: "undoChanges",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "changes",
+			description: "List tracked file changes from this session",
+			usage: "/changes [--files|--tools]",
+			tags: ["undo", "diagnostics"],
+			examples: ["/changes", "/changes --files", "/changes --tools"],
+		},
+		handlerKey: "changes",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "checkpoint",
+			description: "Save/restore named checkpoints for rollback",
+			usage: "/checkpoint [save|list|restore] [name]",
+			tags: ["undo", "safety"],
+			arguments: [
+				{
+					name: "subcommand",
+					type: "enum",
+					required: false,
+					description: "Checkpoint subcommand",
+					choices: ["save", "list", "restore"],
+				},
+				{
+					name: "name",
+					type: "string",
+					required: false,
+					description: "Checkpoint name",
+				},
+			],
+			examples: [
+				"/checkpoint",
+				"/checkpoint save before-refactor",
+				"/checkpoint list",
+				"/checkpoint restore before-refactor",
+			],
+		},
+		handlerKey: "checkpoint",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "memory",
+			description:
+				"Cross-session and repo-scoped memory for facts and learnings",
+			usage:
+				"/memory [save|search|list|session|recent|team|delete|stats|export|import|clear]",
+			tags: ["memory", "session"],
+			arguments: [
+				{
+					name: "subcommand",
+					type: "enum",
+					required: false,
+					description: "Memory subcommand",
+					choices: [
+						"save",
+						"search",
+						"list",
+						"session",
+						"recent",
+						"team",
+						"delete",
+						"stats",
+						"export",
+						"import",
+						"clear",
+					],
+				},
+			],
+			examples: [
+				"/memory",
+				"/memory save api-design Use REST conventions #rest",
+				"/memory search REST",
+				"/memory search REST --session",
+				"/memory list",
+				"/memory list api-design",
+				"/memory session 5",
+				"/memory team",
+				"/memory team init",
+				"/memory stats",
+			],
+		},
+		handlerKey: "memory",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "mention",
+			description: "Search files to mention (same as @ search)",
+			usage: "/mention <query>",
+			tags: ["search"],
+		},
+		handlerKey: "mention",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "run",
+			description: "Run npm script (e.g. /run test --watch)",
+			usage: "/run <script> [--flags]",
+			tags: ["automation"],
+			aliases: ["r"],
+		},
+		handlerKey: "run",
+		match: { kind: CommandMatchKind.WithArgs, aliases: ["r"] },
+		completions: CommandCompletionKind.RunScripts,
+	},
+	{
+		command: {
+			name: "ollama",
+			description: "Control local Ollama models (list, pull, ps)",
+			usage: "/ollama [list|pull <model>|ps]",
+			tags: ["local", "models"],
+			examples: ["/ollama list", "/ollama pull llama3", "/ollama ps"],
+		},
+		handlerKey: "ollama",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "help",
+			description: "List available slash commands",
+			usage: "/help",
+			tags: ["support"],
+			aliases: ["h"],
+		},
+		handlerKey: "help",
+		match: { kind: CommandMatchKind.Exact, aliases: ["h"] },
+	},
+	{
+		command: {
+			name: "update",
+			description: "Check for Maestro CLI updates",
+			usage: "/update",
+			tags: ["system"],
+		},
+		handlerKey: "update",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "changelog",
+			description: "Display full version history",
+			usage: "/changelog",
+			tags: ["system"],
+		},
+		handlerKey: "changelog",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "hotkeys",
+			description: "Show or manage keyboard shortcuts",
+			usage: "/hotkeys [show|path|init|validate]",
+			tags: ["help", "config"],
+			aliases: ["keys", "shortcuts"],
+			examples: [
+				"/hotkeys",
+				"/hotkeys path",
+				"/hotkeys init",
+				"/hotkeys validate",
+			],
+		},
+		handlerKey: "hotkeys",
+		match: { kind: CommandMatchKind.WithArgs, aliases: ["keys", "shortcuts"] },
+		completions: CommandCompletionKind.Hotkeys,
+	},
+	{
+		command: {
+			name: "package",
+			description:
+				"Manage, inspect, or validate Maestro package/plugin bundles",
+			usage:
+				"/package [add|remove|prune-cache|refresh|list|inspect|validate] [source] [--scope ...]",
+			tags: ["tools", "config"],
+			aliases: ["plugin"],
+			examples: [
+				"/package add ./packages/my-pack",
+				"/package list",
+				"/package remove ./packages/my-pack",
+				"/package prune-cache",
+				"/package refresh git:github.com/org/my-pack@main",
+				"/package refresh --all",
+				"/package inspect ./packages/my-pack",
+				"/package validate ./packages/my-pack",
+				"/plugin ./packages/my-pack",
+			],
+		},
+		handlerKey: "package",
+		match: { kind: CommandMatchKind.WithArgs, aliases: ["plugin"] },
+		completions: CommandCompletionKind.Package,
+	},
+	{
+		command: {
+			name: "telemetry",
+			description: "Show telemetry status or toggle runtime overrides",
+			usage: "/telemetry [status|on|off|reset]",
+			tags: ["diagnostics", "telemetry"],
+			arguments: [
+				{
+					name: "action",
+					type: "enum",
+					required: false,
+					description: "Action to perform",
+					choices: ["status", "on", "off", "reset"],
+				},
+			],
+			examples: ["/telemetry", "/telemetry off"],
+		},
+		handlerKey: "telemetry",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "otel",
+			description: "Show OpenTelemetry runtime configuration",
+			usage: "/otel",
+			tags: ["diagnostics", "telemetry"],
+		},
+		handlerKey: "otel",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "training",
+			description: "Toggle model training preference or show status",
+			usage: "/training [status|on|off|reset]",
+			tags: ["privacy"],
+			arguments: [
+				{
+					name: "action",
+					type: "enum",
+					required: false,
+					description: "Training action",
+					choices: ["status", "on", "off", "reset"],
+				},
+			],
+			examples: ["/training", "/training off"],
+		},
+		handlerKey: "training",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "config",
+			description: "Validate and inspect Maestro configuration",
+			usage: "/config [summary|sources|providers|env|files|help]",
+			tags: ["config"],
+			examples: ["/config", "/config sources"],
+		},
+		handlerKey: "config",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "cost",
+			description: "Show usage and cost summary",
+			usage: "/cost [period|breakdown <period>|clear|help]",
+			tags: ["usage"],
+			examples: ["/cost", "/cost breakdown week"],
+		},
+		handlerKey: "cost",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "quota",
+			description: "Show token quota status and usage limits",
+			usage: "/quota [detailed|models|alerts|limit <tokens>|help]",
+			tags: ["usage"],
+			examples: [
+				"/quota",
+				"/quota detailed",
+				"/quota models",
+				"/quota limit 100000",
+			],
+		},
+		handlerKey: "quota",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "stats",
+			description: "Show combined status and cost overview",
+			usage: "/stats",
+			tags: ["diagnostics", "usage"],
+		},
+		handlerKey: "stats",
+		match: { kind: CommandMatchKind.Exact },
+	},
+	{
+		command: {
+			name: "diag",
+			description: "Show provider/model/API key diagnostics",
+			usage: "/diag [lsp|keys]",
+			tags: ["diagnostics"],
+			aliases: ["d", "diagnostics"],
+		},
+		handlerKey: "diagnostics",
+		match: { kind: CommandMatchKind.Diagnostics },
+	},
+	{
+		command: {
+			name: "mcp",
+			description:
+				"Show or manage Model Context Protocol servers and auth presets",
+			usage:
+				"/mcp [add|edit|remove|approve|deny|search|import|auth|resources|prompts]",
+			tags: ["tools"],
+			examples: [
+				"/mcp",
+				"/mcp search linear",
+				"/mcp import linear",
+				"/mcp approve linear",
+				"/mcp auth add linear-auth --header 'Authorization: Bearer ...'",
+				"/mcp add linear https://mcp.linear.app/mcp",
+				"/mcp add linear https://mcp.linear.app/mcp --auth-preset linear-auth",
+				"/mcp edit linear https://mcp.linear.app/mcp --header 'Authorization: Bearer ...'",
+				"/mcp remove linear",
+				"/mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem .",
+			],
+		},
+		handlerKey: "mcp",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "lsp",
+			description: "Manage Language Server Protocol servers",
+			usage: "/lsp [status|start|stop|restart|detect]",
+			tags: ["tools", "diagnostics"],
+			examples: [
+				"/lsp",
+				"/lsp status",
+				"/lsp start",
+				"/lsp stop",
+				"/lsp restart",
+				"/lsp detect",
+			],
+		},
+		handlerKey: "lsp",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "composer",
+			description: "Manage custom composer configurations",
+			usage: "/composer [list|<name>|activate <name>|deactivate]",
+			tags: ["config"],
+			examples: [
+				"/composer",
+				"/composer list",
+				"/composer code-reviewer",
+				"/composer activate code-reviewer",
+				"/composer deactivate",
+			],
+		},
+		handlerKey: "composer",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "prompts",
+			description:
+				"List/run prompt templates from markdown files (~/.maestro/prompts/, .maestro/prompts/).",
+			usage: "/prompts [list|<name> [args]]",
+			tags: ["automation", "session"],
+			examples: [
+				"/prompts",
+				"/prompts list",
+				"/prompts review FILE=src/main.ts",
+				"/pr-review FILE=src/main.ts",
+				'/prompts ticket TICKET_ID=123 TITLE="Fix bug"',
+			],
+		},
+		handlerKey: "prompts",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "compact",
+			description: "Summarize older messages to reclaim context",
+			usage: "/compact [custom instructions]",
+			tags: ["planning"],
+			examples: [
+				"/compact",
+				"/compact Focus on the API changes",
+				"/compact Emphasize database migrations",
+			],
+		},
+		handlerKey: "compact",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "autocompact",
+			description: "Toggle or configure auto-compaction",
+			usage: "/autocompact [on|off|status]",
+			tags: ["planning"],
+			examples: [
+				"/autocompact",
+				"/autocompact on",
+				"/autocompact off",
+				"/autocompact status",
+			],
+		},
+		handlerKey: "autocompact",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "footer",
+			description: "Switch footer style or view/clear footer alerts",
+			usage: "/footer [ensemble|solo|history|clear]",
+			tags: ["ui"],
+			examples: ["/footer", "/footer solo", "/footer history", "/footer clear"],
+		},
+		handlerKey: "footer",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "alerts",
+			description: "Alias for footer alerts (history|clear)",
+			usage: "/alerts [history|clear]",
+			tags: ["ui"],
+			examples: ["/alerts history", "/alerts clear"],
+		},
+		handlerKey: "footer",
+		match: { kind: CommandMatchKind.WithArgs },
+		rewriteTo: "footer",
+	},
+	{
+		command: {
+			name: "compact-tools",
+			description: "Toggle folding of tool outputs",
+			usage: "/compact-tools [on|off]",
+			tags: ["tools"],
+		},
+		handlerKey: "compactTools",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "login",
+			description: "Authenticate with Claude Pro/Max via OAuth",
+			usage: "/login [mode] or /login [provider:mode]",
+			tags: ["auth"],
+			arguments: [
+				{
+					name: "argument",
+					type: "string",
+					required: false,
+					description:
+						"Login mode (pro/console) or provider:mode format (e.g., anthropic:pro)",
+				},
+			],
+			examples: [
+				"/login",
+				"/login pro",
+				"/login console",
+				"/login anthropic:pro",
+			],
+		},
+		handlerKey: "login",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "logout",
+			description: "Remove stored Claude OAuth credentials",
+			usage: "/logout [provider]",
+			tags: ["auth"],
+			arguments: [
+				{
+					name: "provider",
+					type: "string",
+					required: false,
+					description: "OAuth provider to logout from (optional)",
+				},
+			],
+			examples: ["/logout", "/logout anthropic"],
+		},
+		handlerKey: "logout",
+		match: { kind: CommandMatchKind.WithArgs },
+	},
+	{
+		command: {
+			name: "quit",
+			description: "Exit composer (same as ctrl+c twice)",
+			usage: "/quit",
+			tags: ["system"],
+			aliases: ["q", "exit"],
+		},
+		handlerKey: "quit",
+		match: { kind: CommandMatchKind.Quit },
+	},
+	{
+		command: {
+			name: "copy",
+			description: "Copy last assistant message to clipboard",
+			usage: "/copy",
+			tags: ["session"],
+		},
+		handlerKey: "copy",
+		match: { kind: CommandMatchKind.Exact },
+	},
+];
+
+export const POST_SUITE_COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
+	{
+		command: {
+			name: "toolhistory",
+			description: "Show tool execution history and stats",
+			usage: "/toolhistory [count|stats|clear|tool <name>]",
+			tags: ["tools"],
+			aliases: ["th"],
+			examples: ["/toolhistory", "/toolhistory stats", "/toolhistory read"],
+		},
+		handlerKey: "toolHistory",
+		match: { kind: CommandMatchKind.WithArgs, aliases: ["th"] },
+	},
+	{
+		command: {
+			name: "skills",
+			description: "List or manage skills from SKILL.md",
+			usage: "/skills [list|activate|deactivate|reload|info] [skill-name]",
+			tags: ["tools"],
+			aliases: ["skill"],
+			examples: [
+				"/skills",
+				"/skills info my-skill",
+				"/skills activate my-skill",
+			],
+		},
+		handlerKey: "skills",
+		match: { kind: CommandMatchKind.WithArgs, aliases: ["skill"] },
+	},
+];

--- a/src/cli-tui/commands/command-suite-catalog.ts
+++ b/src/cli-tui/commands/command-suite-catalog.ts
@@ -1,0 +1,197 @@
+import type { SlashCommand } from "@evalops/tui";
+import { CommandSuiteKey } from "./command-suite-handlers.js";
+import {
+	AUTH_SUBCOMMANDS,
+	CONFIG_SUBCOMMANDS,
+	DIAG_SUBCOMMANDS,
+	GIT_SUBCOMMANDS,
+	SAFETY_SUBCOMMANDS,
+	SESSION_SUBCOMMANDS,
+	type SubcommandDef,
+	TOOLS_SUBCOMMANDS,
+	UI_SUBCOMMANDS,
+	UNDO_SUBCOMMANDS,
+	USAGE_SUBCOMMANDS,
+} from "./subcommands/index.js";
+
+export type CommandSuiteDefinition = {
+	key: CommandSuiteKey;
+	command: SlashCommand;
+	subcommands: readonly SubcommandDef[];
+};
+
+const COMMAND_SUITE_ORDER = [
+	CommandSuiteKey.Session,
+	CommandSuiteKey.Diag,
+	CommandSuiteKey.Ui,
+	CommandSuiteKey.Safety,
+	CommandSuiteKey.Git,
+	CommandSuiteKey.Auth,
+	CommandSuiteKey.Usage,
+	CommandSuiteKey.Undo,
+	CommandSuiteKey.Config,
+	CommandSuiteKey.Tools,
+] as const;
+
+const COMMAND_SUITE_CATALOG: Record<
+	CommandSuiteKey,
+	Omit<CommandSuiteDefinition, "key">
+> = {
+	[CommandSuiteKey.Session]: {
+		command: {
+			name: "ss",
+			description:
+				"Session management: new, clear, list, load, branch, tree, export, share",
+			usage:
+				"/ss [new|clear|list|load <id>|branch <n>|tree|export|share|queue|info]",
+			tags: ["session"],
+			examples: [
+				"/ss",
+				"/ss new",
+				"/ss list",
+				"/ss load 3",
+				"/ss branch 2",
+				"/ss export",
+			],
+		},
+		subcommands: SESSION_SUBCOMMANDS,
+	},
+	[CommandSuiteKey.Diag]: {
+		command: {
+			name: "diag",
+			description:
+				"Diagnostics: status, about, context, stats, lsp, mcp, telemetry, config",
+			usage:
+				"/diag [status|about|context|stats|lsp|mcp|telemetry|training|config]",
+			tags: ["diagnostics"],
+			aliases: ["d", "diagnostics"],
+			examples: [
+				"/diag",
+				"/diag status",
+				"/diag lsp",
+				"/diag telemetry",
+				"/diag config",
+			],
+		},
+		subcommands: DIAG_SUBCOMMANDS,
+	},
+	[CommandSuiteKey.Ui]: {
+		command: {
+			name: "ui",
+			description:
+				"UI settings: theme, clean, footer, alerts, zen, compact-tools",
+			usage: "/ui [theme|clean|footer|alerts|zen|compact]",
+			tags: ["ui"],
+			examples: ["/ui", "/ui theme", "/ui zen on", "/ui compact off"],
+		},
+		subcommands: UI_SUBCOMMANDS,
+	},
+	[CommandSuiteKey.Safety]: {
+		command: {
+			name: "safe",
+			description: "Safety settings: approvals, plan-mode, guardian",
+			usage: "/safe [approvals|plan|guardian] [args]",
+			tags: ["safety"],
+			examples: [
+				"/safe",
+				"/safe approvals auto",
+				"/safe plan on",
+				"/safe guardian run",
+			],
+		},
+		subcommands: SAFETY_SUBCOMMANDS,
+	},
+	[CommandSuiteKey.Git]: {
+		command: {
+			name: "git",
+			description: "Git operations: status, diff, review",
+			usage: "/git [status|diff <path>|review]",
+			tags: ["git"],
+			examples: ["/git", "/git diff src/index.ts", "/git review"],
+		},
+		subcommands: GIT_SUBCOMMANDS,
+	},
+	[CommandSuiteKey.Auth]: {
+		command: {
+			name: "auth",
+			description: "Authentication: login, logout, status, source-of-truth",
+			usage: "/auth [login|logout|status|source-of-truth] [provider] [area]",
+			tags: ["auth"],
+			examples: [
+				"/auth",
+				"/auth login pro",
+				"/auth logout",
+				"/auth source-of-truth openai analytics",
+			],
+		},
+		subcommands: AUTH_SUBCOMMANDS,
+	},
+	[CommandSuiteKey.Usage]: {
+		command: {
+			name: "usage",
+			description: "Usage tracking: cost, quota, stats",
+			usage: "/usage [cost|quota|stats] [args]",
+			tags: ["usage"],
+			examples: [
+				"/usage",
+				"/usage cost breakdown week",
+				"/usage quota detailed",
+			],
+		},
+		subcommands: USAGE_SUBCOMMANDS,
+	},
+	[CommandSuiteKey.Undo]: {
+		command: {
+			name: "undo",
+			description: "Undo system: undo, checkpoint, changes, history",
+			usage: "/undo [<N>|checkpoint|changes|history] [args]",
+			tags: ["undo"],
+			examples: [
+				"/undo",
+				"/undo 3",
+				"/undo checkpoint save before-refactor",
+				"/undo changes",
+			],
+		},
+		subcommands: UNDO_SUBCOMMANDS,
+	},
+	[CommandSuiteKey.Config]: {
+		command: {
+			name: "cfg",
+			description: "Configuration: validate, import, framework, composer, init",
+			usage: "/cfg [validate|import|framework|composer|init] [args]",
+			tags: ["config"],
+			examples: [
+				"/cfg",
+				"/cfg validate",
+				"/cfg import factory",
+				"/cfg framework react",
+				"/cfg composer code-reviewer",
+			],
+		},
+		subcommands: CONFIG_SUBCOMMANDS,
+	},
+	[CommandSuiteKey.Tools]: {
+		command: {
+			name: "tools",
+			description: "Tools: list, mcp, lsp, workflow, run, commands",
+			usage: "/tools [list|mcp|lsp|workflow|run|commands] [args]",
+			tags: ["tools"],
+			aliases: ["t"],
+			examples: [
+				"/tools",
+				"/tools list",
+				"/tools mcp",
+				"/tools lsp status",
+				"/tools run test",
+			],
+		},
+		subcommands: TOOLS_SUBCOMMANDS,
+	},
+};
+
+export const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] =
+	COMMAND_SUITE_ORDER.map((key) => ({
+		key,
+		...COMMAND_SUITE_CATALOG[key],
+	}));

--- a/src/cli-tui/commands/registry.ts
+++ b/src/cli-tui/commands/registry.ts
@@ -1,45 +1,37 @@
 import type { SlashCommand } from "@evalops/tui";
 import { parseCommandArguments, shouldShowHelp } from "./argument-parser.js";
 import {
-	type CommandSuiteHandlers,
-	CommandSuiteKey,
-} from "./command-suite-handlers.js";
+	type CommandCatalogEntry,
+	CommandCompletionKind,
+	CommandMatchKind,
+	POST_SUITE_COMMAND_CATALOG,
+	PRIMARY_COMMAND_CATALOG,
+} from "./command-catalog.js";
+import {
+	COMMAND_SUITE_DEFINITIONS,
+	type CommandSuiteDefinition,
+} from "./command-suite-catalog.js";
 import { HOTKEYS_SUBCOMMANDS } from "./hotkeys-command.js";
 import { PACKAGE_SUBCOMMANDS } from "./package-handlers.js";
 import {
 	ACCESS_SUBCOMMANDS,
-	AUTH_SUBCOMMANDS,
-	CONFIG_SUBCOMMANDS,
-	DIAG_SUBCOMMANDS,
-	GIT_SUBCOMMANDS,
-	SAFETY_SUBCOMMANDS,
-	SESSION_SUBCOMMANDS,
-	type SubcommandDef,
-	TOOLS_SUBCOMMANDS,
-	UI_SUBCOMMANDS,
-	UNDO_SUBCOMMANDS,
-	USAGE_SUBCOMMANDS,
 	createSubcommandCompletions,
 } from "./subcommands/index.js";
 import type {
 	CommandEntry,
 	CommandExecutionContext,
+	CommandHandlers,
 	CommandRegistryOptions,
+	RunScriptCompletionProvider,
 } from "./types.js";
 
-type CommandSuiteDefinition = {
-	command: SlashCommand;
-	subcommands: readonly SubcommandDef[];
-	handlerKey: CommandSuiteKey;
-};
-
 const equals =
-	(name: string, aliases: string[] = []) =>
+	(name: string, aliases: readonly string[] = []) =>
 	(input: string) =>
 		input === `/${name}` || aliases.some((a) => input === `/${a}`);
 
 const withArgs =
-	(name: string, aliases: string[] = []) =>
+	(name: string, aliases: readonly string[] = []) =>
 	(input: string) =>
 		input === `/${name}` ||
 		input.startsWith(`/${name} `) ||
@@ -55,1275 +47,122 @@ const matchDiagnostics = (input: string) =>
 const matchQuit = (input: string) =>
 	input === "/quit" || input === "/exit" || input === "/q";
 
-const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] = [
-	{
-		command: {
-			name: "ss",
-			description:
-				"Session management: new, clear, list, load, branch, tree, export, share",
-			usage:
-				"/ss [new|clear|list|load <id>|branch <n>|tree|export|share|queue|info]",
-			tags: ["session"],
-			examples: [
-				"/ss",
-				"/ss new",
-				"/ss list",
-				"/ss load 3",
-				"/ss branch 2",
-				"/ss export",
-			],
-		},
-		subcommands: SESSION_SUBCOMMANDS,
-		handlerKey: CommandSuiteKey.Session,
-	},
-	{
-		command: {
-			name: "diag",
-			description:
-				"Diagnostics: status, about, context, stats, lsp, mcp, telemetry, config",
-			usage:
-				"/diag [status|about|context|stats|lsp|mcp|telemetry|training|config]",
-			tags: ["diagnostics"],
-			aliases: ["d", "diagnostics"],
-			examples: [
-				"/diag",
-				"/diag status",
-				"/diag lsp",
-				"/diag telemetry",
-				"/diag config",
-			],
-		},
-		subcommands: DIAG_SUBCOMMANDS,
-		handlerKey: CommandSuiteKey.Diag,
-	},
-	{
-		command: {
-			name: "ui",
-			description:
-				"UI settings: theme, clean, footer, alerts, zen, compact-tools",
-			usage: "/ui [theme|clean|footer|alerts|zen|compact]",
-			tags: ["ui"],
-			examples: ["/ui", "/ui theme", "/ui zen on", "/ui compact off"],
-		},
-		subcommands: UI_SUBCOMMANDS,
-		handlerKey: CommandSuiteKey.Ui,
-	},
-	{
-		command: {
-			name: "safe",
-			description: "Safety settings: approvals, plan-mode, guardian",
-			usage: "/safe [approvals|plan|guardian] [args]",
-			tags: ["safety"],
-			examples: [
-				"/safe",
-				"/safe approvals auto",
-				"/safe plan on",
-				"/safe guardian run",
-			],
-		},
-		subcommands: SAFETY_SUBCOMMANDS,
-		handlerKey: CommandSuiteKey.Safety,
-	},
-	{
-		command: {
-			name: "git",
-			description: "Git operations: status, diff, review",
-			usage: "/git [status|diff <path>|review]",
-			tags: ["git"],
-			examples: ["/git", "/git diff src/index.ts", "/git review"],
-		},
-		subcommands: GIT_SUBCOMMANDS,
-		handlerKey: CommandSuiteKey.Git,
-	},
-	{
-		command: {
-			name: "auth",
-			description: "Authentication: login, logout, status, source-of-truth",
-			usage: "/auth [login|logout|status|source-of-truth] [provider] [area]",
-			tags: ["auth"],
-			examples: [
-				"/auth",
-				"/auth login pro",
-				"/auth logout",
-				"/auth source-of-truth openai analytics",
-			],
-		},
-		subcommands: AUTH_SUBCOMMANDS,
-		handlerKey: CommandSuiteKey.Auth,
-	},
-	{
-		command: {
-			name: "usage",
-			description: "Usage tracking: cost, quota, stats",
-			usage: "/usage [cost|quota|stats] [args]",
-			tags: ["usage"],
-			examples: [
-				"/usage",
-				"/usage cost breakdown week",
-				"/usage quota detailed",
-			],
-		},
-		subcommands: USAGE_SUBCOMMANDS,
-		handlerKey: CommandSuiteKey.Usage,
-	},
-	{
-		command: {
-			name: "undo",
-			description: "Undo system: undo, checkpoint, changes, history",
-			usage: "/undo [<N>|checkpoint|changes|history] [args]",
-			tags: ["undo"],
-			examples: [
-				"/undo",
-				"/undo 3",
-				"/undo checkpoint save before-refactor",
-				"/undo changes",
-			],
-		},
-		subcommands: UNDO_SUBCOMMANDS,
-		handlerKey: CommandSuiteKey.Undo,
-	},
-	{
-		command: {
-			name: "cfg",
-			description: "Configuration: validate, import, framework, composer, init",
-			usage: "/cfg [validate|import|framework|composer|init] [args]",
-			tags: ["config"],
-			examples: [
-				"/cfg",
-				"/cfg validate",
-				"/cfg import factory",
-				"/cfg framework react",
-				"/cfg composer code-reviewer",
-			],
-		},
-		subcommands: CONFIG_SUBCOMMANDS,
-		handlerKey: CommandSuiteKey.Config,
-	},
-	{
-		command: {
-			name: "tools",
-			description: "Tools: list, mcp, lsp, workflow, run, commands",
-			usage: "/tools [list|mcp|lsp|workflow|run|commands] [args]",
-			tags: ["tools"],
-			aliases: ["t"],
-			examples: [
-				"/tools",
-				"/tools list",
-				"/tools mcp",
-				"/tools lsp status",
-				"/tools run test",
-			],
-		},
-		subcommands: TOOLS_SUBCOMMANDS,
-		handlerKey: CommandSuiteKey.Tools,
-	},
-];
-
 export function createCommandRegistry({
 	getRunScriptCompletions,
 	handlers,
 	getCommandSuiteHandlers,
 	createContext,
 }: CommandRegistryOptions): CommandEntry[] {
-	const entries: CommandEntry[] = [
-		buildEntry(
-			{
-				name: "zen",
-				description: "Toggle Zen Mode (hides header, ensures minimal footer)",
-				usage: "/zen [on|off]",
-				tags: ["ui"],
-				examples: ["/zen", "/zen on", "/zen off"],
-			},
-			withArgs("zen"),
-			handlers.zen,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "context",
-				description: "Visualize context usage (tokens per message/file)",
-				usage: "/context",
-				tags: ["diagnostics", "usage"],
-			},
-			equals("context"),
-			handlers.context,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "access",
-				description: "Directory access rules and path testing",
-				usage: "/access [safe|restricted|test <path>]",
-				tags: ["diagnostics", "safety"],
-				examples: ["/access", "/access safe", "/access test ./logs/output.txt"],
-				getArgumentCompletions: createSubcommandCompletions(ACCESS_SUBCOMMANDS),
-			},
-			withArgs("access"),
-			handlers.access,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "pii",
-				description: "PII detection patterns and testing",
-				usage: "/pii [patterns|test <text>]",
-				tags: ["diagnostics", "security"],
-				examples: ["/pii", "/pii patterns", "/pii test jane.doe@example.com"],
-			},
-			withArgs("pii"),
-			handlers.pii,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "audit",
-				description: "Audit log status (enterprise)",
-				usage: "/audit [status]",
-				tags: ["diagnostics", "security"],
-				examples: ["/audit", "/audit status"],
-			},
-			withArgs("audit"),
-			handlers.audit,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "limits",
-				description: "Show configurable runtime limits",
-				usage: "/limits [all|tool|tui|api|session|runtime|help]",
-				tags: ["config", "diagnostics"],
-				examples: ["/limits", "/limits tool", "/limits runtime"],
-			},
-			withArgs("limits"),
-			handlers.limits,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "approvals",
-				description:
-					"Show approval status or switch between auto/prompt/fail modes",
-				usage: "/approvals [auto|prompt|fail]",
-				tags: ["safety"],
-			},
-			withArgs("approvals"),
-			handlers.approvals,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "plan-mode",
-				description: "Toggle plan mode (ask before write/edit/bash)",
-				usage: "/plan-mode [on|off]",
-				tags: ["safety"],
-			},
-			withArgs("plan-mode"),
-			handlers.planMode,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "guardian",
-				description:
-					"Run Maestro Guardian (Semgrep + secrets) or toggle enforcement",
-				usage: "/guardian [run|status|enable|disable|all]",
-				tags: ["safety", "git"],
-				examples: ["/guardian", "/guardian status", "/guardian disable"],
-			},
-			withArgs("guardian"),
-			handlers.guardian,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "workflow",
-				description: "Run declarative multi-step tool workflows",
-				usage: "/workflow [list|run|validate|show] [name]",
-				tags: ["tools", "automation"],
-				arguments: [
-					{
-						name: "subcommand",
-						type: "enum",
-						required: false,
-						description: "Workflow subcommand",
-						choices: ["list", "run", "validate", "show"],
-					},
-					{
-						name: "name",
-						type: "string",
-						required: false,
-						description: "Workflow name",
-					},
-				],
-				examples: [
-					"/workflow",
-					"/workflow list",
-					"/workflow run setup-project",
-					"/workflow validate my-workflow",
-					"/workflow show my-workflow",
-				],
-			},
-			withArgs("workflow"),
-			handlers.workflow,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "framework",
-				description:
-					"Set or show default framework (supports --workspace and list)",
-				usage: "/framework [id|none|list] [--workspace]",
-				tags: ["session"],
-			},
-			withArgs("framework"),
-			handlers.framework,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "commands",
-				description: "List or run user commands from .maestro/commands",
-				usage: "/commands list | /commands run <name> [k=v]...",
-				tags: ["session", "automation"],
-			},
-			withArgs("commands"),
-			handlers.commands,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "report",
-				description: "Collect info for bug reports or general feedback",
-				usage: "/report [bug|feedback]",
-				tags: ["support"],
-				arguments: [
-					{
-						name: "type",
-						type: "enum",
-						required: false,
-						description: "Select report type",
-						choices: ["bug", "feedback"],
-					},
-				],
-				examples: ["/report", "/report bug", "/report feedback"],
-			},
-			withArgs("report"),
-			handlers.report,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "thinking",
-				description: "Adjust reasoning level for supported models",
-				usage: "/thinking [off|minimal|low|medium|high]",
-				tags: ["session"],
-				arguments: [
-					{
-						name: "level",
-						type: "enum",
-						required: false,
-						description: "Thinking level to set",
-						choices: ["off", "minimal", "low", "medium", "high"],
-					},
-				],
-				examples: ["/thinking", "/thinking medium", "/thinking off"],
-			},
-			withArgs("thinking"),
-			handlers.thinking,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "model",
-				description: "Select model (opens selector UI)",
-				usage: "/model",
-				tags: ["session"],
-			},
-			equals("model"),
-			handlers.model,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "mode",
-				description: "Switch agent mode (smart/rush/free)",
-				usage: "/mode [smart|rush|free|list|suggest]",
-				tags: ["session", "model"],
-				examples: ["/mode", "/mode smart", "/mode rush", "/mode free"],
-			},
-			withArgs("mode"),
-			handlers.mode,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "theme",
-				description: "Select color theme (opens selector with live preview)",
-				usage: "/theme",
-				tags: ["ui"],
-			},
-			equals("theme"),
-			handlers.theme,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "clean",
-				description:
-					"Toggle assistant text deduplication during live streaming only",
-				usage: "/clean [off|soft|aggressive]",
-				tags: ["ui"],
-				examples: ["/clean", "/clean soft", "/clean off"],
-			},
-			withArgs("clean"),
-			handlers.clean,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "new",
-				description: "Start a fresh chat session",
-				usage: "/new",
-				tags: ["session"],
-			},
-			equals("new"),
-			handlers.newChat,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "export",
-				description: "Export session to HTML, text, JSON, or JSONL",
-				usage: "/export [path] [html|text|json|jsonl]",
-				tags: ["session", "sharing"],
-				aliases: ["e"],
-			},
-			withArgs("export", ["e"]),
-			handlers.exportSession,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "share",
-				description: "Generate a self-contained HTML share link",
-				usage: "/share [output.html]",
-				tags: ["session", "sharing"],
-			},
-			withArgs("share"),
-			handlers.shareSession,
-			createContext,
-		),
-		// ═══════════════════════════════════════════════════════════════════
-		// STANDALONE COMMANDS - These are also available through subcommand suites
-		// (e.g., /import is also /cfg import, /mcp is also /tools mcp)
-		// Keep for backwards compatibility and discoverability
-		// ═══════════════════════════════════════════════════════════════════
-		buildEntry(
-			{
-				name: "import",
-				description: "Import configuration or portable session files",
-				usage: "/import factory | /import session <file.json|file.jsonl>",
-				tags: ["config"],
-			},
-			withArgs("import"),
-			handlers.importConfig,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "session",
-				description:
-					"Show session info, mark favorite, or add a manual summary",
-				usage:
-					'/session [info|favorite|unfavorite|summary "text"] (defaults: info)',
-				tags: ["session"],
-				aliases: ["s"],
-			},
-			withArgs("session", ["s"]),
-			handlers.session,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "sessions",
-				description:
-					"List, load, favorite, or summarize recent sessions by index",
-				usage:
-					"/sessions [list|load <id>|favorite <id>|unfavorite <id>|summarize <id>]",
-				tags: ["session"],
-				aliases: ["ss"],
-			},
-			withArgs("sessions", ["ss"]),
-			handlers.sessions,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "history",
-				description: "Show or search prompt history",
-				usage: "/history [count|search query|clear]",
-				tags: ["session"],
-				aliases: ["hist"],
-				examples: ["/history", "/history 25", "/history clear"],
-			},
-			withArgs("history", ["hist"]),
-			handlers.history,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "branch",
-				description:
-					"Create a new session from an earlier user message (keeps history up to that point)",
-				usage: "/branch [list|<user-message-number>]",
-				tags: ["session"],
-			},
-			withArgs("branch"),
-			handlers.branch,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "tree",
-				description: "Navigate the session tree and switch branches",
-				usage: "/tree",
-				tags: ["session"],
-			},
-			equals("tree"),
-			handlers.tree,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "queue",
-				description: "List, cancel, or change queue mode",
-				usage: "/queue [list|cancel <id>|mode [steer|followup] <one|all>]",
-				tags: ["session"],
-			},
-			withArgs("queue"),
-			handlers.queue,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "steer",
-				description: "Interrupt current run and run a prompt next",
-				usage: "/steer <message>",
-				tags: ["session"],
-				examples: ["/steer focus on tests next"],
-			},
-			withArgs("steer"),
-			handlers.steer,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "about",
-				description: "Show Maestro build, env, and git info",
-				usage: "/about",
-				tags: ["system", "diagnostics"],
-			},
-			equals("about"),
-			handlers.about,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "clear",
-				description: "Clear context and start a fresh session",
-				usage: "/clear",
-				tags: ["session"],
-			},
-			equals("clear"),
-			handlers.clear,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "plan",
-				description: "Show saved plans/checklists",
-				usage: "/plan [id]",
-				tags: ["planning"],
-				aliases: ["p"],
-			},
-			withArgs("plan", ["p"]),
-			handlers.plan,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "init",
-				description: "Create or overwrite AGENTS.md scaffolding for this repo",
-				usage: "/init [path]",
-				tags: ["config"],
-			},
-			withArgs("init"),
-			handlers.initAgents,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "diff",
-				description: "Show git diff for a file",
-				usage: "/diff <path>",
-				tags: ["git"],
-			},
-			withArgs("diff"),
-			handlers.preview,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "status",
-				description:
-					"Show health snapshot (model, git, plan, telemetry, training)",
-				usage: "/status",
-				tags: ["diagnostics"],
-			},
-			equals("status"),
-			handlers.status,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "background",
-				description:
-					"Configure background task notifications and status redaction",
-				usage:
-					"/background [status|notify <on|off>|details <on|off>|history|path]",
-				tags: ["diagnostics"],
-				examples: [
-					"/background",
-					"/background notify on",
-					"/background details on",
-					"/background history",
-					"/background path",
-				],
-			},
-			withArgs("background"),
-			handlers.background,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "review",
-				description: "Summarize git status and diff stats",
-				usage: "/review",
-				tags: ["git"],
-			},
-			equals("review"),
-			handlers.review,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "undo",
-				description: "Undo last N file changes (beyond git) with preview",
-				usage: "/undo [N] [--preview] [--force]",
-				tags: ["undo", "safety"],
-				arguments: [
-					{
-						name: "count",
-						type: "number",
-						required: false,
-						description: "Number of changes to undo (default: 1)",
-					},
-				],
-				examples: ["/undo", "/undo 3", "/undo --preview", "/undo 2 --force"],
-			},
-			withArgs("undo"),
-			handlers.undoChanges,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "changes",
-				description: "List tracked file changes from this session",
-				usage: "/changes [--files|--tools]",
-				tags: ["undo", "diagnostics"],
-				examples: ["/changes", "/changes --files", "/changes --tools"],
-			},
-			withArgs("changes"),
-			handlers.changes,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "checkpoint",
-				description: "Save/restore named checkpoints for rollback",
-				usage: "/checkpoint [save|list|restore] [name]",
-				tags: ["undo", "safety"],
-				arguments: [
-					{
-						name: "subcommand",
-						type: "enum",
-						required: false,
-						description: "Checkpoint subcommand",
-						choices: ["save", "list", "restore"],
-					},
-					{
-						name: "name",
-						type: "string",
-						required: false,
-						description: "Checkpoint name",
-					},
-				],
-				examples: [
-					"/checkpoint",
-					"/checkpoint save before-refactor",
-					"/checkpoint list",
-					"/checkpoint restore before-refactor",
-				],
-			},
-			withArgs("checkpoint"),
-			handlers.checkpoint,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "memory",
-				description:
-					"Cross-session and repo-scoped memory for facts and learnings",
-				usage:
-					"/memory [save|search|list|session|recent|team|delete|stats|export|import|clear]",
-				tags: ["memory", "session"],
-				arguments: [
-					{
-						name: "subcommand",
-						type: "enum",
-						required: false,
-						description: "Memory subcommand",
-						choices: [
-							"save",
-							"search",
-							"list",
-							"session",
-							"recent",
-							"team",
-							"delete",
-							"stats",
-							"export",
-							"import",
-							"clear",
-						],
-					},
-				],
-				examples: [
-					"/memory",
-					"/memory save api-design Use REST conventions #rest",
-					"/memory search REST",
-					"/memory search REST --session",
-					"/memory list",
-					"/memory list api-design",
-					"/memory session 5",
-					"/memory team",
-					"/memory team init",
-					"/memory stats",
-				],
-			},
-			withArgs("memory"),
-			handlers.memory,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "mention",
-				description: "Search files to mention (same as @ search)",
-				usage: "/mention <query>",
-				tags: ["search"],
-			},
-			withArgs("mention"),
-			handlers.mention,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "run",
-				description: "Run npm script (e.g. /run test --watch)",
-				usage: "/run <script> [--flags]",
-				tags: ["automation"],
-				aliases: ["r"],
-				getArgumentCompletions: getRunScriptCompletions,
-			},
-			withArgs("run", ["r"]),
-			handlers.run,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "ollama",
-				description: "Control local Ollama models (list, pull, ps)",
-				usage: "/ollama [list|pull <model>|ps]",
-				tags: ["local", "models"],
-				examples: ["/ollama list", "/ollama pull llama3", "/ollama ps"],
-			},
-			withArgs("ollama"),
-			handlers.ollama,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "help",
-				description: "List available slash commands",
-				usage: "/help",
-				tags: ["support"],
-				aliases: ["h"],
-			},
-			equals("help", ["h"]),
-			handlers.help,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "update",
-				description: "Check for Maestro CLI updates",
-				usage: "/update",
-				tags: ["system"],
-			},
-			equals("update"),
-			handlers.update,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "changelog",
-				description: "Display full version history",
-				usage: "/changelog",
-				tags: ["system"],
-			},
-			equals("changelog"),
-			handlers.changelog,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "hotkeys",
-				description: "Show or manage keyboard shortcuts",
-				usage: "/hotkeys [show|path|init|validate]",
-				tags: ["help", "config"],
-				aliases: ["keys", "shortcuts"],
-				examples: [
-					"/hotkeys",
-					"/hotkeys path",
-					"/hotkeys init",
-					"/hotkeys validate",
-				],
-				getArgumentCompletions:
-					createSubcommandCompletions(HOTKEYS_SUBCOMMANDS),
-			},
-			withArgs("hotkeys", ["keys", "shortcuts"]),
-			handlers.hotkeys,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "package",
-				description:
-					"Manage, inspect, or validate Maestro package/plugin bundles",
-				usage:
-					"/package [add|remove|prune-cache|refresh|list|inspect|validate] [source] [--scope ...]",
-				tags: ["tools", "config"],
-				aliases: ["plugin"],
-				examples: [
-					"/package add ./packages/my-pack",
-					"/package list",
-					"/package remove ./packages/my-pack",
-					"/package prune-cache",
-					"/package refresh git:github.com/org/my-pack@main",
-					"/package refresh --all",
-					"/package inspect ./packages/my-pack",
-					"/package validate ./packages/my-pack",
-					"/plugin ./packages/my-pack",
-				],
-				getArgumentCompletions:
-					createSubcommandCompletions(PACKAGE_SUBCOMMANDS),
-			},
-			withArgs("package", ["plugin"]),
-			handlers.package,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "telemetry",
-				description: "Show telemetry status or toggle runtime overrides",
-				usage: "/telemetry [status|on|off|reset]",
-				tags: ["diagnostics", "telemetry"],
-				arguments: [
-					{
-						name: "action",
-						type: "enum",
-						required: false,
-						description: "Action to perform",
-						choices: ["status", "on", "off", "reset"],
-					},
-				],
-				examples: ["/telemetry", "/telemetry off"],
-			},
-			withArgs("telemetry"),
-			handlers.telemetry,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "otel",
-				description: "Show OpenTelemetry runtime configuration",
-				usage: "/otel",
-				tags: ["diagnostics", "telemetry"],
-			},
-			equals("otel"),
-			handlers.otel,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "training",
-				description: "Toggle model training preference or show status",
-				usage: "/training [status|on|off|reset]",
-				tags: ["privacy"],
-				arguments: [
-					{
-						name: "action",
-						type: "enum",
-						required: false,
-						description: "Training action",
-						choices: ["status", "on", "off", "reset"],
-					},
-				],
-				examples: ["/training", "/training off"],
-			},
-			withArgs("training"),
-			handlers.training,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "config",
-				description: "Validate and inspect Maestro configuration",
-				usage: "/config [summary|sources|providers|env|files|help]",
-				tags: ["config"],
-				examples: ["/config", "/config sources"],
-			},
-			equals("config"),
-			handlers.config,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "cost",
-				description: "Show usage and cost summary",
-				usage: "/cost [period|breakdown <period>|clear|help]",
-				tags: ["usage"],
-				examples: ["/cost", "/cost breakdown week"],
-			},
-			withArgs("cost"),
-			handlers.cost,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "quota",
-				description: "Show token quota status and usage limits",
-				usage: "/quota [detailed|models|alerts|limit <tokens>|help]",
-				tags: ["usage"],
-				examples: [
-					"/quota",
-					"/quota detailed",
-					"/quota models",
-					"/quota limit 100000",
-				],
-			},
-			withArgs("quota"),
-			handlers.quota,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "stats",
-				description: "Show combined status and cost overview",
-				usage: "/stats",
-				tags: ["diagnostics", "usage"],
-			},
-			equals("stats"),
-			handlers.stats,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "diag",
-				description: "Show provider/model/API key diagnostics",
-				usage: "/diag [lsp|keys]",
-				tags: ["diagnostics"],
-				aliases: ["d", "diagnostics"],
-			},
-			matchDiagnostics,
-			handlers.diagnostics,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "mcp",
-				description:
-					"Show or manage Model Context Protocol servers and auth presets",
-				usage:
-					"/mcp [add|edit|remove|approve|deny|search|import|auth|resources|prompts]",
-				tags: ["tools"],
-				examples: [
-					"/mcp",
-					"/mcp search linear",
-					"/mcp import linear",
-					"/mcp approve linear",
-					"/mcp auth add linear-auth --header 'Authorization: Bearer ...'",
-					"/mcp add linear https://mcp.linear.app/mcp",
-					"/mcp add linear https://mcp.linear.app/mcp --auth-preset linear-auth",
-					"/mcp edit linear https://mcp.linear.app/mcp --header 'Authorization: Bearer ...'",
-					"/mcp remove linear",
-					"/mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem .",
-				],
-			},
-			withArgs("mcp"),
-			handlers.mcp,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "lsp",
-				description: "Manage Language Server Protocol servers",
-				usage: "/lsp [status|start|stop|restart|detect]",
-				tags: ["tools", "diagnostics"],
-				examples: [
-					"/lsp",
-					"/lsp status",
-					"/lsp start",
-					"/lsp stop",
-					"/lsp restart",
-					"/lsp detect",
-				],
-			},
-			withArgs("lsp"),
-			handlers.lsp,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "composer",
-				description: "Manage custom composer configurations",
-				usage: "/composer [list|<name>|activate <name>|deactivate]",
-				tags: ["config"],
-				examples: [
-					"/composer",
-					"/composer list",
-					"/composer code-reviewer",
-					"/composer activate code-reviewer",
-					"/composer deactivate",
-				],
-			},
-			withArgs("composer"),
-			handlers.composer,
-			createContext,
-		),
+	const catalogContext: CommandCatalogBuildContext = {
+		getRunScriptCompletions,
+		handlers,
+		createContext,
+	};
 
-		buildEntry(
-			{
-				name: "prompts",
-				description:
-					"List/run prompt templates from markdown files (~/.maestro/prompts/, .maestro/prompts/).",
-				usage: "/prompts [list|<name> [args]]",
-				tags: ["automation", "session"],
-				examples: [
-					"/prompts",
-					"/prompts list",
-					"/prompts review FILE=src/main.ts",
-					"/pr-review FILE=src/main.ts",
-					'/prompts ticket TICKET_ID=123 TITLE="Fix bug"',
-				],
-			},
-			withArgs("prompts"),
-			handlers.prompts,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "compact",
-				description: "Summarize older messages to reclaim context",
-				usage: "/compact [custom instructions]",
-				tags: ["planning"],
-				examples: [
-					"/compact",
-					"/compact Focus on the API changes",
-					"/compact Emphasize database migrations",
-				],
-			},
-			withArgs("compact"),
-			handlers.compact,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "autocompact",
-				description: "Toggle or configure auto-compaction",
-				usage: "/autocompact [on|off|status]",
-				tags: ["planning"],
-				examples: [
-					"/autocompact",
-					"/autocompact on",
-					"/autocompact off",
-					"/autocompact status",
-				],
-			},
-			withArgs("autocompact"),
-			handlers.autocompact,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "footer",
-				description: "Switch footer style or view/clear footer alerts",
-				usage: "/footer [ensemble|solo|history|clear]",
-				tags: ["ui"],
-				examples: [
-					"/footer",
-					"/footer solo",
-					"/footer history",
-					"/footer clear",
-				],
-			},
-			withArgs("footer"),
-			handlers.footer,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "alerts",
-				description: "Alias for footer alerts (history|clear)",
-				usage: "/alerts [history|clear]",
-				tags: ["ui"],
-				examples: ["/alerts history", "/alerts clear"],
-			},
-			withArgs("alerts"),
-			(context) => {
-				context.rawInput = context.rawInput.replace(/^\/alerts/, "/footer");
-				context.argumentText = context.argumentText.replace(
-					/^alerts/,
-					"footer",
-				);
-				handlers.footer(context);
-			},
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "compact-tools",
-				description: "Toggle folding of tool outputs",
-				usage: "/compact-tools [on|off]",
-				tags: ["tools"],
-			},
-			withArgs("compact-tools"),
-			handlers.compactTools,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "login",
-				description: "Authenticate with Claude Pro/Max via OAuth",
-				usage: "/login [mode] or /login [provider:mode]",
-				tags: ["auth"],
-				arguments: [
-					{
-						name: "argument",
-						type: "string",
-						required: false,
-						description:
-							"Login mode (pro/console) or provider:mode format (e.g., anthropic:pro)",
-					},
-				],
-				examples: [
-					"/login",
-					"/login pro",
-					"/login console",
-					"/login anthropic:pro",
-				],
-			},
-			withArgs("login"),
-			handlers.login,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "logout",
-				description: "Remove stored Claude OAuth credentials",
-				usage: "/logout [provider]",
-				tags: ["auth"],
-				arguments: [
-					{
-						name: "provider",
-						type: "string",
-						required: false,
-						description: "OAuth provider to logout from (optional)",
-					},
-				],
-				examples: ["/logout", "/logout anthropic"],
-			},
-			withArgs("logout"),
-			handlers.logout,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "quit",
-				description: "Exit composer (same as ctrl+c twice)",
-				usage: "/quit",
-				tags: ["system"],
-				aliases: ["q", "exit"],
-			},
-			matchQuit,
-			handlers.quit,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "copy",
-				description: "Copy last assistant message to clipboard",
-				usage: "/copy",
-				tags: ["session"],
-			},
-			equals("copy"),
-			handlers.copy,
-			createContext,
-		),
+	return [
+		...buildCommandCatalogEntries(PRIMARY_COMMAND_CATALOG, catalogContext),
 		...buildCommandSuiteEntries(getCommandSuiteHandlers, createContext),
-		buildEntry(
-			{
-				name: "toolhistory",
-				description: "Show tool execution history and stats",
-				usage: "/toolhistory [count|stats|clear|tool <name>]",
-				tags: ["tools"],
-				aliases: ["th"],
-				examples: ["/toolhistory", "/toolhistory stats", "/toolhistory read"],
-			},
-			withArgs("toolhistory", ["th"]),
-			handlers.toolHistory,
-			createContext,
-		),
-		buildEntry(
-			{
-				name: "skills",
-				description: "List or manage skills from SKILL.md",
-				usage: "/skills [list|activate|deactivate|reload|info] [skill-name]",
-				tags: ["tools"],
-				aliases: ["skill"],
-				examples: [
-					"/skills",
-					"/skills info my-skill",
-					"/skills activate my-skill",
-				],
-			},
-			withArgs("skills", ["skill"]),
-			handlers.skills,
-			createContext,
-		),
+		...buildCommandCatalogEntries(POST_SUITE_COMMAND_CATALOG, catalogContext),
 	];
+}
 
-	return entries;
+type CommandCatalogBuildContext = {
+	getRunScriptCompletions: RunScriptCompletionProvider;
+	handlers: CommandHandlers;
+	createContext: CommandRegistryOptions["createContext"];
+};
+
+function buildCommandCatalogEntries(
+	definitions: readonly CommandCatalogEntry[],
+	context: CommandCatalogBuildContext,
+): CommandEntry[] {
+	return definitions.map((definition) =>
+		buildCommandCatalogEntry(definition, context),
+	);
+}
+
+function buildCommandCatalogEntry(
+	definition: CommandCatalogEntry,
+	context: CommandCatalogBuildContext,
+): CommandEntry {
+	const command = withCatalogCompletions(
+		definition,
+		context.getRunScriptCompletions,
+	);
+	const handler = (executionContext: CommandExecutionContext) => {
+		rewriteCatalogContext(definition, executionContext);
+		return context.handlers[definition.handlerKey](executionContext);
+	};
+	return buildEntry(
+		command,
+		buildCatalogMatcher(definition),
+		handler,
+		context.createContext,
+	);
+}
+
+function withCatalogCompletions(
+	definition: CommandCatalogEntry,
+	getRunScriptCompletions: RunScriptCompletionProvider,
+): SlashCommand {
+	const getArgumentCompletions = resolveCatalogCompletions(
+		definition,
+		getRunScriptCompletions,
+	);
+	return getArgumentCompletions
+		? { ...definition.command, getArgumentCompletions }
+		: definition.command;
+}
+
+function resolveCatalogCompletions(
+	definition: CommandCatalogEntry,
+	getRunScriptCompletions: RunScriptCompletionProvider,
+): SlashCommand["getArgumentCompletions"] | undefined {
+	switch (definition.completions) {
+		case CommandCompletionKind.Access:
+			return createSubcommandCompletions(ACCESS_SUBCOMMANDS);
+		case CommandCompletionKind.Hotkeys:
+			return createSubcommandCompletions(HOTKEYS_SUBCOMMANDS);
+		case CommandCompletionKind.Package:
+			return createSubcommandCompletions(PACKAGE_SUBCOMMANDS);
+		case CommandCompletionKind.RunScripts:
+			return getRunScriptCompletions;
+		case undefined:
+			return undefined;
+	}
+}
+
+function buildCatalogMatcher(
+	definition: CommandCatalogEntry,
+): (input: string) => boolean {
+	const aliases = definition.match.aliases ?? definition.command.aliases;
+	switch (definition.match.kind) {
+		case CommandMatchKind.Exact:
+			return equals(definition.command.name, aliases);
+		case CommandMatchKind.WithArgs:
+			return withArgs(definition.command.name, aliases);
+		case CommandMatchKind.Diagnostics:
+			return matchDiagnostics;
+		case CommandMatchKind.Quit:
+			return matchQuit;
+	}
+}
+
+function rewriteCatalogContext(
+	definition: CommandCatalogEntry,
+	context: CommandExecutionContext,
+): void {
+	if (!definition.rewriteTo) {
+		return;
+	}
+	context.rawInput = context.rawInput.replace(
+		new RegExp(`^/${escapeRegExp(definition.command.name)}(?=\\s|$)`),
+		`/${definition.rewriteTo}`,
+	);
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function buildCommandSuiteEntries(
@@ -1355,7 +194,7 @@ function buildCommandSuiteEntry(
 	createContext: CommandRegistryOptions["createContext"],
 ): CommandEntry {
 	const handler = (context: CommandExecutionContext) =>
-		getCommandSuiteHandlers()[definition.handlerKey](context);
+		getCommandSuiteHandlers()[definition.key](context);
 	return buildEntry(
 		{
 			...definition.command,

--- a/test/cli-tui/commands/command-registry-integration.test.ts
+++ b/test/cli-tui/commands/command-registry-integration.test.ts
@@ -1,6 +1,11 @@
 import type { SlashCommand } from "@evalops/tui";
 import { describe, expect, it, vi } from "vitest";
 import {
+	POST_SUITE_COMMAND_CATALOG,
+	PRIMARY_COMMAND_CATALOG,
+} from "../../../src/cli-tui/commands/command-catalog.js";
+import { COMMAND_SUITE_DEFINITIONS } from "../../../src/cli-tui/commands/command-suite-catalog.js";
+import {
 	type CommandSuiteHandlers,
 	CommandSuiteKey,
 } from "../../../src/cli-tui/commands/command-suite-handlers.js";
@@ -138,6 +143,43 @@ describe("command-registry-integration", () => {
 
 		expect(entries.length).toBeGreaterThan(0);
 		expect(commands.length).toBe(entries.length);
+	});
+
+	it("keeps command suite catalog aligned with enum order", () => {
+		const keys = COMMAND_SUITE_DEFINITIONS.map((definition) => definition.key);
+
+		expect(keys).toEqual([
+			CommandSuiteKey.Session,
+			CommandSuiteKey.Diag,
+			CommandSuiteKey.Ui,
+			CommandSuiteKey.Safety,
+			CommandSuiteKey.Git,
+			CommandSuiteKey.Auth,
+			CommandSuiteKey.Usage,
+			CommandSuiteKey.Undo,
+			CommandSuiteKey.Config,
+			CommandSuiteKey.Tools,
+		]);
+		expect(new Set(keys).size).toBe(keys.length);
+		for (const definition of COMMAND_SUITE_DEFINITIONS) {
+			expect(definition.command.name).toBeTruthy();
+			expect(definition.subcommands.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("keeps top-level command catalogs unique and ordered around suites", () => {
+		const catalogNames = [
+			...PRIMARY_COMMAND_CATALOG.map((definition) => definition.command.name),
+			...POST_SUITE_COMMAND_CATALOG.map(
+				(definition) => definition.command.name,
+			),
+		];
+
+		expect(new Set(catalogNames).size).toBe(catalogNames.length);
+		expect(PRIMARY_COMMAND_CATALOG.at(-1)?.command.name).toBe("copy");
+		expect(
+			POST_SUITE_COMMAND_CATALOG.map((definition) => definition.command.name),
+		).toEqual(["toolhistory", "skills"]);
 	});
 
 	it("uses maestro descriptions for guardian, about, and config", () => {
@@ -380,6 +422,19 @@ describe("command-registry-integration", () => {
 			expect(
 				opts.commandSuiteHandlers[CommandSuiteKey.Safety],
 			).toHaveBeenCalled();
+		});
+
+		it("dispatches /ss to the command suite session handler", () => {
+			const opts = createMockOptions();
+			const { entries } = buildCommandRegistry(opts);
+			const sessionSuiteEntry = entries.find((e) => e.matches("/ss"));
+
+			sessionSuiteEntry!.execute("/ss");
+
+			expect(
+				opts.commandSuiteHandlers[CommandSuiteKey.Session],
+			).toHaveBeenCalled();
+			expect(opts.handlers.sessions).not.toHaveBeenCalled();
 		});
 
 		it("dispatches /cfg to the command suite config handler", () => {


### PR DESCRIPTION
## Summary
- move top-level slash command metadata into an enum-backed command catalog with match/completion kinds
- move command suite metadata into a CommandSuiteKey-backed suite catalog
- shrink registry.ts to catalog adaptation, suite adaptation, and shared execution parsing
- make /ss resolve to the session command suite instead of the legacy /sessions alias shadowing it

## Validation
- npx biome check --write --unsafe src/cli-tui/commands/registry.ts src/cli-tui/commands/command-catalog.ts src/cli-tui/commands/command-suite-catalog.ts test/cli-tui/commands/command-registry-integration.test.ts
- npx --yes bun@1.3.6 run --filter @evalops/tui build
- node ./scripts/run-vitest.js --run test/cli-tui/commands/command-registry-integration.test.ts
- npx --yes bun@1.3.6 run --filter @evalops/contracts build
- npx tsc -p tsconfig.build.json --noEmit
- npx --yes bun@1.3.6 run build
- node ./scripts/run-vitest.js --run test/cli-tui/commands/command-registry-integration.test.ts test/tui/command-registry-options.test.ts test/tui/tui-subcommands.test.ts
- npx --yes bun@1.3.6 run --filter @evalops/ai build
- npx --yes bun@1.3.6 run --filter @evalops/maestro-web build
- node ./scripts/run-vitest.js --run
- git diff --check

Full Vitest result after workspace package builds: 531 files passed, 6544 tests passed, 34 skipped.