### PR TITLE
Flatten command registry catalogs

### DIFF
--- a/src/cli-tui/commands/command-catalog.ts
+++ b/src/cli-tui/commands/command-catalog.ts
@@ -15,636 +15,460 @@ export enum CommandCompletionKind {
 	RunScripts = "run-scripts",
 }
 
-export type CommandCatalogEntry = {
-	command: SlashCommand;
+type CommandCatalogRuntimeFields = {
 	handlerKey: keyof CommandHandlers;
-	match: {
-		kind: CommandMatchKind;
-		aliases?: string[];
-	};
+	matchKind: CommandMatchKind;
+	matchAliases?: readonly string[];
 	completions?: CommandCompletionKind;
 	rewriteTo?: string;
 };
 
+type CommandMetadata = Omit<SlashCommand, "name" | "getArgumentCompletions">;
+
+export type CommandCatalogEntry = CommandMetadata &
+	CommandCatalogRuntimeFields & {
+		name: SlashCommand["name"];
+	};
+
+type CatalogCommandOptions = Omit<
+	CommandCatalogRuntimeFields,
+	"handlerKey" | "matchKind"
+>;
+
+type DefineCatalogCommand = (
+	name: SlashCommand["name"],
+	handlerKey: keyof CommandHandlers,
+	metadata: CommandMetadata,
+	options?: CatalogCommandOptions,
+) => CommandCatalogEntry;
+
+function defineCommand(
+	matchKind: CommandMatchKind,
+	name: SlashCommand["name"],
+	handlerKey: keyof CommandHandlers,
+	metadata: CommandMetadata,
+	options: CatalogCommandOptions = {},
+): CommandCatalogEntry {
+	return {
+		name,
+		...metadata,
+		handlerKey,
+		matchKind,
+		...options,
+	};
+}
+
+const exact: DefineCatalogCommand = (name, handlerKey, metadata, options) =>
+	defineCommand(CommandMatchKind.Exact, name, handlerKey, metadata, options);
+
+const withArgs: DefineCatalogCommand = (name, handlerKey, metadata, options) =>
+	defineCommand(CommandMatchKind.WithArgs, name, handlerKey, metadata, options);
+
+const diagnostics: DefineCatalogCommand = (
+	name,
+	handlerKey,
+	metadata,
+	options,
+) =>
+	defineCommand(
+		CommandMatchKind.Diagnostics,
+		name,
+		handlerKey,
+		metadata,
+		options,
+	);
+
+const quit: DefineCatalogCommand = (name, handlerKey, metadata, options) =>
+	defineCommand(CommandMatchKind.Quit, name, handlerKey, metadata, options);
+
 export const PRIMARY_COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
-	{
-		command: {
-			name: "zen",
-			description: "Toggle Zen Mode (hides header, ensures minimal footer)",
-			usage: "/zen [on|off]",
-			tags: ["ui"],
-			examples: ["/zen", "/zen on", "/zen off"],
-		},
-		handlerKey: "zen",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "context",
-			description: "Visualize context usage (tokens per message/file)",
-			usage: "/context",
-			tags: ["diagnostics", "usage"],
-		},
-		handlerKey: "context",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "access",
+	withArgs("zen", "zen", {
+		description: "Toggle Zen Mode (hides header, ensures minimal footer)",
+		usage: "/zen [on|off]",
+		tags: ["ui"],
+		examples: ["/zen", "/zen on", "/zen off"],
+	}),
+	exact("context", "context", {
+		description: "Visualize context usage (tokens per message/file)",
+		usage: "/context",
+		tags: ["diagnostics", "usage"],
+	}),
+	withArgs(
+		"access",
+		"access",
+		{
 			description: "Directory access rules and path testing",
 			usage: "/access [safe|restricted|test <path>]",
 			tags: ["diagnostics", "safety"],
 			examples: ["/access", "/access safe", "/access test ./logs/output.txt"],
 		},
-		handlerKey: "access",
-		match: { kind: CommandMatchKind.WithArgs },
-		completions: CommandCompletionKind.Access,
-	},
-	{
-		command: {
-			name: "pii",
-			description: "PII detection patterns and testing",
-			usage: "/pii [patterns|test <text>]",
-			tags: ["diagnostics", "security"],
-			examples: ["/pii", "/pii patterns", "/pii test jane.doe@example.com"],
-		},
-		handlerKey: "pii",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "audit",
-			description: "Audit log status (enterprise)",
-			usage: "/audit [status]",
-			tags: ["diagnostics", "security"],
-			examples: ["/audit", "/audit status"],
-		},
-		handlerKey: "audit",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "limits",
-			description: "Show configurable runtime limits",
-			usage: "/limits [all|tool|tui|api|session|runtime|help]",
-			tags: ["config", "diagnostics"],
-			examples: ["/limits", "/limits tool", "/limits runtime"],
-		},
-		handlerKey: "limits",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "approvals",
-			description:
-				"Show approval status or switch between auto/prompt/fail modes",
-			usage: "/approvals [auto|prompt|fail]",
-			tags: ["safety"],
-		},
-		handlerKey: "approvals",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "plan-mode",
-			description: "Toggle plan mode (ask before write/edit/bash)",
-			usage: "/plan-mode [on|off]",
-			tags: ["safety"],
-		},
-		handlerKey: "planMode",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "guardian",
-			description:
-				"Run Maestro Guardian (Semgrep + secrets) or toggle enforcement",
-			usage: "/guardian [run|status|enable|disable|all]",
-			tags: ["safety", "git"],
-			examples: ["/guardian", "/guardian status", "/guardian disable"],
-		},
-		handlerKey: "guardian",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "workflow",
-			description: "Run declarative multi-step tool workflows",
-			usage: "/workflow [list|run|validate|show] [name]",
-			tags: ["tools", "automation"],
-			arguments: [
-				{
-					name: "subcommand",
-					type: "enum",
-					required: false,
-					description: "Workflow subcommand",
-					choices: ["list", "run", "validate", "show"],
-				},
-				{
-					name: "name",
-					type: "string",
-					required: false,
-					description: "Workflow name",
-				},
-			],
-			examples: [
-				"/workflow",
-				"/workflow list",
-				"/workflow run setup-project",
-				"/workflow validate my-workflow",
-				"/workflow show my-workflow",
-			],
-		},
-		handlerKey: "workflow",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "framework",
-			description:
-				"Set or show default framework (supports --workspace and list)",
-			usage: "/framework [id|none|list] [--workspace]",
-			tags: ["session"],
-		},
-		handlerKey: "framework",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "commands",
-			description: "List or run user commands from .maestro/commands",
-			usage: "/commands list | /commands run <name> [k=v]...",
-			tags: ["session", "automation"],
-		},
-		handlerKey: "commands",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "report",
-			description: "Collect info for bug reports or general feedback",
-			usage: "/report [bug|feedback]",
-			tags: ["support"],
-			arguments: [
-				{
-					name: "type",
-					type: "enum",
-					required: false,
-					description: "Select report type",
-					choices: ["bug", "feedback"],
-				},
-			],
-			examples: ["/report", "/report bug", "/report feedback"],
-		},
-		handlerKey: "report",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "thinking",
-			description: "Adjust reasoning level for supported models",
-			usage: "/thinking [off|minimal|low|medium|high]",
-			tags: ["session"],
-			arguments: [
-				{
-					name: "level",
-					type: "enum",
-					required: false,
-					description: "Thinking level to set",
-					choices: ["off", "minimal", "low", "medium", "high"],
-				},
-			],
-			examples: ["/thinking", "/thinking medium", "/thinking off"],
-		},
-		handlerKey: "thinking",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "model",
-			description: "Select model (opens selector UI)",
-			usage: "/model",
-			tags: ["session"],
-		},
-		handlerKey: "model",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "mode",
-			description: "Switch agent mode (smart/rush/free)",
-			usage: "/mode [smart|rush|free|list|suggest]",
-			tags: ["session", "model"],
-			examples: ["/mode", "/mode smart", "/mode rush", "/mode free"],
-		},
-		handlerKey: "mode",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "theme",
-			description: "Select color theme (opens selector with live preview)",
-			usage: "/theme",
-			tags: ["ui"],
-		},
-		handlerKey: "theme",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "clean",
-			description:
-				"Toggle assistant text deduplication during live streaming only",
-			usage: "/clean [off|soft|aggressive]",
-			tags: ["ui"],
-			examples: ["/clean", "/clean soft", "/clean off"],
-		},
-		handlerKey: "clean",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "new",
-			description: "Start a fresh chat session",
-			usage: "/new",
-			tags: ["session"],
-		},
-		handlerKey: "newChat",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "export",
-			description: "Export session to HTML, text, JSON, or JSONL",
-			usage: "/export [path] [html|text|json|jsonl]",
-			tags: ["session", "sharing"],
-			aliases: ["e"],
-		},
-		handlerKey: "exportSession",
-		match: { kind: CommandMatchKind.WithArgs, aliases: ["e"] },
-	},
-	{
-		command: {
-			name: "share",
-			description: "Generate a self-contained HTML share link",
-			usage: "/share [output.html]",
-			tags: ["session", "sharing"],
-		},
-		handlerKey: "shareSession",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "import",
-			description: "Import configuration or portable session files",
-			usage: "/import factory | /import session <file.json|file.jsonl>",
-			tags: ["config"],
-		},
-		handlerKey: "importConfig",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "session",
-			description: "Show session info, mark favorite, or add a manual summary",
-			usage:
-				'/session [info|favorite|unfavorite|summary "text"] (defaults: info)',
-			tags: ["session"],
-			aliases: ["s"],
-		},
-		handlerKey: "session",
-		match: { kind: CommandMatchKind.WithArgs, aliases: ["s"] },
-	},
-	{
-		command: {
-			name: "sessions",
-			description:
-				"List, load, favorite, or summarize recent sessions by index",
-			usage:
-				"/sessions [list|load <id>|favorite <id>|unfavorite <id>|summarize <id>]",
-			tags: ["session"],
-		},
-		handlerKey: "sessions",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "history",
-			description: "Show or search prompt history",
-			usage: "/history [count|search query|clear]",
-			tags: ["session"],
-			aliases: ["hist"],
-			examples: ["/history", "/history 25", "/history clear"],
-		},
-		handlerKey: "history",
-		match: { kind: CommandMatchKind.WithArgs, aliases: ["hist"] },
-	},
-	{
-		command: {
-			name: "branch",
-			description:
-				"Create a new session from an earlier user message (keeps history up to that point)",
-			usage: "/branch [list|<user-message-number>]",
-			tags: ["session"],
-		},
-		handlerKey: "branch",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "tree",
-			description: "Navigate the session tree and switch branches",
-			usage: "/tree",
-			tags: ["session"],
-		},
-		handlerKey: "tree",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "queue",
-			description: "List, cancel, or change queue mode",
-			usage: "/queue [list|cancel <id>|mode [steer|followup] <one|all>]",
-			tags: ["session"],
-		},
-		handlerKey: "queue",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "steer",
-			description: "Interrupt current run and run a prompt next",
-			usage: "/steer <message>",
-			tags: ["session"],
-			examples: ["/steer focus on tests next"],
-		},
-		handlerKey: "steer",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "about",
-			description: "Show Maestro build, env, and git info",
-			usage: "/about",
-			tags: ["system", "diagnostics"],
-		},
-		handlerKey: "about",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "clear",
-			description: "Clear context and start a fresh session",
-			usage: "/clear",
-			tags: ["session"],
-		},
-		handlerKey: "clear",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "plan",
-			description: "Show saved plans/checklists",
-			usage: "/plan [id]",
-			tags: ["planning"],
-			aliases: ["p"],
-		},
-		handlerKey: "plan",
-		match: { kind: CommandMatchKind.WithArgs, aliases: ["p"] },
-	},
-	{
-		command: {
-			name: "init",
-			description: "Create or overwrite AGENTS.md scaffolding for this repo",
-			usage: "/init [path]",
-			tags: ["config"],
-		},
-		handlerKey: "initAgents",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "diff",
-			description: "Show git diff for a file",
-			usage: "/diff <path>",
-			tags: ["git"],
-		},
-		handlerKey: "preview",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "status",
-			description:
-				"Show health snapshot (model, git, plan, telemetry, training)",
-			usage: "/status",
-			tags: ["diagnostics"],
-		},
-		handlerKey: "status",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "background",
-			description:
-				"Configure background task notifications and status redaction",
-			usage:
-				"/background [status|notify <on|off>|details <on|off>|history|path]",
-			tags: ["diagnostics"],
-			examples: [
-				"/background",
-				"/background notify on",
-				"/background details on",
-				"/background history",
-				"/background path",
-			],
-		},
-		handlerKey: "background",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "review",
-			description: "Summarize git status and diff stats",
-			usage: "/review",
-			tags: ["git"],
-		},
-		handlerKey: "review",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "undo",
-			description: "Undo last N file changes (beyond git) with preview",
-			usage: "/undo [N] [--preview] [--force]",
-			tags: ["undo", "safety"],
-			arguments: [
-				{
-					name: "count",
-					type: "number",
-					required: false,
-					description: "Number of changes to undo (default: 1)",
-				},
-			],
-			examples: ["/undo", "/undo 3", "/undo --preview", "/undo 2 --force"],
-		},
-		handlerKey: "undoChanges",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "changes",
-			description: "List tracked file changes from this session",
-			usage: "/changes [--files|--tools]",
-			tags: ["undo", "diagnostics"],
-			examples: ["/changes", "/changes --files", "/changes --tools"],
-		},
-		handlerKey: "changes",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "checkpoint",
-			description: "Save/restore named checkpoints for rollback",
-			usage: "/checkpoint [save|list|restore] [name]",
-			tags: ["undo", "safety"],
-			arguments: [
-				{
-					name: "subcommand",
-					type: "enum",
-					required: false,
-					description: "Checkpoint subcommand",
-					choices: ["save", "list", "restore"],
-				},
-				{
-					name: "name",
-					type: "string",
-					required: false,
-					description: "Checkpoint name",
-				},
-			],
-			examples: [
-				"/checkpoint",
-				"/checkpoint save before-refactor",
-				"/checkpoint list",
-				"/checkpoint restore before-refactor",
-			],
-		},
-		handlerKey: "checkpoint",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "memory",
-			description:
-				"Cross-session and repo-scoped memory for facts and learnings",
-			usage:
-				"/memory [save|search|list|session|recent|team|delete|stats|export|import|clear]",
-			tags: ["memory", "session"],
-			arguments: [
-				{
-					name: "subcommand",
-					type: "enum",
-					required: false,
-					description: "Memory subcommand",
-					choices: [
-						"save",
-						"search",
-						"list",
-						"session",
-						"recent",
-						"team",
-						"delete",
-						"stats",
-						"export",
-						"import",
-						"clear",
-					],
-				},
-			],
-			examples: [
-				"/memory",
-				"/memory save api-design Use REST conventions #rest",
-				"/memory search REST",
-				"/memory search REST --session",
-				"/memory list",
-				"/memory list api-design",
-				"/memory session 5",
-				"/memory team",
-				"/memory team init",
-				"/memory stats",
-			],
-		},
-		handlerKey: "memory",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "mention",
-			description: "Search files to mention (same as @ search)",
-			usage: "/mention <query>",
-			tags: ["search"],
-		},
-		handlerKey: "mention",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "run",
+		{ completions: CommandCompletionKind.Access },
+	),
+	withArgs("pii", "pii", {
+		description: "PII detection patterns and testing",
+		usage: "/pii [patterns|test <text>]",
+		tags: ["diagnostics", "security"],
+		examples: ["/pii", "/pii patterns", "/pii test jane.doe@example.com"],
+	}),
+	withArgs("audit", "audit", {
+		description: "Audit log status (enterprise)",
+		usage: "/audit [status]",
+		tags: ["diagnostics", "security"],
+		examples: ["/audit", "/audit status"],
+	}),
+	withArgs("limits", "limits", {
+		description: "Show configurable runtime limits",
+		usage: "/limits [all|tool|tui|api|session|runtime|help]",
+		tags: ["config", "diagnostics"],
+		examples: ["/limits", "/limits tool", "/limits runtime"],
+	}),
+	withArgs("approvals", "approvals", {
+		description:
+			"Show approval status or switch between auto/prompt/fail modes",
+		usage: "/approvals [auto|prompt|fail]",
+		tags: ["safety"],
+	}),
+	withArgs("plan-mode", "planMode", {
+		description: "Toggle plan mode (ask before write/edit/bash)",
+		usage: "/plan-mode [on|off]",
+		tags: ["safety"],
+	}),
+	withArgs("guardian", "guardian", {
+		description:
+			"Run Maestro Guardian (Semgrep + secrets) or toggle enforcement",
+		usage: "/guardian [run|status|enable|disable|all]",
+		tags: ["safety", "git"],
+		examples: ["/guardian", "/guardian status", "/guardian disable"],
+	}),
+	withArgs("workflow", "workflow", {
+		description: "Run declarative multi-step tool workflows",
+		usage: "/workflow [list|run|validate|show] [name]",
+		tags: ["tools", "automation"],
+		arguments: [
+			{
+				name: "subcommand",
+				type: "enum",
+				required: false,
+				description: "Workflow subcommand",
+				choices: ["list", "run", "validate", "show"],
+			},
+			{
+				name: "name",
+				type: "string",
+				required: false,
+				description: "Workflow name",
+			},
+		],
+		examples: [
+			"/workflow",
+			"/workflow list",
+			"/workflow run setup-project",
+			"/workflow validate my-workflow",
+			"/workflow show my-workflow",
+		],
+	}),
+	withArgs("framework", "framework", {
+		description:
+			"Set or show default framework (supports --workspace and list)",
+		usage: "/framework [id|none|list] [--workspace]",
+		tags: ["session"],
+	}),
+	withArgs("commands", "commands", {
+		description: "List or run user commands from .maestro/commands",
+		usage: "/commands list | /commands run <name> [k=v]...",
+		tags: ["session", "automation"],
+	}),
+	withArgs("report", "report", {
+		description: "Collect info for bug reports or general feedback",
+		usage: "/report [bug|feedback]",
+		tags: ["support"],
+		arguments: [
+			{
+				name: "type",
+				type: "enum",
+				required: false,
+				description: "Select report type",
+				choices: ["bug", "feedback"],
+			},
+		],
+		examples: ["/report", "/report bug", "/report feedback"],
+	}),
+	withArgs("thinking", "thinking", {
+		description: "Adjust reasoning level for supported models",
+		usage: "/thinking [off|minimal|low|medium|high]",
+		tags: ["session"],
+		arguments: [
+			{
+				name: "level",
+				type: "enum",
+				required: false,
+				description: "Thinking level to set",
+				choices: ["off", "minimal", "low", "medium", "high"],
+			},
+		],
+		examples: ["/thinking", "/thinking medium", "/thinking off"],
+	}),
+	exact("model", "model", {
+		description: "Select model (opens selector UI)",
+		usage: "/model",
+		tags: ["session"],
+	}),
+	withArgs("mode", "mode", {
+		description: "Switch agent mode (smart/rush/free)",
+		usage: "/mode [smart|rush|free|list|suggest]",
+		tags: ["session", "model"],
+		examples: ["/mode", "/mode smart", "/mode rush", "/mode free"],
+	}),
+	exact("theme", "theme", {
+		description: "Select color theme (opens selector with live preview)",
+		usage: "/theme",
+		tags: ["ui"],
+	}),
+	withArgs("clean", "clean", {
+		description:
+			"Toggle assistant text deduplication during live streaming only",
+		usage: "/clean [off|soft|aggressive]",
+		tags: ["ui"],
+		examples: ["/clean", "/clean soft", "/clean off"],
+	}),
+	exact("new", "newChat", {
+		description: "Start a fresh chat session",
+		usage: "/new",
+		tags: ["session"],
+	}),
+	withArgs("export", "exportSession", {
+		description: "Export session to HTML, text, JSON, or JSONL",
+		usage: "/export [path] [html|text|json|jsonl]",
+		tags: ["session", "sharing"],
+		aliases: ["e"],
+	}),
+	withArgs("share", "shareSession", {
+		description: "Generate a self-contained HTML share link",
+		usage: "/share [output.html]",
+		tags: ["session", "sharing"],
+	}),
+	withArgs("import", "importConfig", {
+		description: "Import configuration or portable session files",
+		usage: "/import factory | /import session <file.json|file.jsonl>",
+		tags: ["config"],
+	}),
+	withArgs("session", "session", {
+		description: "Show session info, mark favorite, or add a manual summary",
+		usage:
+			'/session [info|favorite|unfavorite|summary "text"] (defaults: info)',
+		tags: ["session"],
+		aliases: ["s"],
+	}),
+	withArgs("sessions", "sessions", {
+		description: "List, load, favorite, or summarize recent sessions by index",
+		usage:
+			"/sessions [list|load <id>|favorite <id>|unfavorite <id>|summarize <id>]",
+		tags: ["session"],
+	}),
+	withArgs("history", "history", {
+		description: "Show or search prompt history",
+		usage: "/history [count|search query|clear]",
+		tags: ["session"],
+		aliases: ["hist"],
+		examples: ["/history", "/history 25", "/history clear"],
+	}),
+	withArgs("branch", "branch", {
+		description:
+			"Create a new session from an earlier user message (keeps history up to that point)",
+		usage: "/branch [list|<user-message-number>]",
+		tags: ["session"],
+	}),
+	exact("tree", "tree", {
+		description: "Navigate the session tree and switch branches",
+		usage: "/tree",
+		tags: ["session"],
+	}),
+	withArgs("queue", "queue", {
+		description: "List, cancel, or change queue mode",
+		usage: "/queue [list|cancel <id>|mode [steer|followup] <one|all>]",
+		tags: ["session"],
+	}),
+	withArgs("steer", "steer", {
+		description: "Interrupt current run and run a prompt next",
+		usage: "/steer <message>",
+		tags: ["session"],
+		examples: ["/steer focus on tests next"],
+	}),
+	exact("about", "about", {
+		description: "Show Maestro build, env, and git info",
+		usage: "/about",
+		tags: ["system", "diagnostics"],
+	}),
+	exact("clear", "clear", {
+		description: "Clear context and start a fresh session",
+		usage: "/clear",
+		tags: ["session"],
+	}),
+	withArgs("plan", "plan", {
+		description: "Show saved plans/checklists",
+		usage: "/plan [id]",
+		tags: ["planning"],
+		aliases: ["p"],
+	}),
+	withArgs("init", "initAgents", {
+		description: "Create or overwrite AGENTS.md scaffolding for this repo",
+		usage: "/init [path]",
+		tags: ["config"],
+	}),
+	withArgs("diff", "preview", {
+		description: "Show git diff for a file",
+		usage: "/diff <path>",
+		tags: ["git"],
+	}),
+	exact("status", "status", {
+		description: "Show health snapshot (model, git, plan, telemetry, training)",
+		usage: "/status",
+		tags: ["diagnostics"],
+	}),
+	withArgs("background", "background", {
+		description: "Configure background task notifications and status redaction",
+		usage: "/background [status|notify <on|off>|details <on|off>|history|path]",
+		tags: ["diagnostics"],
+		examples: [
+			"/background",
+			"/background notify on",
+			"/background details on",
+			"/background history",
+			"/background path",
+		],
+	}),
+	exact("review", "review", {
+		description: "Summarize git status and diff stats",
+		usage: "/review",
+		tags: ["git"],
+	}),
+	withArgs("undo", "undoChanges", {
+		description: "Undo last N file changes (beyond git) with preview",
+		usage: "/undo [N] [--preview] [--force]",
+		tags: ["undo", "safety"],
+		arguments: [
+			{
+				name: "count",
+				type: "number",
+				required: false,
+				description: "Number of changes to undo (default: 1)",
+			},
+		],
+		examples: ["/undo", "/undo 3", "/undo --preview", "/undo 2 --force"],
+	}),
+	withArgs("changes", "changes", {
+		description: "List tracked file changes from this session",
+		usage: "/changes [--files|--tools]",
+		tags: ["undo", "diagnostics"],
+		examples: ["/changes", "/changes --files", "/changes --tools"],
+	}),
+	withArgs("checkpoint", "checkpoint", {
+		description: "Save/restore named checkpoints for rollback",
+		usage: "/checkpoint [save|list|restore] [name]",
+		tags: ["undo", "safety"],
+		arguments: [
+			{
+				name: "subcommand",
+				type: "enum",
+				required: false,
+				description: "Checkpoint subcommand",
+				choices: ["save", "list", "restore"],
+			},
+			{
+				name: "name",
+				type: "string",
+				required: false,
+				description: "Checkpoint name",
+			},
+		],
+		examples: [
+			"/checkpoint",
+			"/checkpoint save before-refactor",
+			"/checkpoint list",
+			"/checkpoint restore before-refactor",
+		],
+	}),
+	withArgs("memory", "memory", {
+		description: "Cross-session and repo-scoped memory for facts and learnings",
+		usage:
+			"/memory [save|search|list|session|recent|team|delete|stats|export|import|clear]",
+		tags: ["memory", "session"],
+		arguments: [
+			{
+				name: "subcommand",
+				type: "enum",
+				required: false,
+				description: "Memory subcommand",
+				choices: [
+					"save",
+					"search",
+					"list",
+					"session",
+					"recent",
+					"team",
+					"delete",
+					"stats",
+					"export",
+					"import",
+					"clear",
+				],
+			},
+		],
+		examples: [
+			"/memory",
+			"/memory save api-design Use REST conventions #rest",
+			"/memory search REST",
+			"/memory search REST --session",
+			"/memory list",
+			"/memory list api-design",
+			"/memory session 5",
+			"/memory team",
+			"/memory team init",
+			"/memory stats",
+		],
+	}),
+	withArgs("mention", "mention", {
+		description: "Search files to mention (same as @ search)",
+		usage: "/mention <query>",
+		tags: ["search"],
+	}),
+	withArgs(
+		"run",
+		"run",
+		{
 			description: "Run npm script (e.g. /run test --watch)",
 			usage: "/run <script> [--flags]",
 			tags: ["automation"],
 			aliases: ["r"],
 		},
-		handlerKey: "run",
-		match: { kind: CommandMatchKind.WithArgs, aliases: ["r"] },
-		completions: CommandCompletionKind.RunScripts,
-	},
-	{
-		command: {
-			name: "ollama",
-			description: "Control local Ollama models (list, pull, ps)",
-			usage: "/ollama [list|pull <model>|ps]",
-			tags: ["local", "models"],
-			examples: ["/ollama list", "/ollama pull llama3", "/ollama ps"],
-		},
-		handlerKey: "ollama",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "help",
-			description: "List available slash commands",
-			usage: "/help",
-			tags: ["support"],
-			aliases: ["h"],
-		},
-		handlerKey: "help",
-		match: { kind: CommandMatchKind.Exact, aliases: ["h"] },
-	},
-	{
-		command: {
-			name: "update",
-			description: "Check for Maestro CLI updates",
-			usage: "/update",
-			tags: ["system"],
-		},
-		handlerKey: "update",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "changelog",
-			description: "Display full version history",
-			usage: "/changelog",
-			tags: ["system"],
-		},
-		handlerKey: "changelog",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "hotkeys",
+		{ completions: CommandCompletionKind.RunScripts },
+	),
+	withArgs("ollama", "ollama", {
+		description: "Control local Ollama models (list, pull, ps)",
+		usage: "/ollama [list|pull <model>|ps]",
+		tags: ["local", "models"],
+		examples: ["/ollama list", "/ollama pull llama3", "/ollama ps"],
+	}),
+	exact("help", "help", {
+		description: "List available slash commands",
+		usage: "/help",
+		tags: ["support"],
+		aliases: ["h"],
+	}),
+	exact("update", "update", {
+		description: "Check for Maestro CLI updates",
+		usage: "/update",
+		tags: ["system"],
+	}),
+	exact("changelog", "changelog", {
+		description: "Display full version history",
+		usage: "/changelog",
+		tags: ["system"],
+	}),
+	withArgs(
+		"hotkeys",
+		"hotkeys",
+		{
 			description: "Show or manage keyboard shortcuts",
 			usage: "/hotkeys [show|path|init|validate]",
 			tags: ["help", "config"],
@@ -656,13 +480,12 @@ export const PRIMARY_COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
 				"/hotkeys validate",
 			],
 		},
-		handlerKey: "hotkeys",
-		match: { kind: CommandMatchKind.WithArgs, aliases: ["keys", "shortcuts"] },
-		completions: CommandCompletionKind.Hotkeys,
-	},
-	{
-		command: {
-			name: "package",
+		{ completions: CommandCompletionKind.Hotkeys },
+	),
+	withArgs(
+		"package",
+		"package",
+		{
 			description:
 				"Manage, inspect, or validate Maestro package/plugin bundles",
 			usage:
@@ -681,354 +504,237 @@ export const PRIMARY_COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
 				"/plugin ./packages/my-pack",
 			],
 		},
-		handlerKey: "package",
-		match: { kind: CommandMatchKind.WithArgs, aliases: ["plugin"] },
-		completions: CommandCompletionKind.Package,
-	},
-	{
-		command: {
-			name: "telemetry",
-			description: "Show telemetry status or toggle runtime overrides",
-			usage: "/telemetry [status|on|off|reset]",
-			tags: ["diagnostics", "telemetry"],
-			arguments: [
-				{
-					name: "action",
-					type: "enum",
-					required: false,
-					description: "Action to perform",
-					choices: ["status", "on", "off", "reset"],
-				},
-			],
-			examples: ["/telemetry", "/telemetry off"],
-		},
-		handlerKey: "telemetry",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "otel",
-			description: "Show OpenTelemetry runtime configuration",
-			usage: "/otel",
-			tags: ["diagnostics", "telemetry"],
-		},
-		handlerKey: "otel",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "training",
-			description: "Toggle model training preference or show status",
-			usage: "/training [status|on|off|reset]",
-			tags: ["privacy"],
-			arguments: [
-				{
-					name: "action",
-					type: "enum",
-					required: false,
-					description: "Training action",
-					choices: ["status", "on", "off", "reset"],
-				},
-			],
-			examples: ["/training", "/training off"],
-		},
-		handlerKey: "training",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "config",
-			description: "Validate and inspect Maestro configuration",
-			usage: "/config [summary|sources|providers|env|files|help]",
-			tags: ["config"],
-			examples: ["/config", "/config sources"],
-		},
-		handlerKey: "config",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "cost",
-			description: "Show usage and cost summary",
-			usage: "/cost [period|breakdown <period>|clear|help]",
-			tags: ["usage"],
-			examples: ["/cost", "/cost breakdown week"],
-		},
-		handlerKey: "cost",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "quota",
-			description: "Show token quota status and usage limits",
-			usage: "/quota [detailed|models|alerts|limit <tokens>|help]",
-			tags: ["usage"],
-			examples: [
-				"/quota",
-				"/quota detailed",
-				"/quota models",
-				"/quota limit 100000",
-			],
-		},
-		handlerKey: "quota",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "stats",
-			description: "Show combined status and cost overview",
-			usage: "/stats",
-			tags: ["diagnostics", "usage"],
-		},
-		handlerKey: "stats",
-		match: { kind: CommandMatchKind.Exact },
-	},
-	{
-		command: {
-			name: "diag",
-			description: "Show provider/model/API key diagnostics",
-			usage: "/diag [lsp|keys]",
-			tags: ["diagnostics"],
-			aliases: ["d", "diagnostics"],
-		},
-		handlerKey: "diagnostics",
-		match: { kind: CommandMatchKind.Diagnostics },
-	},
-	{
-		command: {
-			name: "mcp",
-			description:
-				"Show or manage Model Context Protocol servers and auth presets",
-			usage:
-				"/mcp [add|edit|remove|approve|deny|search|import|auth|resources|prompts]",
-			tags: ["tools"],
-			examples: [
-				"/mcp",
-				"/mcp search linear",
-				"/mcp import linear",
-				"/mcp approve linear",
-				"/mcp auth add linear-auth --header 'Authorization: Bearer ...'",
-				"/mcp add linear https://mcp.linear.app/mcp",
-				"/mcp add linear https://mcp.linear.app/mcp --auth-preset linear-auth",
-				"/mcp edit linear https://mcp.linear.app/mcp --header 'Authorization: Bearer ...'",
-				"/mcp remove linear",
-				"/mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem .",
-			],
-		},
-		handlerKey: "mcp",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "lsp",
-			description: "Manage Language Server Protocol servers",
-			usage: "/lsp [status|start|stop|restart|detect]",
-			tags: ["tools", "diagnostics"],
-			examples: [
-				"/lsp",
-				"/lsp status",
-				"/lsp start",
-				"/lsp stop",
-				"/lsp restart",
-				"/lsp detect",
-			],
-		},
-		handlerKey: "lsp",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "composer",
-			description: "Manage custom composer configurations",
-			usage: "/composer [list|<name>|activate <name>|deactivate]",
-			tags: ["config"],
-			examples: [
-				"/composer",
-				"/composer list",
-				"/composer code-reviewer",
-				"/composer activate code-reviewer",
-				"/composer deactivate",
-			],
-		},
-		handlerKey: "composer",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "prompts",
-			description:
-				"List/run prompt templates from markdown files (~/.maestro/prompts/, .maestro/prompts/).",
-			usage: "/prompts [list|<name> [args]]",
-			tags: ["automation", "session"],
-			examples: [
-				"/prompts",
-				"/prompts list",
-				"/prompts review FILE=src/main.ts",
-				"/pr-review FILE=src/main.ts",
-				'/prompts ticket TICKET_ID=123 TITLE="Fix bug"',
-			],
-		},
-		handlerKey: "prompts",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "compact",
-			description: "Summarize older messages to reclaim context",
-			usage: "/compact [custom instructions]",
-			tags: ["planning"],
-			examples: [
-				"/compact",
-				"/compact Focus on the API changes",
-				"/compact Emphasize database migrations",
-			],
-		},
-		handlerKey: "compact",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "autocompact",
-			description: "Toggle or configure auto-compaction",
-			usage: "/autocompact [on|off|status]",
-			tags: ["planning"],
-			examples: [
-				"/autocompact",
-				"/autocompact on",
-				"/autocompact off",
-				"/autocompact status",
-			],
-		},
-		handlerKey: "autocompact",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "footer",
-			description: "Switch footer style or view/clear footer alerts",
-			usage: "/footer [ensemble|solo|history|clear]",
-			tags: ["ui"],
-			examples: ["/footer", "/footer solo", "/footer history", "/footer clear"],
-		},
-		handlerKey: "footer",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "alerts",
+		{ completions: CommandCompletionKind.Package },
+	),
+	withArgs("telemetry", "telemetry", {
+		description: "Show telemetry status or toggle runtime overrides",
+		usage: "/telemetry [status|on|off|reset]",
+		tags: ["diagnostics", "telemetry"],
+		arguments: [
+			{
+				name: "action",
+				type: "enum",
+				required: false,
+				description: "Action to perform",
+				choices: ["status", "on", "off", "reset"],
+			},
+		],
+		examples: ["/telemetry", "/telemetry off"],
+	}),
+	exact("otel", "otel", {
+		description: "Show OpenTelemetry runtime configuration",
+		usage: "/otel",
+		tags: ["diagnostics", "telemetry"],
+	}),
+	withArgs("training", "training", {
+		description: "Toggle model training preference or show status",
+		usage: "/training [status|on|off|reset]",
+		tags: ["privacy"],
+		arguments: [
+			{
+				name: "action",
+				type: "enum",
+				required: false,
+				description: "Training action",
+				choices: ["status", "on", "off", "reset"],
+			},
+		],
+		examples: ["/training", "/training off"],
+	}),
+	exact("config", "config", {
+		description: "Validate and inspect Maestro configuration",
+		usage: "/config [summary|sources|providers|env|files|help]",
+		tags: ["config"],
+		examples: ["/config", "/config sources"],
+	}),
+	withArgs("cost", "cost", {
+		description: "Show usage and cost summary",
+		usage: "/cost [period|breakdown <period>|clear|help]",
+		tags: ["usage"],
+		examples: ["/cost", "/cost breakdown week"],
+	}),
+	withArgs("quota", "quota", {
+		description: "Show token quota status and usage limits",
+		usage: "/quota [detailed|models|alerts|limit <tokens>|help]",
+		tags: ["usage"],
+		examples: [
+			"/quota",
+			"/quota detailed",
+			"/quota models",
+			"/quota limit 100000",
+		],
+	}),
+	exact("stats", "stats", {
+		description: "Show combined status and cost overview",
+		usage: "/stats",
+		tags: ["diagnostics", "usage"],
+	}),
+	diagnostics("diag", "diagnostics", {
+		description: "Show provider/model/API key diagnostics",
+		usage: "/diag [lsp|keys]",
+		tags: ["diagnostics"],
+		aliases: ["d", "diagnostics"],
+	}),
+	withArgs("mcp", "mcp", {
+		description:
+			"Show or manage Model Context Protocol servers and auth presets",
+		usage:
+			"/mcp [add|edit|remove|approve|deny|search|import|auth|resources|prompts]",
+		tags: ["tools"],
+		examples: [
+			"/mcp",
+			"/mcp search linear",
+			"/mcp import linear",
+			"/mcp approve linear",
+			"/mcp auth add linear-auth --header 'Authorization: Bearer ...'",
+			"/mcp add linear https://mcp.linear.app/mcp",
+			"/mcp add linear https://mcp.linear.app/mcp --auth-preset linear-auth",
+			"/mcp edit linear https://mcp.linear.app/mcp --header 'Authorization: Bearer ...'",
+			"/mcp remove linear",
+			"/mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem .",
+		],
+	}),
+	withArgs("lsp", "lsp", {
+		description: "Manage Language Server Protocol servers",
+		usage: "/lsp [status|start|stop|restart|detect]",
+		tags: ["tools", "diagnostics"],
+		examples: [
+			"/lsp",
+			"/lsp status",
+			"/lsp start",
+			"/lsp stop",
+			"/lsp restart",
+			"/lsp detect",
+		],
+	}),
+	withArgs("composer", "composer", {
+		description: "Manage custom composer configurations",
+		usage: "/composer [list|<name>|activate <name>|deactivate]",
+		tags: ["config"],
+		examples: [
+			"/composer",
+			"/composer list",
+			"/composer code-reviewer",
+			"/composer activate code-reviewer",
+			"/composer deactivate",
+		],
+	}),
+	withArgs("prompts", "prompts", {
+		description:
+			"List/run prompt templates from markdown files (~/.maestro/prompts/, .maestro/prompts/).",
+		usage: "/prompts [list|<name> [args]]",
+		tags: ["automation", "session"],
+		examples: [
+			"/prompts",
+			"/prompts list",
+			"/prompts review FILE=src/main.ts",
+			"/pr-review FILE=src/main.ts",
+			'/prompts ticket TICKET_ID=123 TITLE="Fix bug"',
+		],
+	}),
+	withArgs("compact", "compact", {
+		description: "Summarize older messages to reclaim context",
+		usage: "/compact [custom instructions]",
+		tags: ["planning"],
+		examples: [
+			"/compact",
+			"/compact Focus on the API changes",
+			"/compact Emphasize database migrations",
+		],
+	}),
+	withArgs("autocompact", "autocompact", {
+		description: "Toggle or configure auto-compaction",
+		usage: "/autocompact [on|off|status]",
+		tags: ["planning"],
+		examples: [
+			"/autocompact",
+			"/autocompact on",
+			"/autocompact off",
+			"/autocompact status",
+		],
+	}),
+	withArgs("footer", "footer", {
+		description: "Switch footer style or view/clear footer alerts",
+		usage: "/footer [ensemble|solo|history|clear]",
+		tags: ["ui"],
+		examples: ["/footer", "/footer solo", "/footer history", "/footer clear"],
+	}),
+	withArgs(
+		"alerts",
+		"footer",
+		{
 			description: "Alias for footer alerts (history|clear)",
 			usage: "/alerts [history|clear]",
 			tags: ["ui"],
 			examples: ["/alerts history", "/alerts clear"],
 		},
-		handlerKey: "footer",
-		match: { kind: CommandMatchKind.WithArgs },
-		rewriteTo: "footer",
-	},
-	{
-		command: {
-			name: "compact-tools",
-			description: "Toggle folding of tool outputs",
-			usage: "/compact-tools [on|off]",
-			tags: ["tools"],
-		},
-		handlerKey: "compactTools",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "login",
-			description: "Authenticate with Claude Pro/Max via OAuth",
-			usage: "/login [mode] or /login [provider:mode]",
-			tags: ["auth"],
-			arguments: [
-				{
-					name: "argument",
-					type: "string",
-					required: false,
-					description:
-						"Login mode (pro/console) or provider:mode format (e.g., anthropic:pro)",
-				},
-			],
-			examples: [
-				"/login",
-				"/login pro",
-				"/login console",
-				"/login anthropic:pro",
-			],
-		},
-		handlerKey: "login",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "logout",
-			description: "Remove stored Claude OAuth credentials",
-			usage: "/logout [provider]",
-			tags: ["auth"],
-			arguments: [
-				{
-					name: "provider",
-					type: "string",
-					required: false,
-					description: "OAuth provider to logout from (optional)",
-				},
-			],
-			examples: ["/logout", "/logout anthropic"],
-		},
-		handlerKey: "logout",
-		match: { kind: CommandMatchKind.WithArgs },
-	},
-	{
-		command: {
-			name: "quit",
-			description: "Exit composer (same as ctrl+c twice)",
-			usage: "/quit",
-			tags: ["system"],
-			aliases: ["q", "exit"],
-		},
-		handlerKey: "quit",
-		match: { kind: CommandMatchKind.Quit },
-	},
-	{
-		command: {
-			name: "copy",
-			description: "Copy last assistant message to clipboard",
-			usage: "/copy",
-			tags: ["session"],
-		},
-		handlerKey: "copy",
-		match: { kind: CommandMatchKind.Exact },
-	},
+		{ rewriteTo: "footer" },
+	),
+	withArgs("compact-tools", "compactTools", {
+		description: "Toggle folding of tool outputs",
+		usage: "/compact-tools [on|off]",
+		tags: ["tools"],
+	}),
+	withArgs("login", "login", {
+		description: "Authenticate with Claude Pro/Max via OAuth",
+		usage: "/login [mode] or /login [provider:mode]",
+		tags: ["auth"],
+		arguments: [
+			{
+				name: "argument",
+				type: "string",
+				required: false,
+				description:
+					"Login mode (pro/console) or provider:mode format (e.g., anthropic:pro)",
+			},
+		],
+		examples: [
+			"/login",
+			"/login pro",
+			"/login console",
+			"/login anthropic:pro",
+		],
+	}),
+	withArgs("logout", "logout", {
+		description: "Remove stored Claude OAuth credentials",
+		usage: "/logout [provider]",
+		tags: ["auth"],
+		arguments: [
+			{
+				name: "provider",
+				type: "string",
+				required: false,
+				description: "OAuth provider to logout from (optional)",
+			},
+		],
+		examples: ["/logout", "/logout anthropic"],
+	}),
+	quit("quit", "quit", {
+		description: "Exit composer (same as ctrl+c twice)",
+		usage: "/quit",
+		tags: ["system"],
+		aliases: ["q", "exit"],
+	}),
+	exact("copy", "copy", {
+		description: "Copy last assistant message to clipboard",
+		usage: "/copy",
+		tags: ["session"],
+	}),
 ];
 
 export const POST_SUITE_COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
-	{
-		command: {
-			name: "toolhistory",
-			description: "Show tool execution history and stats",
-			usage: "/toolhistory [count|stats|clear|tool <name>]",
-			tags: ["tools"],
-			aliases: ["th"],
-			examples: ["/toolhistory", "/toolhistory stats", "/toolhistory read"],
-		},
-		handlerKey: "toolHistory",
-		match: { kind: CommandMatchKind.WithArgs, aliases: ["th"] },
-	},
-	{
-		command: {
-			name: "skills",
-			description: "List or manage skills from SKILL.md",
-			usage: "/skills [list|activate|deactivate|reload|info] [skill-name]",
-			tags: ["tools"],
-			aliases: ["skill"],
-			examples: [
-				"/skills",
-				"/skills info my-skill",
-				"/skills activate my-skill",
-			],
-		},
-		handlerKey: "skills",
-		match: { kind: CommandMatchKind.WithArgs, aliases: ["skill"] },
-	},
+	withArgs("toolhistory", "toolHistory", {
+		description: "Show tool execution history and stats",
+		usage: "/toolhistory [count|stats|clear|tool <name>]",
+		tags: ["tools"],
+		aliases: ["th"],
+		examples: ["/toolhistory", "/toolhistory stats", "/toolhistory read"],
+	}),
+	withArgs("skills", "skills", {
+		description: "List or manage skills from SKILL.md",
+		usage: "/skills [list|activate|deactivate|reload|info] [skill-name]",
+		tags: ["tools"],
+		aliases: ["skill"],
+		examples: ["/skills", "/skills info my-skill", "/skills activate my-skill"],
+	}),
 ];

--- a/src/cli-tui/commands/command-registry-adapter.ts
+++ b/src/cli-tui/commands/command-registry-adapter.ts
@@ -1,0 +1,209 @@
+import type { SlashCommand } from "@evalops/tui";
+import { parseCommandArguments, shouldShowHelp } from "./argument-parser.js";
+import {
+	type CommandCatalogEntry,
+	CommandCompletionKind,
+	CommandMatchKind,
+} from "./command-catalog.js";
+import { HOTKEYS_SUBCOMMANDS } from "./hotkeys-command.js";
+import { PACKAGE_SUBCOMMANDS } from "./package-handlers.js";
+import {
+	ACCESS_SUBCOMMANDS,
+	createSubcommandCompletions,
+} from "./subcommands/index.js";
+import type {
+	CommandEntry,
+	CommandExecutionContext,
+	CommandHandlers,
+	CommandRegistryOptions,
+	RunScriptCompletionProvider,
+} from "./types.js";
+
+export type CommandCatalogBuildContext = {
+	getRunScriptCompletions: RunScriptCompletionProvider;
+	handlers: CommandHandlers;
+	createContext: CommandRegistryOptions["createContext"];
+};
+
+export function buildCommandCatalogEntries(
+	definitions: readonly CommandCatalogEntry[],
+	context: CommandCatalogBuildContext,
+): CommandEntry[] {
+	return definitions.map((definition) =>
+		buildCommandCatalogEntry(definition, context),
+	);
+}
+
+export function buildCommandEntry(
+	command: SlashCommand,
+	matches: (input: string) => boolean,
+	handler: (context: CommandExecutionContext) => void | Promise<void>,
+	createContext: CommandRegistryOptions["createContext"],
+): CommandEntry {
+	return {
+		command,
+		matches,
+		execute: (input: string) =>
+			executeCommand(command, input, handler, createContext),
+	};
+}
+
+export const matchCommandWithArgs =
+	(name: string, aliases: readonly string[] = []) =>
+	(input: string) =>
+		input === `/${name}` ||
+		input.startsWith(`/${name} `) ||
+		aliases.some((alias) => {
+			const commandAlias = `/${alias}`;
+			return input === commandAlias || input.startsWith(`${commandAlias} `);
+		});
+
+const matchCommandExactly =
+	(name: string, aliases: readonly string[] = []) =>
+	(input: string) =>
+		input === `/${name}` || aliases.some((alias) => input === `/${alias}`);
+
+const matchDiagnostics = (input: string) =>
+	input === "/diag" ||
+	input.startsWith("/diag ") ||
+	input === "/diagnostics" ||
+	input === "/d" ||
+	input.startsWith("/d ");
+
+const matchQuit = (input: string) =>
+	input === "/quit" || input === "/exit" || input === "/q";
+
+function buildCommandCatalogEntry(
+	definition: CommandCatalogEntry,
+	context: CommandCatalogBuildContext,
+): CommandEntry {
+	const command = withCatalogCompletions(
+		definition,
+		context.getRunScriptCompletions,
+	);
+	const handler = (executionContext: CommandExecutionContext) => {
+		rewriteCatalogContext(definition, executionContext);
+		return context.handlers[definition.handlerKey](executionContext);
+	};
+	return buildCommandEntry(
+		command,
+		buildCatalogMatcher(definition),
+		handler,
+		context.createContext,
+	);
+}
+
+function withCatalogCompletions(
+	definition: CommandCatalogEntry,
+	getRunScriptCompletions: RunScriptCompletionProvider,
+): SlashCommand {
+	const command = commandFromCatalog(definition);
+	const getArgumentCompletions = resolveCatalogCompletions(
+		definition,
+		getRunScriptCompletions,
+	);
+	return getArgumentCompletions
+		? { ...command, getArgumentCompletions }
+		: command;
+}
+
+function commandFromCatalog(definition: CommandCatalogEntry): SlashCommand {
+	return {
+		name: definition.name,
+		description: definition.description,
+		usage: definition.usage,
+		examples: definition.examples,
+		tags: definition.tags,
+		aliases: definition.aliases,
+		arguments: definition.arguments,
+	};
+}
+
+function resolveCatalogCompletions(
+	definition: CommandCatalogEntry,
+	getRunScriptCompletions: RunScriptCompletionProvider,
+): SlashCommand["getArgumentCompletions"] | undefined {
+	switch (definition.completions) {
+		case CommandCompletionKind.Access:
+			return createSubcommandCompletions(ACCESS_SUBCOMMANDS);
+		case CommandCompletionKind.Hotkeys:
+			return createSubcommandCompletions(HOTKEYS_SUBCOMMANDS);
+		case CommandCompletionKind.Package:
+			return createSubcommandCompletions(PACKAGE_SUBCOMMANDS);
+		case CommandCompletionKind.RunScripts:
+			return getRunScriptCompletions;
+		case undefined:
+			return undefined;
+	}
+}
+
+function buildCatalogMatcher(
+	definition: CommandCatalogEntry,
+): (input: string) => boolean {
+	const aliases = definition.matchAliases ?? definition.aliases;
+	switch (definition.matchKind) {
+		case CommandMatchKind.Exact:
+			return matchCommandExactly(definition.name, aliases);
+		case CommandMatchKind.WithArgs:
+			return matchCommandWithArgs(definition.name, aliases);
+		case CommandMatchKind.Diagnostics:
+			return matchDiagnostics;
+		case CommandMatchKind.Quit:
+			return matchQuit;
+	}
+}
+
+function rewriteCatalogContext(
+	definition: CommandCatalogEntry,
+	context: CommandExecutionContext,
+): void {
+	if (!definition.rewriteTo) {
+		return;
+	}
+	context.rawInput = context.rawInput.replace(
+		new RegExp(`^/${escapeRegExp(definition.name)}(?=\\s|$)`),
+		`/${definition.rewriteTo}`,
+	);
+}
+
+function executeCommand(
+	command: SlashCommand,
+	rawInput: string,
+	handler: (context: CommandExecutionContext) => void | Promise<void>,
+	createContext: CommandRegistryOptions["createContext"],
+): void | Promise<void> {
+	const argumentText = extractArgumentText(rawInput);
+	if (shouldShowHelp(argumentText)) {
+		const context = createContext({ command, rawInput, argumentText });
+		context.renderHelp();
+		return;
+	}
+	const parseResult = parseCommandArguments(argumentText, command.arguments);
+	if (!parseResult.ok) {
+		const context = createContext({ command, rawInput, argumentText });
+		context.showError(
+			"errors" in parseResult ? parseResult.errors.join(" ") : "Parse error",
+		);
+		context.renderHelp();
+		return;
+	}
+	const context = createContext({
+		command,
+		rawInput,
+		argumentText,
+		parsedArgs: parseResult.args,
+	});
+	return handler(context);
+}
+
+function extractArgumentText(input: string): string {
+	const spaceIndex = input.indexOf(" ");
+	if (spaceIndex === -1) {
+		return "";
+	}
+	return input.slice(spaceIndex + 1).trim();
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/cli-tui/commands/command-suite-catalog.ts
+++ b/src/cli-tui/commands/command-suite-catalog.ts
@@ -14,11 +14,22 @@ import {
 	USAGE_SUBCOMMANDS,
 } from "./subcommands/index.js";
 
-export type CommandSuiteDefinition = {
+type CommandSuiteRuntimeFields = {
 	key: CommandSuiteKey;
-	command: SlashCommand;
 	subcommands: readonly SubcommandDef[];
 };
+
+type CommandSuiteMetadata = Omit<
+	SlashCommand,
+	"name" | "getArgumentCompletions"
+>;
+
+export type CommandSuiteDefinition = CommandSuiteMetadata &
+	CommandSuiteRuntimeFields & {
+		name: SlashCommand["name"];
+	};
+
+type CommandSuiteCatalogEntry = Omit<CommandSuiteDefinition, "key">;
 
 const COMMAND_SUITE_ORDER = [
 	CommandSuiteKey.Session,
@@ -33,12 +44,9 @@ const COMMAND_SUITE_ORDER = [
 	CommandSuiteKey.Tools,
 ] as const;
 
-const COMMAND_SUITE_CATALOG: Record<
-	CommandSuiteKey,
-	Omit<CommandSuiteDefinition, "key">
-> = {
-	[CommandSuiteKey.Session]: {
-		command: {
+const COMMAND_SUITE_CATALOG: Record<CommandSuiteKey, CommandSuiteCatalogEntry> =
+	{
+		[CommandSuiteKey.Session]: {
 			name: "ss",
 			description:
 				"Session management: new, clear, list, load, branch, tree, export, share",
@@ -53,11 +61,9 @@ const COMMAND_SUITE_CATALOG: Record<
 				"/ss branch 2",
 				"/ss export",
 			],
+			subcommands: SESSION_SUBCOMMANDS,
 		},
-		subcommands: SESSION_SUBCOMMANDS,
-	},
-	[CommandSuiteKey.Diag]: {
-		command: {
+		[CommandSuiteKey.Diag]: {
 			name: "diag",
 			description:
 				"Diagnostics: status, about, context, stats, lsp, mcp, telemetry, config",
@@ -72,22 +78,18 @@ const COMMAND_SUITE_CATALOG: Record<
 				"/diag telemetry",
 				"/diag config",
 			],
+			subcommands: DIAG_SUBCOMMANDS,
 		},
-		subcommands: DIAG_SUBCOMMANDS,
-	},
-	[CommandSuiteKey.Ui]: {
-		command: {
+		[CommandSuiteKey.Ui]: {
 			name: "ui",
 			description:
 				"UI settings: theme, clean, footer, alerts, zen, compact-tools",
 			usage: "/ui [theme|clean|footer|alerts|zen|compact]",
 			tags: ["ui"],
 			examples: ["/ui", "/ui theme", "/ui zen on", "/ui compact off"],
+			subcommands: UI_SUBCOMMANDS,
 		},
-		subcommands: UI_SUBCOMMANDS,
-	},
-	[CommandSuiteKey.Safety]: {
-		command: {
+		[CommandSuiteKey.Safety]: {
 			name: "safe",
 			description: "Safety settings: approvals, plan-mode, guardian",
 			usage: "/safe [approvals|plan|guardian] [args]",
@@ -98,21 +100,17 @@ const COMMAND_SUITE_CATALOG: Record<
 				"/safe plan on",
 				"/safe guardian run",
 			],
+			subcommands: SAFETY_SUBCOMMANDS,
 		},
-		subcommands: SAFETY_SUBCOMMANDS,
-	},
-	[CommandSuiteKey.Git]: {
-		command: {
+		[CommandSuiteKey.Git]: {
 			name: "git",
 			description: "Git operations: status, diff, review",
 			usage: "/git [status|diff <path>|review]",
 			tags: ["git"],
 			examples: ["/git", "/git diff src/index.ts", "/git review"],
+			subcommands: GIT_SUBCOMMANDS,
 		},
-		subcommands: GIT_SUBCOMMANDS,
-	},
-	[CommandSuiteKey.Auth]: {
-		command: {
+		[CommandSuiteKey.Auth]: {
 			name: "auth",
 			description: "Authentication: login, logout, status, source-of-truth",
 			usage: "/auth [login|logout|status|source-of-truth] [provider] [area]",
@@ -123,11 +121,9 @@ const COMMAND_SUITE_CATALOG: Record<
 				"/auth logout",
 				"/auth source-of-truth openai analytics",
 			],
+			subcommands: AUTH_SUBCOMMANDS,
 		},
-		subcommands: AUTH_SUBCOMMANDS,
-	},
-	[CommandSuiteKey.Usage]: {
-		command: {
+		[CommandSuiteKey.Usage]: {
 			name: "usage",
 			description: "Usage tracking: cost, quota, stats",
 			usage: "/usage [cost|quota|stats] [args]",
@@ -137,11 +133,9 @@ const COMMAND_SUITE_CATALOG: Record<
 				"/usage cost breakdown week",
 				"/usage quota detailed",
 			],
+			subcommands: USAGE_SUBCOMMANDS,
 		},
-		subcommands: USAGE_SUBCOMMANDS,
-	},
-	[CommandSuiteKey.Undo]: {
-		command: {
+		[CommandSuiteKey.Undo]: {
 			name: "undo",
 			description: "Undo system: undo, checkpoint, changes, history",
 			usage: "/undo [<N>|checkpoint|changes|history] [args]",
@@ -152,11 +146,9 @@ const COMMAND_SUITE_CATALOG: Record<
 				"/undo checkpoint save before-refactor",
 				"/undo changes",
 			],
+			subcommands: UNDO_SUBCOMMANDS,
 		},
-		subcommands: UNDO_SUBCOMMANDS,
-	},
-	[CommandSuiteKey.Config]: {
-		command: {
+		[CommandSuiteKey.Config]: {
 			name: "cfg",
 			description: "Configuration: validate, import, framework, composer, init",
 			usage: "/cfg [validate|import|framework|composer|init] [args]",
@@ -168,11 +160,9 @@ const COMMAND_SUITE_CATALOG: Record<
 				"/cfg framework react",
 				"/cfg composer code-reviewer",
 			],
+			subcommands: CONFIG_SUBCOMMANDS,
 		},
-		subcommands: CONFIG_SUBCOMMANDS,
-	},
-	[CommandSuiteKey.Tools]: {
-		command: {
+		[CommandSuiteKey.Tools]: {
 			name: "tools",
 			description: "Tools: list, mcp, lsp, workflow, run, commands",
 			usage: "/tools [list|mcp|lsp|workflow|run|commands] [args]",
@@ -185,10 +175,9 @@ const COMMAND_SUITE_CATALOG: Record<
 				"/tools lsp status",
 				"/tools run test",
 			],
+			subcommands: TOOLS_SUBCOMMANDS,
 		},
-		subcommands: TOOLS_SUBCOMMANDS,
-	},
-};
+	};
 
 export const COMMAND_SUITE_DEFINITIONS: readonly CommandSuiteDefinition[] =
 	COMMAND_SUITE_ORDER.map((key) => ({

--- a/src/cli-tui/commands/registry.ts
+++ b/src/cli-tui/commands/registry.ts
@@ -1,51 +1,24 @@
 import type { SlashCommand } from "@evalops/tui";
-import { parseCommandArguments, shouldShowHelp } from "./argument-parser.js";
 import {
-	type CommandCatalogEntry,
-	CommandCompletionKind,
-	CommandMatchKind,
 	POST_SUITE_COMMAND_CATALOG,
 	PRIMARY_COMMAND_CATALOG,
 } from "./command-catalog.js";
 import {
+	type CommandCatalogBuildContext,
+	buildCommandCatalogEntries,
+	buildCommandEntry,
+	matchCommandWithArgs,
+} from "./command-registry-adapter.js";
+import {
 	COMMAND_SUITE_DEFINITIONS,
 	type CommandSuiteDefinition,
 } from "./command-suite-catalog.js";
-import { HOTKEYS_SUBCOMMANDS } from "./hotkeys-command.js";
-import { PACKAGE_SUBCOMMANDS } from "./package-handlers.js";
-import {
-	ACCESS_SUBCOMMANDS,
-	createSubcommandCompletions,
-} from "./subcommands/index.js";
+import { createSubcommandCompletions } from "./subcommands/index.js";
 import type {
 	CommandEntry,
 	CommandExecutionContext,
-	CommandHandlers,
 	CommandRegistryOptions,
-	RunScriptCompletionProvider,
 } from "./types.js";
-
-const equals =
-	(name: string, aliases: readonly string[] = []) =>
-	(input: string) =>
-		input === `/${name}` || aliases.some((a) => input === `/${a}`);
-
-const withArgs =
-	(name: string, aliases: readonly string[] = []) =>
-	(input: string) =>
-		input === `/${name}` ||
-		input.startsWith(`/${name} `) ||
-		aliases.some((a) => input === `/${a}` || input.startsWith(`/${a} `));
-
-const matchDiagnostics = (input: string) =>
-	input === "/diag" ||
-	input.startsWith("/diag ") ||
-	input === "/diagnostics" ||
-	input === "/d" ||
-	input.startsWith("/d ");
-
-const matchQuit = (input: string) =>
-	input === "/quit" || input === "/exit" || input === "/q";
 
 export function createCommandRegistry({
 	getRunScriptCompletions,
@@ -66,105 +39,6 @@ export function createCommandRegistry({
 	];
 }
 
-type CommandCatalogBuildContext = {
-	getRunScriptCompletions: RunScriptCompletionProvider;
-	handlers: CommandHandlers;
-	createContext: CommandRegistryOptions["createContext"];
-};
-
-function buildCommandCatalogEntries(
-	definitions: readonly CommandCatalogEntry[],
-	context: CommandCatalogBuildContext,
-): CommandEntry[] {
-	return definitions.map((definition) =>
-		buildCommandCatalogEntry(definition, context),
-	);
-}
-
-function buildCommandCatalogEntry(
-	definition: CommandCatalogEntry,
-	context: CommandCatalogBuildContext,
-): CommandEntry {
-	const command = withCatalogCompletions(
-		definition,
-		context.getRunScriptCompletions,
-	);
-	const handler = (executionContext: CommandExecutionContext) => {
-		rewriteCatalogContext(definition, executionContext);
-		return context.handlers[definition.handlerKey](executionContext);
-	};
-	return buildEntry(
-		command,
-		buildCatalogMatcher(definition),
-		handler,
-		context.createContext,
-	);
-}
-
-function withCatalogCompletions(
-	definition: CommandCatalogEntry,
-	getRunScriptCompletions: RunScriptCompletionProvider,
-): SlashCommand {
-	const getArgumentCompletions = resolveCatalogCompletions(
-		definition,
-		getRunScriptCompletions,
-	);
-	return getArgumentCompletions
-		? { ...definition.command, getArgumentCompletions }
-		: definition.command;
-}
-
-function resolveCatalogCompletions(
-	definition: CommandCatalogEntry,
-	getRunScriptCompletions: RunScriptCompletionProvider,
-): SlashCommand["getArgumentCompletions"] | undefined {
-	switch (definition.completions) {
-		case CommandCompletionKind.Access:
-			return createSubcommandCompletions(ACCESS_SUBCOMMANDS);
-		case CommandCompletionKind.Hotkeys:
-			return createSubcommandCompletions(HOTKEYS_SUBCOMMANDS);
-		case CommandCompletionKind.Package:
-			return createSubcommandCompletions(PACKAGE_SUBCOMMANDS);
-		case CommandCompletionKind.RunScripts:
-			return getRunScriptCompletions;
-		case undefined:
-			return undefined;
-	}
-}
-
-function buildCatalogMatcher(
-	definition: CommandCatalogEntry,
-): (input: string) => boolean {
-	const aliases = definition.match.aliases ?? definition.command.aliases;
-	switch (definition.match.kind) {
-		case CommandMatchKind.Exact:
-			return equals(definition.command.name, aliases);
-		case CommandMatchKind.WithArgs:
-			return withArgs(definition.command.name, aliases);
-		case CommandMatchKind.Diagnostics:
-			return matchDiagnostics;
-		case CommandMatchKind.Quit:
-			return matchQuit;
-	}
-}
-
-function rewriteCatalogContext(
-	definition: CommandCatalogEntry,
-	context: CommandExecutionContext,
-): void {
-	if (!definition.rewriteTo) {
-		return;
-	}
-	context.rawInput = context.rawInput.replace(
-		new RegExp(`^/${escapeRegExp(definition.command.name)}(?=\\s|$)`),
-		`/${definition.rewriteTo}`,
-	);
-}
-
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function buildCommandSuiteEntries(
 	getCommandSuiteHandlers: CommandRegistryOptions["getCommandSuiteHandlers"],
 	createContext: CommandRegistryOptions["createContext"],
@@ -174,20 +48,6 @@ function buildCommandSuiteEntries(
 	);
 }
 
-function buildEntry(
-	command: SlashCommand,
-	matches: (input: string) => boolean,
-	handler: (context: CommandExecutionContext) => void | Promise<void>,
-	createContext: CommandRegistryOptions["createContext"],
-): CommandEntry {
-	return {
-		command,
-		matches,
-		execute: (input: string) =>
-			executeCommand(command, input, handler, createContext),
-	};
-}
-
 function buildCommandSuiteEntry(
 	definition: CommandSuiteDefinition,
 	getCommandSuiteHandlers: CommandRegistryOptions["getCommandSuiteHandlers"],
@@ -195,53 +55,23 @@ function buildCommandSuiteEntry(
 ): CommandEntry {
 	const handler = (context: CommandExecutionContext) =>
 		getCommandSuiteHandlers()[definition.key](context);
-	return buildEntry(
-		{
-			...definition.command,
-			getArgumentCompletions: createSubcommandCompletions(
-				definition.subcommands,
-			),
-		},
-		withArgs(definition.command.name, definition.command.aliases),
+	return buildCommandEntry(
+		commandFromSuite(definition),
+		matchCommandWithArgs(definition.name, definition.aliases),
 		handler,
 		createContext,
 	);
 }
 
-function executeCommand(
-	command: SlashCommand,
-	rawInput: string,
-	handler: (context: CommandExecutionContext) => void | Promise<void>,
-	createContext: CommandRegistryOptions["createContext"],
-): void | Promise<void> {
-	const argumentText = extractArgumentText(rawInput);
-	if (shouldShowHelp(argumentText)) {
-		const context = createContext({ command, rawInput, argumentText });
-		context.renderHelp();
-		return;
-	}
-	const parseResult = parseCommandArguments(argumentText, command.arguments);
-	if (!parseResult.ok) {
-		const context = createContext({ command, rawInput, argumentText });
-		context.showError(
-			"errors" in parseResult ? parseResult.errors.join(" ") : "Parse error",
-		);
-		context.renderHelp();
-		return;
-	}
-	const context = createContext({
-		command,
-		rawInput,
-		argumentText,
-		parsedArgs: parseResult.args,
-	});
-	return handler(context);
-}
-
-function extractArgumentText(input: string): string {
-	const spaceIndex = input.indexOf(" ");
-	if (spaceIndex === -1) {
-		return "";
-	}
-	return input.slice(spaceIndex + 1).trim();
+function commandFromSuite(definition: CommandSuiteDefinition): SlashCommand {
+	return {
+		name: definition.name,
+		description: definition.description,
+		usage: definition.usage,
+		examples: definition.examples,
+		tags: definition.tags,
+		aliases: definition.aliases,
+		arguments: definition.arguments,
+		getArgumentCompletions: createSubcommandCompletions(definition.subcommands),
+	};
 }

--- a/test/cli-tui/commands/command-registry-integration.test.ts
+++ b/test/cli-tui/commands/command-registry-integration.test.ts
@@ -1,6 +1,7 @@
 import type { SlashCommand } from "@evalops/tui";
 import { describe, expect, it, vi } from "vitest";
 import {
+	CommandMatchKind,
 	POST_SUITE_COMMAND_CATALOG,
 	PRIMARY_COMMAND_CATALOG,
 } from "../../../src/cli-tui/commands/command-catalog.js";
@@ -162,24 +163,36 @@ describe("command-registry-integration", () => {
 		]);
 		expect(new Set(keys).size).toBe(keys.length);
 		for (const definition of COMMAND_SUITE_DEFINITIONS) {
-			expect(definition.command.name).toBeTruthy();
+			expect("command" in definition).toBe(false);
+			expect(definition.name).toBeTruthy();
 			expect(definition.subcommands.length).toBeGreaterThan(0);
 		}
 	});
 
 	it("keeps top-level command catalogs unique and ordered around suites", () => {
 		const catalogNames = [
-			...PRIMARY_COMMAND_CATALOG.map((definition) => definition.command.name),
-			...POST_SUITE_COMMAND_CATALOG.map(
-				(definition) => definition.command.name,
-			),
+			...PRIMARY_COMMAND_CATALOG.map((definition) => definition.name),
+			...POST_SUITE_COMMAND_CATALOG.map((definition) => definition.name),
 		];
 
 		expect(new Set(catalogNames).size).toBe(catalogNames.length);
-		expect(PRIMARY_COMMAND_CATALOG.at(-1)?.command.name).toBe("copy");
+		expect(PRIMARY_COMMAND_CATALOG.at(-1)?.name).toBe("copy");
 		expect(
-			POST_SUITE_COMMAND_CATALOG.map((definition) => definition.command.name),
+			POST_SUITE_COMMAND_CATALOG.map((definition) => definition.name),
 		).toEqual(["toolhistory", "skills"]);
+	});
+
+	it("keeps top-level command catalogs as flat registry specs", () => {
+		const matchKinds = new Set(Object.values(CommandMatchKind));
+		for (const definition of [
+			...PRIMARY_COMMAND_CATALOG,
+			...POST_SUITE_COMMAND_CATALOG,
+		]) {
+			expect("command" in definition).toBe(false);
+			expect(definition.name).toBeTruthy();
+			expect(definition.handlerKey).toBeTruthy();
+			expect(matchKinds.has(definition.matchKind)).toBe(true);
+		}
 	});
 
 	it("uses maestro descriptions for guardian, about, and config", () => {


### PR DESCRIPTION
Summary
- Flatten primary and post-suite command catalog entries so command metadata and registry behavior live in one spec object.
- Add a command-registry adapter that owns matching, completions, context rewrites, and execution glue.
- Flatten command suite catalog definitions and cover the flat shapes in registry integration tests.

Test plan
- npx biome check --write --unsafe src/cli-tui/commands/command-catalog.ts src/cli-tui/commands/command-suite-catalog.ts src/cli-tui/commands/command-registry-adapter.ts src/cli-tui/commands/registry.ts test/cli-tui/commands/command-registry-integration.test.ts
- npx --yes bun@1.3.6 run --filter @evalops/tui build
- npx --yes bun@1.3.6 run --filter @evalops/contracts build
- npx tsc -p tsconfig.build.json --noEmit
- node ./scripts/run-vitest.js --run test/cli-tui/commands/command-registry-integration.test.ts test/tui/command-registry-options.test.ts test/tui/tui-subcommands.test.ts
- npx --yes bun@1.3.6 run build
- npx --yes bun@1.3.6 run --filter @evalops/ai build
- npx --yes bun@1.3.6 run --filter @evalops/maestro-web build
- node ./scripts/run-vitest.js --run
- git diff --check