### PR TITLE
[codex] Fix headless stdio startup and add runner harness

### DIFF
--- a/docs/BUILD_TESTING.md
+++ b/docs/BUILD_TESTING.md
@@ -50,6 +50,8 @@ Tests for the compiled binary (`dist/maestro-bun`):
 End-to-end CLI functionality tests:
 - `--help` command works
 - `--version` command works
+- `--headless` emits only protocol JSON on stdout and completes a `hello`
+  startup handshake
 - Help output contains expected content
 - File existence checks
 - File content validation (shebang, size)
@@ -62,7 +64,20 @@ End-to-end CLI functionality tests:
 
 **Run:** `bun run smoke` or `node scripts/smoke-cli.js`
 
-### 5. Build Verification Script (`scripts/verify-build.ts`)
+Run only the headless stdio regression smoke with
+`bun run smoke:headless` after `bun run build`.
+
+### 5. Headless Responsiveness Harness (`scripts/headless-responsiveness-harness.js`)
+
+The responsiveness harness is a lightweight signal for hosted-runner behavior.
+It exercises an in-process mock runner and the built headless CLI, then emits
+machine-readable JSON with startup, hello, prompt, event, and drain timings.
+Use it for ADR evidence and gateway/substrate comparisons; correctness gates
+belong in the headless protocol and smoke tests.
+
+**Run:** `bun run headless:responsiveness` after `bun run build`
+
+### 6. Build Verification Script (`scripts/verify-build.ts`)
 
 Comprehensive build verification script that runs all checks:
 - Critical files verification
@@ -78,7 +93,7 @@ Comprehensive build verification script that runs all checks:
 - `VERIFY_PACKAGES=1 bun run verify-build` (includes package verification)
 - `npx nx run maestro:verify-build` (Nx target wrapper)
 
-### 6. Platform SDK Contract Smoke (`scripts/check-platform-sdk-contract.ts`)
+### 7. Platform SDK Contract Smoke (`scripts/check-platform-sdk-contract.ts`)
 
 Cross-repo smoke test for the generated Platform TypeScript SDK before
 `@evalops/sdk-ts` is available from npm. The script packs `gen/ts` from a

--- a/docs/protocols/headless.md
+++ b/docs/protocols/headless.md
@@ -8,6 +8,8 @@ Transport rules:
 - stdin carries one JSON object per line into Maestro
 - stdout emits one JSON object per line back to the client
 - stderr is diagnostics only and is not part of the protocol contract
+- startup failures should emit a fatal `error` protocol message on stdout when
+  the headless transport has been requested, with human diagnostics on stderr
 
 ## Compatibility
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "tui": "npm run cli",
     "verify": "npm run format && npm run lint && npm run test && npm run build && npm run verify:runtime-deps && npm run smoke && npm run telemetry:report",
     "smoke": "node scripts/smoke-cli.js",
+    "smoke:headless": "node scripts/smoke-headless.js",
+    "headless:responsiveness": "node scripts/headless-responsiveness-harness.js",
     "smoke:pack": "node scripts/smoke-packed-cli.js",
     "smoke:registry": "node scripts/smoke-registry-install.js",
     "metadata:sync": "node scripts/sync-package-metadata.js",

--- a/scripts/headless-responsiveness-harness.js
+++ b/scripts/headless-responsiveness-harness.js
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+
+const DEFAULT_PROTOCOL_VERSION = "2026-04-02";
+
+function parseArgs(argv) {
+	const args = {
+		target: "all",
+		cli: "dist/cli.js",
+		promptRequests: 100,
+		concurrency: 20,
+		delayMs: 2,
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--target" && argv[i + 1]) {
+			args.target = argv[++i];
+		} else if (arg === "--cli" && argv[i + 1]) {
+			args.cli = argv[++i];
+		} else if (arg === "--prompt-requests" && argv[i + 1]) {
+			args.promptRequests = Number.parseInt(argv[++i], 10);
+		} else if (arg === "--concurrency" && argv[i + 1]) {
+			args.concurrency = Number.parseInt(argv[++i], 10);
+		} else if (arg === "--delay-ms" && argv[i + 1]) {
+			args.delayMs = Number.parseInt(argv[++i], 10);
+		}
+	}
+	return args;
+}
+
+function percentile(values, p) {
+	if (values.length === 0) {
+		return 0;
+	}
+	const sorted = [...values].sort((a, b) => a - b);
+	const index = Math.min(
+		sorted.length - 1,
+		Math.ceil((p / 100) * sorted.length) - 1,
+	);
+	return sorted[index];
+}
+
+async function requestJson(url, options = {}) {
+	const startedAt = performance.now();
+	const response = await fetch(url, {
+		...options,
+		headers: {
+			"content-type": "application/json",
+			...(options.headers ?? {}),
+		},
+	});
+	const text = await response.text();
+	const durationMs = performance.now() - startedAt;
+	let body;
+	try {
+		body = text ? JSON.parse(text) : null;
+	} catch {
+		body = text;
+	}
+	return { status: response.status, body, durationMs };
+}
+
+async function runConcurrent(count, concurrency, fn) {
+	const durations = [];
+	let next = 0;
+	async function worker() {
+		for (;;) {
+			const index = next++;
+			if (index >= count) {
+				return;
+			}
+			const startedAt = performance.now();
+			await fn(index);
+			durations.push(performance.now() - startedAt);
+		}
+	}
+	await Promise.all(
+		Array.from({ length: Math.min(concurrency, count) }, () => worker()),
+	);
+	return {
+		count,
+		concurrency,
+		p50_ms: percentile(durations, 50),
+		p95_ms: percentile(durations, 95),
+		p99_ms: percentile(durations, 99),
+	};
+}
+
+function createMockRunner({ delayMs }) {
+	const events = [
+		{ sequence: 1, type: "ready" },
+		{ sequence: 2, type: "hello_ok" },
+		{ sequence: 3, type: "response_start" },
+		{ sequence: 4, type: "response_end" },
+	];
+	const server = createServer(async (req, res) => {
+		res.setHeader("content-type", "application/json");
+		if (req.method === "GET" && req.url === "/healthz") {
+			res.end(JSON.stringify({ status: "ok" }));
+			return;
+		}
+		if (req.method === "GET" && req.url === "/readyz") {
+			res.end(JSON.stringify({ status: "ready" }));
+			return;
+		}
+		if (req.method === "POST" && req.url === "/headless/hello") {
+			res.end(
+				JSON.stringify({
+					type: "hello_ok",
+					protocol_version: DEFAULT_PROTOCOL_VERSION,
+					connection_id: "mock-local",
+					role: "controller",
+				}),
+			);
+			return;
+		}
+		if (req.method === "POST" && req.url === "/prompt") {
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+			res.end(
+				JSON.stringify({
+					type: "response_end",
+					duration_ms: delayMs,
+					usage: {
+						input_tokens: 1,
+						output_tokens: 1,
+						total_tokens: 2,
+						total_cost_usd: 0,
+					},
+				}),
+			);
+			return;
+		}
+		if (req.method === "GET" && req.url?.startsWith("/events")) {
+			res.end(JSON.stringify({ events }));
+			return;
+		}
+		if (req.method === "POST" && req.url === "/drain") {
+			res.end(
+				JSON.stringify({
+					status: "drained",
+					snapshot_manifest_uri: "mock://snapshot-manifest.json",
+				}),
+			);
+			return;
+		}
+		res.statusCode = 404;
+		res.end(JSON.stringify({ error: "not found" }));
+	});
+	return server;
+}
+
+async function listen(server) {
+	await new Promise((resolve) => {
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("Mock runner did not bind to a TCP port");
+	}
+	return `http://127.0.0.1:${address.port}`;
+}
+
+async function runMockHarness(options) {
+	const server = createMockRunner(options);
+	const baseUrl = await listen(server);
+	try {
+		const health = await requestJson(`${baseUrl}/healthz`);
+		const ready = await requestJson(`${baseUrl}/readyz`);
+		const hello = await requestJson(`${baseUrl}/headless/hello`, {
+			method: "POST",
+			body: JSON.stringify({
+				type: "hello",
+				protocol_version: DEFAULT_PROTOCOL_VERSION,
+			}),
+		});
+		const prompt = await runConcurrent(
+			options.promptRequests,
+			options.concurrency,
+			(index) =>
+				requestJson(`${baseUrl}/prompt`, {
+					method: "POST",
+					body: JSON.stringify({ prompt: `hello ${index}` }),
+				}),
+		);
+		const events = await requestJson(`${baseUrl}/events?cursor=0`);
+		const drain = await requestJson(`${baseUrl}/drain`, { method: "POST" });
+		return {
+			target: "mock",
+			base_url: baseUrl,
+			health,
+			ready,
+			hello,
+			prompt,
+			events_count: Array.isArray(events.body?.events)
+				? events.body.events.length
+				: 0,
+			drain,
+		};
+	} finally {
+		await new Promise((resolve) => server.close(resolve));
+	}
+}
+
+function parseJsonLines(stdout) {
+	const lines = stdout
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean);
+	const messages = [];
+	const invalid = [];
+	for (const [index, line] of lines.entries()) {
+		try {
+			messages.push(JSON.parse(line));
+		} catch (error) {
+			invalid.push({
+				line: index + 1,
+				content: line,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+	return { lines: lines.length, messages, invalid };
+}
+
+function runHeadlessHarness({ cli }) {
+	const home = mkdtempSync(join(tmpdir(), "maestro-headless-harness-"));
+	try {
+		const startedAt = performance.now();
+		const result = spawnSync(
+			"node",
+			[
+				cli,
+				"--headless",
+				"--provider",
+				"openai",
+				"--model",
+				"gpt-4o-mini",
+				"--api-key",
+				"test-key",
+			],
+			{
+				cwd: process.cwd(),
+				encoding: "utf8",
+				input: `${JSON.stringify({
+					type: "hello",
+					protocol_version: DEFAULT_PROTOCOL_VERSION,
+					client_info: {
+						name: "maestro-headless-responsiveness-harness",
+						version: "0.1.0",
+					},
+					role: "controller",
+				})}\n`,
+				env: {
+					...process.env,
+					HOME: home,
+					MAESTRO_HOME: join(home, ".maestro"),
+					OPENAI_API_KEY: "test-key",
+					ANTHROPIC_API_KEY: "test-key",
+				},
+				timeout: 15_000,
+			},
+		);
+		const elapsedMs = performance.now() - startedAt;
+		const parsed = parseJsonLines(result.stdout ?? "");
+		return {
+			target: "headless-cli",
+			cli,
+			exit_code: result.status,
+			elapsed_ms: elapsedMs,
+			stdout_line_count: parsed.lines,
+			invalid_stdout_lines: parsed.invalid,
+			message_types: parsed.messages.map((message) => message.type),
+			stderr: result.stderr,
+			error: result.error
+				? result.error instanceof Error
+					? result.error.message
+					: String(result.error)
+				: undefined,
+		};
+	} finally {
+		rmSync(home, { recursive: true, force: true });
+	}
+}
+
+async function main() {
+	const options = parseArgs(process.argv.slice(2));
+	const startedAt = new Date().toISOString();
+	const results = [];
+	if (options.target === "all" || options.target === "mock") {
+		results.push(await runMockHarness(options));
+	}
+	if (options.target === "all" || options.target === "headless") {
+		results.push(runHeadlessHarness(options));
+	}
+	console.log(
+		JSON.stringify(
+			{
+				started_at: startedAt,
+				protocol_version: DEFAULT_PROTOCOL_VERSION,
+				options,
+				results,
+			},
+			null,
+			2,
+		),
+	);
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.stack : error);
+	process.exit(1);
+});

--- a/scripts/smoke-cli.js
+++ b/scripts/smoke-cli.js
@@ -12,6 +12,11 @@ const commands = [
 		cmd: "node",
 		args: ["dist/cli.js", "--version"],
 	},
+	{
+		name: "headless",
+		cmd: "node",
+		args: ["scripts/smoke-headless.js"],
+	},
 ];
 
 let hadError = false;

--- a/scripts/smoke-headless.js
+++ b/scripts/smoke-headless.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const home = mkdtempSync(join(tmpdir(), "maestro-headless-smoke-"));
+
+function fail(message, details) {
+	console.error(message);
+	if (details) {
+		console.error(details);
+	}
+	process.exitCode = 1;
+}
+
+try {
+	const hello = {
+		type: "hello",
+		protocol_version: "2026-04-02",
+		client_info: { name: "maestro-headless-smoke", version: "0.1.0" },
+		role: "controller",
+	};
+	const result = spawnSync(
+		"node",
+		[
+			"dist/cli.js",
+			"--headless",
+			"--provider",
+			"openai",
+			"--model",
+			"gpt-4o-mini",
+			"--api-key",
+			"test-key",
+		],
+		{
+			cwd: process.cwd(),
+			encoding: "utf8",
+			input: `${JSON.stringify(hello)}\n`,
+			env: {
+				...process.env,
+				HOME: home,
+				MAESTRO_HOME: join(home, ".maestro"),
+				OPENAI_API_KEY: "test-key",
+				ANTHROPIC_API_KEY: "test-key",
+			},
+			timeout: 15_000,
+		},
+	);
+
+	if (result.error) {
+		fail("Headless smoke failed to launch Maestro.", result.error.stack);
+	} else if (result.status !== 0) {
+		fail(
+			`Headless smoke exited with code ${result.status}.`,
+			[
+				result.stdout ? `stdout:\n${result.stdout}` : undefined,
+				result.stderr ? `stderr:\n${result.stderr}` : undefined,
+			]
+				.filter(Boolean)
+				.join("\n\n"),
+		);
+	} else {
+		const stdoutLines = result.stdout
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter(Boolean);
+		const messages = [];
+		for (const [index, line] of stdoutLines.entries()) {
+			try {
+				messages.push(JSON.parse(line));
+			} catch (error) {
+				fail(
+					`Headless stdout line ${index + 1} was not protocol JSON.`,
+					`line: ${line}\nerror: ${error instanceof Error ? error.message : error}`,
+				);
+				break;
+			}
+		}
+
+		if (process.exitCode !== 1) {
+			const types = new Set(messages.map((message) => message.type));
+			if (!types.has("ready")) {
+				fail("Headless smoke did not receive a ready message.");
+			}
+			if (!types.has("hello_ok")) {
+				fail("Headless smoke did not receive a hello_ok message.");
+			}
+		}
+	}
+} finally {
+	rmSync(home, { recursive: true, force: true });
+}
+
+if (process.exitCode === 1) {
+	process.exit(1);
+}
+
+console.log("Headless smoke completed successfully.");

--- a/scripts/smoke-headless.js
+++ b/scripts/smoke-headless.js
@@ -14,29 +14,22 @@ function fail(message, details) {
 	process.exitCode = 1;
 }
 
-try {
-	const hello = {
-		type: "hello",
-		protocol_version: "2026-04-02",
-		client_info: { name: "maestro-headless-smoke", version: "0.1.0" },
-		role: "controller",
-	};
-	const result = spawnSync(
+function runHeadless(args, input = "") {
+	return spawnSync(
 		"node",
 		[
 			"dist/cli.js",
 			"--headless",
 			"--provider",
 			"openai",
-			"--model",
-			"gpt-4o-mini",
 			"--api-key",
 			"test-key",
+			...args,
 		],
 		{
 			cwd: process.cwd(),
 			encoding: "utf8",
-			input: `${JSON.stringify(hello)}\n`,
+			input,
 			env: {
 				...process.env,
 				HOME: home,
@@ -46,6 +39,39 @@ try {
 			},
 			timeout: 15_000,
 		},
+	);
+}
+
+function parseStdoutMessages(stdout) {
+	const stdoutLines = stdout
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean);
+	const messages = [];
+	for (const [index, line] of stdoutLines.entries()) {
+		try {
+			messages.push(JSON.parse(line));
+		} catch (error) {
+			fail(
+				`Headless stdout line ${index + 1} was not protocol JSON.`,
+				`line: ${line}\nerror: ${error instanceof Error ? error.message : error}`,
+			);
+			break;
+		}
+	}
+	return messages;
+}
+
+try {
+	const hello = {
+		type: "hello",
+		protocol_version: "2026-04-02",
+		client_info: { name: "maestro-headless-smoke", version: "0.1.0" },
+		role: "controller",
+	};
+	const result = runHeadless(
+		["--model", "gpt-4o-mini"],
+		`${JSON.stringify(hello)}\n`,
 	);
 
 	if (result.error) {
@@ -61,22 +87,7 @@ try {
 				.join("\n\n"),
 		);
 	} else {
-		const stdoutLines = result.stdout
-			.split(/\r?\n/)
-			.map((line) => line.trim())
-			.filter(Boolean);
-		const messages = [];
-		for (const [index, line] of stdoutLines.entries()) {
-			try {
-				messages.push(JSON.parse(line));
-			} catch (error) {
-				fail(
-					`Headless stdout line ${index + 1} was not protocol JSON.`,
-					`line: ${line}\nerror: ${error instanceof Error ? error.message : error}`,
-				);
-				break;
-			}
-		}
+		const messages = parseStdoutMessages(result.stdout);
 
 		if (process.exitCode !== 1) {
 			const types = new Set(messages.map((message) => message.type));
@@ -86,6 +97,34 @@ try {
 			if (!types.has("hello_ok")) {
 				fail("Headless smoke did not receive a hello_ok message.");
 			}
+		}
+	}
+
+	const startupFailure = runHeadless([
+		"--model",
+		"definitely-not-a-real-model",
+	]);
+	if (startupFailure.error) {
+		fail(
+			"Headless startup-failure smoke failed to launch Maestro.",
+			startupFailure.error.stack,
+		);
+	} else if (startupFailure.status === 0) {
+		fail("Headless startup-failure smoke unexpectedly exited successfully.");
+	} else {
+		const messages = parseStdoutMessages(startupFailure.stdout);
+		const fatalError = messages.find((message) => message.type === "error");
+		if (!fatalError?.fatal) {
+			fail(
+				"Headless startup-failure smoke did not emit a fatal protocol error.",
+				startupFailure.stdout,
+			);
+		}
+		if (!startupFailure.stderr.includes("\n    at ")) {
+			fail(
+				"Headless startup-failure smoke did not preserve stderr stack diagnostics.",
+				startupFailure.stderr,
+			);
 		}
 	}
 } finally {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,43 @@ process.emit = ((event: string | symbol, ...args: unknown[]) => {
 	return originalEmit(event, ...args);
 }) as typeof process.emit;
 
+function isHeadlessInvocation(args: string[]): boolean {
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === "--headless") {
+			return true;
+		}
+		if (arg === "--mode" && args[i + 1] === "headless") {
+			return true;
+		}
+		if (
+			arg?.startsWith("--mode=") &&
+			arg.slice("--mode=".length) === "headless"
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function emitHeadlessStartupError(error: unknown): void {
+	const message = error instanceof Error ? error.message : String(error);
+	const stack = error instanceof Error ? error.stack : undefined;
+	try {
+		process.stdout.write(
+			`${JSON.stringify({
+				type: "error",
+				message: `Headless startup failed: ${message}`,
+				fatal: true,
+				error_type: "fatal",
+			})}\n`,
+		);
+	} catch {
+		// If stdout is unavailable there is no protocol channel left to use.
+	}
+	process.stderr.write(`${stack ?? message}\n`);
+}
+
 const run = async () => {
 	try {
 		// Prefer the TypeScript entry when running under Bun during development,
@@ -44,7 +81,11 @@ const run = async () => {
 		const { main } = await loadMain();
 		await main(process.argv.slice(2));
 	} catch (err) {
-		console.error(err);
+		if (isHeadlessInvocation(process.argv.slice(2))) {
+			emitHeadlessStartupError(err);
+		} else {
+			console.error(err);
+		}
 		process.exit(1);
 	}
 };

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -87,6 +87,19 @@ export function parseArgs(args: string[]): Args {
 			result.help = true;
 		} else if (arg === "--version" || arg === "-v") {
 			result.version = true;
+		} else if (arg?.startsWith("--mode=")) {
+			const mode = arg.slice("--mode=".length);
+			if (
+				mode === "text" ||
+				mode === "json" ||
+				mode === "rpc" ||
+				mode === "headless"
+			) {
+				result.mode = mode;
+				if (mode === "headless") {
+					result.headless = true;
+				}
+			}
 		} else if (arg === "--mode" && i + 1 < args.length) {
 			const mode = args[++i];
 			if (
@@ -96,6 +109,9 @@ export function parseArgs(args: string[]): Args {
 				mode === "headless"
 			) {
 				result.mode = mode;
+				if (mode === "headless") {
+					result.headless = true;
+				}
 			}
 		} else if (arg === "--headless") {
 			result.headless = true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -458,17 +458,9 @@ export async function main(args: string[]) {
 		return;
 	}
 
-	const runtimeConfig = loadRuntimeConfig(parsed, process.cwd());
-	const reasoningSummary =
-		runtimeConfig.config.model_supports_reasoning_summaries === false
-			? undefined
-			: runtimeConfig.config.model_reasoning_summary === "none"
-				? null
-				: runtimeConfig.config.model_reasoning_summary;
-
 	// If we're about to enter interactive TUI mode (no prompt messages and not RPC/exec),
 	// or headless mode (stdout is JSON-only), redirect all logging/console output to a file.
-	// This must run before model loading to catch any early warnings.
+	// This must run before config/model loading to catch any early warnings.
 	const isLikelyInteractiveTui =
 		!parsed.messages.length &&
 		(parsed.mode === "text" || parsed.mode === undefined) &&
@@ -482,10 +474,37 @@ export async function main(args: string[]) {
 			pipeProcessEventsToLogger,
 		} = await import("./utils/logger.js");
 		redirectLoggerToFile();
-		redirectConsoleToLogger();
-		redirectStderrToLogger();
+		redirectConsoleToLogger({ preserveErrorStderr: isHeadlessMode });
+		if (!isHeadlessMode) {
+			redirectStderrToLogger();
+		}
 		pipeProcessEventsToLogger();
 	}
+
+	const runtimeConfig = loadRuntimeConfig(parsed, process.cwd());
+	const reasoningSummary =
+		runtimeConfig.config.model_supports_reasoning_summaries === false
+			? undefined
+			: runtimeConfig.config.model_reasoning_summary === "none"
+				? null
+				: runtimeConfig.config.model_reasoning_summary;
+	const exitWithStartupError = (error: unknown): never => {
+		const message = error instanceof Error ? error.message : String(error);
+		if (isHeadlessMode) {
+			process.stdout.write(
+				`${JSON.stringify({
+					type: "error",
+					message: `Headless startup failed: ${message}`,
+					fatal: true,
+					error_type: "fatal",
+				})}\n`,
+			);
+			process.stderr.write(`${message}\n`);
+		} else {
+			console.error(chalk.red(message));
+		}
+		process.exit(1);
+	};
 
 	const startupProfilingEnabled = process.env.MAESTRO_STARTUP_PROFILE === "1";
 	const logStartupPhase = (label: string, startedAt: number) => {
@@ -581,10 +600,7 @@ export async function main(args: string[]) {
 	try {
 		validateCodexFlags(args, parsed.command);
 	} catch (error) {
-		console.error(
-			chalk.red(error instanceof Error ? error.message : String(error)),
-		);
-		process.exit(1);
+		exitWithStartupError(error);
 	}
 
 	const { requireCredential } = createAuthSetup({
@@ -594,24 +610,18 @@ export async function main(args: string[]) {
 
 	if (parsed.command === "exec") {
 		if (parsed.execFullAuto && parsed.execReadOnly) {
-			console.error(
-				chalk.red(
-					"Cannot combine --full-auto with --read-only in maestro exec.",
-				),
+			exitWithStartupError(
+				"Cannot combine --full-auto with --read-only in maestro exec.",
 			);
-			process.exit(1);
 		}
 	}
 
 	// Validate sandbox mode (applies to both exec and interactive modes)
 	const validSandboxModes = ["docker", "local", "none"];
 	if (parsed.sandbox && !validSandboxModes.includes(parsed.sandbox)) {
-		console.error(
-			chalk.red(
-				`Unknown sandbox mode "${parsed.sandbox}". Supported: ${validSandboxModes.join(", ")}`,
-			),
+		exitWithStartupError(
+			`Unknown sandbox mode "${parsed.sandbox}". Supported: ${validSandboxModes.join(", ")}`,
 		);
-		process.exit(1);
 	}
 
 	// ─────────────────────────────────────────────────────────────────────────────
@@ -942,7 +952,7 @@ export async function main(args: string[]) {
 	// PHASE 8: Model Resolution
 	// ─────────────────────────────────────────────────────────────────────────────
 
-	let model: Model<Api>;
+	let model!: Model<Api>;
 	try {
 		const { resolveModelFromArgs } = await import(
 			"./bootstrap/model-resolution-setup.js"
@@ -954,10 +964,7 @@ export async function main(args: string[]) {
 		});
 		model = resolved.model;
 	} catch (error) {
-		console.error(
-			chalk.red(error instanceof Error ? error.message : String(error)),
-		);
-		process.exit(1);
+		exitWithStartupError(error);
 	}
 	// ─────────────────────────────────────────────────────────────────────────────
 	// PHASE 9: System Prompt and Tool Configuration
@@ -1027,7 +1034,7 @@ export async function main(args: string[]) {
 	// PHASE 10: Tool Registry and Sandbox Setup
 	// ─────────────────────────────────────────────────────────────────────────────
 
-	let toolsResult: Awaited<
+	let toolsResult!: Awaited<
 		ReturnType<
 			typeof import("./bootstrap/tools-setup.js").createToolsAndSandbox
 		>
@@ -1042,10 +1049,7 @@ export async function main(args: string[]) {
 			cwd: process.cwd(),
 		});
 	} catch (error) {
-		console.error(
-			chalk.red(error instanceof Error ? error.message : String(error)),
-		);
-		process.exit(1);
+		exitWithStartupError(error);
 	}
 	const { allTools, sandbox, sandboxMode } = toolsResult;
 	const useInteractiveClientTools = Boolean(interactiveClientToolService);

--- a/src/main.ts
+++ b/src/main.ts
@@ -490,6 +490,7 @@ export async function main(args: string[]) {
 				: runtimeConfig.config.model_reasoning_summary;
 	const exitWithStartupError = (error: unknown): never => {
 		const message = error instanceof Error ? error.message : String(error);
+		const stack = error instanceof Error ? error.stack : undefined;
 		if (isHeadlessMode) {
 			process.stdout.write(
 				`${JSON.stringify({
@@ -499,7 +500,7 @@ export async function main(args: string[]) {
 					error_type: "fatal",
 				})}\n`,
 			);
-			process.stderr.write(`${message}\n`);
+			process.stderr.write(`${stack ?? message}\n`);
 		} else {
 			console.error(chalk.red(message));
 		}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -39,6 +39,14 @@ interface LoggerConfig {
 	output?: (entry: LogEntry) => void;
 }
 
+const originalConsole = {
+	log: console.log.bind(console),
+	info: console.info.bind(console),
+	warn: console.warn.bind(console),
+	error: console.error.bind(console),
+	debug: console.debug.bind(console),
+};
+
 const LOG_LEVELS: Record<LogLevel, number> = {
 	debug: 0,
 	info: 1,
@@ -276,7 +284,9 @@ export function redirectLoggerToFile(filePath?: string): void {
  * output) has been configured; otherwise console.* would route back to the
  * console-backed logger output and recurse.
  */
-export function redirectConsoleToLogger(): void {
+export function redirectConsoleToLogger(options?: {
+	preserveErrorStderr?: boolean;
+}): void {
 	console.log = (...args: unknown[]) => {
 		logger.info(args.map(String).join(" "));
 	};
@@ -287,6 +297,10 @@ export function redirectConsoleToLogger(): void {
 		logger.warn(args.map(String).join(" "));
 	};
 	console.error = (...args: unknown[]) => {
+		if (options?.preserveErrorStderr) {
+			originalConsole.error(...args);
+			return;
+		}
 		// Preserve first Error stack if present
 		const maybeError = args.find((a) => a instanceof Error) as
 			| Error

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -30,6 +30,17 @@ describe("parseArgs", () => {
 		);
 	});
 
+	it("treats --mode headless forms as headless invocations", () => {
+		expect(parseArgs(["--mode", "headless"])).toMatchObject({
+			mode: "headless",
+			headless: true,
+		});
+		expect(parseArgs(["--mode=headless"])).toMatchObject({
+			mode: "headless",
+			headless: true,
+		});
+	});
+
 	it("parses export commands and formats", () => {
 		expect(
 			parseArgs([


### PR DESCRIPTION
## Summary

Fixes #88.
Fixes #89.
Related: evalops/platform#781, evalops/platform#783, evalops/platform#795.

- redirect headless logging before runtime config loading so protocol stdout is not contaminated by startup logs
- preserve stderr diagnostics for headless fatal startup failures and emit a fatal protocol `error` on stdout
- make `--mode=headless` and `--mode headless` both set the headless flag
- add `smoke:headless` and include it in the existing smoke script
- add a hosted-runner responsiveness harness with an in-process mock runner and real built-CLI headless probe

## Validation

- `bun run build`
- `bun run test -- test/cli/args.test.ts test/cli/headless-runtime.test.ts`
- `bun run smoke:headless`
- `bun run headless:responsiveness -- --prompt-requests 20 --concurrency 5`
- `bun run smoke`
- manual startup-failure check: invalid headless model now emits protocol JSON on stdout and a diagnostic on stderr

## Notes

The local clone has an unstaged `bun.lockb` rewrite caused by this machine's Bun version reading an older lockfile format. It is intentionally excluded from this PR.
