### PR TITLE
Add remote runner CLI integration

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -23,6 +23,8 @@ export interface Args {
 	safeMode?: boolean;
 	command?: string;
 	subcommand?: string;
+	/** Raw arguments owned by command-group handlers. */
+	commandArgs?: string[];
 	approvalMode?: "auto" | "prompt" | "fail";
 	authMode?: "auto" | "api-key" | "claude";
 	force?: boolean;
@@ -61,6 +63,7 @@ const COMMANDS = new Set([
 	"openai",
 	"hooks",
 	"memory",
+	"remote",
 	"export",
 	"import",
 ]);
@@ -73,6 +76,7 @@ const SUBCOMMAND_COMMANDS = new Set([
 	"openai",
 	"hooks",
 	"memory",
+	"remote",
 ]);
 
 export function parseArgs(args: string[]): Args {
@@ -243,6 +247,10 @@ export function parseArgs(args: string[]): Args {
 				) {
 					result.subcommand = nextArg;
 					i++;
+				}
+				if (arg === "remote") {
+					result.commandArgs = args.slice(i + 1);
+					break;
 				}
 			} else {
 				result.messages.push(arg);

--- a/src/cli/commands/remote.ts
+++ b/src/cli/commands/remote.ts
@@ -1,0 +1,662 @@
+import { headlessProtocolVersion } from "@evalops/contracts";
+import chalk from "chalk";
+import { getPackageVersion } from "../../package-metadata.js";
+import {
+	RUNNER_ATTACH_ROLES,
+	type RunnerAttachRole,
+	type RunnerSession,
+	type RunnerSessionState,
+	createRunnerSession,
+	extendRunnerSession,
+	getRemoteRunnerStatus,
+	getRunnerSession,
+	listRunnerSessionEvents,
+	listRunnerSessions,
+	mintRunnerAttachToken,
+	remoteRunnerGatewayBaseUrl,
+	resolveRemoteRunnerConfig,
+	revokeRunnerAttachToken,
+	stopRunnerSession,
+	verifyRunnerHeadlessAttach,
+} from "../../remote-runner/client.js";
+
+type RemoteFlagValue = true | string;
+
+interface RemoteCommandOptions {
+	flags: Map<string, RemoteFlagValue[]>;
+	positionals: string[];
+}
+
+const REMOTE_USAGE = `maestro remote <command> [options]
+
+Commands:
+  start --workspace <id> --repo <repo> --branch <branch> [--ttl 90m] [--profile standard]
+  list --workspace <id> [--state running] [--limit 20]
+  status --workspace <id>
+  events <session-id> [--after <sequence>] [--limit 50]
+  extend <session-id> --ttl 2h [--idle-ttl 30m]
+  stop <session-id> [--reason <text>]
+  attach <session-id> [--role controller] [--ttl 30m] [--verify]
+  attach-token <session-id> [--role viewer] [--ttl 30m] [--json]
+  revoke-token <session-id> <token-id>
+
+Shared options:
+  --base-url <url>       Remote runner URL (defaults to https://runner.evalops.dev)
+  --org <id>            EvalOps organization id
+  --workspace <id>      EvalOps workspace id
+  --token <token>       EvalOps access token
+  --json                Print machine-readable JSON
+  --help                Show this help`;
+
+function parseRemoteOptions(args: readonly string[]): RemoteCommandOptions {
+	const flags = new Map<string, RemoteFlagValue[]>();
+	const positionals: string[] = [];
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (!arg) {
+			continue;
+		}
+		if (arg === "--") {
+			positionals.push(...args.slice(index + 1));
+			break;
+		}
+		if (!arg.startsWith("--")) {
+			positionals.push(arg);
+			continue;
+		}
+		const equalsIndex = arg.indexOf("=");
+		const key = equalsIndex >= 0 ? arg.slice(2, equalsIndex) : arg.slice(2);
+		const inlineValue =
+			equalsIndex >= 0 ? arg.slice(equalsIndex + 1) : undefined;
+		const next = args[index + 1];
+		const value =
+			inlineValue !== undefined
+				? inlineValue
+				: next && !next.startsWith("--")
+					? next
+					: true;
+		if (inlineValue === undefined && value !== true) {
+			index += 1;
+		}
+		const values = flags.get(key) ?? [];
+		values.push(value);
+		flags.set(key, values);
+	}
+
+	return { flags, positionals };
+}
+
+function hasFlag(options: RemoteCommandOptions, name: string): boolean {
+	return options.flags.has(name);
+}
+
+function getFlag(
+	options: RemoteCommandOptions,
+	...names: string[]
+): string | undefined {
+	for (const name of names) {
+		const values = options.flags.get(name);
+		const last = values?.at(-1);
+		if (typeof last === "string" && last.trim().length > 0) {
+			return last.trim();
+		}
+	}
+	return undefined;
+}
+
+function getRepeatedFlag(
+	options: RemoteCommandOptions,
+	...names: string[]
+): string[] {
+	const values: string[] = [];
+	for (const name of names) {
+		for (const value of options.flags.get(name) ?? []) {
+			if (typeof value === "string" && value.trim().length > 0) {
+				values.push(value.trim());
+			}
+		}
+	}
+	return values;
+}
+
+function parseIntFlag(
+	options: RemoteCommandOptions,
+	name: string,
+	fallback?: number,
+): number | undefined {
+	const raw = getFlag(options, name);
+	if (!raw) {
+		return fallback;
+	}
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isInteger(parsed) || parsed < 0) {
+		throw new Error(`--${name} must be a non-negative integer`);
+	}
+	return parsed;
+}
+
+export function parseRemoteDurationMinutes(
+	raw: string | undefined,
+	fallback: number,
+): number {
+	if (!raw) {
+		return fallback;
+	}
+	const value = raw.trim().toLowerCase();
+	const match = value.match(
+		/^(\d+(?:\.\d+)?)(m|min|mins|minute|minutes|h|hr|hrs|hour|hours)?$/u,
+	);
+	if (!match) {
+		throw new Error(`Invalid duration "${raw}". Use minutes, 90m, or 2h.`);
+	}
+	const amount = Number(match[1]);
+	const unit = match[2] ?? "m";
+	const minutes = unit.startsWith("h") ? amount * 60 : amount;
+	if (!Number.isFinite(minutes) || minutes <= 0 || !Number.isInteger(minutes)) {
+		throw new Error(
+			`Invalid duration "${raw}". Duration must resolve to whole minutes.`,
+		);
+	}
+	return minutes;
+}
+
+function parseOptionalDurationMinutes(
+	raw: string | undefined,
+): number | undefined {
+	if (!raw) {
+		return undefined;
+	}
+	return parseRemoteDurationMinutes(raw, 0);
+}
+
+function parseMetadata(
+	values: readonly string[],
+): Record<string, unknown> | undefined {
+	if (!values.length) {
+		return undefined;
+	}
+	const metadata: Record<string, unknown> = {};
+	for (const value of values) {
+		const equalsIndex = value.indexOf("=");
+		if (equalsIndex <= 0) {
+			throw new Error(`--metadata values must be key=value pairs: ${value}`);
+		}
+		const key = value.slice(0, equalsIndex).trim();
+		const raw = value.slice(equalsIndex + 1).trim();
+		if (!key) {
+			throw new Error(`--metadata values must include a key: ${value}`);
+		}
+		metadata[key] = raw;
+	}
+	return metadata;
+}
+
+function jsonFlag(options: RemoteCommandOptions): boolean {
+	return hasFlag(options, "json");
+}
+
+function clientOptions(options: RemoteCommandOptions) {
+	return {
+		baseUrl: getFlag(options, "base-url", "url"),
+		token: getFlag(options, "token"),
+		organizationId: getFlag(options, "org", "organization"),
+		workspaceId: getFlag(options, "workspace"),
+	};
+}
+
+function stateLabel(state: RunnerSessionState | string | undefined): string {
+	return (
+		state
+			?.replace(/^RUNNER_SESSION_STATE_/u, "")
+			.toLowerCase()
+			.replaceAll("_", "-") ?? "unknown"
+	);
+}
+
+function roleValues(options: RemoteCommandOptions): RunnerAttachRole[] {
+	const rawRoles = getRepeatedFlag(options, "role", "roles");
+	const roles = rawRoles.length
+		? rawRoles.flatMap((role) => role.split(","))
+		: hasFlag(options, "viewer")
+			? ["viewer"]
+			: hasFlag(options, "admin")
+				? ["admin"]
+				: ["controller"];
+	return roles.map((role) => {
+		const normalized = role
+			.trim()
+			.toUpperCase()
+			.replace(/^RUNNER_ATTACH_ROLE_/u, "");
+		const value =
+			RUNNER_ATTACH_ROLES[normalized as keyof typeof RUNNER_ATTACH_ROLES];
+		if (!value || value === RUNNER_ATTACH_ROLES.UNSPECIFIED) {
+			throw new Error(`Unknown remote attach role: ${role}`);
+		}
+		return value;
+	});
+}
+
+function printJson(value: unknown): void {
+	console.log(JSON.stringify(value, null, 2));
+}
+
+function printSession(session: RunnerSession): void {
+	console.log(chalk.bold(session.id));
+	console.log(`  state:     ${stateLabel(session.state)}`);
+	console.log(`  workspace: ${session.workspaceId ?? "-"}`);
+	console.log(`  profile:   ${session.runnerProfile ?? "-"}`);
+	console.log(`  repo:      ${session.repoUrl ?? "-"}`);
+	console.log(`  branch:    ${session.branch ?? "-"}`);
+	console.log(`  expires:   ${session.expiresAt ?? "-"}`);
+	console.log(`  idle:      ${session.idleExpiresAt ?? "-"}`);
+	if (session.stopReason) {
+		console.log(`  stopped:   ${session.stopReason}`);
+	}
+}
+
+function printSessionTable(sessions: readonly RunnerSession[]): void {
+	if (!sessions.length) {
+		console.log(chalk.dim("No remote runner sessions found."));
+		return;
+	}
+	const rows = sessions.map((session) => ({
+		id: session.id,
+		state: stateLabel(session.state),
+		profile: session.runnerProfile ?? "-",
+		repo: session.repoUrl ?? "-",
+		branch: session.branch ?? "-",
+		expires: session.expiresAt ?? "-",
+	}));
+	const widths = {
+		id: Math.max("session".length, ...rows.map((row) => row.id.length)),
+		state: Math.max("state".length, ...rows.map((row) => row.state.length)),
+		profile: Math.max(
+			"profile".length,
+			...rows.map((row) => row.profile.length),
+		),
+		repo: Math.max("repo".length, ...rows.map((row) => row.repo.length)),
+		branch: Math.max("branch".length, ...rows.map((row) => row.branch.length)),
+	};
+	console.log(
+		[
+			"session".padEnd(widths.id),
+			"state".padEnd(widths.state),
+			"profile".padEnd(widths.profile),
+			"repo".padEnd(widths.repo),
+			"branch".padEnd(widths.branch),
+			"expires",
+		].join("  "),
+	);
+	for (const row of rows) {
+		console.log(
+			[
+				row.id.padEnd(widths.id),
+				row.state.padEnd(widths.state),
+				row.profile.padEnd(widths.profile),
+				row.repo.padEnd(widths.repo),
+				row.branch.padEnd(widths.branch),
+				row.expires,
+			].join("  "),
+		);
+	}
+}
+
+function printAttachInstructions(input: {
+	sessionId: string;
+	gatewayBaseUrl: string;
+	tokenId: string;
+	tokenSecret: string;
+	expiresAt?: string;
+	json: boolean;
+	showSecret: boolean;
+	verified?: Record<string, unknown>;
+}): void {
+	if (input.json) {
+		printJson({
+			sessionId: input.sessionId,
+			gatewayBaseUrl: input.gatewayBaseUrl,
+			tokenId: input.tokenId,
+			tokenSecret: input.tokenSecret,
+			expiresAt: input.expiresAt,
+			verified: input.verified,
+		});
+		return;
+	}
+	console.log(
+		chalk.bold(`Remote runner attach token minted for ${input.sessionId}`),
+	);
+	console.log(`  gateway: ${input.gatewayBaseUrl}`);
+	console.log(`  token:   ${input.tokenId}`);
+	console.log(`  expires: ${input.expiresAt ?? "-"}`);
+	if (input.verified) {
+		console.log(chalk.green("  headless gateway: verified"));
+	}
+	if (input.showSecret || !input.verified) {
+		console.log("");
+		console.log(chalk.dim("Ephemeral remote transport environment:"));
+		console.log(
+			`export MAESTRO_REMOTE_BASE_URL=${JSON.stringify(input.gatewayBaseUrl)}`,
+		);
+		console.log(
+			`export MAESTRO_REMOTE_API_KEY=${JSON.stringify(input.tokenSecret)}`,
+		);
+		console.log(
+			`export MAESTRO_REMOTE_HEADER_X_EVALOPS_RUNNER_ATTACH_TOKEN_ID=${JSON.stringify(
+				input.tokenId,
+			)}`,
+		);
+	} else {
+		console.log(
+			chalk.dim(
+				"  token secret hidden; rerun with --show-secret or --json when handoff needs it.",
+			),
+		);
+	}
+}
+
+async function handleStart(options: RemoteCommandOptions): Promise<void> {
+	const ttlMinutes = parseRemoteDurationMinutes(getFlag(options, "ttl"), 90);
+	const idleTtlMinutes = parseOptionalDurationMinutes(
+		getFlag(options, "idle-ttl", "idle"),
+	);
+	const result = await createRunnerSession(
+		{
+			workspaceId: getFlag(options, "workspace"),
+			userId: getFlag(options, "user"),
+			agentRunId: getFlag(options, "agent-run"),
+			maestroSessionId: getFlag(options, "maestro-session", "session"),
+			idempotencyKey: getFlag(options, "idempotency-key"),
+			runnerProfile: getFlag(options, "profile") ?? "standard",
+			runnerImage: getFlag(options, "image"),
+			workspaceSource: getFlag(options, "workspace-source"),
+			repoUrl: getFlag(options, "repo", "repo-url"),
+			branch: getFlag(options, "branch") ?? "main",
+			model: getFlag(options, "model"),
+			ttlMinutes,
+			idleTtlMinutes,
+			metadata: parseMetadata(getRepeatedFlag(options, "metadata")),
+		},
+		clientOptions(options),
+	);
+	if (jsonFlag(options)) {
+		printJson(result);
+		return;
+	}
+	printSession(result.session);
+	if (result.replayed) {
+		console.log(chalk.dim("  replayed:  existing idempotent request"));
+	}
+	console.log("");
+	console.log(chalk.dim(`Attach: maestro remote attach ${result.session.id}`));
+}
+
+async function handleList(options: RemoteCommandOptions): Promise<void> {
+	const result = await listRunnerSessions(
+		{
+			workspaceId: getFlag(options, "workspace"),
+			state: getFlag(options, "state"),
+			limit: parseIntFlag(options, "limit", 20),
+			offset: parseIntFlag(options, "offset", 0),
+		},
+		clientOptions(options),
+	);
+	if (jsonFlag(options)) {
+		printJson(result);
+		return;
+	}
+	printSessionTable(result.sessions);
+	if (result.nextOffset !== undefined && result.nextOffset > 0) {
+		console.log(chalk.dim(`next offset: ${result.nextOffset}`));
+	}
+}
+
+async function handleStatus(options: RemoteCommandOptions): Promise<void> {
+	const status = await getRemoteRunnerStatus(
+		getFlag(options, "workspace"),
+		clientOptions(options),
+	);
+	if (jsonFlag(options)) {
+		printJson(status);
+		return;
+	}
+	console.log(chalk.bold(status.service ?? "remote-runner"));
+	console.log(`  workspace: ${status.workspaceId ?? "-"}`);
+	console.log(`  policy:    ${status.downstreamPolicy ?? "-"}`);
+}
+
+async function handleGet(options: RemoteCommandOptions): Promise<void> {
+	const sessionId = options.positionals[0];
+	if (!sessionId) {
+		throw new Error("Usage: maestro remote get <session-id>");
+	}
+	const session = await getRunnerSession(sessionId, clientOptions(options));
+	if (jsonFlag(options)) {
+		printJson(session);
+		return;
+	}
+	printSession(session);
+}
+
+async function handleEvents(options: RemoteCommandOptions): Promise<void> {
+	const sessionId = options.positionals[0];
+	if (!sessionId) {
+		throw new Error("Usage: maestro remote events <session-id>");
+	}
+	const result = await listRunnerSessionEvents(
+		{
+			sessionId,
+			afterSequence: parseIntFlag(options, "after"),
+			limit: parseIntFlag(options, "limit", 50),
+		},
+		clientOptions(options),
+	);
+	if (jsonFlag(options)) {
+		printJson(result);
+		return;
+	}
+	for (const event of result.events) {
+		console.log(
+			`${String(event.sequence ?? "-").padStart(4)}  ${
+				event.occurredAt ?? "-"
+			}  ${event.eventType ?? "-"}`,
+		);
+	}
+	if (!result.events.length) {
+		console.log(chalk.dim("No remote runner events found."));
+	}
+}
+
+async function handleStop(options: RemoteCommandOptions): Promise<void> {
+	const sessionId = options.positionals[0];
+	if (!sessionId) {
+		throw new Error("Usage: maestro remote stop <session-id> [--reason text]");
+	}
+	const result = await stopRunnerSession(
+		sessionId,
+		getFlag(options, "reason") ?? "maestro remote stop",
+		clientOptions(options),
+	);
+	if (jsonFlag(options)) {
+		printJson(result);
+		return;
+	}
+	printSession(result.session);
+}
+
+async function handleExtend(options: RemoteCommandOptions): Promise<void> {
+	const sessionId = options.positionals[0];
+	if (!sessionId) {
+		throw new Error("Usage: maestro remote extend <session-id> --ttl 2h");
+	}
+	const ttl = getFlag(options, "ttl", "add-ttl");
+	if (!ttl) {
+		throw new Error("maestro remote extend requires --ttl");
+	}
+	const result = await extendRunnerSession(
+		{
+			sessionId,
+			additionalMinutes: parseRemoteDurationMinutes(ttl, 0),
+			additionalIdleMinutes: parseOptionalDurationMinutes(
+				getFlag(options, "idle-ttl", "add-idle-ttl"),
+			),
+			reason: getFlag(options, "reason") ?? "maestro remote extend",
+		},
+		clientOptions(options),
+	);
+	if (jsonFlag(options)) {
+		printJson(result);
+		return;
+	}
+	printSession(result.session);
+}
+
+async function mintAttach(options: RemoteCommandOptions) {
+	const sessionId = options.positionals[0];
+	if (!sessionId) {
+		throw new Error("Usage: maestro remote attach <session-id>");
+	}
+	return mintRunnerAttachToken(
+		{
+			sessionId,
+			subjectId: getFlag(options, "subject", "user"),
+			roles: roleValues(options),
+			ttlMinutes: parseRemoteDurationMinutes(getFlag(options, "ttl"), 30),
+		},
+		clientOptions(options),
+	);
+}
+
+async function handleAttach(options: RemoteCommandOptions): Promise<void> {
+	const sessionId = options.positionals[0];
+	const minted = await mintAttach(options);
+	let verified: Record<string, unknown> | undefined;
+	if (hasFlag(options, "verify")) {
+		verified = await verifyRunnerHeadlessAttach({
+			gatewayBaseUrl: minted.gatewayBaseUrl,
+			tokenId: minted.token.id,
+			tokenSecret: minted.tokenSecret,
+			sessionId: sessionId!,
+			protocolVersion: headlessProtocolVersion,
+			clientVersion: getPackageVersion(),
+			takeControl: hasFlag(options, "take-control"),
+		});
+	}
+	printAttachInstructions({
+		sessionId: sessionId!,
+		gatewayBaseUrl: minted.gatewayBaseUrl,
+		tokenId: minted.token.id,
+		tokenSecret: minted.tokenSecret,
+		expiresAt: minted.token.expiresAt,
+		json: jsonFlag(options),
+		showSecret: hasFlag(options, "show-secret"),
+		verified,
+	});
+}
+
+async function handleAttachToken(options: RemoteCommandOptions): Promise<void> {
+	const sessionId = options.positionals[0];
+	const minted = await mintAttach(options);
+	if (jsonFlag(options)) {
+		printJson(minted);
+		return;
+	}
+	console.log(chalk.bold(`Attach token for ${sessionId}`));
+	console.log(`  gateway: ${minted.gatewayBaseUrl}`);
+	console.log(`  token:   ${minted.token.id}`);
+	console.log(`  secret:  ${minted.tokenSecret}`);
+	console.log(`  expires: ${minted.token.expiresAt ?? "-"}`);
+}
+
+async function handleRevokeToken(options: RemoteCommandOptions): Promise<void> {
+	const sessionId = options.positionals[0];
+	const tokenId = options.positionals[1];
+	if (!sessionId || !tokenId) {
+		throw new Error(
+			"Usage: maestro remote revoke-token <session-id> <token-id>",
+		);
+	}
+	const result = await revokeRunnerAttachToken(
+		{ sessionId, tokenId },
+		clientOptions(options),
+	);
+	if (jsonFlag(options)) {
+		printJson(result);
+		return;
+	}
+	console.log(chalk.bold(`Revoked attach token ${result.token.id}`));
+}
+
+async function handleTarget(options: RemoteCommandOptions): Promise<void> {
+	const sessionId = options.positionals[0];
+	if (!sessionId) {
+		throw new Error("Usage: maestro remote target <session-id>");
+	}
+	const config = await resolveRemoteRunnerConfig(clientOptions(options));
+	if (!config) {
+		throw new Error(
+			"Remote runner target requires EvalOps organization and access token.",
+		);
+	}
+	const gatewayBaseUrl = remoteRunnerGatewayBaseUrl(config, sessionId);
+	if (jsonFlag(options)) {
+		printJson({ sessionId, gatewayBaseUrl });
+		return;
+	}
+	console.log(gatewayBaseUrl);
+}
+
+export async function handleRemoteCommand(
+	subcommand: string | undefined,
+	args: string[] = [],
+): Promise<void> {
+	const options = parseRemoteOptions(args);
+	if (!subcommand || subcommand === "help" || hasFlag(options, "help")) {
+		console.log(REMOTE_USAGE);
+		return;
+	}
+
+	try {
+		switch (subcommand) {
+			case "start":
+				await handleStart(options);
+				return;
+			case "list":
+				await handleList(options);
+				return;
+			case "status":
+				await handleStatus(options);
+				return;
+			case "get":
+				await handleGet(options);
+				return;
+			case "events":
+				await handleEvents(options);
+				return;
+			case "stop":
+				await handleStop(options);
+				return;
+			case "extend":
+				await handleExtend(options);
+				return;
+			case "attach":
+				await handleAttach(options);
+				return;
+			case "attach-token":
+				await handleAttachToken(options);
+				return;
+			case "revoke-token":
+				await handleRevokeToken(options);
+				return;
+			case "target":
+				await handleTarget(options);
+				return;
+			default:
+				throw new Error(`Unknown remote command: ${subcommand}`);
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(chalk.red(message));
+		process.exitCode = 1;
+	}
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -96,7 +96,10 @@ export function printHelp(version: string) {
   maestro export <session-id> ./session.json --format json --redact-secrets
 
   # Import a portable session log into this workspace
-  maestro import ./session.json`,
+  maestro import ./session.json
+
+  # Start a hosted EvalOps runner session
+  maestro remote start --workspace ws_123 --repo evalops/foo --branch main --ttl 90m`,
 	)}`;
 	const env = `${sectionHeading("Environment Variables:")}${muted(
 		`  GEMINI_API_KEY          - Google Gemini API key
@@ -115,6 +118,10 @@ export function printHelp(version: string) {
   MAESTRO_MEMORY_TEAM_ID - Optional team scope for durable memory service
   MAESTRO_SHARED_MEMORY_BASE - Shared memory base URL (Cloudflare Durable Objects worker)
   MAESTRO_SHARED_MEMORY_API_KEY - API key for shared memory service
+  MAESTRO_REMOTE_RUNNER_URL - Hosted runner control-plane URL (default: https://runner.evalops.dev)
+  MAESTRO_REMOTE_RUNNER_TOKEN - Hosted runner bearer token override
+  MAESTRO_REMOTE_RUNNER_ORG_ID - EvalOps organization id for hosted runner sessions
+  MAESTRO_REMOTE_RUNNER_WORKSPACE_ID - EvalOps workspace id for hosted runner sessions
   CODING_AGENT_DIR        - Legacy session directory override (fallback)`,
 	)}`;
 	const execSection = `${sectionHeading("maestro exec")}${muted(
@@ -152,6 +159,13 @@ export function printHelp(version: string) {
   maestro memory audit <id> [n]   Show recent sync audit entries
   maestro memory export <id>      Export metrics log as JSONL
   maestro memory watch [id] [ms]  Poll status/metrics continuously`,
+	)}`;
+	const remoteSection = `${sectionHeading("maestro remote")}${muted(
+		`  maestro remote start --workspace <id> --repo <repo> --branch <branch> [--ttl 90m]
+  maestro remote list --workspace <id> [--state running]
+  maestro remote attach <session-id> [--verify]
+  maestro remote extend <session-id> --ttl 2h
+  maestro remote stop <session-id> [--reason <text>]`,
 	)}`;
 	const sessionsSection = `${sectionHeading("Session Metadata")}${muted(
 		`  /session favorite|unfavorite      Toggle favorite for current session
@@ -197,6 +211,7 @@ export function printHelp(version: string) {
 			webSection,
 			portabilitySection,
 			memorySection,
+			remoteSection,
 			sessionsSection,
 			sessionsDiscovery,
 			`${sectionHeading("Tips")}${badge(

--- a/src/main.ts
+++ b/src/main.ts
@@ -757,6 +757,12 @@ export async function main(args: string[]) {
 		return;
 	}
 
+	if (parsed.command === "remote") {
+		const { handleRemoteCommand } = await import("./cli/commands/remote.js");
+		await handleRemoteCommand(parsed.subcommand, parsed.commandArgs ?? []);
+		return;
+	}
+
 	if (parsed.command === "anthropic") {
 		const { handleAnthropicCommand } = await import(
 			"./cli/commands/anthropic.js"

--- a/src/platform/core-services.ts
+++ b/src/platform/core-services.ts
@@ -10,6 +10,7 @@ export const PLATFORM_CONNECT_SERVICES = {
 	llmGateway: "llmgateway.v1.GatewayService",
 	meter: "meter.v1.MeterService",
 	prompts: "prompts.v1.PromptService",
+	remoteRunner: "remoterunner.v1.RemoteRunnerService",
 } as const;
 
 export const PLATFORM_CONNECT_METHODS = {
@@ -111,6 +112,44 @@ export const PLATFORM_CONNECT_METHODS = {
 		resolve: {
 			service: PLATFORM_CONNECT_SERVICES.prompts,
 			method: "Resolve",
+		},
+	},
+	remoteRunner: {
+		createRunnerSession: {
+			service: PLATFORM_CONNECT_SERVICES.remoteRunner,
+			method: "CreateRunnerSession",
+		},
+		extendRunnerSession: {
+			service: PLATFORM_CONNECT_SERVICES.remoteRunner,
+			method: "ExtendRunnerSession",
+		},
+		getRunnerSession: {
+			service: PLATFORM_CONNECT_SERVICES.remoteRunner,
+			method: "GetRunnerSession",
+		},
+		getStatus: {
+			service: PLATFORM_CONNECT_SERVICES.remoteRunner,
+			method: "GetStatus",
+		},
+		listRunnerSessionEvents: {
+			service: PLATFORM_CONNECT_SERVICES.remoteRunner,
+			method: "ListRunnerSessionEvents",
+		},
+		listRunnerSessions: {
+			service: PLATFORM_CONNECT_SERVICES.remoteRunner,
+			method: "ListRunnerSessions",
+		},
+		mintAttachToken: {
+			service: PLATFORM_CONNECT_SERVICES.remoteRunner,
+			method: "MintAttachToken",
+		},
+		revokeAttachToken: {
+			service: PLATFORM_CONNECT_SERVICES.remoteRunner,
+			method: "RevokeAttachToken",
+		},
+		stopRunnerSession: {
+			service: PLATFORM_CONNECT_SERVICES.remoteRunner,
+			method: "StopRunnerSession",
 		},
 	},
 } as const;

--- a/src/remote-runner/client.ts
+++ b/src/remote-runner/client.ts
@@ -1,0 +1,967 @@
+import { randomUUID } from "node:crypto";
+import {
+	type PlatformServiceConfig,
+	fetchWithRetry,
+	getEnvValue,
+	normalizeBaseUrl,
+	postPlatformConnect,
+	resolvePlatformServiceConfig,
+	trimString,
+} from "../platform/client.js";
+import {
+	PLATFORM_CONNECT_METHODS,
+	PLATFORM_CONNECT_SERVICES,
+	platformConnectMethodPath,
+	platformConnectServicePath,
+} from "../platform/core-services.js";
+
+export const DEFAULT_REMOTE_RUNNER_BASE_URL = "https://runner.evalops.dev";
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_ATTEMPTS = 2;
+
+const CREATE_RUNNER_SESSION_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.remoteRunner.createRunnerSession,
+);
+const GET_RUNNER_SESSION_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.remoteRunner.getRunnerSession,
+);
+const LIST_RUNNER_SESSIONS_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.remoteRunner.listRunnerSessions,
+);
+const STOP_RUNNER_SESSION_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.remoteRunner.stopRunnerSession,
+);
+const EXTEND_RUNNER_SESSION_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.remoteRunner.extendRunnerSession,
+);
+const MINT_ATTACH_TOKEN_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.remoteRunner.mintAttachToken,
+);
+const REVOKE_ATTACH_TOKEN_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.remoteRunner.revokeAttachToken,
+);
+const LIST_RUNNER_SESSION_EVENTS_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.remoteRunner.listRunnerSessionEvents,
+);
+const GET_REMOTE_RUNNER_STATUS_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.remoteRunner.getStatus,
+);
+
+export const RUNNER_SESSION_STATES = {
+	UNSPECIFIED: "RUNNER_SESSION_STATE_UNSPECIFIED",
+	REQUESTED: "RUNNER_SESSION_STATE_REQUESTED",
+	PROVISIONING: "RUNNER_SESSION_STATE_PROVISIONING",
+	RUNNING: "RUNNER_SESSION_STATE_RUNNING",
+	IDLE: "RUNNER_SESSION_STATE_IDLE",
+	STOPPING: "RUNNER_SESSION_STATE_STOPPING",
+	STOPPED: "RUNNER_SESSION_STATE_STOPPED",
+	EXPIRED: "RUNNER_SESSION_STATE_EXPIRED",
+	FAILED: "RUNNER_SESSION_STATE_FAILED",
+	LOST: "RUNNER_SESSION_STATE_LOST",
+} as const;
+
+export type RunnerSessionState =
+	(typeof RUNNER_SESSION_STATES)[keyof typeof RUNNER_SESSION_STATES];
+
+export const RUNNER_ATTACH_ROLES = {
+	UNSPECIFIED: "RUNNER_ATTACH_ROLE_UNSPECIFIED",
+	VIEWER: "RUNNER_ATTACH_ROLE_VIEWER",
+	CONTROLLER: "RUNNER_ATTACH_ROLE_CONTROLLER",
+	ADMIN: "RUNNER_ATTACH_ROLE_ADMIN",
+} as const;
+
+export type RunnerAttachRole =
+	(typeof RUNNER_ATTACH_ROLES)[keyof typeof RUNNER_ATTACH_ROLES];
+
+const REMOTE_RUNNER_BASE_URL_ENV_VARS = [
+	"MAESTRO_REMOTE_RUNNER_URL",
+	"REMOTE_RUNNER_SERVICE_URL",
+	"EVALOPS_REMOTE_RUNNER_URL",
+] as const;
+
+const REMOTE_RUNNER_TOKEN_ENV_VARS = [
+	"MAESTRO_REMOTE_RUNNER_TOKEN",
+	"REMOTE_RUNNER_SERVICE_TOKEN",
+	"MAESTRO_EVALOPS_ACCESS_TOKEN",
+	"EVALOPS_TOKEN",
+] as const;
+
+const REMOTE_RUNNER_ORGANIZATION_ENV_VARS = [
+	"MAESTRO_REMOTE_RUNNER_ORG_ID",
+	"REMOTE_RUNNER_ORGANIZATION_ID",
+	"MAESTRO_EVALOPS_ORG_ID",
+	"EVALOPS_ORGANIZATION_ID",
+	"MAESTRO_ENTERPRISE_ORG_ID",
+] as const;
+
+const REMOTE_RUNNER_WORKSPACE_ENV_VARS = [
+	"MAESTRO_REMOTE_RUNNER_WORKSPACE_ID",
+	"REMOTE_RUNNER_WORKSPACE_ID",
+	"MAESTRO_WORKSPACE_ID",
+	"EVALOPS_WORKSPACE_ID",
+] as const;
+
+const REMOTE_RUNNER_TIMEOUT_ENV_VARS = [
+	"MAESTRO_REMOTE_RUNNER_TIMEOUT_MS",
+	"REMOTE_RUNNER_SERVICE_TIMEOUT_MS",
+] as const;
+
+const REMOTE_RUNNER_MAX_ATTEMPTS_ENV_VARS = [
+	"MAESTRO_REMOTE_RUNNER_MAX_ATTEMPTS",
+	"REMOTE_RUNNER_SERVICE_MAX_ATTEMPTS",
+] as const;
+
+const REMOTE_RUNNER_BASE_URL_SUFFIXES = [
+	CREATE_RUNNER_SESSION_PATH,
+	GET_RUNNER_SESSION_PATH,
+	LIST_RUNNER_SESSIONS_PATH,
+	STOP_RUNNER_SESSION_PATH,
+	EXTEND_RUNNER_SESSION_PATH,
+	MINT_ATTACH_TOKEN_PATH,
+	REVOKE_ATTACH_TOKEN_PATH,
+	LIST_RUNNER_SESSION_EVENTS_PATH,
+	GET_REMOTE_RUNNER_STATUS_PATH,
+	platformConnectServicePath(PLATFORM_CONNECT_SERVICES.remoteRunner),
+	"/v1/runner-sessions",
+	"/v1/runner-sessions/",
+] as const;
+
+export interface RemoteRunnerServiceConfig extends PlatformServiceConfig {
+	organizationId: string;
+	token: string;
+}
+
+export interface RemoteRunnerClientOptions {
+	baseUrl?: string;
+	token?: string;
+	organizationId?: string;
+	workspaceId?: string;
+	timeoutMs?: number;
+	maxAttempts?: number;
+}
+
+export interface RunnerSession {
+	id: string;
+	organizationId?: string;
+	workspaceId?: string;
+	userId?: string;
+	agentRunId?: string;
+	maestroSessionId?: string;
+	state?: RunnerSessionState | string;
+	runnerProfile?: string;
+	runnerImage?: string;
+	workspaceSource?: string;
+	repoUrl?: string;
+	branch?: string;
+	model?: string;
+	ownerInstanceId?: string;
+	runnerPodNamespace?: string;
+	runnerPodName?: string;
+	runnerServiceName?: string;
+	createdAt?: string;
+	startedAt?: string;
+	expiresAt?: string;
+	idleExpiresAt?: string;
+	stoppedAt?: string;
+	stopReason?: string;
+	lastHeartbeatAt?: string;
+	usedRunnerSeconds?: number;
+	usedIdleSeconds?: number;
+	estimatedCostMicros?: number;
+	metadata?: Record<string, unknown>;
+}
+
+export interface RunnerSessionEvent {
+	id?: string;
+	sessionId?: string;
+	sequence?: number;
+	eventType?: string;
+	occurredAt?: string;
+	payload?: Record<string, unknown>;
+}
+
+export interface RunnerAttachToken {
+	id: string;
+	sessionId?: string;
+	subjectId?: string;
+	roles?: Array<RunnerAttachRole | string>;
+	createdAt?: string;
+	expiresAt?: string;
+	revokedAt?: string;
+}
+
+export interface CreateRunnerSessionInput {
+	workspaceId?: string;
+	userId?: string;
+	agentRunId?: string;
+	maestroSessionId?: string;
+	idempotencyKey?: string;
+	runnerProfile: string;
+	runnerImage?: string;
+	workspaceSource?: string;
+	repoUrl?: string;
+	branch?: string;
+	model?: string;
+	ttlMinutes: number;
+	idleTtlMinutes?: number;
+	metadata?: Record<string, unknown>;
+}
+
+export interface ListRunnerSessionsInput {
+	workspaceId?: string;
+	state?: RunnerSessionState | string;
+	limit?: number;
+	offset?: number;
+}
+
+export interface ExtendRunnerSessionInput {
+	sessionId: string;
+	additionalMinutes: number;
+	additionalIdleMinutes?: number;
+	reason?: string;
+}
+
+export interface MintAttachTokenInput {
+	sessionId: string;
+	subjectId?: string;
+	roles?: Array<RunnerAttachRole | string>;
+	ttlMinutes?: number;
+}
+
+export interface RevokeAttachTokenInput {
+	sessionId: string;
+	tokenId: string;
+}
+
+export interface ListRunnerSessionEventsInput {
+	sessionId: string;
+	afterSequence?: number;
+	limit?: number;
+}
+
+export interface RemoteRunnerStatus {
+	service?: string;
+	workspaceId?: string;
+	downstreamPolicy?: string;
+}
+
+function firstString(
+	record: Record<string, unknown> | undefined,
+	...names: string[]
+): string | undefined {
+	for (const name of names) {
+		const value = record?.[name];
+		if (typeof value === "string" && value.trim().length > 0) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function firstNumber(
+	record: Record<string, unknown> | undefined,
+	...names: string[]
+): number | undefined {
+	for (const name of names) {
+		const value = record?.[name];
+		if (typeof value === "number" && Number.isFinite(value)) {
+			return value;
+		}
+		if (typeof value === "string") {
+			const parsed = Number(value);
+			if (Number.isFinite(parsed)) {
+				return parsed;
+			}
+		}
+	}
+	return undefined;
+}
+
+function firstRecord(
+	record: Record<string, unknown> | undefined,
+	...names: string[]
+): Record<string, unknown> | undefined {
+	for (const name of names) {
+		const value = record?.[name];
+		if (value && typeof value === "object" && !Array.isArray(value)) {
+			return value as Record<string, unknown>;
+		}
+	}
+	return undefined;
+}
+
+function firstArray(
+	record: Record<string, unknown> | undefined,
+	...names: string[]
+): unknown[] | undefined {
+	for (const name of names) {
+		const value = record?.[name];
+		if (Array.isArray(value)) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function stripUndefinedValues(
+	body: Record<string, unknown>,
+): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(body).filter((entry): entry is [string, unknown] => {
+			return entry[1] !== undefined;
+		}),
+	);
+}
+
+function normalizeRunnerSession(value: unknown): RunnerSession | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	const id = firstString(record, "id");
+	if (!id) {
+		return undefined;
+	}
+	return {
+		id,
+		organizationId: firstString(record, "organizationId", "organization_id"),
+		workspaceId: firstString(record, "workspaceId", "workspace_id"),
+		userId: firstString(record, "userId", "user_id"),
+		agentRunId: firstString(record, "agentRunId", "agent_run_id"),
+		maestroSessionId: firstString(
+			record,
+			"maestroSessionId",
+			"maestro_session_id",
+		),
+		state: firstString(record, "state"),
+		runnerProfile: firstString(record, "runnerProfile", "runner_profile"),
+		runnerImage: firstString(record, "runnerImage", "runner_image"),
+		workspaceSource: firstString(record, "workspaceSource", "workspace_source"),
+		repoUrl: firstString(record, "repoUrl", "repo_url"),
+		branch: firstString(record, "branch"),
+		model: firstString(record, "model"),
+		ownerInstanceId: firstString(
+			record,
+			"ownerInstanceId",
+			"owner_instance_id",
+		),
+		runnerPodNamespace: firstString(
+			record,
+			"runnerPodNamespace",
+			"runner_pod_namespace",
+		),
+		runnerPodName: firstString(record, "runnerPodName", "runner_pod_name"),
+		runnerServiceName: firstString(
+			record,
+			"runnerServiceName",
+			"runner_service_name",
+		),
+		createdAt: firstString(record, "createdAt", "created_at"),
+		startedAt: firstString(record, "startedAt", "started_at"),
+		expiresAt: firstString(record, "expiresAt", "expires_at"),
+		idleExpiresAt: firstString(record, "idleExpiresAt", "idle_expires_at"),
+		stoppedAt: firstString(record, "stoppedAt", "stopped_at"),
+		stopReason: firstString(record, "stopReason", "stop_reason"),
+		lastHeartbeatAt: firstString(
+			record,
+			"lastHeartbeatAt",
+			"last_heartbeat_at",
+		),
+		usedRunnerSeconds: firstNumber(
+			record,
+			"usedRunnerSeconds",
+			"used_runner_seconds",
+		),
+		usedIdleSeconds: firstNumber(
+			record,
+			"usedIdleSeconds",
+			"used_idle_seconds",
+		),
+		estimatedCostMicros: firstNumber(
+			record,
+			"estimatedCostMicros",
+			"estimated_cost_micros",
+		),
+		metadata: firstRecord(record, "metadata"),
+	};
+}
+
+function normalizeRunnerSessionEvent(
+	value: unknown,
+): RunnerSessionEvent | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	return {
+		id: firstString(record, "id"),
+		sessionId: firstString(record, "sessionId", "session_id"),
+		sequence: firstNumber(record, "sequence"),
+		eventType: firstString(record, "eventType", "event_type"),
+		occurredAt: firstString(record, "occurredAt", "occurred_at"),
+		payload: firstRecord(record, "payload"),
+	};
+}
+
+function normalizeRunnerAttachToken(
+	value: unknown,
+): RunnerAttachToken | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	const id = firstString(record, "id");
+	if (!id) {
+		return undefined;
+	}
+	return {
+		id,
+		sessionId: firstString(record, "sessionId", "session_id"),
+		subjectId: firstString(record, "subjectId", "subject_id"),
+		roles: firstArray(record, "roles")?.filter(
+			(value): value is RunnerAttachRole | string => typeof value === "string",
+		),
+		createdAt: firstString(record, "createdAt", "created_at"),
+		expiresAt: firstString(record, "expiresAt", "expires_at"),
+		revokedAt: firstString(record, "revokedAt", "revoked_at"),
+	};
+}
+
+function requireSession(
+	payload: Record<string, unknown>,
+	serviceName: string,
+): RunnerSession {
+	const session = normalizeRunnerSession(payload.session);
+	if (!session) {
+		throw new Error(`${serviceName} returned no runner session`);
+	}
+	return session;
+}
+
+function requireAttachToken(
+	payload: Record<string, unknown>,
+	serviceName: string,
+): RunnerAttachToken {
+	const token = normalizeRunnerAttachToken(payload.token);
+	if (!token) {
+		throw new Error(`${serviceName} returned no attach token`);
+	}
+	return token;
+}
+
+function ensurePositiveMinutes(
+	value: number,
+	field: string,
+	max = 1440,
+): number {
+	if (!Number.isInteger(value) || value < 1 || value > max) {
+		throw new Error(`${field} must be an integer between 1 and ${max}`);
+	}
+	return value;
+}
+
+function ensureNonNegativeMinutes(
+	value: number | undefined,
+	field: string,
+	max = 1440,
+): number | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (!Number.isInteger(value) || value < 0 || value > max) {
+		throw new Error(`${field} must be an integer between 0 and ${max}`);
+	}
+	return value;
+}
+
+function normalizeRole(role: RunnerAttachRole | string): RunnerAttachRole {
+	const normalized = role
+		.trim()
+		.toUpperCase()
+		.replace(/^RUNNER_ATTACH_ROLE_/u, "");
+	const matched =
+		RUNNER_ATTACH_ROLES[normalized as keyof typeof RUNNER_ATTACH_ROLES];
+	if (!matched || matched === RUNNER_ATTACH_ROLES.UNSPECIFIED) {
+		throw new Error(`Unknown runner attach role: ${role}`);
+	}
+	return matched;
+}
+
+function normalizeState(
+	state: RunnerSessionState | string,
+): RunnerSessionState {
+	const normalized = state
+		.trim()
+		.toUpperCase()
+		.replace(/^RUNNER_SESSION_STATE_/u, "");
+	const matched =
+		RUNNER_SESSION_STATES[normalized as keyof typeof RUNNER_SESSION_STATES];
+	if (!matched || matched === RUNNER_SESSION_STATES.UNSPECIFIED) {
+		throw new Error(`Unknown runner session state: ${state}`);
+	}
+	return matched;
+}
+
+function normalizeConfig(
+	config: PlatformServiceConfig,
+	overrides: RemoteRunnerClientOptions,
+): RemoteRunnerServiceConfig | null {
+	const organizationId = trimString(
+		overrides.organizationId ?? config.organizationId,
+	);
+	const token = trimString(overrides.token ?? config.token);
+	if (!organizationId || !token) {
+		return null;
+	}
+	const explicitBaseUrl = trimString(overrides.baseUrl ?? config.baseUrl);
+	const baseUrl = normalizeBaseUrl(
+		explicitBaseUrl ?? DEFAULT_REMOTE_RUNNER_BASE_URL,
+		REMOTE_RUNNER_BASE_URL_SUFFIXES,
+	);
+	return {
+		...config,
+		baseUrl,
+		token,
+		organizationId,
+		workspaceId: trimString(overrides.workspaceId ?? config.workspaceId),
+		timeoutMs: overrides.timeoutMs ?? config.timeoutMs,
+		maxAttempts: overrides.maxAttempts ?? config.maxAttempts,
+	};
+}
+
+export async function resolveRemoteRunnerConfig(
+	overrides: RemoteRunnerClientOptions = {},
+): Promise<RemoteRunnerServiceConfig | null> {
+	const config = await resolvePlatformServiceConfig({
+		baseUrlEnvVars: REMOTE_RUNNER_BASE_URL_ENV_VARS,
+		tokenEnvVars: REMOTE_RUNNER_TOKEN_ENV_VARS,
+		organizationEnvVars: REMOTE_RUNNER_ORGANIZATION_ENV_VARS,
+		workspaceEnvVars: REMOTE_RUNNER_WORKSPACE_ENV_VARS,
+		timeoutEnvVars: REMOTE_RUNNER_TIMEOUT_ENV_VARS,
+		maxAttemptsEnvVars: REMOTE_RUNNER_MAX_ATTEMPTS_ENV_VARS,
+		baseUrlSuffixes: REMOTE_RUNNER_BASE_URL_SUFFIXES,
+		defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+		defaultMaxAttempts: DEFAULT_MAX_ATTEMPTS,
+		requireBaseUrl: false,
+		requireOrganizationId: true,
+		requireToken: true,
+	});
+	if (!config) {
+		return null;
+	}
+	return normalizeConfig(config, overrides);
+}
+
+export function hasRemoteRunnerDestination(): boolean {
+	const organizationId = getEnvValue(REMOTE_RUNNER_ORGANIZATION_ENV_VARS);
+	const token = getEnvValue(REMOTE_RUNNER_TOKEN_ENV_VARS);
+	return Boolean(organizationId && token);
+}
+
+export function remoteRunnerGatewayBaseUrl(
+	config: Pick<RemoteRunnerServiceConfig, "baseUrl">,
+	sessionId: string,
+): string {
+	return `${config.baseUrl}/v1/runner-sessions/${encodeURIComponent(
+		sessionId,
+	)}/headless`;
+}
+
+async function postRemoteRunner<T>(
+	config: RemoteRunnerServiceConfig,
+	path: string,
+	body: Record<string, unknown>,
+	normalize: (payload: Record<string, unknown>) => T,
+): Promise<T> {
+	const response = await postPlatformConnect(
+		config,
+		path,
+		stripUndefinedValues(body),
+		{
+			serviceName: "remote runner service",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`remote runner service returned ${response.status}: ${
+				text || response.statusText
+			}`,
+		);
+	}
+	const text = await response.text();
+	if (!text.trim()) {
+		throw new Error("remote runner service returned empty response");
+	}
+	return normalize(JSON.parse(text) as Record<string, unknown>);
+}
+
+async function requireRemoteRunnerConfig(
+	overrides: RemoteRunnerClientOptions,
+): Promise<RemoteRunnerServiceConfig> {
+	const config = await resolveRemoteRunnerConfig(overrides);
+	if (!config) {
+		throw new Error(
+			"Remote runner requires EvalOps organization and access token. Set MAESTRO_REMOTE_RUNNER_ORG_ID/MAESTRO_EVALOPS_ORG_ID and MAESTRO_REMOTE_RUNNER_TOKEN/MAESTRO_EVALOPS_ACCESS_TOKEN, or run EvalOps login.",
+		);
+	}
+	return config;
+}
+
+export async function createRunnerSession(
+	input: CreateRunnerSessionInput,
+	options: RemoteRunnerClientOptions = {},
+): Promise<{
+	session: RunnerSession;
+	events: RunnerSessionEvent[];
+	replayed: boolean;
+}> {
+	const config = await requireRemoteRunnerConfig(options);
+	const workspaceId = trimString(input.workspaceId ?? config.workspaceId);
+	if (!workspaceId) {
+		throw new Error(
+			"Remote runner start requires a workspace id. Pass --workspace or set MAESTRO_REMOTE_RUNNER_WORKSPACE_ID.",
+		);
+	}
+	const ttlMinutes = ensurePositiveMinutes(input.ttlMinutes, "ttlMinutes");
+	const idleTtlMinutes = ensureNonNegativeMinutes(
+		input.idleTtlMinutes,
+		"idleTtlMinutes",
+	);
+	return postRemoteRunner(
+		config,
+		CREATE_RUNNER_SESSION_PATH,
+		{
+			organizationId: config.organizationId,
+			workspaceId,
+			userId: trimString(input.userId),
+			agentRunId: trimString(input.agentRunId),
+			maestroSessionId: trimString(input.maestroSessionId),
+			idempotencyKey: trimString(input.idempotencyKey) ?? randomUUID(),
+			runnerProfile: trimString(input.runnerProfile),
+			runnerImage: trimString(input.runnerImage),
+			workspaceSource: trimString(input.workspaceSource),
+			repoUrl: trimString(input.repoUrl),
+			branch: trimString(input.branch),
+			model: trimString(input.model),
+			ttlMinutes,
+			idleTtlMinutes,
+			metadata: input.metadata,
+		},
+		(payload) => ({
+			session: requireSession(payload, "remote runner service"),
+			events:
+				firstArray(payload, "events")
+					?.map(normalizeRunnerSessionEvent)
+					.filter((event): event is RunnerSessionEvent => Boolean(event)) ?? [],
+			replayed: payload.replayed === true,
+		}),
+	);
+}
+
+export async function getRunnerSession(
+	sessionId: string,
+	options: RemoteRunnerClientOptions = {},
+): Promise<RunnerSession> {
+	const config = await requireRemoteRunnerConfig(options);
+	return postRemoteRunner(
+		config,
+		GET_RUNNER_SESSION_PATH,
+		{ sessionId: trimString(sessionId) },
+		(payload) => requireSession(payload, "remote runner service"),
+	);
+}
+
+export async function listRunnerSessions(
+	input: ListRunnerSessionsInput = {},
+	options: RemoteRunnerClientOptions = {},
+): Promise<{ sessions: RunnerSession[]; nextOffset?: number }> {
+	const config = await requireRemoteRunnerConfig(options);
+	const workspaceId = trimString(input.workspaceId ?? config.workspaceId);
+	if (!workspaceId) {
+		throw new Error(
+			"Remote runner list requires a workspace id. Pass --workspace or set MAESTRO_REMOTE_RUNNER_WORKSPACE_ID.",
+		);
+	}
+	return postRemoteRunner(
+		config,
+		LIST_RUNNER_SESSIONS_PATH,
+		{
+			organizationId: config.organizationId,
+			workspaceId,
+			state: input.state ? normalizeState(input.state) : undefined,
+			limit: input.limit,
+			offset: input.offset,
+		},
+		(payload) => ({
+			sessions:
+				firstArray(payload, "sessions")
+					?.map(normalizeRunnerSession)
+					.filter((session): session is RunnerSession => Boolean(session)) ??
+				[],
+			nextOffset: firstNumber(payload, "nextOffset", "next_offset"),
+		}),
+	);
+}
+
+export async function stopRunnerSession(
+	sessionId: string,
+	reason?: string,
+	options: RemoteRunnerClientOptions = {},
+): Promise<{ session: RunnerSession; event?: RunnerSessionEvent }> {
+	const config = await requireRemoteRunnerConfig(options);
+	return postRemoteRunner(
+		config,
+		STOP_RUNNER_SESSION_PATH,
+		{ sessionId: trimString(sessionId), reason: trimString(reason) },
+		(payload) => ({
+			session: requireSession(payload, "remote runner service"),
+			event: normalizeRunnerSessionEvent(payload.event),
+		}),
+	);
+}
+
+export async function extendRunnerSession(
+	input: ExtendRunnerSessionInput,
+	options: RemoteRunnerClientOptions = {},
+): Promise<{ session: RunnerSession; event?: RunnerSessionEvent }> {
+	const config = await requireRemoteRunnerConfig(options);
+	return postRemoteRunner(
+		config,
+		EXTEND_RUNNER_SESSION_PATH,
+		{
+			sessionId: trimString(input.sessionId),
+			additionalMinutes: ensurePositiveMinutes(
+				input.additionalMinutes,
+				"additionalMinutes",
+			),
+			additionalIdleMinutes: ensureNonNegativeMinutes(
+				input.additionalIdleMinutes,
+				"additionalIdleMinutes",
+			),
+			reason: trimString(input.reason),
+		},
+		(payload) => ({
+			session: requireSession(payload, "remote runner service"),
+			event: normalizeRunnerSessionEvent(payload.event),
+		}),
+	);
+}
+
+export async function mintRunnerAttachToken(
+	input: MintAttachTokenInput,
+	options: RemoteRunnerClientOptions = {},
+): Promise<{
+	token: RunnerAttachToken;
+	tokenSecret: string;
+	gatewayBaseUrl: string;
+}> {
+	const config = await requireRemoteRunnerConfig(options);
+	const sessionId = trimString(input.sessionId);
+	if (!sessionId) {
+		throw new Error("Attach token requires a runner session id");
+	}
+	const roles = (
+		input.roles?.length ? input.roles : [RUNNER_ATTACH_ROLES.CONTROLLER]
+	).map(normalizeRole);
+	const ttlMinutes = ensureNonNegativeMinutes(
+		input.ttlMinutes ?? 30,
+		"ttlMinutes",
+		60,
+	);
+	const result = await postRemoteRunner(
+		config,
+		MINT_ATTACH_TOKEN_PATH,
+		{
+			sessionId,
+			subjectId: trimString(input.subjectId),
+			roles,
+			ttlMinutes,
+		},
+		(payload) => {
+			const tokenSecret = firstString(payload, "tokenSecret", "token_secret");
+			if (!tokenSecret) {
+				throw new Error(
+					"remote runner service returned no attach token secret",
+				);
+			}
+			return {
+				token: requireAttachToken(payload, "remote runner service"),
+				tokenSecret,
+			};
+		},
+	);
+	return {
+		...result,
+		gatewayBaseUrl: remoteRunnerGatewayBaseUrl(config, sessionId),
+	};
+}
+
+export async function revokeRunnerAttachToken(
+	input: RevokeAttachTokenInput,
+	options: RemoteRunnerClientOptions = {},
+): Promise<{ token: RunnerAttachToken; event?: RunnerSessionEvent }> {
+	const config = await requireRemoteRunnerConfig(options);
+	return postRemoteRunner(
+		config,
+		REVOKE_ATTACH_TOKEN_PATH,
+		{
+			sessionId: trimString(input.sessionId),
+			tokenId: trimString(input.tokenId),
+		},
+		(payload) => ({
+			token: requireAttachToken(payload, "remote runner service"),
+			event: normalizeRunnerSessionEvent(payload.event),
+		}),
+	);
+}
+
+export async function listRunnerSessionEvents(
+	input: ListRunnerSessionEventsInput,
+	options: RemoteRunnerClientOptions = {},
+): Promise<{ events: RunnerSessionEvent[]; nextSequence?: number }> {
+	const config = await requireRemoteRunnerConfig(options);
+	return postRemoteRunner(
+		config,
+		LIST_RUNNER_SESSION_EVENTS_PATH,
+		{
+			sessionId: trimString(input.sessionId),
+			afterSequence: input.afterSequence,
+			limit: input.limit,
+		},
+		(payload) => ({
+			events:
+				firstArray(payload, "events")
+					?.map(normalizeRunnerSessionEvent)
+					.filter((event): event is RunnerSessionEvent => Boolean(event)) ?? [],
+			nextSequence: firstNumber(payload, "nextSequence", "next_sequence"),
+		}),
+	);
+}
+
+export async function getRemoteRunnerStatus(
+	workspaceId?: string,
+	options: RemoteRunnerClientOptions = {},
+): Promise<RemoteRunnerStatus> {
+	const config = await requireRemoteRunnerConfig(options);
+	const resolvedWorkspaceId = trimString(workspaceId ?? config.workspaceId);
+	if (!resolvedWorkspaceId) {
+		throw new Error(
+			"Remote runner status requires a workspace id. Pass --workspace or set MAESTRO_REMOTE_RUNNER_WORKSPACE_ID.",
+		);
+	}
+	return postRemoteRunner(
+		config,
+		GET_REMOTE_RUNNER_STATUS_PATH,
+		{
+			workspaceId: resolvedWorkspaceId,
+		},
+		(payload) => ({
+			service: firstString(payload, "service"),
+			workspaceId: firstString(payload, "workspaceId", "workspace_id"),
+			downstreamPolicy: firstString(
+				payload,
+				"downstreamPolicy",
+				"downstream_policy",
+			),
+		}),
+	);
+}
+
+export async function verifyRunnerHeadlessAttach(input: {
+	gatewayBaseUrl: string;
+	tokenId: string;
+	tokenSecret: string;
+	sessionId: string;
+	protocolVersion: string;
+	clientVersion?: string;
+	takeControl?: boolean;
+	timeoutMs?: number;
+}): Promise<{
+	sessionId?: string;
+	connectionId?: string;
+	heartbeatIntervalMs?: number;
+	role?: string;
+}> {
+	const headers = {
+		Authorization: `Bearer ${input.tokenSecret}`,
+		"Content-Type": "application/json",
+		Accept: "application/json",
+		"X-EvalOps-Runner-Attach-Token-Id": input.tokenId,
+	};
+	const body = {
+		sessionId: input.sessionId,
+		protocolVersion: input.protocolVersion,
+		clientInfo: {
+			name: "maestro-remote-cli",
+			version: input.clientVersion,
+		},
+		role: "controller",
+		takeControl: input.takeControl ?? false,
+		optOutNotifications: ["heartbeat"],
+		capabilities: {
+			serverRequests: ["approval", "user_input", "tool_retry"],
+			utilityOperations: [
+				"command_exec",
+				"file_search",
+				"file_read",
+				"file_watch",
+			],
+		},
+	};
+	const response = await fetchWithRetry(
+		`${input.gatewayBaseUrl}/api/headless/connections`,
+		{
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+		},
+		{
+			serviceName: "remote runner headless gateway",
+			timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+			maxAttempts: 1,
+		},
+	);
+	const text = await response.text();
+	if (!response.ok) {
+		throw new Error(
+			`remote runner headless gateway returned ${response.status}: ${
+				text || response.statusText
+			}`,
+		);
+	}
+	const payload = text.trim()
+		? (JSON.parse(text) as Record<string, unknown>)
+		: {};
+	const connectionId = firstString(payload, "connection_id", "connectionId");
+	const runtimeSessionId = firstString(payload, "session_id", "sessionId");
+	if (connectionId || runtimeSessionId) {
+		void fetchWithRetry(
+			`${input.gatewayBaseUrl}/api/headless/sessions/${encodeURIComponent(
+				runtimeSessionId ?? input.sessionId,
+			)}/disconnect`,
+			{
+				method: "POST",
+				headers,
+				body: JSON.stringify({ connectionId }),
+			},
+			{
+				serviceName: "remote runner headless gateway",
+				timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+				maxAttempts: 1,
+			},
+		).catch(() => undefined);
+	}
+	return {
+		sessionId: runtimeSessionId,
+		connectionId,
+		heartbeatIntervalMs: firstNumber(
+			payload,
+			"heartbeat_interval_ms",
+			"heartbeatIntervalMs",
+		),
+		role: firstString(payload, "role"),
+	};
+}

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -65,4 +65,23 @@ describe("parseArgs", () => {
 			messages: ["./session.jsonl"],
 		});
 	});
+
+	it("preserves remote command-group arguments for the remote handler", () => {
+		expect(
+			parseArgs([
+				"remote",
+				"start",
+				"--workspace",
+				"ws_123",
+				"--repo",
+				"evalops/foo",
+				"--json",
+			]),
+		).toMatchObject({
+			command: "remote",
+			subcommand: "start",
+			commandArgs: ["--workspace", "ws_123", "--repo", "evalops/foo", "--json"],
+			messages: [],
+		});
+	});
 });

--- a/test/cli/remote-command.test.ts
+++ b/test/cli/remote-command.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { parseRemoteDurationMinutes } from "../../src/cli/commands/remote.js";
+
+describe("remote command helpers", () => {
+	it("parses runner TTL values as whole minutes", () => {
+		expect(parseRemoteDurationMinutes("90m", 1)).toBe(90);
+		expect(parseRemoteDurationMinutes("2h", 1)).toBe(120);
+		expect(parseRemoteDurationMinutes("45", 1)).toBe(45);
+		expect(parseRemoteDurationMinutes(undefined, 30)).toBe(30);
+	});
+
+	it("rejects sub-minute or fractional-minute TTL values", () => {
+		expect(() => parseRemoteDurationMinutes("1.5m", 1)).toThrow(
+			"whole minutes",
+		);
+		expect(() => parseRemoteDurationMinutes("soon", 1)).toThrow(
+			"Invalid duration",
+		);
+	});
+});

--- a/test/platform/core-services.test.ts
+++ b/test/platform/core-services.test.ts
@@ -51,6 +51,21 @@ describe("Platform core service contract names", () => {
 				PLATFORM_CONNECT_METHODS.llmGateway.createMessage,
 			),
 		).toBe("/llmgateway.v1.GatewayService/CreateMessage");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.remoteRunner.createRunnerSession,
+			),
+		).toBe("/remoterunner.v1.RemoteRunnerService/CreateRunnerSession");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.remoteRunner.mintAttachToken,
+			),
+		).toBe("/remoterunner.v1.RemoteRunnerService/MintAttachToken");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.remoteRunner.getStatus,
+			),
+		).toBe("/remoterunner.v1.RemoteRunnerService/GetStatus");
 	});
 
 	it("keeps durable memory on the existing HTTP JSON route", () => {

--- a/test/remote-runner/client.test.ts
+++ b/test/remote-runner/client.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	RUNNER_ATTACH_ROLES,
+	RUNNER_SESSION_STATES,
+	createRunnerSession,
+	listRunnerSessions,
+	mintRunnerAttachToken,
+	verifyRunnerHeadlessAttach,
+} from "../../src/remote-runner/client.js";
+
+type CapturedRequest = {
+	body?: Record<string, unknown>;
+	headers: Record<string, string>;
+	method?: string;
+	pathname: string;
+	url: string;
+};
+
+function headersToRecord(
+	headers: HeadersInit | undefined,
+): Record<string, string> {
+	return Object.fromEntries(new Headers(headers).entries());
+}
+
+function parseRequestBody(
+	body: BodyInit | null | undefined,
+): Record<string, unknown> | undefined {
+	return typeof body === "string"
+		? (JSON.parse(body) as Record<string, unknown>)
+		: undefined;
+}
+
+describe("remote runner client", () => {
+	let requests: CapturedRequest[];
+
+	beforeEach(() => {
+		requests = [];
+		for (const name of [
+			"MAESTRO_REMOTE_RUNNER_URL",
+			"REMOTE_RUNNER_SERVICE_URL",
+			"EVALOPS_REMOTE_RUNNER_URL",
+			"MAESTRO_PLATFORM_BASE_URL",
+			"MAESTRO_EVALOPS_BASE_URL",
+			"EVALOPS_BASE_URL",
+			"MAESTRO_REMOTE_RUNNER_TOKEN",
+			"REMOTE_RUNNER_SERVICE_TOKEN",
+			"MAESTRO_EVALOPS_ACCESS_TOKEN",
+			"EVALOPS_TOKEN",
+			"MAESTRO_REMOTE_RUNNER_ORG_ID",
+			"REMOTE_RUNNER_ORGANIZATION_ID",
+			"MAESTRO_EVALOPS_ORG_ID",
+			"EVALOPS_ORGANIZATION_ID",
+			"MAESTRO_ENTERPRISE_ORG_ID",
+			"MAESTRO_REMOTE_RUNNER_WORKSPACE_ID",
+			"REMOTE_RUNNER_WORKSPACE_ID",
+			"MAESTRO_WORKSPACE_ID",
+			"EVALOPS_WORKSPACE_ID",
+		]) {
+			vi.stubEnv(name, "");
+		}
+		vi.stubEnv("MAESTRO_EVALOPS_ACCESS_TOKEN", "evalops-token");
+		vi.stubEnv("MAESTRO_EVALOPS_ORG_ID", "org_evalops");
+		vi.stubEnv("MAESTRO_REMOTE_RUNNER_WORKSPACE_ID", "ws_evalops");
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				const request = {
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				};
+				requests.push(request);
+
+				if (
+					parsed.pathname ===
+					"/remoterunner.v1.RemoteRunnerService/CreateRunnerSession"
+				) {
+					return new Response(
+						JSON.stringify({
+							session: {
+								id: "mrs_create_1",
+								workspaceId: request.body?.workspaceId,
+								state: RUNNER_SESSION_STATES.REQUESTED,
+								runnerProfile: request.body?.runnerProfile,
+								repoUrl: request.body?.repoUrl,
+								branch: request.body?.branch,
+							},
+							events: [
+								{
+									id: "evt_1",
+									sessionId: "mrs_create_1",
+									sequence: 1,
+									eventType: "runner_session.requested",
+								},
+							],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (
+					parsed.pathname ===
+					"/remoterunner.v1.RemoteRunnerService/ListRunnerSessions"
+				) {
+					return new Response(
+						JSON.stringify({
+							sessions: [
+								{
+									id: "mrs_list_1",
+									workspace_id: request.body?.workspaceId,
+									state: RUNNER_SESSION_STATES.RUNNING,
+								},
+							],
+							next_offset: 2,
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (
+					parsed.pathname ===
+					"/remoterunner.v1.RemoteRunnerService/MintAttachToken"
+				) {
+					return new Response(
+						JSON.stringify({
+							token: {
+								id: "rat_1",
+								sessionId: request.body?.sessionId,
+								roles: request.body?.roles,
+								expiresAt: "2026-04-22T23:59:00Z",
+							},
+							tokenSecret: "runner-secret",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (parsed.pathname.endsWith("/api/headless/connections")) {
+					return new Response(
+						JSON.stringify({
+							session_id: "sess_runtime_1",
+							connection_id: "conn_1",
+							heartbeat_interval_ms: 30000,
+							role: "controller",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (parsed.pathname.endsWith("/disconnect")) {
+					return new Response(JSON.stringify({ success: true }), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+
+				throw new Error(`Unexpected remote runner request: ${url}`);
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+	});
+
+	it("creates runner sessions through the shared Platform Connect catalog", async () => {
+		vi.stubEnv("MAESTRO_REMOTE_RUNNER_URL", "https://runner.test/");
+
+		await expect(
+			createRunnerSession({
+				runnerProfile: "standard",
+				repoUrl: "evalops/foo",
+				branch: "main",
+				ttlMinutes: 90,
+				metadata: { source: "test" },
+			}),
+		).resolves.toMatchObject({
+			session: {
+				id: "mrs_create_1",
+				workspaceId: "ws_evalops",
+				state: RUNNER_SESSION_STATES.REQUESTED,
+			},
+			events: [{ eventType: "runner_session.requested" }],
+		});
+
+		expect(requests[0]).toMatchObject({
+			method: "POST",
+			url: "https://runner.test/remoterunner.v1.RemoteRunnerService/CreateRunnerSession",
+			headers: expect.objectContaining({
+				authorization: "Bearer evalops-token",
+				"connect-protocol-version": "1",
+				"x-organization-id": "org_evalops",
+			}),
+			body: expect.objectContaining({
+				organizationId: "org_evalops",
+				workspaceId: "ws_evalops",
+				runnerProfile: "standard",
+				repoUrl: "evalops/foo",
+				branch: "main",
+				ttlMinutes: 90,
+				metadata: { source: "test" },
+			}),
+		});
+	});
+
+	it("normalizes list filters and snake_case response fields", async () => {
+		await expect(
+			listRunnerSessions({
+				state: "running",
+				limit: 10,
+				offset: 1,
+			}),
+		).resolves.toMatchObject({
+			sessions: [
+				{
+					id: "mrs_list_1",
+					workspaceId: "ws_evalops",
+					state: RUNNER_SESSION_STATES.RUNNING,
+				},
+			],
+			nextOffset: 2,
+		});
+
+		expect(requests[0]).toMatchObject({
+			url: "https://runner.evalops.dev/remoterunner.v1.RemoteRunnerService/ListRunnerSessions",
+			body: expect.objectContaining({
+				state: RUNNER_SESSION_STATES.RUNNING,
+				limit: 10,
+				offset: 1,
+			}),
+		});
+	});
+
+	it("mints attach tokens and exposes the headless gateway target", async () => {
+		vi.stubEnv("REMOTE_RUNNER_SERVICE_URL", "https://runner.staging.test");
+
+		await expect(
+			mintRunnerAttachToken({
+				sessionId: "mrs_attach_1",
+				roles: ["viewer", RUNNER_ATTACH_ROLES.CONTROLLER],
+				ttlMinutes: 15,
+			}),
+		).resolves.toMatchObject({
+			token: {
+				id: "rat_1",
+				sessionId: "mrs_attach_1",
+				roles: [RUNNER_ATTACH_ROLES.VIEWER, RUNNER_ATTACH_ROLES.CONTROLLER],
+			},
+			tokenSecret: "runner-secret",
+			gatewayBaseUrl:
+				"https://runner.staging.test/v1/runner-sessions/mrs_attach_1/headless",
+		});
+
+		expect(requests[0]).toMatchObject({
+			body: expect.objectContaining({
+				sessionId: "mrs_attach_1",
+				roles: [RUNNER_ATTACH_ROLES.VIEWER, RUNNER_ATTACH_ROLES.CONTROLLER],
+				ttlMinutes: 15,
+			}),
+		});
+	});
+
+	it("verifies the existing headless gateway protocol with attach headers", async () => {
+		await expect(
+			verifyRunnerHeadlessAttach({
+				gatewayBaseUrl:
+					"https://runner.test/v1/runner-sessions/mrs_attach_1/headless",
+				tokenId: "rat_1",
+				tokenSecret: "runner-secret",
+				sessionId: "mrs_attach_1",
+				protocolVersion: "2026-04-02",
+			}),
+		).resolves.toMatchObject({
+			sessionId: "sess_runtime_1",
+			connectionId: "conn_1",
+			heartbeatIntervalMs: 30000,
+			role: "controller",
+		});
+
+		expect(requests[0]).toMatchObject({
+			method: "POST",
+			url: "https://runner.test/v1/runner-sessions/mrs_attach_1/headless/api/headless/connections",
+			headers: expect.objectContaining({
+				authorization: "Bearer runner-secret",
+				"x-evalops-runner-attach-token-id": "rat_1",
+			}),
+			body: expect.objectContaining({
+				sessionId: "mrs_attach_1",
+				protocolVersion: "2026-04-02",
+				role: "controller",
+			}),
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add remote-runner Connect service/method catalog entries for Maestro Platform clients
- add a typed remote-runner client for create/list/get/extend/stop/events/status/attach-token/revoke flows
- add `maestro remote` commands with raw command-group arg parsing, help text, TTL/profile/workspace/repo options, and attach gateway verification support
- cover catalog paths, command parsing, TTL parsing, lifecycle payloads, attach-token minting, and headless gateway headers in tests

Refs #82

## Verification
- `PATH=/tmp/bun-v1.3.6-darwin-aarch64/bun-darwin-aarch64:$PATH /tmp/bun-v1.3.6-darwin-aarch64/bun-darwin-aarch64/bun run build`
- `PATH=/tmp/bun-v1.3.6-darwin-aarch64/bun-darwin-aarch64:$PATH node ./scripts/run-vitest.js --run test/platform/core-services.test.ts test/cli/args.test.ts test/remote-runner/client.test.ts test/cli/remote-command.test.ts`
- `PATH=/tmp/bun-v1.3.6-darwin-aarch64/bun-darwin-aarch64:$PATH /tmp/bun-v1.3.6-darwin-aarch64/bun-darwin-aarch64/bun x biome check src/platform/core-services.ts src/remote-runner/client.ts src/cli/commands/remote.ts src/cli/args.ts src/main.ts src/cli/help.ts test/platform/core-services.test.ts test/cli/args.test.ts test/remote-runner/client.test.ts test/cli/remote-command.test.ts`
- pre-commit hook: guardian, `bunx biome check .`, `bun run lint:evals`, `bun run build`, `bun build ./dist/cli.js --compile ...`