### PR TITLE
Add hosted runner entrypoint

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -59,6 +59,7 @@ const COMMANDS = new Set([
 	"agents",
 	"exec",
 	"web",
+	"hosted-runner",
 	"anthropic",
 	"openai",
 	"hooks",
@@ -248,7 +249,7 @@ export function parseArgs(args: string[]): Args {
 					result.subcommand = nextArg;
 					i++;
 				}
-				if (arg === "remote") {
+				if (arg === "remote" || arg === "hosted-runner") {
 					result.commandArgs = args.slice(i + 1);
 					break;
 				}

--- a/src/cli/commands/hosted-runner.ts
+++ b/src/cli/commands/hosted-runner.ts
@@ -1,0 +1,297 @@
+import { realpath, stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import chalk from "chalk";
+import type { HostedRunnerContext } from "../../server/app-context.js";
+
+type HostedRunnerFlagValue = true | string;
+
+interface HostedRunnerOptions {
+	flags: Map<string, HostedRunnerFlagValue[]>;
+	positionals: string[];
+}
+
+export interface HostedRunnerConfig {
+	runnerSessionId: string;
+	workspaceRoot: string;
+	host?: string;
+	port: number;
+	workspaceId?: string;
+	agentRunId?: string;
+	maestroSessionId?: string;
+	attachAudience?: string;
+}
+
+interface HostedRunnerResolveOptions {
+	defaultPort?: number;
+}
+
+const HOSTED_RUNNER_USAGE = `maestro hosted-runner [options]
+
+Options:
+  --runner-session-id <id>  Platform remote-runner session id (required)
+  --workspace-root <path>   Workspace root mounted into the runtime pod (required)
+  --listen <host:port>      Address to bind, for example 0.0.0.0:8080
+  --host <host>             Bind host when --listen is not used
+  --port <port>             Bind port when --listen is not used
+  --workspace-id <id>       EvalOps workspace id for metadata
+  --agent-run-id <id>       Platform AgentRun id for metadata
+  --maestro-session-id <id> Existing Maestro session id for metadata
+  --attach-audience <aud>   Expected attach audience metadata
+  --help                    Show this help
+
+Environment:
+  MAESTRO_RUNNER_SESSION_ID, REMOTE_RUNNER_SESSION_ID
+  MAESTRO_WORKSPACE_ROOT
+  MAESTRO_HOSTED_RUNNER_LISTEN, MAESTRO_HOSTED_RUNNER_HOST, MAESTRO_HOSTED_RUNNER_PORT, PORT
+  MAESTRO_REMOTE_RUNNER_WORKSPACE_ID, MAESTRO_AGENT_RUN_ID, MAESTRO_SESSION_ID
+  MAESTRO_ATTACH_AUDIENCE`;
+
+function parseHostedRunnerOptions(
+	args: readonly string[],
+): HostedRunnerOptions {
+	const flags = new Map<string, HostedRunnerFlagValue[]>();
+	const positionals: string[] = [];
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (!arg) {
+			continue;
+		}
+		if (arg === "--") {
+			positionals.push(...args.slice(index + 1));
+			break;
+		}
+		if (!arg.startsWith("--")) {
+			positionals.push(arg);
+			continue;
+		}
+		const equalsIndex = arg.indexOf("=");
+		const key = equalsIndex >= 0 ? arg.slice(2, equalsIndex) : arg.slice(2);
+		const inlineValue =
+			equalsIndex >= 0 ? arg.slice(equalsIndex + 1) : undefined;
+		const next = args[index + 1];
+		const value =
+			inlineValue !== undefined
+				? inlineValue
+				: next && !next.startsWith("--")
+					? next
+					: true;
+		if (inlineValue === undefined && value !== true) {
+			index += 1;
+		}
+		const values = flags.get(key) ?? [];
+		values.push(value);
+		flags.set(key, values);
+	}
+
+	return { flags, positionals };
+}
+
+function getLastFlag(
+	options: HostedRunnerOptions,
+	key: string,
+): string | undefined {
+	const values = options.flags.get(key);
+	const value = values?.at(-1);
+	return typeof value === "string" ? value.trim() : undefined;
+}
+
+function hasFlag(options: HostedRunnerOptions, key: string): boolean {
+	return options.flags.has(key);
+}
+
+function getEnvValue(
+	env: NodeJS.ProcessEnv,
+	keys: readonly string[],
+): string | undefined {
+	for (const key of keys) {
+		const value = env[key]?.trim();
+		if (value) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function parsePort(
+	value: string | undefined,
+	label: string,
+): number | undefined {
+	if (!value) {
+		return undefined;
+	}
+	if (!/^\d+$/.test(value.trim())) {
+		throw new Error(`${label} must be a TCP port between 1 and 65535`);
+	}
+	const port = Number.parseInt(value, 10);
+	if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+		throw new Error(`${label} must be a TCP port between 1 and 65535`);
+	}
+	return port;
+}
+
+function parseListen(value: string | undefined): {
+	host?: string;
+	port?: number;
+} {
+	if (!value) {
+		return {};
+	}
+	const trimmed = value.trim();
+	if (/^\d+$/.test(trimmed)) {
+		return { port: parsePort(trimmed, "--listen") };
+	}
+	const separatorIndex = trimmed.lastIndexOf(":");
+	if (separatorIndex <= 0 || separatorIndex === trimmed.length - 1) {
+		throw new Error("--listen must be <host:port> or <port>");
+	}
+	return {
+		host: trimmed.slice(0, separatorIndex),
+		port: parsePort(trimmed.slice(separatorIndex + 1), "--listen"),
+	};
+}
+
+async function resolveWorkspaceRoot(path: string | undefined): Promise<string> {
+	if (!path) {
+		throw new Error(
+			"maestro hosted-runner requires --workspace-root or MAESTRO_WORKSPACE_ROOT",
+		);
+	}
+	const workspaceRoot = resolve(path);
+	const stats = await stat(workspaceRoot);
+	if (!stats.isDirectory()) {
+		throw new Error(`Hosted runner workspace root is not a directory: ${path}`);
+	}
+	return realpath(workspaceRoot);
+}
+
+export function formatHostedRunnerUsage(): string {
+	return HOSTED_RUNNER_USAGE;
+}
+
+export async function resolveHostedRunnerConfig(
+	args: readonly string[],
+	env: NodeJS.ProcessEnv = process.env,
+	options: HostedRunnerResolveOptions = {},
+): Promise<HostedRunnerConfig> {
+	const parsed = parseHostedRunnerOptions(args);
+	if (parsed.positionals.length > 0) {
+		throw new Error(
+			`Unexpected hosted-runner argument: ${parsed.positionals[0]}`,
+		);
+	}
+
+	const runnerSessionId =
+		getLastFlag(parsed, "runner-session-id") ??
+		getEnvValue(env, ["MAESTRO_RUNNER_SESSION_ID", "REMOTE_RUNNER_SESSION_ID"]);
+	if (!runnerSessionId) {
+		throw new Error(
+			"maestro hosted-runner requires --runner-session-id or MAESTRO_RUNNER_SESSION_ID",
+		);
+	}
+
+	const listen = parseListen(
+		getLastFlag(parsed, "listen") ?? env.MAESTRO_HOSTED_RUNNER_LISTEN,
+	);
+	const port =
+		listen.port ??
+		parsePort(getLastFlag(parsed, "port"), "--port") ??
+		parsePort(env.MAESTRO_HOSTED_RUNNER_PORT, "MAESTRO_HOSTED_RUNNER_PORT") ??
+		parsePort(env.PORT, "PORT") ??
+		options.defaultPort ??
+		8080;
+
+	return {
+		runnerSessionId,
+		workspaceRoot: await resolveWorkspaceRoot(
+			getLastFlag(parsed, "workspace-root") ??
+				getEnvValue(env, ["MAESTRO_WORKSPACE_ROOT", "WORKSPACE_ROOT"]),
+		),
+		host:
+			listen.host ??
+			getLastFlag(parsed, "host") ??
+			env.MAESTRO_HOSTED_RUNNER_HOST,
+		port,
+		workspaceId:
+			getLastFlag(parsed, "workspace-id") ??
+			getEnvValue(env, [
+				"MAESTRO_REMOTE_RUNNER_WORKSPACE_ID",
+				"MAESTRO_WORKSPACE_ID",
+			]),
+		agentRunId: getLastFlag(parsed, "agent-run-id") ?? env.MAESTRO_AGENT_RUN_ID,
+		maestroSessionId:
+			getLastFlag(parsed, "maestro-session-id") ?? env.MAESTRO_SESSION_ID,
+		attachAudience:
+			getLastFlag(parsed, "attach-audience") ?? env.MAESTRO_ATTACH_AUDIENCE,
+	};
+}
+
+export function applyHostedRunnerEnvironment(config: HostedRunnerConfig): void {
+	process.env.MAESTRO_HOSTED_RUNNER_MODE = "1";
+	process.env.MAESTRO_RUNNER_SESSION_ID = config.runnerSessionId;
+	process.env.MAESTRO_WORKSPACE_ROOT = config.workspaceRoot;
+	process.env.MAESTRO_PROFILE ??= "hosted-runner";
+	process.env.MAESTRO_WEB_REQUIRE_KEY ??= "0";
+	process.env.MAESTRO_WEB_REQUIRE_REDIS ??= "0";
+	process.env.MAESTRO_WEB_REQUIRE_CSRF ??= "0";
+	process.env.MAESTRO_AGENT_DIR ??= resolve(
+		config.workspaceRoot,
+		".maestro",
+		"agent",
+	);
+	if (config.workspaceId) {
+		process.env.MAESTRO_REMOTE_RUNNER_WORKSPACE_ID = config.workspaceId;
+	}
+	if (config.agentRunId) {
+		process.env.MAESTRO_AGENT_RUN_ID = config.agentRunId;
+	}
+	if (config.maestroSessionId) {
+		process.env.MAESTRO_SESSION_ID = config.maestroSessionId;
+	}
+	if (config.attachAudience) {
+		process.env.MAESTRO_ATTACH_AUDIENCE = config.attachAudience;
+	}
+	process.chdir(config.workspaceRoot);
+}
+
+export function toHostedRunnerContext(
+	config: HostedRunnerConfig,
+): HostedRunnerContext {
+	return {
+		enabled: true,
+		runnerSessionId: config.runnerSessionId,
+		workspaceRoot: config.workspaceRoot,
+		listenHost: config.host,
+		listenPort: config.port,
+		workspaceId: config.workspaceId,
+		agentRunId: config.agentRunId,
+		attachAudience: config.attachAudience,
+		configuredMaestroSessionId: config.maestroSessionId,
+		activeMaestroSessionId: config.maestroSessionId,
+	};
+}
+
+export async function handleHostedRunnerCommand(
+	args: readonly string[],
+	options: HostedRunnerResolveOptions = {},
+): Promise<void> {
+	const parsed = parseHostedRunnerOptions(args);
+	if (hasFlag(parsed, "help")) {
+		console.log(formatHostedRunnerUsage());
+		return;
+	}
+
+	try {
+		const config = await resolveHostedRunnerConfig(args, process.env, options);
+		applyHostedRunnerEnvironment(config);
+		const { startWebServer } = await import("../../web-server.js");
+		await startWebServer(config.port, {
+			host: config.host,
+			hostedRunner: toHostedRunnerContext(config),
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(chalk.red(message));
+		process.exit(1);
+	}
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -99,7 +99,10 @@ export function printHelp(version: string) {
   maestro import ./session.json
 
   # Start a hosted EvalOps runner session
-  maestro remote start --workspace ws_123 --repo evalops/foo --branch main --ttl 90m`,
+  maestro remote start --workspace ws_123 --repo evalops/foo --branch main --ttl 90m
+
+  # Run a single-session hosted runtime pod entrypoint
+  maestro hosted-runner --runner-session-id mrs_abc --workspace-root /workspace --listen 0.0.0.0:8080`,
 	)}`;
 	const env = `${sectionHeading("Environment Variables:")}${muted(
 		`  GEMINI_API_KEY          - Google Gemini API key
@@ -167,6 +170,12 @@ export function printHelp(version: string) {
   maestro remote extend <session-id> --ttl 2h
   maestro remote stop <session-id> [--reason <text>]`,
 	)}`;
+	const hostedRunnerSection = `${sectionHeading("maestro hosted-runner")}${muted(
+		`  maestro hosted-runner --runner-session-id <id> --workspace-root <path> [--listen 0.0.0.0:8080]
+
+  Env mode:
+    MAESTRO_RUNNER_SESSION_ID=mrs_abc MAESTRO_WORKSPACE_ROOT=/workspace maestro hosted-runner`,
+	)}`;
 	const sessionsSection = `${sectionHeading("Session Metadata")}${muted(
 		`  /session favorite|unfavorite      Toggle favorite for current session
   /session summary "<text>"         Save a manual summary for current session
@@ -212,6 +221,7 @@ export function printHelp(version: string) {
 			portabilitySection,
 			memorySection,
 			remoteSection,
+			hostedRunnerSection,
 			sessionsSection,
 			sessionsDiscovery,
 			`${sectionHeading("Tips")}${badge(

--- a/src/headless/utility-command-manager.ts
+++ b/src/headless/utility-command-manager.ts
@@ -17,6 +17,7 @@ import {
 	encodeHeadlessPtyHelperConfig,
 	getHeadlessPtyPythonCommand,
 } from "./pty-helper.js";
+import { resolveHostedWorkspacePath } from "./workspace-root.js";
 
 export interface HeadlessUtilityCommandStartRequest {
 	command_id: string;
@@ -195,12 +196,16 @@ export class HeadlessUtilityCommandManager {
 			request.cwd,
 			request.env,
 		);
+		const commandCwd =
+			resolveHostedWorkspacePath(resolvedCwd) ??
+			resolveHostedWorkspacePath(process.cwd()) ??
+			resolvedCwd;
 		const env = request.env ? { ...process.env, ...request.env } : process.env;
 
 		if (terminalMode === "pty") {
 			await this.startPtyCommand({
 				...request,
-				cwd: resolvedCwd,
+				cwd: commandCwd,
 				shell_mode: shellMode,
 				terminal_mode: terminalMode,
 				allow_stdin: allowStdin,
@@ -218,7 +223,7 @@ export class HeadlessUtilityCommandManager {
 		if (shellMode === "shell") {
 			const { shell, args } = getShellConfig();
 			child = spawn(shell, [...args, request.command], {
-				cwd: resolvedCwd,
+				cwd: commandCwd,
 				env,
 				stdio: [allowStdin ? "pipe" : "ignore", "pipe", "pipe"],
 			});
@@ -228,7 +233,7 @@ export class HeadlessUtilityCommandManager {
 				throw new Error("Command must contain an executable to run");
 			}
 			child = spawn(parsed[0]!, parsed.slice(1), {
-				cwd: resolvedCwd,
+				cwd: commandCwd,
 				env,
 				stdio: [allowStdin ? "pipe" : "ignore", "pipe", "pipe"],
 			});
@@ -237,7 +242,7 @@ export class HeadlessUtilityCommandManager {
 		const active: ActiveCommand = {
 			child,
 			command: request.command,
-			cwd: resolvedCwd,
+			cwd: commandCwd,
 			shell_mode: shellMode,
 			terminal_mode: terminalMode,
 			allow_stdin: allowStdin,
@@ -249,7 +254,7 @@ export class HeadlessUtilityCommandManager {
 			type: "started",
 			command_id: request.command_id,
 			command: request.command,
-			cwd: resolvedCwd,
+			cwd: commandCwd,
 			shell_mode: shellMode,
 			terminal_mode: terminalMode,
 			pid: child.pid ?? undefined,

--- a/src/headless/utility-file-read.ts
+++ b/src/headless/utility-file-read.ts
@@ -2,6 +2,10 @@ import { readFile } from "node:fs/promises";
 import { relative, resolve } from "node:path";
 import { isProbablyBinary } from "../utils/file-content.js";
 import { validatePath } from "../utils/path-validation.js";
+import {
+	assertWithinHostedWorkspaceRoot,
+	resolveHostedWorkspacePath,
+} from "./workspace-root.js";
 
 export interface HeadlessUtilityFileReadRequest {
 	path: string;
@@ -44,7 +48,7 @@ function toLines(text: string): string[] {
 export async function readWorkspaceFile(
 	request: HeadlessUtilityFileReadRequest,
 ): Promise<HeadlessUtilityFileReadResult> {
-	const cwd = resolve(request.cwd ?? process.cwd());
+	const cwd = resolveHostedWorkspacePath(request.cwd) ?? resolve(process.cwd());
 	const offset = Math.max(1, request.offset ?? 1);
 	const limit = Math.max(
 		1,
@@ -57,6 +61,7 @@ export async function readWorkspaceFile(
 		mustBeReadable: true,
 		maxSize: MAX_FILE_BYTES,
 	});
+	assertWithinHostedWorkspaceRoot(validatedPath);
 	const buffer = await readFile(validatedPath);
 	if (isProbablyBinary(buffer)) {
 		throw new Error(

--- a/src/headless/utility-file-search.ts
+++ b/src/headless/utility-file-search.ts
@@ -1,5 +1,6 @@
 import { basename, resolve } from "node:path";
 import { getWorkspaceFiles } from "../utils/workspace-files.js";
+import { resolveHostedWorkspacePath } from "./workspace-root.js";
 
 export interface HeadlessUtilityFileSearchRequest {
 	query: string;
@@ -92,7 +93,7 @@ function scorePathMatch(path: string, normalizedQuery: string): number {
 export function searchWorkspaceFiles(
 	request: HeadlessUtilityFileSearchRequest,
 ): HeadlessUtilityFileSearchResult {
-	const cwd = resolve(request.cwd ?? process.cwd());
+	const cwd = resolveHostedWorkspacePath(request.cwd) ?? resolve(process.cwd());
 	const query = request.query.trim();
 	const limit = Math.max(
 		1,

--- a/src/headless/utility-file-watch-manager.ts
+++ b/src/headless/utility-file-watch-manager.ts
@@ -6,6 +6,7 @@ import {
 	FileWatcher,
 	type FileWatcherConfig,
 } from "../tools/file-watcher.js";
+import { resolveHostedWorkspacePath } from "./workspace-root.js";
 
 export interface HeadlessUtilityFileWatchStartRequest {
 	watch_id: string;
@@ -121,7 +122,8 @@ export class HeadlessUtilityFileWatchManager {
 			throw new Error(`Utility file watch already exists: ${request.watch_id}`);
 		}
 
-		const rootDir = resolve(request.root_dir ?? process.cwd());
+		const rootDir =
+			resolveHostedWorkspacePath(request.root_dir) ?? resolve(process.cwd());
 		const debounceMs = Math.max(0, request.debounce_ms ?? DEFAULT_DEBOUNCE_MS);
 		if (!existsSync(rootDir)) {
 			throw new Error(

--- a/src/headless/workspace-root.ts
+++ b/src/headless/workspace-root.ts
@@ -1,0 +1,51 @@
+import { realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+function isInsidePath(parent: string, candidate: string): boolean {
+	const rel = relative(parent, candidate);
+	return rel === "" || (!rel.startsWith("..") && !rel.includes(`..${sep}`));
+}
+
+export function getHostedWorkspaceRoot(env = process.env): string | undefined {
+	if (env.MAESTRO_HOSTED_RUNNER_MODE !== "1") {
+		return undefined;
+	}
+	const root = env.MAESTRO_WORKSPACE_ROOT?.trim();
+	return root ? resolve(root) : undefined;
+}
+
+export function assertWithinHostedWorkspaceRoot(
+	path: string,
+	env = process.env,
+): string {
+	const workspaceRoot = getHostedWorkspaceRoot(env);
+	if (!workspaceRoot) {
+		return resolve(path);
+	}
+
+	const resolvedWorkspaceRoot = realpathSync(workspaceRoot);
+	const resolvedPath = realpathSync(resolve(path));
+	if (!isInsidePath(resolvedWorkspaceRoot, resolvedPath)) {
+		throw new Error(
+			`Path is outside hosted runner workspace root: ${resolvedPath}`,
+		);
+	}
+	return resolvedPath;
+}
+
+export function resolveHostedWorkspacePath(
+	path: string | undefined,
+	env = process.env,
+): string | undefined {
+	const workspaceRoot = getHostedWorkspaceRoot(env);
+	if (!workspaceRoot) {
+		return path ? resolve(path) : undefined;
+	}
+
+	const candidate = path
+		? isAbsolute(path)
+			? resolve(path)
+			: resolve(workspaceRoot, path)
+		: workspaceRoot;
+	return assertWithinHostedWorkspaceRoot(candidate, env);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -440,6 +440,18 @@ export async function main(args: string[]) {
 		process.exit(1);
 	}
 
+	// Handle `maestro hosted-runner` before importing web-server so hosted
+	// defaults are visible to its module-level runtime profile.
+	if (parsed.command === "hosted-runner") {
+		const { handleHostedRunnerCommand } = await import(
+			"./cli/commands/hosted-runner.js"
+		);
+		await handleHostedRunnerCommand(parsed.commandArgs ?? [], {
+			defaultPort: parsed.port,
+		});
+		return;
+	}
+
 	// Handle `maestro web` early exit (start the bundled web server + UI).
 	if (parsed.command === "web") {
 		if (parsed.messages.length > 0) {

--- a/src/server/app-context.ts
+++ b/src/server/app-context.ts
@@ -17,6 +17,21 @@ export interface WebServerConfig {
 	defaultApprovalMode: ApprovalMode;
 	defaultProvider: string;
 	defaultModelId: string;
+	hostedRunner?: HostedRunnerContext;
+}
+
+export interface HostedRunnerContext {
+	enabled: true;
+	runnerSessionId: string;
+	workspaceRoot: string;
+	listenHost?: string;
+	listenPort?: number;
+	workspaceId?: string;
+	agentRunId?: string;
+	attachAudience?: string;
+	configuredMaestroSessionId?: string;
+	activeMaestroSessionId?: string;
+	draining?: boolean;
 }
 
 export interface WebServerServices {

--- a/src/server/handlers/headless-sessions.ts
+++ b/src/server/handlers/headless-sessions.ts
@@ -446,7 +446,9 @@ async function ensureRuntime(
 		context,
 		sessionManager,
 	});
-	claimHostedRunnerSession(context, runtime.getSnapshot().session_id);
+	if (context.hostedRunner) {
+		claimHostedRunnerSession(context, runtime.getSnapshot().session_id);
+	}
 	return runtime;
 }
 
@@ -500,7 +502,9 @@ function getRuntime(
 	if (!runtime) {
 		throw new ApiError(404, "Headless session not found");
 	}
-	claimHostedRunnerSession(context, runtime.getSnapshot().session_id);
+	if (context.hostedRunner) {
+		claimHostedRunnerSession(context, runtime.getSnapshot().session_id);
+	}
 	return runtime;
 }
 

--- a/src/server/handlers/headless-sessions.ts
+++ b/src/server/handlers/headless-sessions.ts
@@ -277,6 +277,54 @@ function getScopeKey(req: IncomingMessage): string {
 	return getAuthSubject(req);
 }
 
+function ensureHostedRunnerCanUseSession(
+	context: WebServerContext,
+	requestedSessionId: string | undefined,
+): void {
+	const hostedRunner = context.hostedRunner;
+	if (!hostedRunner) {
+		return;
+	}
+	const activeSessionId =
+		hostedRunner.activeMaestroSessionId ??
+		hostedRunner.configuredMaestroSessionId;
+	if (!activeSessionId) {
+		return;
+	}
+	if (!requestedSessionId) {
+		throw new ApiError(
+			409,
+			`Hosted runner is already bound to Maestro session ${activeSessionId}`,
+		);
+	}
+	if (requestedSessionId !== activeSessionId) {
+		throw new ApiError(
+			409,
+			`Hosted runner is bound to Maestro session ${activeSessionId}`,
+		);
+	}
+}
+
+function claimHostedRunnerSession(
+	context: WebServerContext,
+	sessionId: string,
+): void {
+	const hostedRunner = context.hostedRunner;
+	if (!hostedRunner) {
+		return;
+	}
+	const activeSessionId =
+		hostedRunner.activeMaestroSessionId ??
+		hostedRunner.configuredMaestroSessionId;
+	if (activeSessionId && activeSessionId !== sessionId) {
+		throw new ApiError(
+			409,
+			`Hosted runner is bound to Maestro session ${activeSessionId}`,
+		);
+	}
+	hostedRunner.activeMaestroSessionId = sessionId;
+}
+
 function rethrowHeadlessMessageError(error: unknown): never {
 	if (!(error instanceof Error)) {
 		throw error;
@@ -325,6 +373,7 @@ async function ensureRuntime(
 	const sessionManager = createSessionManagerForRequest(req, false);
 	const role = getHeadlessRole(req, input.role);
 	const requestedSessionId = input.sessionId?.trim() || undefined;
+	ensureHostedRunnerCanUseSession(context, requestedSessionId);
 	if (requestedSessionId) {
 		const sessionFile = sessionManager.getSessionFileById(requestedSessionId);
 		if (!sessionFile) {
@@ -373,7 +422,7 @@ async function ensureRuntime(
 		defaultApprovalMode: context.defaultApprovalMode,
 	});
 
-	return context.headlessRuntimeService.ensureRuntime({
+	const runtime = await context.headlessRuntimeService.ensureRuntime({
 		scope_key: getScopeKey(req),
 		sessionId: requestedSessionId,
 		subject,
@@ -397,6 +446,8 @@ async function ensureRuntime(
 		context,
 		sessionManager,
 	});
+	claimHostedRunnerSession(context, runtime.getSnapshot().session_id);
+	return runtime;
 }
 
 async function ensureConnection(
@@ -449,6 +500,7 @@ function getRuntime(
 	if (!runtime) {
 		throw new ApiError(404, "Headless session not found");
 	}
+	claimHostedRunnerSession(context, runtime.getSnapshot().session_id);
 	return runtime;
 }
 

--- a/src/server/handlers/health.ts
+++ b/src/server/handlers/health.ts
@@ -1,9 +1,11 @@
+import { stat } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
 	isDatabaseConfigured,
 	isDbAvailable,
 	testConnection,
 } from "../../db/client.js";
+import type { HostedRunnerContext } from "../app-context.js";
 import { sendJson } from "../server-utils.js";
 
 export interface HealthCheckResult {
@@ -13,22 +15,80 @@ export interface HealthCheckResult {
 			status: "up" | "down" | "unconfigured";
 			latencyMs?: number;
 		};
+		hostedRunner?: {
+			status: "ready" | "draining" | "unavailable";
+			runnerSessionId: string;
+			workspaceRoot: string;
+			workspaceId?: string;
+			agentRunId?: string;
+			maestroSessionId?: string;
+			error?: string;
+		};
 	};
 	timestamp: number;
 }
+
+type HostedRunnerHealthCheck = NonNullable<
+	HealthCheckResult["checks"]["hostedRunner"]
+>;
 
 export async function handleReadyz(
 	req: IncomingMessage,
 	res: ServerResponse,
 	cors: Record<string, string>,
+	hostedRunner?: HostedRunnerContext,
 ): Promise<void> {
-	const result = await runHealthChecks();
+	const result = await runHealthChecks({ hostedRunner });
 
 	const httpStatus = result.status === "unhealthy" ? 503 : 200;
 	sendJson(res, httpStatus, result, cors, req);
 }
 
-export async function runHealthChecks(): Promise<HealthCheckResult> {
+async function checkHostedRunnerWorkspace(
+	hostedRunner: HostedRunnerContext,
+): Promise<HostedRunnerHealthCheck> {
+	const base = {
+		runnerSessionId: hostedRunner.runnerSessionId,
+		workspaceRoot: hostedRunner.workspaceRoot,
+		workspaceId: hostedRunner.workspaceId,
+		agentRunId: hostedRunner.agentRunId,
+		maestroSessionId:
+			hostedRunner.activeMaestroSessionId ??
+			hostedRunner.configuredMaestroSessionId,
+	};
+	if (hostedRunner.draining) {
+		return {
+			...base,
+			status: "draining",
+		};
+	}
+	try {
+		const stats = await stat(hostedRunner.workspaceRoot);
+		if (!stats.isDirectory()) {
+			return {
+				...base,
+				status: "unavailable",
+				error: "workspace root is not a directory",
+			};
+		}
+		return {
+			...base,
+			status: "ready",
+		};
+	} catch (error) {
+		return {
+			...base,
+			status: "unavailable",
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+export async function runHealthChecks(
+	options: {
+		hostedRunner?: HostedRunnerContext;
+	} = {},
+): Promise<HealthCheckResult> {
 	const checks: HealthCheckResult["checks"] = {
 		database: { status: "unconfigured" },
 	};
@@ -52,6 +112,16 @@ export async function runHealthChecks(): Promise<HealthCheckResult> {
 		} else {
 			checks.database.status = "down";
 			overallStatus = "degraded";
+		}
+	}
+
+	if (options.hostedRunner) {
+		const hostedRunnerCheck = await checkHostedRunnerWorkspace(
+			options.hostedRunner,
+		);
+		checks.hostedRunner = hostedRunnerCheck;
+		if (hostedRunnerCheck.status !== "ready") {
+			overallStatus = "unhealthy";
 		}
 	}
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -110,7 +110,8 @@ export function createRoutes(context: WebServerContext): Route[] {
 		{
 			method: "GET",
 			path: "/readyz",
-			handler: (req, res) => handleReadyz(req, res, corsHeaders),
+			handler: (req, res) =>
+				handleReadyz(req, res, corsHeaders, context.hostedRunner),
 		},
 		{
 			method: "POST",

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -59,7 +59,10 @@ import {
 } from "./providers/auth.js";
 import { registerBackgroundTaskShutdownHooks } from "./runtime/background-task-hooks.js";
 import { configureSafeMode } from "./safety/safe-mode.js";
-import type { WebServerContext } from "./server/app-context.js";
+import type {
+	HostedRunnerContext,
+	WebServerContext,
+} from "./server/app-context.js";
 import { recordApiRequest } from "./telemetry.js";
 import { artifactsClientTool } from "./tools/artifacts-client.js";
 import { askUserClientTool } from "./tools/ask-user-client.js";
@@ -716,7 +719,19 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse) {
 	});
 }
 
-export async function startWebServer(port = 8080) {
+export interface StartWebServerOptions {
+	host?: string;
+	hostedRunner?: HostedRunnerContext;
+}
+
+export async function startWebServer(
+	port = 8080,
+	options: StartWebServerOptions = {},
+) {
+	if (options.hostedRunner) {
+		context.hostedRunner = options.hostedRunner;
+	}
+
 	registerCrashHandlers();
 	await reloadModelConfig();
 	await initLifecycle();
@@ -854,19 +869,37 @@ export async function startWebServer(port = 8080) {
 		});
 	});
 
-	server.listen(port, () => {
+	const onListening = () => {
 		logStartup(port);
+		if (context.hostedRunner) {
+			logger.info("Hosted runner mode enabled", {
+				runnerSessionId: context.hostedRunner.runnerSessionId,
+				workspaceRoot: context.hostedRunner.workspaceRoot,
+				workspaceId: context.hostedRunner.workspaceId,
+				agentRunId: context.hostedRunner.agentRunId,
+				listenHost: options.host,
+				listenPort: port,
+			});
+		}
 		startStatsCollection();
-	});
+	};
+	if (options.host) {
+		server.listen(port, options.host, onListening);
+	} else {
+		server.listen(port, onListening);
+	}
 
 	// Don't register signal handlers in test mode - vitest manages process lifecycle
 	const isTestMode =
 		process.env.VITEST === "true" || process.env.NODE_ENV === "test";
 	if (!isTestMode) {
-		process.on("SIGINT", async () => {
+		const beginShutdown = async (signal: NodeJS.Signals) => {
 			if (shuttingDown) return;
 			shuttingDown = true;
-			logger.info("SIGINT received. Starting graceful shutdown...");
+			if (context.hostedRunner) {
+				context.hostedRunner.draining = true;
+			}
+			logger.info(`${signal} received. Starting graceful shutdown...`);
 			stopStatsCollection();
 			disposeCheckpointService();
 			// End enterprise session if initialized
@@ -906,6 +939,12 @@ export async function startWebServer(port = 8080) {
 				logger.info("No active requests. Exiting.");
 				process.exit(0);
 			}
+		};
+		process.on("SIGINT", () => {
+			void beginShutdown("SIGINT");
+		});
+		process.on("SIGTERM", () => {
+			void beginShutdown("SIGTERM");
 		});
 	}
 

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -84,4 +84,29 @@ describe("parseArgs", () => {
 			messages: [],
 		});
 	});
+
+	it("preserves hosted-runner arguments for the hosted entrypoint", () => {
+		expect(
+			parseArgs([
+				"hosted-runner",
+				"--runner-session-id",
+				"mrs_123",
+				"--workspace-root",
+				"/workspace",
+				"--listen",
+				"0.0.0.0:8080",
+			]),
+		).toMatchObject({
+			command: "hosted-runner",
+			commandArgs: [
+				"--runner-session-id",
+				"mrs_123",
+				"--workspace-root",
+				"/workspace",
+				"--listen",
+				"0.0.0.0:8080",
+			],
+			messages: [],
+		});
+	});
 });

--- a/test/cli/hosted-runner-command.test.ts
+++ b/test/cli/hosted-runner-command.test.ts
@@ -1,0 +1,87 @@
+import { realpathSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	resolveHostedRunnerConfig,
+	toHostedRunnerContext,
+} from "../../src/cli/commands/hosted-runner.js";
+
+const tempDirs: string[] = [];
+
+async function createTempWorkspace(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "maestro-hosted-runner-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })),
+	);
+});
+
+describe("hosted-runner command config", () => {
+	it("resolves required hosted runner flags", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const config = await resolveHostedRunnerConfig(
+			[
+				"--runner-session-id",
+				"mrs_123",
+				"--workspace-root",
+				workspaceRoot,
+				"--listen",
+				"0.0.0.0:9090",
+				"--workspace-id",
+				"ws_123",
+				"--agent-run-id",
+				"ar_123",
+			],
+			{},
+		);
+
+		expect(config).toMatchObject({
+			runnerSessionId: "mrs_123",
+			workspaceRoot: realpathSync(workspaceRoot),
+			host: "0.0.0.0",
+			port: 9090,
+			workspaceId: "ws_123",
+			agentRunId: "ar_123",
+		});
+		expect(toHostedRunnerContext(config)).toMatchObject({
+			enabled: true,
+			runnerSessionId: "mrs_123",
+			workspaceRoot: realpathSync(workspaceRoot),
+			listenHost: "0.0.0.0",
+			listenPort: 9090,
+		});
+	});
+
+	it("resolves env-driven hosted runner config", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const config = await resolveHostedRunnerConfig([], {
+			MAESTRO_RUNNER_SESSION_ID: "mrs_env",
+			MAESTRO_WORKSPACE_ROOT: workspaceRoot,
+			MAESTRO_HOSTED_RUNNER_PORT: "7070",
+			MAESTRO_REMOTE_RUNNER_WORKSPACE_ID: "ws_env",
+		});
+
+		expect(config).toMatchObject({
+			runnerSessionId: "mrs_env",
+			workspaceRoot: realpathSync(workspaceRoot),
+			port: 7070,
+			workspaceId: "ws_env",
+		});
+	});
+
+	it("rejects missing runner session and workspace root", async () => {
+		await expect(resolveHostedRunnerConfig([], {})).rejects.toThrow(
+			/runner-session-id/,
+		);
+
+		await expect(
+			resolveHostedRunnerConfig(["--runner-session-id", "mrs_123"], {}),
+		).rejects.toThrow(/workspace-root/);
+	});
+});

--- a/test/headless/workspace-root.test.ts
+++ b/test/headless/workspace-root.test.ts
@@ -1,0 +1,56 @@
+import { realpathSync } from "node:fs";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveHostedWorkspacePath } from "../../src/headless/workspace-root.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(prefix: string): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })),
+	);
+});
+
+describe("hosted workspace root guard", () => {
+	it("allows paths inside the hosted workspace root", async () => {
+		const workspaceRoot = await createTempDir("maestro-workspace-root-");
+		expect(
+			resolveHostedWorkspacePath(workspaceRoot, {
+				MAESTRO_HOSTED_RUNNER_MODE: "1",
+				MAESTRO_WORKSPACE_ROOT: workspaceRoot,
+			}),
+		).toBe(realpathSync(workspaceRoot));
+	});
+
+	it("resolves relative paths against the hosted workspace root", async () => {
+		const workspaceRoot = await createTempDir("maestro-workspace-root-");
+		await mkdir(join(workspaceRoot, "src"));
+
+		expect(
+			resolveHostedWorkspacePath("src", {
+				MAESTRO_HOSTED_RUNNER_MODE: "1",
+				MAESTRO_WORKSPACE_ROOT: workspaceRoot,
+			}),
+		).toBe(realpathSync(join(workspaceRoot, "src")));
+	});
+
+	it("rejects paths outside the hosted workspace root", async () => {
+		const workspaceRoot = await createTempDir("maestro-workspace-root-");
+		const outsideRoot = await createTempDir("maestro-workspace-outside-");
+
+		expect(() =>
+			resolveHostedWorkspacePath(outsideRoot, {
+				MAESTRO_HOSTED_RUNNER_MODE: "1",
+				MAESTRO_WORKSPACE_ROOT: workspaceRoot,
+			}),
+		).toThrow(/outside hosted runner workspace root/);
+	});
+});

--- a/test/server/health.test.ts
+++ b/test/server/health.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runHealthChecks } from "../../src/server/handlers/health.js";
+
+const tempDirs: string[] = [];
+
+async function createTempWorkspace(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "maestro-health-workspace-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })),
+	);
+});
+
+describe("runHealthChecks", () => {
+	it("reports hosted runner metadata when the workspace root is ready", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const result = await runHealthChecks({
+			hostedRunner: {
+				enabled: true,
+				runnerSessionId: "mrs_123",
+				workspaceRoot,
+				workspaceId: "ws_123",
+				activeMaestroSessionId: "session_123",
+			},
+		});
+
+		expect(result.checks.hostedRunner).toMatchObject({
+			status: "ready",
+			runnerSessionId: "mrs_123",
+			workspaceRoot,
+			workspaceId: "ws_123",
+			maestroSessionId: "session_123",
+		});
+	});
+
+	it("marks hosted runner readiness unhealthy while draining", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const result = await runHealthChecks({
+			hostedRunner: {
+				enabled: true,
+				runnerSessionId: "mrs_123",
+				workspaceRoot,
+				draining: true,
+			},
+		});
+
+		expect(result.status).toBe("unhealthy");
+		expect(result.checks.hostedRunner?.status).toBe("draining");
+	});
+});


### PR DESCRIPTION
## Summary
- add `maestro hosted-runner` as a single-session runtime pod entrypoint with flag/env config and hosted defaults
- thread hosted runner metadata into web server readiness, bind the first headless session, and mark SIGTERM/SIGINT draining
- guard headless utility cwd/root resolution against escaping `MAESTRO_WORKSPACE_ROOT` in hosted mode

## Tests
- `bun test test/cli/args.test.ts test/cli/hosted-runner-command.test.ts test/headless/workspace-root.test.ts test/server/health.test.ts`
- `bun x biome check ...` (focused changed files)
- `bun run build`
- pre-commit: guardian, Biome, lint:evals, generated proto checks, build, Bun compile