### PR TITLE
Expose hosted runner identity endpoint

### DIFF
--- a/docs/protocols/headless.md
+++ b/docs/protocols/headless.md
@@ -30,6 +30,38 @@ Compatibility expectations:
 - reject unknown message `type` values unless your client intentionally ignores them
 - compare `protocol_version` during handshake when you require exact compatibility
 
+## Hosted Remote-Runner Identity
+
+When Maestro runs through `maestro hosted-runner`, the HTTP server exposes a
+Platform attach-fencing endpoint:
+
+```http
+GET /.well-known/evalops/remote-runner/identity
+```
+
+The endpoint returns only runtime identity needed by Platform's headless
+gateway:
+
+```json
+{
+  "protocol_version": "evalops.remote-runner.identity.v1",
+  "runner_session_id": "mrs_123",
+  "owner_instance_id": "pod_123",
+  "ready": true,
+  "draining": false
+}
+```
+
+`runner_session_id` comes from `--runner-session-id`, `MAESTRO_RUNNER_SESSION_ID`,
+or `REMOTE_RUNNER_SESSION_ID`. `owner_instance_id` comes from
+`--owner-instance-id`, `MAESTRO_REMOTE_RUNNER_OWNER_INSTANCE_ID`, or
+`REMOTE_RUNNER_OWNER_INSTANCE_ID`.
+
+This surface intentionally omits workspace, organization, user, token, and
+prompt metadata. Platform compares the returned session and owner generation
+with the control-plane session before proxying attach traffic. `ready=false` or
+`draining=true` means the runtime should not receive new attach requests yet.
+
 ## Handshake
 
 Typical controller flow:

--- a/src/cli/commands/hosted-runner.ts
+++ b/src/cli/commands/hosted-runner.ts
@@ -12,6 +12,7 @@ interface HostedRunnerOptions {
 
 export interface HostedRunnerConfig {
 	runnerSessionId: string;
+	ownerInstanceId?: string;
 	workspaceRoot: string;
 	host?: string;
 	port: number;
@@ -29,6 +30,7 @@ const HOSTED_RUNNER_USAGE = `maestro hosted-runner [options]
 
 Options:
   --runner-session-id <id>  Platform remote-runner session id (required)
+  --owner-instance-id <id>  Platform runtime owner generation for attach fencing
   --workspace-root <path>   Workspace root mounted into the runtime pod (required)
   --listen <host:port>      Address to bind, for example 0.0.0.0:8080
   --host <host>             Bind host when --listen is not used
@@ -41,6 +43,7 @@ Options:
 
 Environment:
   MAESTRO_RUNNER_SESSION_ID, REMOTE_RUNNER_SESSION_ID
+  MAESTRO_REMOTE_RUNNER_OWNER_INSTANCE_ID, REMOTE_RUNNER_OWNER_INSTANCE_ID
   MAESTRO_WORKSPACE_ROOT
   MAESTRO_HOSTED_RUNNER_LISTEN, MAESTRO_HOSTED_RUNNER_HOST, MAESTRO_HOSTED_RUNNER_PORT, PORT
   MAESTRO_REMOTE_RUNNER_WORKSPACE_ID, MAESTRO_AGENT_RUN_ID, MAESTRO_SESSION_ID
@@ -203,6 +206,12 @@ export async function resolveHostedRunnerConfig(
 
 	return {
 		runnerSessionId,
+		ownerInstanceId:
+			getLastFlag(parsed, "owner-instance-id") ??
+			getEnvValue(env, [
+				"MAESTRO_REMOTE_RUNNER_OWNER_INSTANCE_ID",
+				"REMOTE_RUNNER_OWNER_INSTANCE_ID",
+			]),
 		workspaceRoot: await resolveWorkspaceRoot(
 			getLastFlag(parsed, "workspace-root") ??
 				getEnvValue(env, ["MAESTRO_WORKSPACE_ROOT", "WORKSPACE_ROOT"]),
@@ -230,6 +239,11 @@ export function applyHostedRunnerEnvironment(config: HostedRunnerConfig): void {
 	process.env.MAESTRO_HOSTED_RUNNER_MODE = "1";
 	process.env.MAESTRO_RUNNER_SESSION_ID = config.runnerSessionId;
 	process.env.MAESTRO_WORKSPACE_ROOT = config.workspaceRoot;
+	if (config.ownerInstanceId) {
+		process.env.MAESTRO_REMOTE_RUNNER_OWNER_INSTANCE_ID =
+			config.ownerInstanceId;
+		process.env.REMOTE_RUNNER_OWNER_INSTANCE_ID = config.ownerInstanceId;
+	}
 	process.env.MAESTRO_PROFILE ??= "hosted-runner";
 	process.env.MAESTRO_WEB_REQUIRE_KEY ??= "0";
 	process.env.MAESTRO_WEB_REQUIRE_REDIS ??= "0";
@@ -260,6 +274,7 @@ export function toHostedRunnerContext(
 	return {
 		enabled: true,
 		runnerSessionId: config.runnerSessionId,
+		ownerInstanceId: config.ownerInstanceId,
 		workspaceRoot: config.workspaceRoot,
 		listenHost: config.host,
 		listenPort: config.port,

--- a/src/server/app-context.ts
+++ b/src/server/app-context.ts
@@ -23,6 +23,7 @@ export interface WebServerConfig {
 export interface HostedRunnerContext {
 	enabled: true;
 	runnerSessionId: string;
+	ownerInstanceId?: string;
 	workspaceRoot: string;
 	listenHost?: string;
 	listenPort?: number;

--- a/src/server/handlers/health.ts
+++ b/src/server/handlers/health.ts
@@ -18,6 +18,7 @@ export interface HealthCheckResult {
 		hostedRunner?: {
 			status: "ready" | "draining" | "unavailable";
 			runnerSessionId: string;
+			ownerInstanceId?: string;
 			workspaceRoot: string;
 			workspaceId?: string;
 			agentRunId?: string;
@@ -28,7 +29,7 @@ export interface HealthCheckResult {
 	timestamp: number;
 }
 
-type HostedRunnerHealthCheck = NonNullable<
+export type HostedRunnerHealthCheck = NonNullable<
 	HealthCheckResult["checks"]["hostedRunner"]
 >;
 
@@ -44,11 +45,12 @@ export async function handleReadyz(
 	sendJson(res, httpStatus, result, cors, req);
 }
 
-async function checkHostedRunnerWorkspace(
+export async function checkHostedRunnerReadiness(
 	hostedRunner: HostedRunnerContext,
 ): Promise<HostedRunnerHealthCheck> {
 	const base = {
 		runnerSessionId: hostedRunner.runnerSessionId,
+		ownerInstanceId: hostedRunner.ownerInstanceId,
 		workspaceRoot: hostedRunner.workspaceRoot,
 		workspaceId: hostedRunner.workspaceId,
 		agentRunId: hostedRunner.agentRunId,
@@ -116,7 +118,7 @@ export async function runHealthChecks(
 	}
 
 	if (options.hostedRunner) {
-		const hostedRunnerCheck = await checkHostedRunnerWorkspace(
+		const hostedRunnerCheck = await checkHostedRunnerReadiness(
 			options.hostedRunner,
 		);
 		checks.hostedRunner = hostedRunnerCheck;

--- a/src/server/handlers/hosted-runner-identity.ts
+++ b/src/server/handlers/hosted-runner-identity.ts
@@ -1,0 +1,61 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { HostedRunnerContext } from "../app-context.js";
+import { sendJson } from "../server-utils.js";
+import { checkHostedRunnerReadiness } from "./health.js";
+
+export const HOSTED_RUNNER_IDENTITY_PATH =
+	"/.well-known/evalops/remote-runner/identity";
+
+export const HOSTED_RUNNER_IDENTITY_PROTOCOL_VERSION =
+	"evalops.remote-runner.identity.v1";
+
+export interface HostedRunnerIdentity {
+	protocol_version: typeof HOSTED_RUNNER_IDENTITY_PROTOCOL_VERSION;
+	runner_session_id: string;
+	owner_instance_id: string;
+	ready: boolean;
+	draining: boolean;
+}
+
+export async function buildHostedRunnerIdentity(
+	hostedRunner?: HostedRunnerContext,
+): Promise<HostedRunnerIdentity | null> {
+	if (!hostedRunner?.runnerSessionId || !hostedRunner.ownerInstanceId) {
+		return null;
+	}
+
+	const readiness = await checkHostedRunnerReadiness(hostedRunner);
+	const draining = readiness.status === "draining";
+
+	return {
+		protocol_version: HOSTED_RUNNER_IDENTITY_PROTOCOL_VERSION,
+		runner_session_id: hostedRunner.runnerSessionId,
+		owner_instance_id: hostedRunner.ownerInstanceId,
+		ready: readiness.status === "ready",
+		draining,
+	};
+}
+
+export async function handleHostedRunnerIdentity(
+	req: IncomingMessage,
+	res: ServerResponse,
+	cors: Record<string, string>,
+	hostedRunner?: HostedRunnerContext,
+): Promise<void> {
+	res.setHeader("Cache-Control", "no-store");
+	const identity = await buildHostedRunnerIdentity(hostedRunner);
+	if (!identity) {
+		sendJson(
+			res,
+			404,
+			{
+				error: "hosted runner identity unavailable",
+			},
+			cors,
+			req,
+		);
+		return;
+	}
+
+	sendJson(res, 200, identity, cors, req);
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -43,6 +43,10 @@ import {
 	handleHeadlessSessionUnsubscribe,
 } from "./handlers/headless-sessions.js";
 import { handleReadyz } from "./handlers/health.js";
+import {
+	HOSTED_RUNNER_IDENTITY_PATH,
+	handleHostedRunnerIdentity,
+} from "./handlers/hosted-runner-identity.js";
 import { handleLsp } from "./handlers/lsp.js";
 import { handleMcpStatus } from "./handlers/mcp.js";
 import { handleMemory } from "./handlers/memory.js";
@@ -112,6 +116,12 @@ export function createRoutes(context: WebServerContext): Route[] {
 			path: "/readyz",
 			handler: (req, res) =>
 				handleReadyz(req, res, corsHeaders, context.hostedRunner),
+		},
+		{
+			method: "GET",
+			path: HOSTED_RUNNER_IDENTITY_PATH,
+			handler: (req, res) =>
+				handleHostedRunnerIdentity(req, res, corsHeaders, context.hostedRunner),
 		},
 		{
 			method: "POST",

--- a/test/cli/hosted-runner-command.test.ts
+++ b/test/cli/hosted-runner-command.test.ts
@@ -29,6 +29,8 @@ describe("hosted-runner command config", () => {
 			[
 				"--runner-session-id",
 				"mrs_123",
+				"--owner-instance-id",
+				"pod_123",
 				"--workspace-root",
 				workspaceRoot,
 				"--listen",
@@ -43,6 +45,7 @@ describe("hosted-runner command config", () => {
 
 		expect(config).toMatchObject({
 			runnerSessionId: "mrs_123",
+			ownerInstanceId: "pod_123",
 			workspaceRoot: realpathSync(workspaceRoot),
 			host: "0.0.0.0",
 			port: 9090,
@@ -52,6 +55,7 @@ describe("hosted-runner command config", () => {
 		expect(toHostedRunnerContext(config)).toMatchObject({
 			enabled: true,
 			runnerSessionId: "mrs_123",
+			ownerInstanceId: "pod_123",
 			workspaceRoot: realpathSync(workspaceRoot),
 			listenHost: "0.0.0.0",
 			listenPort: 9090,
@@ -62,6 +66,7 @@ describe("hosted-runner command config", () => {
 		const workspaceRoot = await createTempWorkspace();
 		const config = await resolveHostedRunnerConfig([], {
 			MAESTRO_RUNNER_SESSION_ID: "mrs_env",
+			MAESTRO_REMOTE_RUNNER_OWNER_INSTANCE_ID: "pod_env",
 			MAESTRO_WORKSPACE_ROOT: workspaceRoot,
 			MAESTRO_HOSTED_RUNNER_PORT: "7070",
 			MAESTRO_REMOTE_RUNNER_WORKSPACE_ID: "ws_env",
@@ -69,10 +74,30 @@ describe("hosted-runner command config", () => {
 
 		expect(config).toMatchObject({
 			runnerSessionId: "mrs_env",
+			ownerInstanceId: "pod_env",
 			workspaceRoot: realpathSync(workspaceRoot),
 			port: 7070,
 			workspaceId: "ws_env",
 		});
+	});
+
+	it("lets CLI owner generation override stale environment", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const config = await resolveHostedRunnerConfig(
+			[
+				"--runner-session-id",
+				"mrs_123",
+				"--owner-instance-id",
+				"pod_current",
+				"--workspace-root",
+				workspaceRoot,
+			],
+			{
+				MAESTRO_REMOTE_RUNNER_OWNER_INSTANCE_ID: "pod_stale",
+			},
+		);
+
+		expect(config.ownerInstanceId).toBe("pod_current");
 	});
 
 	it("rejects missing runner session and workspace root", async () => {

--- a/test/server/health.test.ts
+++ b/test/server/health.test.ts
@@ -25,6 +25,7 @@ describe("runHealthChecks", () => {
 			hostedRunner: {
 				enabled: true,
 				runnerSessionId: "mrs_123",
+				ownerInstanceId: "pod_123",
 				workspaceRoot,
 				workspaceId: "ws_123",
 				activeMaestroSessionId: "session_123",
@@ -34,6 +35,7 @@ describe("runHealthChecks", () => {
 		expect(result.checks.hostedRunner).toMatchObject({
 			status: "ready",
 			runnerSessionId: "mrs_123",
+			ownerInstanceId: "pod_123",
 			workspaceRoot,
 			workspaceId: "ws_123",
 			maestroSessionId: "session_123",

--- a/test/server/hosted-runner-identity.test.ts
+++ b/test/server/hosted-runner-identity.test.ts
@@ -1,0 +1,92 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	HOSTED_RUNNER_IDENTITY_PROTOCOL_VERSION,
+	buildHostedRunnerIdentity,
+} from "../../src/server/handlers/hosted-runner-identity.js";
+
+const tempDirs: string[] = [];
+
+async function createTempWorkspace(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "maestro-runner-identity-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })),
+	);
+});
+
+describe("hosted runner identity", () => {
+	it("returns the Platform attach fence identity when the runtime is ready", async () => {
+		const workspaceRoot = await createTempWorkspace();
+
+		await expect(
+			buildHostedRunnerIdentity({
+				enabled: true,
+				runnerSessionId: "mrs_123",
+				ownerInstanceId: "pod_123",
+				workspaceRoot,
+			}),
+		).resolves.toEqual({
+			protocol_version: HOSTED_RUNNER_IDENTITY_PROTOCOL_VERSION,
+			runner_session_id: "mrs_123",
+			owner_instance_id: "pod_123",
+			ready: true,
+			draining: false,
+		});
+	});
+
+	it("reports draining runtimes as not ready", async () => {
+		const workspaceRoot = await createTempWorkspace();
+
+		await expect(
+			buildHostedRunnerIdentity({
+				enabled: true,
+				runnerSessionId: "mrs_123",
+				ownerInstanceId: "pod_123",
+				workspaceRoot,
+				draining: true,
+			}),
+		).resolves.toMatchObject({
+			runner_session_id: "mrs_123",
+			owner_instance_id: "pod_123",
+			ready: false,
+			draining: true,
+		});
+	});
+
+	it("does not expose identity without the Platform owner generation", async () => {
+		const workspaceRoot = await createTempWorkspace();
+
+		await expect(
+			buildHostedRunnerIdentity({
+				enabled: true,
+				runnerSessionId: "mrs_123",
+				workspaceRoot,
+			}),
+		).resolves.toBeNull();
+	});
+
+	it("reports missing workspaces as unavailable without changing identity", async () => {
+		const workspaceRoot = join(tmpdir(), "maestro-runner-identity-missing");
+
+		await expect(
+			buildHostedRunnerIdentity({
+				enabled: true,
+				runnerSessionId: "mrs_123",
+				ownerInstanceId: "pod_123",
+				workspaceRoot,
+			}),
+		).resolves.toMatchObject({
+			runner_session_id: "mrs_123",
+			owner_instance_id: "pod_123",
+			ready: false,
+			draining: false,
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add the hosted remote-runner identity endpoint used by Platform attach fencing
- propagate the Platform owner generation through hosted-runner flags/env/context
- document the safe identity contract and add ready/draining/missing identity tests

Closes #95

## Test Plan
- ./node_modules/.bin/vitest run test/cli/hosted-runner-command.test.ts test/server/health.test.ts test/server/hosted-runner-identity.test.ts
- ./node_modules/.bin/biome check docs/protocols/headless.md src/cli/commands/hosted-runner.ts src/server/app-context.ts src/server/handlers/health.ts src/server/handlers/hosted-runner-identity.ts src/server/routes.ts test/cli/hosted-runner-command.test.ts test/server/health.test.ts test/server/hosted-runner-identity.test.ts
- npx bun@1.3.6 run build