### PR TITLE
Add hosted runner drain snapshot hook

### DIFF
--- a/docs/protocols/headless.md
+++ b/docs/protocols/headless.md
@@ -62,6 +62,70 @@ prompt metadata. Platform compares the returned session and owner generation
 with the control-plane session before proxying attach traffic. `ready=false` or
 `draining=true` means the runtime should not receive new attach requests yet.
 
+## Hosted Remote-Runner Drain
+
+Hosted runner mode also exposes a local drain/snapshot hook for Platform:
+
+```http
+POST /.well-known/evalops/remote-runner/drain
+```
+
+The request body is optional:
+
+```json
+{
+  "reason": "ttl_expired",
+  "requested_by": "platform",
+  "export_paths": ["."]
+}
+```
+
+The endpoint immediately marks the runtime as draining, stops active headless
+runtime work, flushes Maestro session and memory state, validates every
+`export_paths` entry stays inside the hosted workspace root, and writes a
+snapshot manifest. The manifest directory comes from `--snapshot-root`,
+`MAESTRO_REMOTE_RUNNER_SNAPSHOT_ROOT`, or
+`REMOTE_RUNNER_SNAPSHOT_ROOT`; the default is
+`.maestro/runner-snapshots` under the workspace root.
+
+```json
+{
+  "protocol_version": "evalops.remote-runner.drain.v1",
+  "status": "drained",
+  "manifest_path": "/workspace/.maestro/runner-snapshots/mrs_123-2026-04-23T00_00_00_000Z.json",
+  "manifest": {
+    "manifest_version": "evalops.remote-runner.snapshot-manifest.v1",
+    "runner_session_id": "mrs_123",
+    "owner_instance_id": "pod_123",
+    "maestro_session_id": "session_123",
+    "workspace_root": "/workspace",
+    "runtime": {
+      "flush_status": "completed",
+      "session_id": "session_123",
+      "session_file": "/workspace/.maestro/agent/sessions/session.jsonl"
+    },
+    "workspace_export": {
+      "mode": "local_path_contract",
+      "paths": [
+        {
+          "input": ".",
+          "path": "/workspace",
+          "relative_path": ".",
+          "type": "directory"
+        }
+      ]
+    }
+  }
+}
+```
+
+`status=interrupted` means Maestro entered draining mode and wrote a manifest,
+but runtime flush failed before completion. Platform should treat the manifest
+as a partial handoff record, stop sending attach traffic, and decide whether to
+retry drain or terminate the pod. Maestro does not upload to GCS or require a
+Cloud Storage mount; Platform/deploy own artifact upload, retention, and any
+future resume controller behavior.
+
 ## Handshake
 
 Typical controller flow:

--- a/src/cli/commands/hosted-runner.ts
+++ b/src/cli/commands/hosted-runner.ts
@@ -14,6 +14,7 @@ export interface HostedRunnerConfig {
 	runnerSessionId: string;
 	ownerInstanceId?: string;
 	workspaceRoot: string;
+	snapshotRoot: string;
 	host?: string;
 	port: number;
 	workspaceId?: string;
@@ -32,6 +33,7 @@ Options:
   --runner-session-id <id>  Platform remote-runner session id (required)
   --owner-instance-id <id>  Platform runtime owner generation for attach fencing
   --workspace-root <path>   Workspace root mounted into the runtime pod (required)
+  --snapshot-root <path>    Directory for drain snapshot manifests
   --listen <host:port>      Address to bind, for example 0.0.0.0:8080
   --host <host>             Bind host when --listen is not used
   --port <port>             Bind port when --listen is not used
@@ -45,6 +47,7 @@ Environment:
   MAESTRO_RUNNER_SESSION_ID, REMOTE_RUNNER_SESSION_ID
   MAESTRO_REMOTE_RUNNER_OWNER_INSTANCE_ID, REMOTE_RUNNER_OWNER_INSTANCE_ID
   MAESTRO_WORKSPACE_ROOT
+  MAESTRO_REMOTE_RUNNER_SNAPSHOT_ROOT, REMOTE_RUNNER_SNAPSHOT_ROOT
   MAESTRO_HOSTED_RUNNER_LISTEN, MAESTRO_HOSTED_RUNNER_HOST, MAESTRO_HOSTED_RUNNER_PORT, PORT
   MAESTRO_REMOTE_RUNNER_WORKSPACE_ID, MAESTRO_AGENT_RUN_ID, MAESTRO_SESSION_ID
   MAESTRO_ATTACH_AUDIENCE`;
@@ -168,6 +171,16 @@ async function resolveWorkspaceRoot(path: string | undefined): Promise<string> {
 	return realpath(workspaceRoot);
 }
 
+function resolveSnapshotRoot(
+	path: string | undefined,
+	workspaceRoot: string,
+): string {
+	if (!path) {
+		return resolve(workspaceRoot, ".maestro", "runner-snapshots");
+	}
+	return resolve(workspaceRoot, path);
+}
+
 export function formatHostedRunnerUsage(): string {
 	return HOSTED_RUNNER_USAGE;
 }
@@ -203,6 +216,10 @@ export async function resolveHostedRunnerConfig(
 		parsePort(env.PORT, "PORT") ??
 		options.defaultPort ??
 		8080;
+	const workspaceRoot = await resolveWorkspaceRoot(
+		getLastFlag(parsed, "workspace-root") ??
+			getEnvValue(env, ["MAESTRO_WORKSPACE_ROOT", "WORKSPACE_ROOT"]),
+	);
 
 	return {
 		runnerSessionId,
@@ -212,9 +229,14 @@ export async function resolveHostedRunnerConfig(
 				"MAESTRO_REMOTE_RUNNER_OWNER_INSTANCE_ID",
 				"REMOTE_RUNNER_OWNER_INSTANCE_ID",
 			]),
-		workspaceRoot: await resolveWorkspaceRoot(
-			getLastFlag(parsed, "workspace-root") ??
-				getEnvValue(env, ["MAESTRO_WORKSPACE_ROOT", "WORKSPACE_ROOT"]),
+		workspaceRoot,
+		snapshotRoot: resolveSnapshotRoot(
+			getLastFlag(parsed, "snapshot-root") ??
+				getEnvValue(env, [
+					"MAESTRO_REMOTE_RUNNER_SNAPSHOT_ROOT",
+					"REMOTE_RUNNER_SNAPSHOT_ROOT",
+				]),
+			workspaceRoot,
 		),
 		host:
 			listen.host ??
@@ -239,6 +261,7 @@ export function applyHostedRunnerEnvironment(config: HostedRunnerConfig): void {
 	process.env.MAESTRO_HOSTED_RUNNER_MODE = "1";
 	process.env.MAESTRO_RUNNER_SESSION_ID = config.runnerSessionId;
 	process.env.MAESTRO_WORKSPACE_ROOT = config.workspaceRoot;
+	process.env.MAESTRO_REMOTE_RUNNER_SNAPSHOT_ROOT = config.snapshotRoot;
 	if (config.ownerInstanceId) {
 		process.env.MAESTRO_REMOTE_RUNNER_OWNER_INSTANCE_ID =
 			config.ownerInstanceId;
@@ -276,6 +299,7 @@ export function toHostedRunnerContext(
 		runnerSessionId: config.runnerSessionId,
 		ownerInstanceId: config.ownerInstanceId,
 		workspaceRoot: config.workspaceRoot,
+		snapshotRoot: config.snapshotRoot,
 		listenHost: config.host,
 		listenPort: config.port,
 		workspaceId: config.workspaceId,

--- a/src/server/app-context.ts
+++ b/src/server/app-context.ts
@@ -25,6 +25,7 @@ export interface HostedRunnerContext {
 	runnerSessionId: string;
 	ownerInstanceId?: string;
 	workspaceRoot: string;
+	snapshotRoot?: string;
 	listenHost?: string;
 	listenPort?: number;
 	workspaceId?: string;

--- a/src/server/handlers/health.ts
+++ b/src/server/handlers/health.ts
@@ -20,6 +20,7 @@ export interface HealthCheckResult {
 			runnerSessionId: string;
 			ownerInstanceId?: string;
 			workspaceRoot: string;
+			snapshotRoot?: string;
 			workspaceId?: string;
 			agentRunId?: string;
 			maestroSessionId?: string;
@@ -52,6 +53,9 @@ export async function checkHostedRunnerReadiness(
 		runnerSessionId: hostedRunner.runnerSessionId,
 		ownerInstanceId: hostedRunner.ownerInstanceId,
 		workspaceRoot: hostedRunner.workspaceRoot,
+		...(hostedRunner.snapshotRoot
+			? { snapshotRoot: hostedRunner.snapshotRoot }
+			: {}),
 		workspaceId: hostedRunner.workspaceId,
 		agentRunId: hostedRunner.agentRunId,
 		maestroSessionId:

--- a/src/server/handlers/hosted-runner-drain.ts
+++ b/src/server/handlers/hosted-runner-drain.ts
@@ -1,0 +1,430 @@
+import { execFile } from "node:child_process";
+import { mkdir, realpath, stat, writeFile } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+import type { HostedRunnerContext, WebServerContext } from "../app-context.js";
+import { ApiError, readJsonBody, sendJson } from "../server-utils.js";
+
+const execFileAsync = promisify(execFile);
+
+export const HOSTED_RUNNER_DRAIN_PATH =
+	"/.well-known/evalops/remote-runner/drain";
+
+export const HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION =
+	"evalops.remote-runner.drain.v1";
+
+export const HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION =
+	"evalops.remote-runner.snapshot-manifest.v1";
+
+type SnapshotManifestStatus = "drained" | "interrupted";
+
+export interface HostedRunnerDrainInput {
+	reason?: string;
+	requestedBy?: string;
+	exportPaths?: string[];
+}
+
+export interface HostedRunnerRuntimeDrainResult {
+	sessionId: string;
+	sessionFile?: string;
+	protocolVersion?: string;
+	cursor?: number;
+}
+
+export interface HostedRunnerWorkspaceExportPath {
+	input: string;
+	path: string;
+	relative_path: string;
+	type: "file" | "directory";
+}
+
+export interface HostedRunnerSnapshotManifest {
+	manifest_version: typeof HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION;
+	protocol_version: typeof HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION;
+	status: SnapshotManifestStatus;
+	runner_session_id: string;
+	owner_instance_id?: string;
+	workspace_id?: string;
+	agent_run_id?: string;
+	maestro_session_id?: string;
+	workspace_root: string;
+	snapshot_root: string;
+	snapshot_path: string;
+	requested_at: string;
+	completed_at: string;
+	stop_reason: string;
+	requested_by?: string;
+	runtime: {
+		flush_status: "completed" | "failed" | "skipped";
+		error?: string;
+		session_id?: string;
+		session_file?: string;
+		protocol_version?: string;
+		cursor?: number;
+	};
+	workspace_export: {
+		mode: "local_path_contract";
+		paths: HostedRunnerWorkspaceExportPath[];
+	};
+	git?: {
+		commit?: string;
+		branch?: string;
+		dirty?: boolean;
+	};
+}
+
+export interface HostedRunnerDrainResult {
+	status: SnapshotManifestStatus;
+	manifest_path: string;
+	manifest: HostedRunnerSnapshotManifest;
+}
+
+export interface DrainHostedRunnerOptions {
+	hostedRunner?: HostedRunnerContext;
+	drainRuntime?: (
+		sessionId: string,
+	) => Promise<HostedRunnerRuntimeDrainResult | null>;
+	now?: () => Date;
+}
+
+function getString(value: unknown, field: string): string | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new ApiError(400, `${field} must be a string`);
+	}
+	const trimmed = value.trim();
+	return trimmed || undefined;
+}
+
+function getStringArray(value: unknown, field: string): string[] | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (!Array.isArray(value)) {
+		throw new ApiError(400, `${field} must be an array of strings`);
+	}
+	const strings = value.map((entry, index) => {
+		if (typeof entry !== "string" || !entry.trim()) {
+			throw new ApiError(400, `${field}[${index}] must be a non-empty string`);
+		}
+		if (entry.includes("\0")) {
+			throw new ApiError(400, `${field}[${index}] contains a null byte`);
+		}
+		return entry.trim();
+	});
+	return strings.length ? strings : undefined;
+}
+
+export function parseHostedRunnerDrainInput(
+	body: unknown,
+): HostedRunnerDrainInput {
+	if (body === undefined || body === null) {
+		return {};
+	}
+	if (typeof body !== "object" || Array.isArray(body)) {
+		throw new ApiError(400, "Drain payload must be a JSON object");
+	}
+	const record = body as Record<string, unknown>;
+	return {
+		reason:
+			getString(record.reason, "reason") ??
+			getString(record.stop_reason, "stop_reason"),
+		requestedBy:
+			getString(record.requested_by, "requested_by") ??
+			getString(record.requestedBy, "requestedBy"),
+		exportPaths:
+			getStringArray(record.export_paths, "export_paths") ??
+			getStringArray(record.exportPaths, "exportPaths"),
+	};
+}
+
+function isWithinPath(root: string, target: string): boolean {
+	const rel = relative(root, target);
+	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function safeManifestFileName(
+	runnerSessionId: string,
+	requestedAt: string,
+): string {
+	const safeSession = runnerSessionId.replace(/[^A-Za-z0-9_.-]/g, "_");
+	const safeTimestamp = requestedAt.replace(/[^A-Za-z0-9_.-]/g, "_");
+	return `${safeSession}-${safeTimestamp}.json`;
+}
+
+async function resolveWorkspaceRoot(
+	hostedRunner: HostedRunnerContext,
+): Promise<string> {
+	try {
+		const workspaceRoot = await realpath(hostedRunner.workspaceRoot);
+		const stats = await stat(workspaceRoot);
+		if (!stats.isDirectory()) {
+			throw new ApiError(
+				503,
+				"Hosted runner workspace root is not a directory",
+			);
+		}
+		return workspaceRoot;
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw error;
+		}
+		throw new ApiError(
+			503,
+			`Hosted runner workspace root is unavailable: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+}
+
+async function resolveWorkspaceExportPaths(
+	workspaceRoot: string,
+	exportPaths: readonly string[] | undefined,
+): Promise<HostedRunnerWorkspaceExportPath[]> {
+	const requested = exportPaths?.length ? exportPaths : ["."];
+	const paths: HostedRunnerWorkspaceExportPath[] = [];
+	for (const input of requested) {
+		const logicalPath = isAbsolute(input)
+			? resolve(input)
+			: resolve(workspaceRoot, input);
+		let realPath: string;
+		try {
+			realPath = await realpath(logicalPath);
+		} catch (error) {
+			throw new ApiError(
+				400,
+				`Export path is unavailable: ${input} (${
+					error instanceof Error ? error.message : String(error)
+				})`,
+			);
+		}
+		if (!isWithinPath(workspaceRoot, realPath)) {
+			throw new ApiError(
+				400,
+				`Export path escapes hosted runner workspace root: ${input}`,
+			);
+		}
+		const pathStat = await stat(realPath);
+		paths.push({
+			input,
+			path: realPath,
+			relative_path: relative(workspaceRoot, realPath) || ".",
+			type: pathStat.isDirectory() ? "directory" : "file",
+		});
+	}
+	return paths;
+}
+
+async function gitOutput(
+	workspaceRoot: string,
+	args: readonly string[],
+): Promise<string | undefined> {
+	try {
+		const { stdout } = await execFileAsync(
+			"git",
+			["-C", workspaceRoot, ...args],
+			{
+				encoding: "utf8",
+				timeout: 1000,
+			},
+		);
+		const output = stdout.trim();
+		return output || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function collectGitState(
+	workspaceRoot: string,
+): Promise<HostedRunnerSnapshotManifest["git"] | undefined> {
+	const [commit, branch, status] = await Promise.all([
+		gitOutput(workspaceRoot, ["rev-parse", "HEAD"]),
+		gitOutput(workspaceRoot, ["rev-parse", "--abbrev-ref", "HEAD"]),
+		gitOutput(workspaceRoot, ["status", "--porcelain"]),
+	]);
+	if (!commit && !branch && status === undefined) {
+		return undefined;
+	}
+	return {
+		...(commit ? { commit } : {}),
+		...(branch && branch !== "HEAD" ? { branch } : {}),
+		dirty: Boolean(status),
+	};
+}
+
+export async function drainHostedRunner(
+	input: HostedRunnerDrainInput,
+	options: DrainHostedRunnerOptions,
+): Promise<HostedRunnerDrainResult | null> {
+	const hostedRunner = options.hostedRunner;
+	if (!hostedRunner?.enabled || !hostedRunner.runnerSessionId) {
+		return null;
+	}
+
+	hostedRunner.draining = true;
+	const requestedAt = (options.now?.() ?? new Date()).toISOString();
+	const stopReason = input.reason ?? "platform_requested_drain";
+	const workspaceRoot = await resolveWorkspaceRoot(hostedRunner);
+	const snapshotRoot = resolve(
+		workspaceRoot,
+		hostedRunner.snapshotRoot ?? ".maestro/runner-snapshots",
+	);
+	const exportPaths = await resolveWorkspaceExportPaths(
+		workspaceRoot,
+		input.exportPaths,
+	);
+	const activeSessionId =
+		hostedRunner.activeMaestroSessionId ??
+		hostedRunner.configuredMaestroSessionId;
+
+	let status: SnapshotManifestStatus = "drained";
+	let runtime: HostedRunnerSnapshotManifest["runtime"] = {
+		flush_status: "skipped",
+		...(activeSessionId ? { session_id: activeSessionId } : {}),
+	};
+
+	if (activeSessionId && options.drainRuntime) {
+		try {
+			const runtimeResult = await options.drainRuntime(activeSessionId);
+			runtime = runtimeResult
+				? {
+						flush_status: "completed",
+						session_id: runtimeResult.sessionId,
+						...(runtimeResult.sessionFile
+							? { session_file: runtimeResult.sessionFile }
+							: {}),
+						...(runtimeResult.protocolVersion
+							? { protocol_version: runtimeResult.protocolVersion }
+							: {}),
+						...(runtimeResult.cursor !== undefined
+							? { cursor: runtimeResult.cursor }
+							: {}),
+					}
+				: {
+						flush_status: "skipped",
+						session_id: activeSessionId,
+					};
+		} catch (error) {
+			status = "interrupted";
+			runtime = {
+				flush_status: "failed",
+				session_id: activeSessionId,
+				error: error instanceof Error ? error.message : String(error),
+			};
+		}
+	}
+
+	await mkdir(snapshotRoot, { recursive: true });
+	const snapshotPath = join(
+		snapshotRoot,
+		safeManifestFileName(hostedRunner.runnerSessionId, requestedAt),
+	);
+	const completedAt = (options.now?.() ?? new Date()).toISOString();
+	const git = await collectGitState(workspaceRoot);
+	const manifest: HostedRunnerSnapshotManifest = {
+		manifest_version: HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
+		protocol_version: HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION,
+		status,
+		runner_session_id: hostedRunner.runnerSessionId,
+		...(hostedRunner.ownerInstanceId
+			? { owner_instance_id: hostedRunner.ownerInstanceId }
+			: {}),
+		...(hostedRunner.workspaceId
+			? { workspace_id: hostedRunner.workspaceId }
+			: {}),
+		...(hostedRunner.agentRunId
+			? { agent_run_id: hostedRunner.agentRunId }
+			: {}),
+		...(activeSessionId ? { maestro_session_id: activeSessionId } : {}),
+		workspace_root: workspaceRoot,
+		snapshot_root: snapshotRoot,
+		snapshot_path: snapshotPath,
+		requested_at: requestedAt,
+		completed_at: completedAt,
+		stop_reason: stopReason,
+		...(input.requestedBy ? { requested_by: input.requestedBy } : {}),
+		runtime,
+		workspace_export: {
+			mode: "local_path_contract",
+			paths: exportPaths,
+		},
+		...(git ? { git } : {}),
+	};
+
+	await writeFile(
+		snapshotPath,
+		`${JSON.stringify(manifest, null, 2)}\n`,
+		"utf8",
+	);
+
+	return {
+		status,
+		manifest_path: snapshotPath,
+		manifest,
+	};
+}
+
+async function drainActiveRuntime(
+	context: WebServerContext,
+	sessionId: string,
+): Promise<HostedRunnerRuntimeDrainResult | null> {
+	const runtime =
+		context.headlessRuntimeService.getRuntimeBySessionId(sessionId);
+	if (!runtime) {
+		return null;
+	}
+	const snapshot = runtime.getSnapshot();
+	const sessionFile = runtime.getSessionFile();
+	await runtime.dispose();
+	return {
+		sessionId: snapshot.session_id,
+		sessionFile,
+		protocolVersion: snapshot.protocolVersion,
+		cursor: snapshot.cursor,
+	};
+}
+
+export async function handleHostedRunnerDrain(
+	req: IncomingMessage,
+	res: ServerResponse,
+	context: WebServerContext,
+): Promise<void> {
+	res.setHeader("Cache-Control", "no-store");
+	const body = await readJsonBody<Record<string, unknown>>(req, 64_000);
+	const input = parseHostedRunnerDrainInput(body);
+	const result = await drainHostedRunner(input, {
+		hostedRunner: context.hostedRunner,
+		drainRuntime: (sessionId) => drainActiveRuntime(context, sessionId),
+	});
+
+	if (!result) {
+		sendJson(
+			res,
+			404,
+			{
+				error: "hosted runner drain unavailable",
+			},
+			context.corsHeaders,
+			req,
+		);
+		return;
+	}
+
+	sendJson(
+		res,
+		result.status === "interrupted" ? 503 : 200,
+		{
+			protocol_version: HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION,
+			status: result.status,
+			manifest_path: result.manifest_path,
+			manifest: result.manifest,
+		},
+		context.corsHeaders,
+		req,
+	);
+}

--- a/src/server/headless-runtime-service.ts
+++ b/src/server/headless-runtime-service.ts
@@ -690,6 +690,7 @@ export class HeadlessSessionRuntime {
 			this.agent.abort();
 			await this.automaticMemoryExtraction.flush();
 			await this.automaticMemoryConsolidation.flush();
+			await this.sessionManager.flush();
 			this.finalizeDisposal();
 		})();
 		this.disposePromise = disposePromise;
@@ -749,6 +750,10 @@ export class HeadlessSessionRuntime {
 		};
 		assertHeadlessRuntimeSnapshot(snapshot, "headless runtime snapshot");
 		return snapshot;
+	}
+
+	getSessionFile(): string {
+		return this.sessionManager.getSessionFile();
 	}
 
 	replayFrom(cursor: number): HeadlessRuntimeStreamEnvelope[] | null {
@@ -2207,6 +2212,15 @@ export class HeadlessRuntimeService {
 			return undefined;
 		}
 		return runtime;
+	}
+
+	getRuntimeBySessionId(sessionId: string): HeadlessSessionRuntime | undefined {
+		for (const runtime of this.runtimes.values()) {
+			if (!runtime.isDisposed() && runtime.id() === sessionId) {
+				return runtime;
+			}
+		}
+		return undefined;
 	}
 
 	private async cleanup(): Promise<void> {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -44,6 +44,10 @@ import {
 } from "./handlers/headless-sessions.js";
 import { handleReadyz } from "./handlers/health.js";
 import {
+	HOSTED_RUNNER_DRAIN_PATH,
+	handleHostedRunnerDrain,
+} from "./handlers/hosted-runner-drain.js";
+import {
 	HOSTED_RUNNER_IDENTITY_PATH,
 	handleHostedRunnerIdentity,
 } from "./handlers/hosted-runner-identity.js";
@@ -122,6 +126,11 @@ export function createRoutes(context: WebServerContext): Route[] {
 			path: HOSTED_RUNNER_IDENTITY_PATH,
 			handler: (req, res) =>
 				handleHostedRunnerIdentity(req, res, corsHeaders, context.hostedRunner),
+		},
+		{
+			method: "POST",
+			path: HOSTED_RUNNER_DRAIN_PATH,
+			handler: (req, res) => handleHostedRunnerDrain(req, res, context),
 		},
 		{
 			method: "POST",

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -875,6 +875,7 @@ export async function startWebServer(
 			logger.info("Hosted runner mode enabled", {
 				runnerSessionId: context.hostedRunner.runnerSessionId,
 				workspaceRoot: context.hostedRunner.workspaceRoot,
+				snapshotRoot: context.hostedRunner.snapshotRoot,
 				workspaceId: context.hostedRunner.workspaceId,
 				agentRunId: context.hostedRunner.agentRunId,
 				listenHost: options.host,

--- a/test/cli/hosted-runner-command.test.ts
+++ b/test/cli/hosted-runner-command.test.ts
@@ -33,6 +33,8 @@ describe("hosted-runner command config", () => {
 				"pod_123",
 				"--workspace-root",
 				workspaceRoot,
+				"--snapshot-root",
+				".runner-snapshots",
 				"--listen",
 				"0.0.0.0:9090",
 				"--workspace-id",
@@ -47,6 +49,7 @@ describe("hosted-runner command config", () => {
 			runnerSessionId: "mrs_123",
 			ownerInstanceId: "pod_123",
 			workspaceRoot: realpathSync(workspaceRoot),
+			snapshotRoot: join(realpathSync(workspaceRoot), ".runner-snapshots"),
 			host: "0.0.0.0",
 			port: 9090,
 			workspaceId: "ws_123",
@@ -57,6 +60,7 @@ describe("hosted-runner command config", () => {
 			runnerSessionId: "mrs_123",
 			ownerInstanceId: "pod_123",
 			workspaceRoot: realpathSync(workspaceRoot),
+			snapshotRoot: join(realpathSync(workspaceRoot), ".runner-snapshots"),
 			listenHost: "0.0.0.0",
 			listenPort: 9090,
 		});
@@ -68,6 +72,7 @@ describe("hosted-runner command config", () => {
 			MAESTRO_RUNNER_SESSION_ID: "mrs_env",
 			MAESTRO_REMOTE_RUNNER_OWNER_INSTANCE_ID: "pod_env",
 			MAESTRO_WORKSPACE_ROOT: workspaceRoot,
+			MAESTRO_REMOTE_RUNNER_SNAPSHOT_ROOT: ".snapshots",
 			MAESTRO_HOSTED_RUNNER_PORT: "7070",
 			MAESTRO_REMOTE_RUNNER_WORKSPACE_ID: "ws_env",
 		});
@@ -76,6 +81,7 @@ describe("hosted-runner command config", () => {
 			runnerSessionId: "mrs_env",
 			ownerInstanceId: "pod_env",
 			workspaceRoot: realpathSync(workspaceRoot),
+			snapshotRoot: join(realpathSync(workspaceRoot), ".snapshots"),
 			port: 7070,
 			workspaceId: "ws_env",
 		});

--- a/test/server/hosted-runner-drain.test.ts
+++ b/test/server/hosted-runner-drain.test.ts
@@ -1,0 +1,186 @@
+import {
+	mkdir,
+	mkdtemp,
+	readFile,
+	realpath,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HostedRunnerContext } from "../../src/server/app-context.js";
+import {
+	HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION,
+	HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
+	drainHostedRunner,
+} from "../../src/server/handlers/hosted-runner-drain.js";
+
+const tempDirs: string[] = [];
+
+async function createTempWorkspace(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "maestro-runner-drain-"));
+	const resolved = await realpath(dir);
+	tempDirs.push(resolved);
+	await writeFile(join(resolved, "README.md"), "# workspace\n", "utf8");
+	return resolved;
+}
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })),
+	);
+});
+
+function hostedRunnerContext(
+	workspaceRoot: string,
+	snapshotRoot = join(workspaceRoot, ".maestro", "runner-snapshots"),
+): HostedRunnerContext {
+	return {
+		enabled: true,
+		runnerSessionId: "mrs_123",
+		ownerInstanceId: "pod_123",
+		workspaceRoot,
+		snapshotRoot,
+		workspaceId: "ws_123",
+		agentRunId: "ar_123",
+		activeMaestroSessionId: "session_123",
+	};
+}
+
+describe("hosted runner drain", () => {
+	it("drains the active runtime and writes a bounded snapshot manifest", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const context = hostedRunnerContext(workspaceRoot);
+		const drainRuntime = vi.fn().mockResolvedValue({
+			sessionId: "session_123",
+			sessionFile: join(workspaceRoot, ".maestro", "sessions", "session.jsonl"),
+			protocolVersion: "2026-04-02",
+			cursor: 7,
+		});
+
+		const result = await drainHostedRunner(
+			{
+				reason: "ttl_expired",
+				requestedBy: "platform",
+				exportPaths: [".", "README.md"],
+			},
+			{
+				hostedRunner: context,
+				drainRuntime,
+				now: () => new Date("2026-04-23T00:00:00.000Z"),
+			},
+		);
+
+		expect(result?.status).toBe("drained");
+		expect(context.draining).toBe(true);
+		expect(drainRuntime).toHaveBeenCalledWith("session_123");
+		expect(result?.manifest).toMatchObject({
+			manifest_version: HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
+			protocol_version: HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION,
+			status: "drained",
+			runner_session_id: "mrs_123",
+			owner_instance_id: "pod_123",
+			workspace_id: "ws_123",
+			agent_run_id: "ar_123",
+			maestro_session_id: "session_123",
+			workspace_root: workspaceRoot,
+			stop_reason: "ttl_expired",
+			requested_by: "platform",
+			runtime: {
+				flush_status: "completed",
+				session_id: "session_123",
+				protocol_version: "2026-04-02",
+				cursor: 7,
+			},
+		});
+		expect(result?.manifest.workspace_export.paths).toEqual([
+			{
+				input: ".",
+				path: workspaceRoot,
+				relative_path: ".",
+				type: "directory",
+			},
+			{
+				input: "README.md",
+				path: join(workspaceRoot, "README.md"),
+				relative_path: "README.md",
+				type: "file",
+			},
+		]);
+
+		const persisted = JSON.parse(
+			await readFile(result!.manifest_path, "utf8"),
+		) as unknown;
+		expect(persisted).toEqual(result?.manifest);
+	});
+
+	it("records an interrupted manifest when runtime drain fails", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const context = hostedRunnerContext(workspaceRoot);
+		const drainRuntime = vi
+			.fn()
+			.mockRejectedValue(new Error("flush timed out"));
+
+		const result = await drainHostedRunner(
+			{ reason: "preempted" },
+			{
+				hostedRunner: context,
+				drainRuntime,
+				now: () => new Date("2026-04-23T00:01:00.000Z"),
+			},
+		);
+
+		expect(result?.status).toBe("interrupted");
+		expect(context.draining).toBe(true);
+		expect(result?.manifest.runtime).toMatchObject({
+			flush_status: "failed",
+			session_id: "session_123",
+			error: "flush timed out",
+		});
+		const persisted = JSON.parse(
+			await readFile(result!.manifest_path, "utf8"),
+		) as { status: string };
+		expect(persisted.status).toBe("interrupted");
+	});
+
+	it("rejects export paths outside the hosted workspace root", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const outsideRoot = await mkdtemp(
+			join(tmpdir(), "maestro-outside-export-"),
+		);
+		tempDirs.push(outsideRoot);
+		await mkdir(join(outsideRoot, "subdir"));
+		const context = hostedRunnerContext(workspaceRoot);
+
+		await expect(
+			drainHostedRunner(
+				{ exportPaths: [join(outsideRoot, "subdir")] },
+				{
+					hostedRunner: context,
+					drainRuntime: vi.fn(),
+					now: () => new Date("2026-04-23T00:02:00.000Z"),
+				},
+			),
+		).rejects.toMatchObject({
+			statusCode: 400,
+			message: expect.stringContaining("escapes hosted runner workspace root"),
+		});
+	});
+
+	it("leaves local/offline servers unchanged when hosted mode is unavailable", async () => {
+		const drainRuntime = vi.fn();
+
+		const result = await drainHostedRunner(
+			{ reason: "local" },
+			{
+				drainRuntime,
+				now: () => new Date("2026-04-23T00:03:00.000Z"),
+			},
+		);
+
+		expect(result).toBeNull();
+		expect(drainRuntime).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- Add POST /.well-known/evalops/remote-runner/drain for hosted remote-runner teardown.
- Flush active headless runtime/session state before manifest handoff and mark readiness as draining.
- Validate workspace export paths stay inside the hosted workspace root and document the Platform/deploy handoff contract.

Refs #83

## Test plan
- ./node_modules/.bin/vitest run test/cli/hosted-runner-command.test.ts test/server/health.test.ts test/server/hosted-runner-identity.test.ts test/server/hosted-runner-drain.test.ts
- ./node_modules/.bin/biome check docs/protocols/headless.md src/cli/commands/hosted-runner.ts src/server/app-context.ts src/server/handlers/health.ts src/server/handlers/hosted-runner-drain.ts src/server/headless-runtime-service.ts src/server/routes.ts src/web-server.ts test/cli/hosted-runner-command.test.ts test/server/hosted-runner-drain.test.ts
- npx bun@1.3.6 run build
- git -c core.fsmonitor=false diff --check