### PR TITLE
Wire hosted runner executor to supervisor drain

### DIFF
--- a/packages/tui-rs/src/headless/mod.rs
+++ b/packages/tui-rs/src/headless/mod.rs
@@ -246,7 +246,8 @@ pub use session::{
 
 // Supervisor with reconnection
 pub use supervisor::{
-    AgentSupervisor, HealthStatus, SupervisorBuilder, SupervisorConfig, SupervisorEvent,
+    agent_event_to_message, AgentSupervisor, HealthStatus, SupervisorBuilder, SupervisorConfig,
+    SupervisorEvent,
 };
 
 // Message framing

--- a/packages/tui-rs/src/headless/supervisor.rs
+++ b/packages/tui-rs/src/headless/supervisor.rs
@@ -516,6 +516,27 @@ impl AgentSupervisor {
         Ok(())
     }
 
+    /// Send a protocol message and drain any agent messages that are already available.
+    pub fn send_and_drain_agent_messages(
+        &mut self,
+        msg: ToAgentMessage,
+    ) -> Result<Vec<FromAgentMessage>, AsyncTransportError> {
+        self.send(msg)?;
+        Ok(self.drain_available_agent_messages())
+    }
+
+    /// Drain currently available supervisor agent events as headless protocol messages.
+    #[must_use]
+    pub fn drain_available_agent_messages(&mut self) -> Vec<FromAgentMessage> {
+        let mut messages = Vec::new();
+        while let Some(event) = self.poll() {
+            if let SupervisorEvent::Agent(agent_event) = event {
+                messages.push(agent_event_to_message(&agent_event));
+            }
+        }
+        messages
+    }
+
     /// Send a prompt
     pub fn prompt(&mut self, content: impl Into<String>) -> Result<(), AsyncTransportError> {
         self.send(ToAgentMessage::Prompt {
@@ -1158,45 +1179,46 @@ impl Default for SupervisorBuilder {
     }
 }
 
-#[cfg(test)]
-fn event_to_message(event: &AgentEvent) -> Option<FromAgentMessage> {
+/// Convert a supervisor agent event into the wire-level headless message shape.
+#[must_use]
+pub fn agent_event_to_message(event: &AgentEvent) -> FromAgentMessage {
     match event {
-        AgentEvent::RawAgentEvent { event_type, event } => Some(FromAgentMessage::RawAgentEvent {
+        AgentEvent::RawAgentEvent { event_type, event } => FromAgentMessage::RawAgentEvent {
             event_type: event_type.clone(),
             event: event.clone(),
-        }),
+        },
         AgentEvent::Ready {
             protocol_version,
             model,
             provider,
             session_id,
-        } => Some(FromAgentMessage::Ready {
+        } => FromAgentMessage::Ready {
             protocol_version: protocol_version.clone(),
             model: model.clone(),
             provider: provider.clone(),
             session_id: session_id.clone(),
-        }),
+        },
         AgentEvent::SessionInfo {
             session_id,
             cwd,
             git_branch,
-        } => Some(FromAgentMessage::SessionInfo {
+        } => FromAgentMessage::SessionInfo {
             session_id: session_id.clone(),
             cwd: cwd.clone(),
             git_branch: git_branch.clone(),
-        }),
-        AgentEvent::ResponseStart { response_id } => Some(FromAgentMessage::ResponseStart {
+        },
+        AgentEvent::ResponseStart { response_id } => FromAgentMessage::ResponseStart {
             response_id: response_id.clone(),
-        }),
+        },
         AgentEvent::ResponseChunk {
             response_id,
             content,
             is_thinking,
-        } => Some(FromAgentMessage::ResponseChunk {
+        } => FromAgentMessage::ResponseChunk {
             response_id: response_id.clone(),
             content: content.clone(),
             is_thinking: *is_thinking,
-        }),
+        },
         AgentEvent::ResponseEnd {
             response_id,
             usage,
@@ -1204,60 +1226,60 @@ fn event_to_message(event: &AgentEvent) -> Option<FromAgentMessage> {
             duration_ms,
             ttft_ms,
             ..
-        } => Some(FromAgentMessage::ResponseEnd {
+        } => FromAgentMessage::ResponseEnd {
             response_id: response_id.clone(),
             usage: usage.clone(),
             tools_summary: tools_summary.clone(),
             duration_ms: *duration_ms,
             ttft_ms: *ttft_ms,
-        }),
+        },
         AgentEvent::ToolCall {
             call_id,
             tool,
             args,
-        } => Some(FromAgentMessage::ToolCall {
+        } => FromAgentMessage::ToolCall {
             call_id: call_id.clone(),
             tool: tool.clone(),
             args: args.clone(),
             requires_approval: false,
-        }),
+        },
         AgentEvent::ApprovalRequired {
             call_id,
             tool,
             args,
-        } => Some(FromAgentMessage::ToolCall {
+        } => FromAgentMessage::ToolCall {
             call_id: call_id.clone(),
             tool: tool.clone(),
             args: args.clone(),
             requires_approval: true,
-        }),
-        AgentEvent::ToolStart { call_id, .. } => Some(FromAgentMessage::ToolStart {
+        },
+        AgentEvent::ToolStart { call_id, .. } => FromAgentMessage::ToolStart {
             call_id: call_id.clone(),
-        }),
-        AgentEvent::ToolOutput { call_id, content } => Some(FromAgentMessage::ToolOutput {
+        },
+        AgentEvent::ToolOutput { call_id, content } => FromAgentMessage::ToolOutput {
             call_id: call_id.clone(),
             content: content.clone(),
-        }),
+        },
         AgentEvent::ToolEnd {
             call_id, success, ..
-        } => Some(FromAgentMessage::ToolEnd {
+        } => FromAgentMessage::ToolEnd {
             call_id: call_id.clone(),
             success: *success,
-        }),
+        },
         AgentEvent::Error {
             request_id,
             message,
             fatal,
             error_type,
-        } => Some(FromAgentMessage::Error {
+        } => FromAgentMessage::Error {
             request_id: request_id.clone(),
             message: message.clone(),
             fatal: *fatal,
             error_type: *error_type,
-        }),
-        AgentEvent::Status { message } => Some(FromAgentMessage::Status {
+        },
+        AgentEvent::Status { message } => FromAgentMessage::Status {
             message: message.clone(),
-        }),
+        },
         AgentEvent::Compaction {
             summary,
             first_kept_entry_index,
@@ -1265,14 +1287,14 @@ fn event_to_message(event: &AgentEvent) -> Option<FromAgentMessage> {
             auto,
             custom_instructions,
             timestamp,
-        } => Some(FromAgentMessage::Compaction {
+        } => FromAgentMessage::Compaction {
             summary: summary.clone(),
             first_kept_entry_index: *first_kept_entry_index,
             tokens_before: *tokens_before,
             auto: *auto,
             custom_instructions: custom_instructions.clone(),
             timestamp: timestamp.clone(),
-        }),
+        },
     }
 }
 
@@ -2335,14 +2357,13 @@ mod tests {
     }
 
     #[test]
-    fn event_to_message_preserves_headless_metadata() {
-        let ready = event_to_message(&AgentEvent::Ready {
+    fn agent_event_to_message_preserves_headless_metadata() {
+        let ready = agent_event_to_message(&AgentEvent::Ready {
             protocol_version: Some("2026-03-30".to_string()),
             model: "claude-3-opus".to_string(),
             provider: "anthropic".to_string(),
             session_id: Some("sess_123".to_string()),
-        })
-        .expect("ready message");
+        });
         assert!(matches!(
             ready,
             super::super::messages::FromAgentMessage::Ready {
@@ -2352,7 +2373,7 @@ mod tests {
             } if version == "2026-03-30" && session_id == "sess_123"
         ));
 
-        let response_end = event_to_message(&AgentEvent::ResponseEnd {
+        let response_end = agent_event_to_message(&AgentEvent::ResponseEnd {
             response_id: "resp_1".to_string(),
             usage: Some(TokenUsage {
                 input_tokens: 10,
@@ -2368,8 +2389,7 @@ mod tests {
             duration_ms: Some(2400),
             ttft_ms: Some(150),
             full_text: Some("Hello".to_string()),
-        })
-        .expect("response end message");
+        });
         assert!(matches!(
             response_end,
             super::super::messages::FromAgentMessage::ResponseEnd {
@@ -2379,13 +2399,12 @@ mod tests {
             }
         ));
 
-        let error = event_to_message(&AgentEvent::Error {
+        let error = agent_event_to_message(&AgentEvent::Error {
             request_id: None,
             message: "cancelled".to_string(),
             fatal: false,
             error_type: Some(HeadlessErrorType::Cancelled),
-        })
-        .expect("error message");
+        });
         assert!(matches!(
             error,
             super::super::messages::FromAgentMessage::Error {
@@ -2393,6 +2412,50 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn drain_available_agent_messages_skips_supervisor_lifecycle_events() {
+        let mut supervisor = AgentSupervisor::new(SupervisorConfig::default());
+        supervisor
+            .event_tx
+            .send(SupervisorEvent::Connected)
+            .expect("connected event");
+        supervisor
+            .event_tx
+            .send(SupervisorEvent::Agent(Box::new(AgentEvent::Status {
+                message: "queued status".to_string(),
+            })))
+            .expect("status event");
+        supervisor
+            .event_tx
+            .send(SupervisorEvent::HealthChanged {
+                status: HealthStatus::Healthy,
+            })
+            .expect("health event");
+        supervisor
+            .event_tx
+            .send(SupervisorEvent::Agent(Box::new(
+                AgentEvent::ResponseStart {
+                    response_id: "resp_drain".to_string(),
+                },
+            )))
+            .expect("response start event");
+
+        let messages = supervisor.drain_available_agent_messages();
+
+        assert_eq!(messages.len(), 2);
+        assert!(matches!(
+            messages[0],
+            super::super::messages::FromAgentMessage::Status { ref message }
+                if message == "queued status"
+        ));
+        assert!(matches!(
+            messages[1],
+            super::super::messages::FromAgentMessage::ResponseStart { ref response_id }
+                if response_id == "resp_drain"
+        ));
+        assert!(supervisor.poll().is_none());
     }
 
     #[cfg(unix)]

--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -21,8 +21,9 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio_util::sync::CancellationToken;
 
 use crate::headless::{
-    ClientCapabilities, ClientInfo, ConnectionRole, FromAgentMessage, ServerRequestType,
-    ToAgentMessage, UtilityOperation, HEADLESS_PROTOCOL_VERSION,
+    AgentSupervisor, AsyncTransportError, ClientCapabilities, ClientInfo, ConnectionRole,
+    FromAgentMessage, ServerRequestType, ToAgentMessage, UtilityOperation,
+    HEADLESS_PROTOCOL_VERSION,
 };
 
 pub const HOSTED_RUNNER_IDENTITY_PATH: &str = "/.well-known/evalops/remote-runner/identity";
@@ -583,12 +584,18 @@ impl HostedRunnerRuntime {
             .map(|value| validate_headless_id(&value, "subscriptionId"))
             .transpose()?;
 
+        let connection_id = {
+            let inner = self.inner.lock().expect("hosted runner mutex poisoned");
+            inner.ensure_headless_session(session_id)?;
+            subscription_id
+                .as_deref()
+                .map(|subscription_id| inner.resolve_subscription(subscription_id))
+                .transpose()?
+        };
+        self.publish_drained_headless_runtime_messages(session_id)?;
+
         let inner = self.inner.lock().expect("hosted runner mutex poisoned");
         inner.ensure_headless_session(session_id)?;
-        let connection_id = subscription_id
-            .as_deref()
-            .map(|subscription_id| inner.resolve_subscription(subscription_id))
-            .transpose()?;
         Ok(inner.headless_stream_events(cursor, connection_id.as_deref()))
     }
 
@@ -643,6 +650,27 @@ impl HostedRunnerRuntime {
             "published_messages": published_message_count,
             "message": result.message
         }))
+    }
+
+    fn publish_drained_headless_runtime_messages(
+        &self,
+        session_id: &str,
+    ) -> Result<usize, HostedRunnerError> {
+        let executor = {
+            let inner = self.inner.lock().expect("hosted runner mutex poisoned");
+            inner.ensure_headless_session(session_id)?;
+            Arc::clone(&inner.message_executor)
+        };
+        let messages = executor.drain()?;
+        let message_count = messages.len();
+        if message_count == 0 {
+            return Ok(0);
+        }
+
+        let mut inner = self.inner.lock().expect("hosted runner mutex poisoned");
+        inner.ensure_headless_session(session_id)?;
+        inner.publish_headless_messages(messages);
+        Ok(message_count)
     }
 }
 
@@ -776,6 +804,67 @@ pub trait HostedRunnerHeadlessMessageExecutor: Send + Sync {
         context: &HostedRunnerHeadlessMessageContext,
         message: ToAgentMessage,
     ) -> Result<HostedRunnerHeadlessMessageResult, HostedRunnerError>;
+
+    fn drain(&self) -> Result<Vec<FromAgentMessage>, HostedRunnerError> {
+        Ok(Vec::new())
+    }
+}
+
+#[derive(Clone)]
+pub struct AgentSupervisorHostedRunnerMessageExecutor {
+    supervisor: Arc<Mutex<AgentSupervisor>>,
+}
+
+impl AgentSupervisorHostedRunnerMessageExecutor {
+    #[must_use]
+    pub fn new(supervisor: Arc<Mutex<AgentSupervisor>>) -> Self {
+        Self { supervisor }
+    }
+
+    #[must_use]
+    pub fn supervisor(&self) -> Arc<Mutex<AgentSupervisor>> {
+        Arc::clone(&self.supervisor)
+    }
+}
+
+impl std::fmt::Debug for AgentSupervisorHostedRunnerMessageExecutor {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AgentSupervisorHostedRunnerMessageExecutor")
+            .finish_non_exhaustive()
+    }
+}
+
+impl HostedRunnerHeadlessMessageExecutor for AgentSupervisorHostedRunnerMessageExecutor {
+    fn execute(
+        &self,
+        context: &HostedRunnerHeadlessMessageContext,
+        message: ToAgentMessage,
+    ) -> Result<HostedRunnerHeadlessMessageResult, HostedRunnerError> {
+        let include_hosted_hello = matches!(message, ToAgentMessage::Hello { .. });
+        let mut supervisor = self
+            .supervisor
+            .lock()
+            .map_err(|_| HostedRunnerError::internal("agent supervisor mutex poisoned"))?;
+        let mut messages = supervisor
+            .send_and_drain_agent_messages(message)
+            .map_err(hosted_runner_error_from_async_transport)?;
+        if include_hosted_hello {
+            messages.insert(0, hosted_hello_ok_for_context(context));
+        }
+        Ok(HostedRunnerHeadlessMessageResult::runtime_handled(
+            messages,
+            "Rust hosted runner forwarded the headless message to AgentSupervisor",
+        ))
+    }
+
+    fn drain(&self) -> Result<Vec<FromAgentMessage>, HostedRunnerError> {
+        let mut supervisor = self
+            .supervisor
+            .lock()
+            .map_err(|_| HostedRunnerError::internal("agent supervisor mutex poisoned"))?;
+        Ok(supervisor.drain_available_agent_messages())
+    }
 }
 
 #[derive(Debug, Default)]
@@ -788,17 +877,7 @@ impl HostedRunnerHeadlessMessageExecutor for TransportOnlyHostedRunnerMessageExe
         message: ToAgentMessage,
     ) -> Result<HostedRunnerHeadlessMessageResult, HostedRunnerError> {
         let response = match message {
-            ToAgentMessage::Hello { .. } => FromAgentMessage::HelloOk {
-                protocol_version: HEADLESS_PROTOCOL_VERSION.to_string(),
-                connection_id: Some(context.connection_id.clone()),
-                client_protocol_version: context.client_protocol_version.clone(),
-                client_info: context.client_info.clone(),
-                capabilities: context.capabilities.clone(),
-                opt_out_notifications: context.opt_out_notifications.clone(),
-                role: Some(context.role),
-                controller_connection_id: context.controller_connection_id.clone(),
-                lease_expires_at: Some(context.lease_expires_at.clone()),
-            },
+            ToAgentMessage::Hello { .. } => hosted_hello_ok_for_context(context),
             _ => FromAgentMessage::Status {
                 message: "Rust hosted runner accepted the headless message; agent execution is not attached yet".to_string(),
             },
@@ -808,6 +887,24 @@ impl HostedRunnerHeadlessMessageExecutor for TransportOnlyHostedRunnerMessageExe
             "Rust hosted runner accepted the headless message; agent execution is not attached yet",
         ))
     }
+}
+
+fn hosted_hello_ok_for_context(context: &HostedRunnerHeadlessMessageContext) -> FromAgentMessage {
+    FromAgentMessage::HelloOk {
+        protocol_version: HEADLESS_PROTOCOL_VERSION.to_string(),
+        connection_id: Some(context.connection_id.clone()),
+        client_protocol_version: context.client_protocol_version.clone(),
+        client_info: context.client_info.clone(),
+        capabilities: context.capabilities.clone(),
+        opt_out_notifications: context.opt_out_notifications.clone(),
+        role: Some(context.role),
+        controller_connection_id: context.controller_connection_id.clone(),
+        lease_expires_at: Some(context.lease_expires_at.clone()),
+    }
+}
+
+fn hosted_runner_error_from_async_transport(error: AsyncTransportError) -> HostedRunnerError {
+    HostedRunnerError::runtime_not_ready(format!("agent supervisor is not ready: {error}"))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2336,7 +2433,7 @@ fn is_headless_path(path: &str) -> bool {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
 
     fn runtime() -> (TempDir, HostedRunnerRuntime) {
@@ -2393,6 +2490,35 @@ mod tests {
                     "Rust hosted runner message handled by runtime executor",
                 )),
             }
+        }
+    }
+
+    struct DrainableRuntimeExecutor {
+        messages: Mutex<Vec<FromAgentMessage>>,
+    }
+
+    impl DrainableRuntimeExecutor {
+        fn new(messages: Vec<FromAgentMessage>) -> Self {
+            Self {
+                messages: Mutex::new(messages),
+            }
+        }
+    }
+
+    impl HostedRunnerHeadlessMessageExecutor for DrainableRuntimeExecutor {
+        fn execute(
+            &self,
+            _context: &HostedRunnerHeadlessMessageContext,
+            _message: ToAgentMessage,
+        ) -> Result<HostedRunnerHeadlessMessageResult, HostedRunnerError> {
+            Ok(HostedRunnerHeadlessMessageResult::runtime_handled(
+                Vec::new(),
+                "accepted by drainable runtime",
+            ))
+        }
+
+        fn drain(&self) -> Result<Vec<FromAgentMessage>, HostedRunnerError> {
+            Ok(self.messages.lock().expect("messages").drain(..).collect())
         }
     }
 
@@ -2902,6 +3028,93 @@ mod tests {
         assert_eq!(events.body[1]["message"]["content"], "hello from hosted");
         assert_eq!(events.body[2]["cursor"], 3);
         assert_eq!(events.body[2]["message"]["type"], "response_end");
+    }
+
+    #[test]
+    fn event_replay_drains_runtime_executor_messages() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = HostedRunnerConfig::new("mrs/test:1", temp_dir.path())
+            .unwrap()
+            .with_owner_instance_id("owner-1")
+            .with_maestro_session_id("maestro-session-1");
+        let executor = Arc::new(DrainableRuntimeExecutor::new(vec![
+            FromAgentMessage::ResponseStart {
+                response_id: "resp-drain-1".to_string(),
+            },
+            FromAgentMessage::ResponseChunk {
+                response_id: "resp-drain-1".to_string(),
+                content: "drained later".to_string(),
+                is_thinking: false,
+            },
+        ]));
+        let runtime = HostedRunnerRuntime::new_with_message_executor(config, executor);
+
+        let controller = runtime.handle_request(
+            "POST",
+            "/api/headless/connections",
+            Some(r#"{"protocolVersion":"headless.v1","role":"controller"}"#),
+        );
+        assert_eq!(controller.status, 200);
+        let subscribe = runtime.handle_request(
+            "POST",
+            "/api/headless/sessions/maestro-session-1/subscribe",
+            Some(r#"{"connectionId":"hconn_1","role":"controller"}"#),
+        );
+        assert_eq!(subscribe.status, 200);
+
+        let events = runtime.handle_request(
+            "GET",
+            "/api/headless/sessions/maestro-session-1/events?cursor=0&subscriptionId=hsub_1",
+            None,
+        );
+        assert_eq!(events.status, 200);
+        assert_eq!(events.body[0]["cursor"], 1);
+        assert_eq!(events.body[0]["message"]["type"], "response_start");
+        assert_eq!(events.body[1]["cursor"], 2);
+        assert_eq!(events.body[1]["message"]["type"], "response_chunk");
+        assert_eq!(events.body[1]["message"]["content"], "drained later");
+
+        let replay = runtime.handle_request(
+            "GET",
+            "/api/headless/sessions/maestro-session-1/events?cursor=2&subscriptionId=hsub_1",
+            None,
+        );
+        assert_eq!(replay.status, 200);
+        assert_eq!(replay.body[0]["type"], "heartbeat");
+        assert_eq!(replay.body[0]["cursor"], 2);
+    }
+
+    #[test]
+    fn supervisor_executor_reports_runtime_not_ready_until_connected() {
+        let supervisor = Arc::new(Mutex::new(AgentSupervisor::new(
+            crate::headless::SupervisorConfig::default(),
+        )));
+        let executor = AgentSupervisorHostedRunnerMessageExecutor::new(supervisor);
+        let context = HostedRunnerHeadlessMessageContext {
+            session_id: "maestro-session-1".to_string(),
+            connection_id: "hconn_1".to_string(),
+            subscription_id: Some("hsub_1".to_string()),
+            role: ConnectionRole::Controller,
+            controller_connection_id: Some("hconn_1".to_string()),
+            client_protocol_version: Some(HEADLESS_PROTOCOL_VERSION.to_string()),
+            client_info: None,
+            capabilities: None,
+            opt_out_notifications: None,
+            lease_expires_at: format_timestamp(Utc::now()),
+            workspace_root: TempDir::new().unwrap().path().to_path_buf(),
+        };
+
+        let error = executor
+            .execute(
+                &context,
+                ToAgentMessage::Prompt {
+                    content: "hello".to_string(),
+                    attachments: None,
+                },
+            )
+            .expect_err("disconnected supervisor should not accept prompts");
+
+        assert_eq!(error.code, HostedRunnerErrorCode::RuntimeNotReady);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- expose supervisor helpers to send a headless protocol message and drain already-available agent messages as `FromAgentMessage` envelopes
- add an `AgentSupervisorHostedRunnerMessageExecutor` for the Rust hosted-runner `/messages` hook introduced by #109
- flush executor-drained messages into the hosted replay buffer before serving `/events`, giving the Rust hosted surface a supervisor-owned message pump without claiming long-lived SSE is finished

Part of #102. Builds directly on #109: this is the first real AgentSupervisor integration boundary, while remaining work still needs async/live event pumping, durable replay/reset, workspace utilities, and drain-time session-file flush.

## Tests
- cargo +1.88.0 fmt
- cargo +1.88.0 test hosted_runner --lib
- cargo +1.88.0 test supervisor --lib
- cargo +1.88.0 test remote_transport --lib
- git diff --check
- cargo +1.88.0 clippy --all-targets --all-features -- -D warnings

Note: clippy completed successfully; the crate still emits the existing duplicate `unknown lint: clippy::duration_suboptimal_units` warning from configured allowances.