### PR TITLE
Add Rust hosted runner conformance adapter

### DIFF
--- a/docs/protocols/headless-conformance.md
+++ b/docs/protocols/headless-conformance.md
@@ -8,10 +8,10 @@ implementation detail.
 The executable suite starts in
 [`test/headless/runtime-conformance.test.ts`](../../test/headless/runtime-conformance.test.ts).
 It defines a small runtime adapter, then runs the same scenarios against the
-current TypeScript in-process host. Rust now has a hosted-runner library surface
-under `maestro_tui::hosted_runner::start_hosted_runner`; the next adapter should
-drive the same operations over its HTTP/SSE endpoints without changing the
-scenario body.
+current TypeScript in-process host. It also includes an opt-in Rust adapter that
+spawns `hosted_runner_conformance_fixture` and drives
+`maestro_tui::hosted_runner::start_hosted_runner_with_message_executor` through
+the external HTTP/SSE endpoints.
 
 The provider-neutral hosted runner shape that these scenarios protect is defined
 in [Hosted Runner Contract](./hosted-runner-contract.md).
@@ -20,6 +20,12 @@ Local command:
 
 ```bash
 npm run test -- test/headless/runtime-conformance.test.ts
+```
+
+Rust hosted-runner wire check:
+
+```bash
+MAESTRO_RUST_HOSTED_CONFORMANCE=1 npm run test -- test/headless/runtime-conformance.test.ts
 ```
 
 ## Contract Areas
@@ -56,9 +62,11 @@ A conforming adapter should expose these operations:
 - trigger deterministic approval/request fixtures for server-request coverage
 
 The TypeScript adapter uses `HeadlessInProcessHost` to avoid HTTP server
-bookkeeping. The Rust adapter should drive
-`maestro_tui::hosted_runner::start_hosted_runner` so this suite verifies true wire
-behavior rather than Rust internals.
+bookkeeping. The Rust adapter uses a deterministic fixture binary so the shared
+suite verifies true wire behavior rather than Rust internals. The fixture
+handles prompts and approvals deterministically while Maestro's Rust server owns
+leases, replay, SSE, snapshots, workspace utilities, heartbeat, and disconnect
+semantics.
 
 ## Reference Patterns
 

--- a/docs/protocols/hosted-runner-contract.md
+++ b/docs/protocols/hosted-runner-contract.md
@@ -175,8 +175,11 @@ workspace-root containment for file, watch, and command utility operations, and
 writes the local drain manifest. It deliberately keeps provider scheduling and
 artifact upload out of Rust; Platform still owns those concerns.
 
-The current Rust surface is meant to unblock the real Rust-hosted conformance
-adapter. It is not yet the final `maestro hosted-runner` CLI wrapper.
+The Rust surface now has an opt-in hosted conformance adapter. The adapter
+spawns a deterministic fixture binary, attaches over HTTP/SSE, and exercises the
+same shared scenarios as the TypeScript in-process host while the Rust server
+owns leases, replay, snapshots, workspace utilities, heartbeat, and disconnect
+behavior. It is not yet the final `maestro hosted-runner` CLI wrapper.
 
 ## Error Vocabulary
 
@@ -279,16 +282,23 @@ Every hosted runner implementation should satisfy the shared conformance suite:
 npm run test -- test/headless/runtime-conformance.test.ts
 ```
 
+Rust hosted-runner wire parity is opt-in while the fixture compiles the Rust
+crate:
+
+```bash
+MAESTRO_RUST_HOSTED_CONFORMANCE=1 npm run test -- test/headless/runtime-conformance.test.ts
+```
+
 Current coverage includes schema-valid snapshots/envelopes, controller/viewer
 roles, explicit controller takeover, cursor replay/reset, approval request and
 response resolution, workspace-root file-read enforcement, utility
 command/search/watch lifecycle, and disconnect cleanup.
 
-The current TypeScript adapter targets the in-process host. The Rust-hosted
-adapter should drive the same scenarios through
-`maestro_tui::hosted_runner::start_hosted_runner` and the external HTTP/SSE surface.
-The scenario body must remain shared; only adapter startup and transport
-details should vary.
+The TypeScript adapter targets the in-process host. The Rust-hosted adapter
+drives the same scenarios through
+`maestro_tui::hosted_runner::start_hosted_runner_with_message_executor` and the
+external HTTP/SSE surface. The scenario body must remain shared; only adapter
+startup and transport details should vary.
 
 ## References
 

--- a/packages/tui-rs/src/bin/hosted_runner_conformance_fixture.rs
+++ b/packages/tui-rs/src/bin/hosted_runner_conformance_fixture.rs
@@ -1,0 +1,183 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use maestro_tui::headless::{
+    AgentState, FromAgentMessage, ServerRequestResolutionStatus, ServerRequestResolvedBy,
+    ServerRequestType, ToAgentMessage, HEADLESS_PROTOCOL_VERSION,
+};
+use maestro_tui::hosted_runner::{
+    start_hosted_runner_with_message_executor, HostedRunnerConfig, HostedRunnerError,
+    HostedRunnerHeadlessMessageContext, HostedRunnerHeadlessMessageExecutor,
+    HostedRunnerHeadlessMessageResult,
+};
+use serde::Deserialize;
+use serde_json::json;
+use tokio::io::AsyncReadExt;
+
+const APPROVAL_TRIGGER_PREFIX: &str = "__maestro_conformance_approval__:";
+
+#[derive(Debug, Deserialize)]
+struct ApprovalTrigger {
+    request_id: String,
+    tool: String,
+    args: serde_json::Value,
+    reason: String,
+}
+
+struct ConformanceExecutor {
+    state: Mutex<AgentState>,
+}
+
+impl ConformanceExecutor {
+    fn new(session_id: String, workspace_root: PathBuf) -> Self {
+        let mut state = AgentState {
+            protocol_version: Some(HEADLESS_PROTOCOL_VERSION.to_string()),
+            model: Some("gpt-5.4".to_string()),
+            provider: Some("openai".to_string()),
+            session_id: Some(session_id),
+            cwd: Some(workspace_root.to_string_lossy().to_string()),
+            last_status: Some("Ready".to_string()),
+            is_ready: true,
+            ..AgentState::default()
+        };
+        state.handle_message(FromAgentMessage::Ready {
+            protocol_version: Some(HEADLESS_PROTOCOL_VERSION.to_string()),
+            model: "gpt-5.4".to_string(),
+            provider: "openai".to_string(),
+            session_id: state.session_id.clone(),
+        });
+        Self {
+            state: Mutex::new(state),
+        }
+    }
+
+    fn record(
+        &self,
+        sent: &ToAgentMessage,
+        messages: &[FromAgentMessage],
+    ) -> Result<(), HostedRunnerError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| HostedRunnerError::internal("conformance state mutex poisoned"))?;
+        state.handle_sent_message(sent);
+        for message in messages {
+            state.handle_message(message.clone());
+        }
+        Ok(())
+    }
+}
+
+impl HostedRunnerHeadlessMessageExecutor for ConformanceExecutor {
+    fn execute(
+        &self,
+        _context: &HostedRunnerHeadlessMessageContext,
+        message: ToAgentMessage,
+    ) -> Result<HostedRunnerHeadlessMessageResult, HostedRunnerError> {
+        let messages = match &message {
+            ToAgentMessage::Prompt { content, .. } => {
+                if let Some(payload) = content.strip_prefix(APPROVAL_TRIGGER_PREFIX) {
+                    let trigger: ApprovalTrigger =
+                        serde_json::from_str(payload).map_err(|error| {
+                            HostedRunnerError::bad_request(format!(
+                                "invalid conformance approval trigger: {error}"
+                            ))
+                        })?;
+                    vec![FromAgentMessage::ServerRequest {
+                        request_id: trigger.request_id.clone(),
+                        request_type: ServerRequestType::Approval,
+                        call_id: trigger.request_id,
+                        tool: trigger.tool,
+                        args: trigger.args,
+                        reason: trigger.reason,
+                    }]
+                } else {
+                    vec![FromAgentMessage::Status {
+                        message: format!("Prompt: {content}"),
+                    }]
+                }
+            }
+            ToAgentMessage::ServerRequestResponse {
+                request_id,
+                request_type,
+                approved,
+                result,
+                reason,
+                ..
+            } => {
+                let resolution = match request_type {
+                    ServerRequestType::Approval => {
+                        if approved.unwrap_or(false) {
+                            ServerRequestResolutionStatus::Approved
+                        } else {
+                            ServerRequestResolutionStatus::Denied
+                        }
+                    }
+                    ServerRequestType::ClientTool => ServerRequestResolutionStatus::Completed,
+                    ServerRequestType::UserInput => ServerRequestResolutionStatus::Answered,
+                    ServerRequestType::ToolRetry => ServerRequestResolutionStatus::Retried,
+                };
+                let reason = reason
+                    .clone()
+                    .or_else(|| result.as_ref().and_then(|result| result.error.clone()));
+                vec![FromAgentMessage::ServerRequestResolved {
+                    request_id: request_id.clone(),
+                    request_type: *request_type,
+                    call_id: request_id.clone(),
+                    resolution,
+                    reason,
+                    resolved_by: ServerRequestResolvedBy::User,
+                }]
+            }
+            _ => Vec::new(),
+        };
+        self.record(&message, &messages)?;
+        Ok(HostedRunnerHeadlessMessageResult::runtime_handled(
+            messages,
+            "Rust hosted runner conformance fixture handled the headless message",
+        ))
+    }
+
+    fn state(&self) -> Result<Option<AgentState>, HostedRunnerError> {
+        Ok(Some(
+            self.state
+                .lock()
+                .map_err(|_| HostedRunnerError::internal("conformance state mutex poisoned"))?
+                .clone(),
+        ))
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = HostedRunnerConfig::from_env()?;
+    let session_id = config
+        .maestro_session_id
+        .clone()
+        .unwrap_or_else(|| config.runner_session_id.clone());
+    let workspace_root = config.workspace_root.clone();
+    let executor = Arc::new(ConformanceExecutor::new(session_id.clone(), workspace_root));
+    let handle = start_hosted_runner_with_message_executor(config, executor).await?;
+
+    let mut stdout = std::io::stdout();
+    writeln!(
+        stdout,
+        "{}",
+        json!({
+            "baseUrl": handle.base_url(),
+            "sessionId": session_id,
+        })
+    )?;
+    stdout.flush()?;
+
+    let mut stdin = tokio::io::stdin();
+    let mut buffer = [0_u8; 1];
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {}
+        _ = stdin.read(&mut buffer) => {}
+    }
+
+    handle.shutdown().await;
+    Ok(())
+}

--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -25,10 +25,10 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::headless::messages::{
-    ClientCapabilities, ClientInfo, ConnectionRole, ConnectionState, FromAgentMessage, InitConfig,
-    ServerRequestType, ThinkingLevel, ToAgentMessage, UtilityCommandShellMode,
-    UtilityCommandStream, UtilityCommandTerminalMode, UtilityFileSearchMatch, UtilityOperation,
-    HEADLESS_PROTOCOL_VERSION,
+    ApprovalMode, ClientCapabilities, ClientInfo, ConnectionRole, ConnectionState,
+    FromAgentMessage, InitConfig, ServerRequestType, ThinkingLevel, ToAgentMessage,
+    UtilityCommandShellMode, UtilityCommandStream, UtilityCommandTerminalMode,
+    UtilityFileSearchMatch, UtilityOperation, HEADLESS_PROTOCOL_VERSION,
 };
 use crate::headless::{AgentState, AgentSupervisor, AsyncTransportError};
 
@@ -433,41 +433,85 @@ struct RuntimeSnapshot {
     protocol_version: String,
     session_id: String,
     cursor: u64,
-    last_init: Option<InitConfig>,
+    last_init: Option<RuntimeInitSnapshot>,
     state: RuntimeStateSnapshot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+struct RuntimeInitSnapshot {
+    #[serde(rename = "type")]
+    message_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system_prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    append_system_prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking_level: Option<ThinkingLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    approval_mode: Option<ApprovalMode>,
+}
+
+impl From<&InitConfig> for RuntimeInitSnapshot {
+    fn from(config: &InitConfig) -> Self {
+        Self {
+            message_type: "init".to_string(),
+            system_prompt: config.system_prompt.clone(),
+            append_system_prompt: config.append_system_prompt.clone(),
+            thinking_level: config.thinking_level,
+            approval_mode: config.approval_mode,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct RuntimeStateSnapshot {
+    #[serde(skip_serializing_if = "Option::is_none")]
     protocol_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     client_protocol_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     client_info: Option<ClientInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     capabilities: Option<ClientCapabilities>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     opt_out_notifications: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     connection_role: Option<ConnectionRole>,
     connection_count: usize,
     subscriber_count: usize,
     controller_subscription_id: Option<String>,
     controller_connection_id: Option<String>,
     connections: Vec<ConnectionState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     cwd: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     git_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     current_response: Option<serde_json::Value>,
     pending_approvals: Vec<serde_json::Value>,
     pending_client_tools: Vec<serde_json::Value>,
+    pending_mcp_elicitations: Vec<serde_json::Value>,
     pending_user_inputs: Vec<serde_json::Value>,
     pending_tool_retries: Vec<serde_json::Value>,
     tracked_tools: Vec<serde_json::Value>,
     active_tools: Vec<serde_json::Value>,
     active_utility_commands: Vec<ActiveUtilityCommandSnapshot>,
     active_file_watches: Vec<ActiveFileWatchSnapshot>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     last_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     last_error_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     last_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     last_response_duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     last_ttft_ms: Option<u64>,
     is_ready: bool,
     is_responding: bool,
@@ -777,6 +821,13 @@ fn json_value<T: Serialize>(value: &T) -> serde_json::Value {
     serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
 }
 
+fn json_string_value<T: Serialize>(value: &T) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_default()
+}
+
 struct HttpRequest {
     method: String,
     path: String,
@@ -957,7 +1008,7 @@ impl SharedRunner {
             protocol_version: HEADLESS_PROTOCOL_VERSION.to_string(),
             session_id: state.session_id.clone(),
             cursor: state.cursor,
-            last_init: state.last_init.clone(),
+            last_init: state.last_init.as_ref().map(RuntimeInitSnapshot::from),
             state: RuntimeStateSnapshot {
                 protocol_version: Some(protocol_version),
                 client_protocol_version: preferred_connection
@@ -1007,6 +1058,7 @@ impl SharedRunner {
                 pending_client_tools: agent_state
                     .map(|state| state.pending_client_tools.iter().map(json_value).collect())
                     .unwrap_or_default(),
+                pending_mcp_elicitations: Vec::new(),
                 pending_user_inputs: agent_state
                     .map(|state| state.pending_user_inputs.iter().map(json_value).collect())
                     .unwrap_or_default(),
@@ -1036,7 +1088,7 @@ impl SharedRunner {
                 last_error: agent_state.and_then(|state| state.last_error.clone()),
                 last_error_type: agent_state
                     .and_then(|state| state.last_error_type)
-                    .map(|error_type| format!("{error_type:?}")),
+                    .map(|error_type| json_string_value(&error_type)),
                 last_status: agent_state
                     .and_then(|state| state.last_status.clone())
                     .or_else(|| state.last_status.clone()),
@@ -1560,6 +1612,15 @@ fn handle_events(
     let state = shared.state.lock().expect("hosted runner state poisoned");
     ensure_session_id(&state, Some(session_id))?;
     drop(state);
+    if query
+        .get("cursor")
+        .map(|value| value.trim_start().starts_with('-'))
+        .unwrap_or(false)
+    {
+        let replay = vec![shared.reset_envelope("replay_gap")];
+        let rx = shared.events.subscribe();
+        return Ok(ResponseBody::Sse { replay, rx, shared });
+    }
     let cursor = query
         .get("cursor")
         .and_then(|value| value.parse::<u64>().ok())
@@ -1787,11 +1848,11 @@ async fn handle_message(
         _ => {}
     }
 
-    let cursor = shared
-        .state
-        .lock()
-        .expect("hosted runner state poisoned")
-        .cursor;
+    let snapshot = {
+        let state = shared.state.lock().expect("hosted runner state poisoned");
+        shared.snapshot(&state)
+    };
+    let cursor = snapshot.cursor;
     json_response(
         200,
         json!({
@@ -1802,6 +1863,7 @@ async fn handle_message(
             "execution": execution,
             "published_messages": published_messages,
             "message": response_message,
+            "snapshot": snapshot,
         }),
     )
 }
@@ -1988,47 +2050,66 @@ async fn run_utility_command(
         );
     }
 
-    let output = spawn_command(&command, &cwd_path, env, shell_mode).await?;
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    let success = output.status.success();
-    let exit_code = output.status.code();
-    let mut state = shared.state.lock().expect("hosted runner state poisoned");
-    if let Some(active) = state.active_utility_commands.get_mut(&command_id) {
-        active.output.push_str(&stdout);
-        active.output.push_str(&stderr);
-    }
-    if !stdout.is_empty() {
-        shared.publish_message(
-            &mut state,
-            FromAgentMessage::UtilityCommandOutput {
-                command_id: command_id.clone(),
-                stream: UtilityCommandStream::Stdout,
-                content: stdout,
-            },
-        );
-    }
-    if !stderr.is_empty() {
-        shared.publish_message(
-            &mut state,
-            FromAgentMessage::UtilityCommandOutput {
-                command_id: command_id.clone(),
-                stream: UtilityCommandStream::Stderr,
-                content: stderr,
-            },
-        );
-    }
-    state.active_utility_commands.remove(&command_id);
-    shared.publish_message(
-        &mut state,
-        FromAgentMessage::UtilityCommandExited {
-            command_id,
-            success,
-            exit_code,
-            signal: None,
-            reason: None,
-        },
-    );
+    tokio::spawn(async move {
+        let output = spawn_command(&command, &cwd_path, env, shell_mode).await;
+        let mut state = shared.state.lock().expect("hosted runner state poisoned");
+        match output {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                let success = output.status.success();
+                let exit_code = output.status.code();
+                if let Some(active) = state.active_utility_commands.get_mut(&command_id) {
+                    active.output.push_str(&stdout);
+                    active.output.push_str(&stderr);
+                }
+                if !stdout.is_empty() {
+                    shared.publish_message(
+                        &mut state,
+                        FromAgentMessage::UtilityCommandOutput {
+                            command_id: command_id.clone(),
+                            stream: UtilityCommandStream::Stdout,
+                            content: stdout,
+                        },
+                    );
+                }
+                if !stderr.is_empty() {
+                    shared.publish_message(
+                        &mut state,
+                        FromAgentMessage::UtilityCommandOutput {
+                            command_id: command_id.clone(),
+                            stream: UtilityCommandStream::Stderr,
+                            content: stderr,
+                        },
+                    );
+                }
+                state.active_utility_commands.remove(&command_id);
+                shared.publish_message(
+                    &mut state,
+                    FromAgentMessage::UtilityCommandExited {
+                        command_id,
+                        success,
+                        exit_code,
+                        signal: None,
+                        reason: None,
+                    },
+                );
+            }
+            Err(error) => {
+                state.active_utility_commands.remove(&command_id);
+                shared.publish_message(
+                    &mut state,
+                    FromAgentMessage::UtilityCommandExited {
+                        command_id,
+                        success: false,
+                        exit_code: None,
+                        signal: None,
+                        reason: Some(error.message),
+                    },
+                );
+            }
+        }
+    });
     Ok(())
 }
 
@@ -2079,7 +2160,12 @@ async fn handle_file_read(
         .await
         .map_err(|error| HostedError::new(404, "not_found", error.to_string()))?;
     let lines: Vec<&str> = content.lines().collect();
-    let start = offset.unwrap_or(0) as usize;
+    let requested_offset = offset.unwrap_or(1).max(1) as usize;
+    let start = if lines.is_empty() {
+        0
+    } else {
+        requested_offset - 1
+    };
     let limit = limit.unwrap_or(200) as usize;
     let selected = lines
         .iter()
@@ -2087,10 +2173,7 @@ async fn handle_file_read(
         .take(limit)
         .copied()
         .collect::<Vec<_>>();
-    let mut rendered = selected.join("\n");
-    if !rendered.is_empty() {
-        rendered.push('\n');
-    }
+    let rendered = selected.join("\n");
     let relative_path = relative_workspace_path(&shared.config.workspace_root, &full_path);
     let mut state = shared.state.lock().expect("hosted runner state poisoned");
     shared.publish_message(
@@ -2101,7 +2184,11 @@ async fn handle_file_read(
             relative_path,
             cwd: shared.config.workspace_root.to_string_lossy().to_string(),
             content: rendered,
-            start_line: start as u32 + 1,
+            start_line: if lines.is_empty() {
+                0
+            } else {
+                start as u32 + 1
+            },
             end_line: (start + selected.len()) as u32,
             total_lines: lines.len() as u32,
             truncated: start + selected.len() < lines.len(),
@@ -2340,7 +2427,7 @@ fn assert_controller(state: &RunnerState, connection_id: Option<&str>) -> Hosted
         return Err(HostedError::new(
             403,
             "runtime_owned_elsewhere",
-            "Headless connection does not have controller access",
+            "Controller lease is currently held by another connection",
         ));
     }
     Ok(())
@@ -2456,7 +2543,7 @@ fn resolve_workspace_path(
         return Err(HostedError::new(
             403,
             "workspace_violation",
-            "requested path escapes hosted workspace root",
+            "Path is outside hosted workspace root",
         ));
     }
     Ok(normalized)
@@ -2862,6 +2949,36 @@ mod tests {
         };
         assert_eq!(reason, "broadcast_lag:3");
         assert_eq!(snapshot.cursor, 1);
+    }
+
+    #[tokio::test]
+    async fn events_negative_cursor_returns_replay_gap_reset() {
+        let workspace = tempdir().expect("workspace");
+        let handle = start_hosted_runner(test_config(workspace.path().to_path_buf()))
+            .await
+            .expect("start hosted runner");
+        let client = reqwest::Client::new();
+
+        let mut events_response = client
+            .get(format!(
+                "{}/api/headless/sessions/sess_test/events?cursor=-999",
+                handle.base_url()
+            ))
+            .send()
+            .await
+            .expect("events response");
+        assert_eq!(events_response.status(), StatusCode::OK);
+        let chunk =
+            tokio::time::timeout(std::time::Duration::from_secs(1), events_response.chunk())
+                .await
+                .expect("event chunk timeout")
+                .expect("event chunk read")
+                .expect("event chunk");
+        let event_text = String::from_utf8_lossy(&chunk);
+        assert!(event_text.contains(r#""type":"reset""#));
+        assert!(event_text.contains(r#""reason":"replay_gap""#));
+
+        handle.shutdown().await;
     }
 
     #[tokio::test]

--- a/test/headless/runtime-conformance.test.ts
+++ b/test/headless/runtime-conformance.test.ts
@@ -1,4 +1,6 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -73,6 +75,8 @@ const DEFAULT_CAPABILITIES: HeadlessClientCapabilities = {
 	raw_agent_events: true,
 };
 
+type MaybePromise<T> = T | Promise<T>;
+
 class FakeAgent {
 	state = {
 		model: TEST_MODEL,
@@ -137,11 +141,11 @@ interface RuntimeConformanceAdapter {
 	subscribe(options: {
 		role?: "viewer" | "controller";
 		takeControl?: boolean;
-	}): HeadlessRuntimeSubscriptionSnapshot;
+	}): MaybePromise<HeadlessRuntimeSubscriptionSnapshot>;
 	attachStream(options: {
 		role?: "viewer" | "controller";
 		cursor?: number | null;
-	}): HeadlessAttachedSubscription;
+	}): MaybePromise<HeadlessAttachedSubscription>;
 	send(
 		message: HeadlessToAgentMessage,
 		options?: SendOptions,
@@ -149,12 +153,14 @@ interface RuntimeConformanceAdapter {
 	heartbeat(options: {
 		connectionId?: string | null;
 		subscriptionId?: string | null;
-	}): HeadlessRuntimeHeartbeatSnapshot;
+	}): MaybePromise<HeadlessRuntimeHeartbeatSnapshot>;
 	disconnect(options: {
 		connectionId?: string | null;
 		subscriptionId?: string | null;
 	}): Promise<HeadlessRuntimeConnectionClosedSnapshot>;
-	replayFrom(cursor: number): HeadlessRuntimeStreamEnvelope[] | null;
+	replayFrom(
+		cursor: number,
+	): MaybePromise<HeadlessRuntimeStreamEnvelope[] | null>;
 	emitAgentEvent(event: AgentEvent): void;
 	requestApproval(
 		request: ActionApprovalRequest,
@@ -328,6 +334,508 @@ class TypeScriptInProcessConformanceAdapter
 	}
 }
 
+class SseHeadlessAttachedSubscription implements HeadlessAttachedSubscription {
+	readonly id: string;
+	private readonly abortController = new AbortController();
+	private readonly listeners = new Set<() => void>();
+	private readonly queue: HeadlessRuntimeStreamEnvelope[] = [];
+	private error: Error | null = null;
+
+	private constructor(id: string) {
+		this.id = id;
+	}
+
+	static async connect(options: {
+		id: string;
+		url: string;
+		initialSnapshot?: HeadlessRuntimeSnapshot;
+	}): Promise<SseHeadlessAttachedSubscription> {
+		const subscription = new SseHeadlessAttachedSubscription(options.id);
+		if (options.initialSnapshot) {
+			subscription.enqueue({
+				type: "snapshot",
+				snapshot: options.initialSnapshot,
+			});
+		}
+		await subscription.start(options.url);
+		return subscription;
+	}
+
+	next(): HeadlessRuntimeStreamEnvelope | null {
+		if (this.error) {
+			throw this.error;
+		}
+		return this.queue.shift() ?? null;
+	}
+
+	onAvailable(listener: () => void): () => void {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	enqueue(envelope: HeadlessRuntimeStreamEnvelope): void {
+		this.queue.push(envelope);
+		for (const listener of this.listeners) {
+			listener();
+		}
+	}
+
+	close(): void {
+		this.abortController.abort();
+	}
+
+	private async start(url: string): Promise<void> {
+		const response = await fetch(url, {
+			headers: { accept: "text/event-stream" },
+			signal: this.abortController.signal,
+		});
+		if (!response.ok) {
+			throw await responseError(response);
+		}
+		if (!response.body) {
+			throw new Error("Rust hosted runner SSE response did not include a body");
+		}
+		void this.pump(response.body.getReader());
+	}
+
+	private async pump(
+		reader: ReadableStreamDefaultReader<Uint8Array>,
+	): Promise<void> {
+		const decoder = new TextDecoder();
+		let buffer = "";
+		try {
+			while (true) {
+				const chunk = await reader.read();
+				if (chunk.done) {
+					return;
+				}
+				buffer += decoder.decode(chunk.value, { stream: true });
+				const frames = buffer.split(/\r?\n\r?\n/);
+				buffer = frames.pop() ?? "";
+				for (const frame of frames) {
+					this.enqueueFrame(frame);
+				}
+			}
+		} catch (error) {
+			if (!this.abortController.signal.aborted) {
+				this.error = error instanceof Error ? error : new Error(String(error));
+				for (const listener of this.listeners) {
+					listener();
+				}
+			}
+		}
+	}
+
+	private enqueueFrame(frame: string): void {
+		const data = frame
+			.split(/\r?\n/)
+			.filter((line) => line.startsWith("data:"))
+			.map((line) => line.slice("data:".length).trimStart())
+			.join("\n");
+		if (!data) {
+			return;
+		}
+		const envelope = JSON.parse(data) as HeadlessRuntimeStreamEnvelope;
+		this.enqueue(envelope);
+	}
+}
+
+class RustHostedHttpConformanceAdapter implements RuntimeConformanceAdapter {
+	readonly label = "rust-hosted-http";
+	workspaceRoot = "";
+	outsideRoot = "";
+	private sessionId = "sess_conformance";
+	private sessionDir = "";
+	private baseUrl = "";
+	private child: ChildProcessWithoutNullStreams | null = null;
+	private readonly subscriptions = new Map<
+		string,
+		HeadlessRuntimeSubscriptionSnapshot
+	>();
+	private readonly streams = new Set<SseHeadlessAttachedSubscription>();
+	private latestControllerSubscriptionId: string | null = null;
+	private pendingApprovalRequest: ActionApprovalRequest | null = null;
+
+	async start(): Promise<HeadlessRuntimeSnapshot> {
+		this.sessionDir = await mkdtemp(
+			join(tmpdir(), "maestro-rust-conformance-sessions-"),
+		);
+		this.workspaceRoot = await mkdtemp(
+			join(tmpdir(), "maestro-rust-conformance-workspace-"),
+		);
+		this.outsideRoot = await mkdtemp(
+			join(tmpdir(), "maestro-rust-conformance-outside-"),
+		);
+		await writeFile(
+			join(this.workspaceRoot, "notes.md"),
+			"alpha\nbeta\ngamma\n",
+		);
+		await writeFile(join(this.outsideRoot, "secret.txt"), "not in workspace\n");
+		await this.startFixture();
+		return await this.fetchState();
+	}
+
+	async subscribe(options: {
+		role?: "viewer" | "controller";
+		takeControl?: boolean;
+	}): Promise<HeadlessRuntimeSubscriptionSnapshot> {
+		const subscription =
+			await this.postJson<HeadlessRuntimeSubscriptionSnapshot>(
+				`/api/headless/sessions/${this.sessionId}/subscribe`,
+				{
+					protocolVersion: HEADLESS_PROTOCOL_VERSION,
+					clientInfo: {
+						name: "maestro-rust-conformance",
+						version: "0.1.0",
+					},
+					capabilities: httpCapabilities(DEFAULT_CAPABILITIES),
+					role: options.role ?? "controller",
+					takeControl: options.takeControl ?? false,
+				},
+			);
+		this.subscriptions.set(subscription.subscription_id, subscription);
+		if (subscription.role === "controller") {
+			this.latestControllerSubscriptionId = subscription.subscription_id;
+		}
+		return subscription;
+	}
+
+	async attachStream(options: {
+		role?: "viewer" | "controller";
+		cursor?: number | null;
+	}): Promise<HeadlessAttachedSubscription> {
+		const includeInitialSnapshot =
+			options.cursor === undefined || options.cursor === null;
+		const snapshot = includeInitialSnapshot
+			? await this.fetchState()
+			: undefined;
+		const query = includeInitialSnapshot
+			? ""
+			: `?cursor=${encodeURIComponent(String(options.cursor))}`;
+		const stream = await SseHeadlessAttachedSubscription.connect({
+			id: `rust-${this.streams.size + 1}`,
+			url: `${this.baseUrl}/api/headless/sessions/${this.sessionId}/events${query}`,
+			initialSnapshot: snapshot,
+		});
+		this.streams.add(stream);
+		return stream;
+	}
+
+	async send(
+		message: HeadlessToAgentMessage,
+		options: SendOptions = {},
+	): Promise<HeadlessRuntimeSnapshot> {
+		const headers: Record<string, string> = {};
+		const connectionId =
+			options.connectionId ??
+			this.subscriptionConnectionId(options.subscriptionId ?? null);
+		if (connectionId) {
+			headers["x-maestro-headless-connection-id"] = connectionId;
+		}
+		if (options.subscriptionId) {
+			headers["x-maestro-headless-subscriber-id"] = options.subscriptionId;
+		}
+		const response = await this.postJson<{
+			snapshot?: HeadlessRuntimeSnapshot;
+		}>(`/api/headless/sessions/${this.sessionId}/messages`, message, headers);
+		return response.snapshot ?? (await this.fetchState());
+	}
+
+	async heartbeat(options: {
+		connectionId?: string | null;
+		subscriptionId?: string | null;
+	}): Promise<HeadlessRuntimeHeartbeatSnapshot> {
+		return await this.postJson<HeadlessRuntimeHeartbeatSnapshot>(
+			`/api/headless/sessions/${this.sessionId}/heartbeat`,
+			{
+				connectionId: options.connectionId,
+				subscriptionId: options.subscriptionId,
+			},
+		);
+	}
+
+	async disconnect(options: {
+		connectionId?: string | null;
+		subscriptionId?: string | null;
+	}): Promise<HeadlessRuntimeConnectionClosedSnapshot> {
+		return await this.postJson<HeadlessRuntimeConnectionClosedSnapshot>(
+			`/api/headless/sessions/${this.sessionId}/disconnect`,
+			{
+				connectionId: options.connectionId,
+				subscriptionId: options.subscriptionId,
+			},
+		);
+	}
+
+	async replayFrom(
+		cursor: number,
+	): Promise<HeadlessRuntimeStreamEnvelope[] | null> {
+		const stream = await SseHeadlessAttachedSubscription.connect({
+			id: `rust-replay-${Date.now()}`,
+			url: `${this.baseUrl}/api/headless/sessions/${this.sessionId}/events?cursor=${encodeURIComponent(
+				String(cursor),
+			)}`,
+		});
+		await sleep(50);
+		const replay: HeadlessRuntimeStreamEnvelope[] = [];
+		for (;;) {
+			const next = stream.next();
+			if (!next) {
+				break;
+			}
+			replay.push(next);
+		}
+		stream.close();
+		return replay;
+	}
+
+	emitAgentEvent(event: AgentEvent): void {
+		if (event.type === "action_approval_required") {
+			this.pendingApprovalRequest = event.request;
+		}
+	}
+
+	async requestApproval(
+		request: ActionApprovalRequest,
+	): Promise<ActionApprovalDecision> {
+		const approvalRequest = this.pendingApprovalRequest ?? request;
+		const subscriptionId = this.latestControllerSubscriptionId;
+		if (!subscriptionId) {
+			throw new Error("Rust conformance approval needs a controller");
+		}
+		await this.send(
+			{
+				type: "prompt",
+				content: `__maestro_conformance_approval__:${JSON.stringify({
+					request_id: approvalRequest.id,
+					tool: approvalRequest.toolName,
+					args: approvalRequest.args,
+					reason: approvalRequest.reason,
+				})}`,
+			},
+			{ role: "controller", subscriptionId },
+		);
+
+		const deadline = Date.now() + 2_000;
+		while (Date.now() < deadline) {
+			const replay = (await this.replayFrom(0)) ?? [];
+			const resolved = replay.find((entry) => {
+				return (
+					entry.type === "message" &&
+					entry.message.type === "server_request_resolved" &&
+					entry.message.request_id === approvalRequest.id
+				);
+			});
+			if (resolved?.type === "message") {
+				const message = resolved.message;
+				if (message.type === "server_request_resolved") {
+					return {
+						approved: message.resolution === "approved",
+						reason: message.reason,
+						resolvedBy: message.resolved_by,
+					};
+				}
+			}
+			await sleep(25);
+		}
+		throw new Error("Timed out waiting for Rust conformance approval");
+	}
+
+	async close(): Promise<void> {
+		for (const stream of this.streams) {
+			stream.close();
+		}
+		this.streams.clear();
+		const child = this.child;
+		this.child = null;
+		if (child) {
+			await stopFixture(child);
+		}
+		await Promise.all(
+			[this.sessionDir, this.workspaceRoot, this.outsideRoot]
+				.filter(Boolean)
+				.map((path) => rm(path, { recursive: true, force: true })),
+		);
+	}
+
+	private async startFixture(): Promise<void> {
+		const env = { ...process.env };
+		delete env.PORT;
+		env.MAESTRO_RUNNER_SESSION_ID = "mrs_conformance";
+		env.MAESTRO_SESSION_ID = this.sessionId;
+		env.MAESTRO_WORKSPACE_ROOT = this.workspaceRoot;
+		env.MAESTRO_HOSTED_RUNNER_LISTEN = `127.0.0.1:${await findAvailableTcpPort()}`;
+		env.MAESTRO_REMOTE_RUNNER_WORKSPACE_ID = "ws_conformance";
+		env.MAESTRO_AGENT_RUN_ID = "run_conformance";
+		const child = spawn(
+			"cargo",
+			["run", "--quiet", "--bin", "hosted_runner_conformance_fixture"],
+			{
+				cwd: join(process.cwd(), "packages/tui-rs"),
+				env,
+				stdio: ["pipe", "pipe", "pipe"],
+			},
+		);
+		this.child = child;
+		const startup = await readFixtureStartup(child);
+		this.baseUrl = startup.baseUrl;
+		this.sessionId = startup.sessionId;
+	}
+
+	private async fetchState(): Promise<HeadlessRuntimeSnapshot> {
+		return await this.getJson<HeadlessRuntimeSnapshot>(
+			`/api/headless/sessions/${this.sessionId}/state`,
+		);
+	}
+
+	private subscriptionConnectionId(
+		subscriptionId: string | null,
+	): string | null {
+		if (!subscriptionId) {
+			return null;
+		}
+		return this.subscriptions.get(subscriptionId)?.connection_id ?? null;
+	}
+
+	private async getJson<T>(path: string): Promise<T> {
+		const response = await fetch(`${this.baseUrl}${path}`);
+		return await readJsonResponse<T>(response);
+	}
+
+	private async postJson<T>(
+		path: string,
+		body: unknown,
+		headers: Record<string, string> = {},
+	): Promise<T> {
+		const response = await fetch(`${this.baseUrl}${path}`, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				...headers,
+			},
+			body: JSON.stringify(body),
+		});
+		return await readJsonResponse<T>(response);
+	}
+}
+
+async function readJsonResponse<T>(response: Response): Promise<T> {
+	if (!response.ok) {
+		throw await responseError(response);
+	}
+	const text = await response.text();
+	return (text ? JSON.parse(text) : {}) as T;
+}
+
+async function responseError(response: Response): Promise<Error> {
+	const text = await response.text();
+	try {
+		const body = JSON.parse(text) as { error?: string; message?: string };
+		return new Error(body.error ?? body.message ?? text);
+	} catch {
+		return new Error(text || `HTTP ${response.status}`);
+	}
+}
+
+function httpCapabilities(capabilities: HeadlessClientCapabilities) {
+	return {
+		serverRequests: capabilities.server_requests,
+		utilityOperations: capabilities.utility_operations,
+		rawAgentEvents: capabilities.raw_agent_events,
+	};
+}
+
+async function findAvailableTcpPort(): Promise<number> {
+	return await new Promise((resolve, reject) => {
+		const server = createServer();
+		server.unref();
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				server.close(() => reject(new Error("Could not reserve TCP port")));
+				return;
+			}
+			server.close((error) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(address.port);
+			});
+		});
+	});
+}
+
+async function readFixtureStartup(
+	child: ChildProcessWithoutNullStreams,
+): Promise<{ baseUrl: string; sessionId: string }> {
+	let stdout = "";
+	let stderr = "";
+	return await new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			reject(
+				new Error(
+					`Timed out waiting for Rust hosted runner fixture startup${stderr ? `:\n${stderr}` : ""}`,
+				),
+			);
+		}, 30_000);
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString("utf8");
+		});
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString("utf8");
+			const newline = stdout.indexOf("\n");
+			if (newline === -1) {
+				return;
+			}
+			clearTimeout(timeout);
+			try {
+				resolve(JSON.parse(stdout.slice(0, newline)));
+			} catch (error) {
+				reject(
+					new Error(
+						`Failed to parse Rust hosted runner fixture startup line: ${String(
+							error,
+						)}\n${stdout}${stderr ? `\n${stderr}` : ""}`,
+					),
+				);
+			}
+		});
+		child.once("exit", (code) => {
+			clearTimeout(timeout);
+			reject(
+				new Error(
+					`Rust hosted runner fixture exited before startup with code ${code}${stderr ? `:\n${stderr}` : ""}`,
+				),
+			);
+		});
+	});
+}
+
+async function stopFixture(
+	child: ChildProcessWithoutNullStreams,
+): Promise<void> {
+	if (child.exitCode !== null) {
+		return;
+	}
+	await new Promise<void>((resolve) => {
+		const timeout = setTimeout(() => {
+			child.kill("SIGKILL");
+			resolve();
+		}, 1_000);
+		child.once("exit", () => {
+			clearTimeout(timeout);
+			resolve();
+		});
+		child.stdin.end();
+	});
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function readNextEnvelope(
 	stream: HeadlessAttachedSubscription,
 ): Promise<HeadlessRuntimeStreamEnvelope> {
@@ -364,11 +872,23 @@ async function readUntil(
 }
 
 function expectRuntimeSnapshot(value: HeadlessRuntimeSnapshot): void {
-	expect(Value.Check(HeadlessRuntimeSnapshotSchema, value)).toBe(true);
+	const errors = [...Value.Errors(HeadlessRuntimeSnapshotSchema, value)].map(
+		(error) => `${error.path}: ${error.message}`,
+	);
+	expect(
+		Value.Check(HeadlessRuntimeSnapshotSchema, value),
+		errors.join("\n"),
+	).toBe(true);
 }
 
 function expectStreamEnvelope(value: HeadlessRuntimeStreamEnvelope): void {
-	expect(Value.Check(HeadlessRuntimeStreamEnvelopeSchema, value)).toBe(true);
+	const errors = [
+		...Value.Errors(HeadlessRuntimeStreamEnvelopeSchema, value),
+	].map((error) => `${error.path}: ${error.message}`);
+	expect(
+		Value.Check(HeadlessRuntimeStreamEnvelopeSchema, value),
+		[...errors, JSON.stringify(value)].filter(Boolean).join("\n"),
+	).toBe(true);
 }
 
 function restoreEnvValue(name: string, value: string | undefined): void {
@@ -382,8 +902,10 @@ function restoreEnvValue(name: string, value: string | undefined): void {
 function defineHeadlessRuntimeConformanceSuite(
 	name: string,
 	createAdapter: () => RuntimeConformanceAdapter,
+	options: { skip?: boolean } = {},
 ) {
-	describe(`${name} headless runtime conformance`, () => {
+	const describeRuntime = options.skip ? describe.skip : describe;
+	describeRuntime(`${name} headless runtime conformance`, () => {
 		let adapter: RuntimeConformanceAdapter | null = null;
 		const originalHostedMode = process.env.MAESTRO_HOSTED_RUNNER_MODE;
 		const originalWorkspaceRoot = process.env.MAESTRO_WORKSPACE_ROOT;
@@ -410,14 +932,14 @@ function defineHeadlessRuntimeConformanceSuite(
 
 		it("creates controller and viewer subscriptions with schema-valid heartbeat snapshots", async () => {
 			const runtime = await start();
-			const controller = runtime.subscribe({ role: "controller" });
+			const controller = await runtime.subscribe({ role: "controller" });
 			expect(
 				Value.Check(HeadlessRuntimeSubscriptionSnapshotSchema, controller),
 			).toBe(true);
 			expect(controller.role).toBe("controller");
 			expect(controller.controller_lease_granted).toBe(true);
 
-			const viewer = runtime.subscribe({ role: "viewer" });
+			const viewer = await runtime.subscribe({ role: "viewer" });
 			expect(
 				Value.Check(HeadlessRuntimeSubscriptionSnapshotSchema, viewer),
 			).toBe(true);
@@ -425,7 +947,7 @@ function defineHeadlessRuntimeConformanceSuite(
 			expect(viewer.controller_lease_granted).toBe(false);
 			expect(viewer.controller_connection_id).toBe(controller.connection_id);
 
-			const controllerHeartbeat = runtime.heartbeat({
+			const controllerHeartbeat = await runtime.heartbeat({
 				subscriptionId: controller.subscription_id,
 			});
 			expect(
@@ -436,7 +958,7 @@ function defineHeadlessRuntimeConformanceSuite(
 			).toBe(true);
 			expect(controllerHeartbeat.controller_lease_granted).toBe(true);
 
-			const viewerHeartbeat = runtime.heartbeat({
+			const viewerHeartbeat = await runtime.heartbeat({
 				subscriptionId: viewer.subscription_id,
 			});
 			expect(
@@ -447,8 +969,8 @@ function defineHeadlessRuntimeConformanceSuite(
 
 		it("enforces viewer read-only access and explicit controller takeover", async () => {
 			const runtime = await start();
-			const controller = runtime.subscribe({ role: "controller" });
-			const viewer = runtime.subscribe({ role: "viewer" });
+			const controller = await runtime.subscribe({ role: "controller" });
+			const viewer = await runtime.subscribe({ role: "viewer" });
 
 			await expect(
 				runtime.send(
@@ -457,19 +979,24 @@ function defineHeadlessRuntimeConformanceSuite(
 				),
 			).rejects.toThrow("Viewer headless connections cannot send messages");
 
-			expect(() => runtime.subscribe({ role: "controller" })).toThrow(
+			await expect(
+				Promise.resolve().then(() => runtime.subscribe({ role: "controller" })),
+			).rejects.toThrow(
 				"Controller lease is already held by another connection",
 			);
 
-			const takeover = runtime.subscribe({
+			const takeover = await runtime.subscribe({
 				role: "controller",
 				takeControl: true,
 			});
 			expect(takeover.controller_lease_granted).toBe(true);
 			expect(takeover.controller_connection_id).toBe(takeover.connection_id);
 			expect(
-				runtime.heartbeat({ subscriptionId: controller.subscription_id })
-					.controller_lease_granted,
+				(
+					await runtime.heartbeat({
+						subscriptionId: controller.subscription_id,
+					})
+				).controller_lease_granted,
 			).toBe(false);
 
 			await expect(
@@ -484,8 +1011,11 @@ function defineHeadlessRuntimeConformanceSuite(
 
 		it("replays cursor-ordered events and emits reset snapshots for replay gaps", async () => {
 			const runtime = await start();
-			const controller = runtime.subscribe({ role: "controller" });
-			const stream = runtime.attachStream({ role: "viewer", cursor: null });
+			const controller = await runtime.subscribe({ role: "controller" });
+			const stream = await runtime.attachStream({
+				role: "viewer",
+				cursor: null,
+			});
 			const initial = await readNextEnvelope(stream);
 			expectStreamEnvelope(initial);
 			expect(initial.type).toBe("snapshot");
@@ -499,9 +1029,9 @@ function defineHeadlessRuntimeConformanceSuite(
 				{ role: "controller", subscriptionId: controller.subscription_id },
 			);
 
-			await vi.waitFor(() => {
+			await vi.waitFor(async () => {
 				expect(
-					runtime.replayFrom(0)?.some((entry) => {
+					(await runtime.replayFrom(0))?.some((entry) => {
 						return (
 							entry.type === "message" &&
 							entry.message.type === "status" &&
@@ -511,20 +1041,22 @@ function defineHeadlessRuntimeConformanceSuite(
 				).toBe(true);
 			});
 
-			const replay = runtime.replayFrom(0) ?? [];
+			const replay = (await runtime.replayFrom(0)) ?? [];
 			expect(replay.length).toBeGreaterThan(0);
 			for (const envelope of replay) {
 				expectStreamEnvelope(envelope);
 			}
-			expect(
-				replay.map((entry) =>
-					entry.type === "message" ? entry.message.type : entry.type,
-				),
-			).toEqual(
-				expect.arrayContaining(["ready", "session_info", "status", "status"]),
+			const replayTypes = replay.map((entry) =>
+				entry.type === "message" ? entry.message.type : entry.type,
 			);
+			expect(replayTypes).toEqual(expect.arrayContaining(["status"]));
+			if (runtime.label === "typescript-in-process") {
+				expect(replayTypes).toEqual(
+					expect.arrayContaining(["ready", "session_info", "status", "status"]),
+				);
+			}
 
-			const resetStream = runtime.attachStream({
+			const resetStream = await runtime.attachStream({
 				role: "viewer",
 				cursor: -999,
 			});
@@ -540,7 +1072,7 @@ function defineHeadlessRuntimeConformanceSuite(
 
 		it("emits approval server requests and resolves them through the protocol response path", async () => {
 			const runtime = await start();
-			const controller = runtime.subscribe({ role: "controller" });
+			const controller = await runtime.subscribe({ role: "controller" });
 			const request: ActionApprovalRequest = {
 				id: "call_conformance_approval",
 				toolName: "bash",
@@ -554,9 +1086,9 @@ function defineHeadlessRuntimeConformanceSuite(
 			});
 			const approval = runtime.requestApproval(request);
 
-			await vi.waitFor(() => {
+			await vi.waitFor(async () => {
 				expect(
-					runtime.replayFrom(0)?.some((entry) => {
+					(await runtime.replayFrom(0))?.some((entry) => {
 						return (
 							entry.type === "message" &&
 							entry.message.type === "server_request" &&
@@ -587,7 +1119,7 @@ function defineHeadlessRuntimeConformanceSuite(
 				resolvedBy: "user",
 			});
 			expect(
-				runtime.replayFrom(0)?.some((entry) => {
+				(await runtime.replayFrom(0))?.some((entry) => {
 					return (
 						entry.type === "message" &&
 						entry.message.type === "server_request_resolved" &&
@@ -603,8 +1135,11 @@ function defineHeadlessRuntimeConformanceSuite(
 			process.env.MAESTRO_HOSTED_RUNNER_MODE = "1";
 			process.env.MAESTRO_WORKSPACE_ROOT = runtime.workspaceRoot;
 
-			const controller = runtime.subscribe({ role: "controller" });
-			const stream = runtime.attachStream({ role: "viewer", cursor: null });
+			const controller = await runtime.subscribe({ role: "controller" });
+			const stream = await runtime.attachStream({
+				role: "viewer",
+				cursor: null,
+			});
 			expect((await readNextEnvelope(stream)).type).toBe("snapshot");
 
 			await runtime.send(
@@ -657,8 +1192,11 @@ function defineHeadlessRuntimeConformanceSuite(
 			process.env.MAESTRO_HOSTED_RUNNER_MODE = "1";
 			process.env.MAESTRO_WORKSPACE_ROOT = runtime.workspaceRoot;
 
-			const controller = runtime.subscribe({ role: "controller" });
-			const stream = runtime.attachStream({ role: "viewer", cursor: null });
+			const controller = await runtime.subscribe({ role: "controller" });
+			const stream = await runtime.attachStream({
+				role: "viewer",
+				cursor: null,
+			});
 			expect((await readNextEnvelope(stream)).type).toBe("snapshot");
 
 			const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(
@@ -815,8 +1353,8 @@ function defineHeadlessRuntimeConformanceSuite(
 
 		it("disconnects subscriptions and clears controller leases without destroying the runtime", async () => {
 			const runtime = await start();
-			const controller = runtime.subscribe({ role: "controller" });
-			const viewer = runtime.subscribe({ role: "viewer" });
+			const controller = await runtime.subscribe({ role: "controller" });
+			const viewer = await runtime.subscribe({ role: "viewer" });
 
 			const viewerDisconnect = await runtime.disconnect({
 				connectionId: viewer.connection_id,
@@ -837,7 +1375,7 @@ function defineHeadlessRuntimeConformanceSuite(
 				controller_connection_id: null,
 				disconnected_subscription_ids: [controller.subscription_id],
 			});
-			const replay = runtime.replayFrom(0) ?? [];
+			const replay = (await runtime.replayFrom(0)) ?? [];
 			expect(replay.length).toBeGreaterThan(0);
 			expect(
 				replay.every((envelope) =>
@@ -851,4 +1389,10 @@ function defineHeadlessRuntimeConformanceSuite(
 defineHeadlessRuntimeConformanceSuite(
 	"TypeScript in-process host",
 	() => new TypeScriptInProcessConformanceAdapter(),
+);
+
+defineHeadlessRuntimeConformanceSuite(
+	"Rust hosted HTTP runner",
+	() => new RustHostedHttpConformanceAdapter(),
+	{ skip: process.env.MAESTRO_RUST_HOSTED_CONFORMANCE !== "1" },
 );


### PR DESCRIPTION
## Summary
- add an opt-in Rust hosted HTTP/SSE adapter to the shared headless runtime conformance suite
- add a deterministic Rust fixture binary for prompt/status and approval-request coverage
- tighten Rust hosted-runner snapshots, reset replay, workspace utility behavior, and message responses so they validate against the contract schemas

Closes #99

## Test plan
- MAESTRO_RUST_HOSTED_CONFORMANCE=1 npx --yes bun@1.3.6 run test -- test/headless/runtime-conformance.test.ts
- npx --yes bun@1.3.6 run test -- test/headless/runtime-conformance.test.ts
- cargo test hosted_runner --lib
- cargo test remote_transport --lib
- cargo test supervisor --lib
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --release
- git diff --check