### PR TITLE
Add Rust hosted runner conformance adapter

### DIFF
--- a/test/headless/runtime-conformance.test.ts
+++ b/test/headless/runtime-conformance.test.ts
@@ -1183,7 +1183,9 @@ function defineHeadlessRuntimeConformanceSuite(
 					},
 					{ role: "controller", subscriptionId: controller.subscription_id },
 				),
-			).rejects.toThrow(/outside|Access denied|Path is outside/);
+			).rejects.toThrow(
+				/outside|Access denied|Path is outside|escapes hosted workspace/,
+			);
 			stream.close();
 		});
 


### PR DESCRIPTION
## Summary
- add an opt-in Rust hosted HTTP/SSE adapter to the shared headless runtime conformance suite
- add a deterministic Rust fixture binary that drives `start_hosted_runner_with_message_executor` without model calls
- tighten Rust hosted runner snapshot/replay shape for schema-valid reset snapshots and async utility command state
- document the Rust-hosted conformance command in the headless and hosted-runner protocol docs

Closes #99.

## Validation
- `npm run test -- test/headless/runtime-conformance.test.ts`
- `MAESTRO_RUST_HOSTED_CONFORMANCE=1 npm run test -- test/headless/runtime-conformance.test.ts`
- `cargo test hosted_runner --lib`
- `cargo check --bin hosted_runner_conformance_fixture`

Note: a local pre-commit attempt reached the broader build hook but failed because the hook invoked Bun 1.1.31, which cannot parse this repo's newer lockfile version under `--frozen-lockfile`. The targeted checks above passed after the code changes.