### PR TITLE
Require Rust hosted conformance in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,33 @@ jobs:
           path: nx-tests-attempt-*.log
           if-no-files-found: ignore
 
+  rust-hosted-conformance:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
+          workspaces: packages/tui-rs -> target
+
+      - uses: ./.github/actions/setup-bun-nx
+        with:
+          ensure-ripgrep: "true"
+
+      - name: Build workspace packages
+        run: npm run build
+
+      - name: Build Rust conformance fixture
+        working-directory: packages/tui-rs
+        run: cargo build --bin hosted_runner_conformance_fixture
+
+      - name: Rust-hosted headless conformance
+        env:
+          MAESTRO_RUST_HOSTED_CONFORMANCE: "1"
+        run: npm run test -- test/headless/runtime-conformance.test.ts
+
   coverage-scope:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10

--- a/docs/protocols/headless-conformance.md
+++ b/docs/protocols/headless-conformance.md
@@ -8,7 +8,7 @@ implementation detail.
 The executable suite starts in
 [`test/headless/runtime-conformance.test.ts`](../../test/headless/runtime-conformance.test.ts).
 It defines a small runtime adapter, then runs the same scenarios against the
-current TypeScript in-process host. It also includes an opt-in Rust adapter that
+current TypeScript in-process host. It also includes a Rust adapter that
 spawns `hosted_runner_conformance_fixture` and drives
 `maestro_tui::hosted_runner::start_hosted_runner_with_message_executor` through
 the external HTTP/SSE endpoints.
@@ -28,6 +28,11 @@ Rust hosted-runner wire check:
 MAESTRO_RUST_HOSTED_CONFORMANCE=1 npm run test -- test/headless/runtime-conformance.test.ts
 ```
 
+CI runs the Rust-hosted command as the dedicated
+`rust-hosted-conformance` job. The environment flag remains the local switch
+that chooses whether this file runs only the TypeScript in-process adapter or
+also starts the Rust fixture.
+
 ## Contract Areas
 
 The first conformance tranche covers:
@@ -44,9 +49,9 @@ The first conformance tranche covers:
 - disconnect behavior that clears subscriptions and controller leases without
   destroying the runtime state
 
-These cases intentionally avoid external model calls. They use a deterministic
-fake agent and local scratch workspaces so CI can run them as protocol tests,
-not as provider integration tests.
+These cases intentionally avoid external model calls. They use deterministic
+fake/fixture agents and local scratch workspaces so CI can run them as protocol
+tests, not as provider integration tests.
 
 ## Adapter Expectations
 

--- a/docs/protocols/hosted-runner-contract.md
+++ b/docs/protocols/hosted-runner-contract.md
@@ -282,8 +282,8 @@ Every hosted runner implementation should satisfy the shared conformance suite:
 npm run test -- test/headless/runtime-conformance.test.ts
 ```
 
-Rust hosted-runner wire parity is opt-in while the fixture compiles the Rust
-crate:
+Rust hosted-runner wire parity is enforced by the dedicated
+`rust-hosted-conformance` CI job. Run the same gate locally with:
 
 ```bash
 MAESTRO_RUST_HOSTED_CONFORMANCE=1 npm run test -- test/headless/runtime-conformance.test.ts


### PR DESCRIPTION
## Summary
- add a dedicated `rust-hosted-conformance` CI job that builds workspace packages, sets up Rust, and runs the Rust HTTP/SSE adapter
- document the job as the authoritative Rust hosted-runner parity gate while keeping the env flag as the local switch
- keep Rust compilation isolated from the general Vitest shard

Closes #114

## Test plan
- actionlint .github/workflows/ci.yml
- npx --yes bun@1.3.6 install --frozen-lockfile
- npx --yes bun@1.3.6 run build
- MAESTRO_RUST_HOSTED_CONFORMANCE=1 npm run test -- test/headless/runtime-conformance.test.ts
- npm run test -- test/headless/runtime-conformance.test.ts
- npx --yes bun@1.3.6 run bun:lint
- git -c core.fsmonitor=false diff --check