### PR TITLE
Tighten hosted runner drain conformance

### DIFF
--- a/docs/protocols/headless-conformance.md
+++ b/docs/protocols/headless-conformance.md
@@ -46,6 +46,8 @@ The first conformance tranche covers:
 - approval server request emission and protocol response resolution
 - hosted workspace-root enforcement for file reads
 - hosted utility command/search/watch lifecycle
+- hosted drain/snapshot handoff, including manifest export paths and post-drain
+  mutation rejection
 - disconnect behavior that clears subscriptions and controller leases without
   destroying the runtime state
 
@@ -65,6 +67,8 @@ A conforming adapter should expose these operations:
 - disconnect a connection or subscription
 - replay events from a cursor or return a reset snapshot for gaps
 - trigger deterministic approval/request fixtures for server-request coverage
+- drain hosted runtimes into a provider-neutral snapshot manifest when the
+  adapter exposes hosted lifecycle hooks
 
 The TypeScript adapter uses `HeadlessInProcessHost` to avoid HTTP server
 bookkeeping. The Rust adapter uses a deterministic fixture binary so the shared

--- a/docs/protocols/headless.md
+++ b/docs/protocols/headless.md
@@ -96,15 +96,18 @@ snapshot manifest. The manifest directory comes from `--snapshot-root`,
   "status": "drained",
   "manifest_path": "/workspace/.maestro/runner-snapshots/mrs_123-2026-04-23T00_00_00_000Z.json",
   "manifest": {
-    "manifest_version": "evalops.remote-runner.snapshot-manifest.v1",
+    "protocol_version": "evalops.remote-runner.snapshot-manifest.v1",
     "runner_session_id": "mrs_123",
-    "owner_instance_id": "pod_123",
+    "workspace_id": "workspace_123",
+    "agent_run_id": "run_123",
     "maestro_session_id": "session_123",
     "workspace_root": "/workspace",
     "runtime": {
       "flush_status": "completed",
       "session_id": "session_123",
-      "session_file": "/workspace/.maestro/agent/sessions/session.jsonl"
+      "session_file": "/workspace/.maestro/agent/sessions/session.jsonl",
+      "protocol_version": "2026-04-02",
+      "cursor": 42
     },
     "workspace_export": {
       "mode": "local_path_contract",

--- a/docs/protocols/hosted-runner-contract.md
+++ b/docs/protocols/hosted-runner-contract.md
@@ -172,14 +172,18 @@ The Rust crate exposes a first hosted-runner library surface through
 runtime for tests and local adapters, exposes the identity/readiness/drain
 contract, serves the replayable headless attach endpoints, enforces
 workspace-root containment for file, watch, and command utility operations, and
-writes the local drain manifest. It deliberately keeps provider scheduling and
-artifact upload out of Rust; Platform still owns those concerns.
+writes the local drain manifest with the requested workspace export paths. It
+deliberately keeps provider scheduling and artifact upload out of Rust;
+Platform still owns those concerns.
 
 The Rust surface now has an opt-in hosted conformance adapter. The adapter
 spawns a deterministic fixture binary, attaches over HTTP/SSE, and exercises the
 same shared scenarios as the TypeScript in-process host while the Rust server
 owns leases, replay, snapshots, workspace utilities, heartbeat, and disconnect
-behavior. It is not yet the final `maestro hosted-runner` CLI wrapper.
+behavior. The required hosted adapter also covers the drain handoff shape:
+manifest response, persisted snapshot file, export-path recording, and
+post-drain mutation rejection. It is not yet the final `maestro hosted-runner`
+CLI wrapper.
 
 ## Error Vocabulary
 

--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -944,6 +944,7 @@ impl SharedRunner {
     fn snapshot(&self, state: &RunnerState) -> RuntimeSnapshot {
         let agent_state = self.message_executor.state().ok().flatten();
         let agent_state = agent_state.as_ref();
+        let host_ready = state.ready && !state.draining;
         let controller_subscription_id = state
             .controller_connection_id
             .as_ref()
@@ -1089,15 +1090,20 @@ impl SharedRunner {
                 last_error_type: agent_state
                     .and_then(|state| state.last_error_type)
                     .map(|error_type| json_string_value(&error_type)),
-                last_status: agent_state
-                    .and_then(|state| state.last_status.clone())
-                    .or_else(|| state.last_status.clone()),
+                last_status: if host_ready {
+                    agent_state
+                        .and_then(|state| state.last_status.clone())
+                        .or_else(|| state.last_status.clone())
+                } else {
+                    state
+                        .last_status
+                        .clone()
+                        .or_else(|| agent_state.and_then(|state| state.last_status.clone()))
+                },
                 last_response_duration_ms: agent_state
                     .and_then(|state| state.last_response_duration_ms),
                 last_ttft_ms: agent_state.and_then(|state| state.last_ttft_ms),
-                is_ready: agent_state
-                    .map(|state| state.is_ready)
-                    .unwrap_or(state.ready && !state.draining),
+                is_ready: host_ready && agent_state.map(|state| state.is_ready).unwrap_or(true),
                 is_responding: agent_state
                     .map(|state| state.is_responding)
                     .unwrap_or(false),
@@ -1460,7 +1466,7 @@ async fn handle_drain(shared: SharedRunner, input: DrainRequest) -> HostedResult
         }
     }
 
-    let manifest_path = write_snapshot_manifest(&shared, &input).await?;
+    let (manifest_path, manifest) = write_snapshot_manifest(&shared, &input).await?;
     {
         let mut state = shared.state.lock().expect("hosted runner state poisoned");
         state.draining = true;
@@ -1477,6 +1483,7 @@ async fn handle_drain(shared: SharedRunner, input: DrainRequest) -> HostedResult
             "requested_by": input.requested_by,
             "reason": input.reason,
             "manifest_path": manifest_path.to_string_lossy(),
+            "manifest": manifest,
         }),
     )
 }
@@ -2282,7 +2289,7 @@ fn handle_file_watch_stop(shared: SharedRunner, watch_id: String) -> HostedResul
 async fn write_snapshot_manifest(
     shared: &SharedRunner,
     input: &DrainRequest,
-) -> HostedResult<PathBuf> {
+) -> HostedResult<(PathBuf, serde_json::Value)> {
     let root = shared.config.snapshot_root.clone().unwrap_or_else(|| {
         shared
             .config
@@ -2303,6 +2310,48 @@ async fn write_snapshot_manifest(
         (state.session_id.clone(), shared.snapshot(&state))
     };
     let has_runtime_activity = snapshot.cursor > 0;
+    let export_paths = input
+        .export_paths
+        .clone()
+        .unwrap_or_else(|| vec![".".to_string()]);
+    let mut workspace_export_paths = Vec::with_capacity(export_paths.len());
+    for export_path in &export_paths {
+        let resolved_path = resolve_workspace_path(
+            &shared.config.workspace_root,
+            None,
+            Some(export_path.as_str()),
+        )?;
+        let metadata = tokio::fs::metadata(&resolved_path).await.ok();
+        let path_type = metadata
+            .as_ref()
+            .map(|metadata| {
+                if metadata.is_dir() {
+                    "directory"
+                } else if metadata.is_file() {
+                    "file"
+                } else {
+                    "other"
+                }
+            })
+            .unwrap_or("missing");
+        let relative_path = resolved_path
+            .strip_prefix(&shared.config.workspace_root)
+            .ok()
+            .and_then(|path| {
+                if path.as_os_str().is_empty() {
+                    Some(".".to_string())
+                } else {
+                    path.to_str().map(ToOwned::to_owned)
+                }
+            })
+            .unwrap_or_else(|| export_path.clone());
+        workspace_export_paths.push(json!({
+            "input": export_path,
+            "path": resolved_path,
+            "relative_path": relative_path,
+            "type": path_type,
+        }));
+    }
     let body = json!({
         "protocol_version": HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
         "runner_session_id": shared.config.runner_session_id,
@@ -2329,14 +2378,18 @@ async fn write_snapshot_manifest(
                 None
             },
         },
+        "workspace_export": {
+            "mode": "local_path_contract",
+            "paths": workspace_export_paths,
+        },
         "snapshot": snapshot,
     });
-    let body = serde_json::to_vec_pretty(&body)
+    let body_bytes = serde_json::to_vec_pretty(&body)
         .map_err(|error| HostedError::new(500, "runtime_failed", error.to_string()))?;
-    tokio::fs::write(&path, body)
+    tokio::fs::write(&path, body_bytes)
         .await
         .map_err(|error| HostedError::new(500, "runtime_failed", error.to_string()))?;
-    Ok(path)
+    Ok((path, body))
 }
 
 fn safe_manifest_component(value: &str) -> String {
@@ -3020,6 +3073,24 @@ mod tests {
         assert_eq!(drain["status"], "drained");
         let manifest_path = drain["manifest_path"].as_str().expect("manifest path");
         assert!(Path::new(manifest_path).exists());
+        let manifest: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(manifest_path).expect("manifest contents"),
+        )
+        .expect("manifest json");
+        assert_eq!(drain["manifest"], manifest);
+        assert_eq!(
+            manifest["protocol_version"],
+            HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION
+        );
+        assert_eq!(manifest["workspace_export"]["mode"], "local_path_contract");
+        assert_eq!(
+            manifest["workspace_export"]["paths"][0]["relative_path"],
+            "."
+        );
+        assert_eq!(
+            manifest["workspace_export"]["paths"][0]["type"],
+            "directory"
+        );
 
         let post_drain_identity: HostedRunnerIdentity = client
             .get(format!(
@@ -3035,6 +3106,20 @@ mod tests {
         assert!(!post_drain_identity.ready);
         assert!(post_drain_identity.draining);
 
+        let post_drain_state: serde_json::Value = client
+            .get(format!(
+                "{}/api/headless/sessions/sess_test/state",
+                handle.base_url()
+            ))
+            .send()
+            .await
+            .expect("state response")
+            .json()
+            .await
+            .expect("state json");
+        assert_eq!(post_drain_state["state"]["is_ready"], false);
+        assert_eq!(post_drain_state["state"]["last_status"], "Drained");
+
         let attach = client
             .post(format!("{}/api/headless/connections", handle.base_url()))
             .json(&json!({"sessionId": "sess_test", "role": "controller"}))
@@ -3048,6 +3133,7 @@ mod tests {
     #[tokio::test]
     async fn drain_manifest_records_runtime_cursor_after_activity() {
         let workspace = tempdir().expect("workspace");
+        std::fs::write(workspace.path().join("notes.md"), "notes").expect("workspace file");
         let handle = start_hosted_runner(test_config(workspace.path().to_path_buf()))
             .await
             .expect("start hosted runner");
@@ -3088,7 +3174,7 @@ mod tests {
                 "{}/.well-known/evalops/remote-runner/drain",
                 handle.base_url()
             ))
-            .json(&json!({"reason": "cursor-check"}))
+            .json(&json!({"reason": "cursor-check", "export_paths": ["notes.md"]}))
             .send()
             .await
             .expect("drain response")
@@ -3106,6 +3192,16 @@ mod tests {
             HEADLESS_PROTOCOL_VERSION
         );
         assert!(manifest["runtime"]["cursor"].as_u64().unwrap_or_default() >= 2);
+        assert_eq!(drain["manifest"], manifest);
+        assert_eq!(
+            manifest["workspace_export"]["paths"][0]["input"],
+            "notes.md"
+        );
+        assert_eq!(
+            manifest["workspace_export"]["paths"][0]["relative_path"],
+            "notes.md"
+        );
+        assert_eq!(manifest["workspace_export"]["paths"][0]["type"], "file");
 
         handle.shutdown().await;
     }

--- a/test/headless/runtime-conformance.test.ts
+++ b/test/headless/runtime-conformance.test.ts
@@ -1,5 +1,5 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -133,6 +133,22 @@ interface SendOptions {
 	subscriptionId?: string | null;
 }
 
+interface HostedDrainRequest {
+	reason?: string;
+	requested_by?: string;
+	export_paths?: string[];
+}
+
+interface HostedDrainResult {
+	protocol_version: string;
+	status: string;
+	runner_session_id: string;
+	requested_by?: string | null;
+	reason?: string | null;
+	manifest_path: string;
+	manifest?: Record<string, unknown>;
+}
+
 interface RuntimeConformanceAdapter {
 	readonly label: string;
 	readonly workspaceRoot: string;
@@ -165,6 +181,7 @@ interface RuntimeConformanceAdapter {
 	requestApproval(
 		request: ActionApprovalRequest,
 	): Promise<ActionApprovalDecision>;
+	drain?(request: HostedDrainRequest): Promise<HostedDrainResult>;
 	close(): Promise<void>;
 }
 
@@ -639,6 +656,19 @@ class RustHostedHttpConformanceAdapter implements RuntimeConformanceAdapter {
 			await sleep(25);
 		}
 		throw new Error("Timed out waiting for Rust conformance approval");
+	}
+
+	async drain(request: HostedDrainRequest): Promise<HostedDrainResult> {
+		const response = await this.postJson<HostedDrainResult>(
+			"/.well-known/evalops/remote-runner/drain",
+			request,
+		);
+		if (!response.manifest) {
+			response.manifest = JSON.parse(
+				await readFile(response.manifest_path, "utf8"),
+			) as Record<string, unknown>;
+		}
+		return response;
 	}
 
 	async close(): Promise<void> {
@@ -1350,6 +1380,121 @@ function defineHeadlessRuntimeConformanceSuite(
 					reason: "Stopped by controller",
 				},
 			});
+			stream.close();
+		});
+
+		it("drains hosted runners into a manifest and rejects new mutations", async () => {
+			const runtime = await start();
+			if (!runtime.drain) {
+				expect(runtime.label).toBe("typescript-in-process");
+				return;
+			}
+
+			const controller = await runtime.subscribe({ role: "controller" });
+			const stream = await runtime.attachStream({
+				role: "viewer",
+				cursor: null,
+			});
+			expect((await readNextEnvelope(stream)).type).toBe("snapshot");
+
+			await runtime.send(
+				{ type: "prompt", content: "before hosted drain" },
+				{ role: "controller", subscriptionId: controller.subscription_id },
+			);
+			await vi.waitFor(async () => {
+				expect(
+					(await runtime.replayFrom(0))?.some((entry) => {
+						return (
+							entry.type === "message" &&
+							entry.message.type === "status" &&
+							entry.message.message === "Prompt: before hosted drain"
+						);
+					}),
+				).toBe(true);
+			});
+
+			const drain = await runtime.drain({
+				reason: "conformance_stop",
+				requested_by: "runtime-conformance",
+				export_paths: ["notes.md"],
+			});
+			expect(drain).toMatchObject({
+				protocol_version: "evalops.remote-runner.drain.v1",
+				status: "drained",
+				runner_session_id: "mrs_conformance",
+				requested_by: "runtime-conformance",
+				reason: "conformance_stop",
+				manifest_path: expect.stringContaining("mrs_conformance"),
+			});
+			expect(drain.manifest).toBeDefined();
+			const manifest = drain.manifest as Record<string, unknown>;
+			expect(manifest).toMatchObject({
+				protocol_version: "evalops.remote-runner.snapshot-manifest.v1",
+				runner_session_id: "mrs_conformance",
+				workspace_id: "ws_conformance",
+				agent_run_id: "run_conformance",
+				maestro_session_id: "sess_conformance",
+				reason: "conformance_stop",
+				requested_by: "runtime-conformance",
+			});
+			const runtimeManifest = manifest.runtime as {
+				cursor?: number;
+				flush_status?: string;
+				protocol_version?: string;
+				session_id?: string;
+			};
+			expect(runtimeManifest).toMatchObject({
+				flush_status: "completed",
+				protocol_version: HEADLESS_PROTOCOL_VERSION,
+				session_id: "sess_conformance",
+			});
+			expect(runtimeManifest.cursor).toBeGreaterThan(0);
+			const snapshot = manifest.snapshot as HeadlessRuntimeSnapshot;
+			expectRuntimeSnapshot(snapshot);
+			expect(snapshot.cursor).toBeGreaterThan(0);
+			const workspaceExport = manifest.workspace_export as {
+				mode?: string;
+				paths?: Array<Record<string, unknown>>;
+			};
+			expect(workspaceExport).toMatchObject({
+				mode: "local_path_contract",
+			});
+			expect(workspaceExport.paths).toContainEqual(
+				expect.objectContaining({
+					input: "notes.md",
+					relative_path: "notes.md",
+					type: "file",
+				}),
+			);
+
+			const drainedSnapshot = await readUntil(
+				stream,
+				(envelope) =>
+					envelope.type === "snapshot" &&
+					envelope.snapshot.state.last_status === "Drained",
+			);
+			for (const envelope of drainedSnapshot) {
+				expectStreamEnvelope(envelope);
+			}
+			expect(drainedSnapshot.at(-1)).toMatchObject({
+				type: "snapshot",
+				snapshot: {
+					state: {
+						is_ready: false,
+						last_status: "Drained",
+					},
+				},
+			});
+
+			await expect(
+				runtime.send(
+					{ type: "prompt", content: "after hosted drain" },
+					{ role: "controller", subscriptionId: controller.subscription_id },
+				),
+			).rejects.toThrow(/runtime_not_ready|draining|not ready/);
+			await expect(runtime.subscribe({ role: "viewer" })).rejects.toThrow(
+				/runtime_not_ready|draining|not ready|not accepting new attachments/,
+			);
 			stream.close();
 		});
 


### PR DESCRIPTION
## Summary
- return the hosted drain snapshot manifest in the drain response and persist requested workspace export paths
- make hosted lifecycle readiness win over inner agent readiness once the runner is draining
- extend shared headless conformance and Rust hosted-runner unit coverage for drain manifests, terminal snapshots, and post-drain mutation rejection

## Test plan
- npm run test -- test/headless/runtime-conformance.test.ts
- MAESTRO_RUST_HOSTED_CONFORMANCE=1 npm run test -- test/headless/runtime-conformance.test.ts
- cargo test hosted_runner --lib
- git diff --check

Refs #83.
Refs #85.