### PR TITLE
Bridge Maestro tool calls into Platform ToolExecution

### DIFF
--- a/docs/design/INDEX.md
+++ b/docs/design/INDEX.md
@@ -24,6 +24,7 @@ This directory contains detailed design documentation for each major feature and
 | Document | Description |
 |----------|-------------|
 | [Safety & Firewall System](SAFETY_FIREWALL.md) | Rule-based safety enforcement, dangerous command detection |
+| [Platform ToolExecution Bridge](PLATFORM_TOOL_EXECUTION_BRIDGE.md) | Shared policy, approval, and audit bridge for Maestro tool calls |
 | [Enterprise RBAC & Audit](ENTERPRISE_RBAC.md) | Role-based access control, audit logging, and multi-tenancy |
 
 ## Supporting Systems

--- a/docs/design/PLATFORM_TOOL_EXECUTION_BRIDGE.md
+++ b/docs/design/PLATFORM_TOOL_EXECUTION_BRIDGE.md
@@ -1,0 +1,187 @@
+# Platform ToolExecution Bridge
+
+This document describes how Maestro maps local tool calls onto Platform `ToolExecution`
+records so policy, approval, audit, and provenance can share one lifecycle.
+
+## Overview
+
+The bridge sits between Maestro's local safety pipeline and actual tool execution.
+It decides whether a tool call should:
+
+- stay local with no Platform traffic
+- run locally and write an observe-only `ToolExecution` record
+- create a governed `ToolExecution` first and wait for a Platform decision
+
+The first implementation keeps local Maestro execution authoritative. Platform
+currently governs classification, approval, and provenance, but the actual tool
+handler still runs inside Maestro after approval.
+
+## Rollout Flags
+
+Feature flags are read from the JSON snapshot at `EVALOPS_FEATURE_FLAGS_PATH`.
+
+| Flag | Effect |
+|------|--------|
+| `maestro.platform_runtime.agent_runtime_observe` | Enables observe-only Platform recording for supported tool calls |
+| `maestro.platform_runtime.tool_execution_bridge` | Enables governed ToolExecution preflight and approval flow |
+| `platform.kill_switches.maestro.platform_runtime_bridge` | Hard-disables the bridge even if rollout flags are on |
+
+Rollout semantics:
+
+- no rollout flags: Maestro stays fully local
+- observe flag only: supported tool calls run locally and then write best-effort summaries to Platform
+- bridge flag: observe mode is also enabled, and governed tool families can preflight through Platform
+- kill switch: bridge logic is skipped entirely
+
+## Supported Tool Families
+
+The first cut supports Bash and MCP-backed tools.
+
+| Tool family | Classification | Platform mode |
+|-------------|----------------|---------------|
+| `bash` read-only commands such as `git status`, `ls`, `cat`, `rg` | low risk | observe |
+| `bash` mutating commands such as `git push`, `rm`, `kubectl apply`, `npm publish` | high or critical risk | governed when bridge flag is enabled |
+| `mcp__...` tools | medium or high risk based on read-only hints | governed when bridge flag is enabled, otherwise observe-only when observe mode is enabled |
+
+Governed Bash calls fail closed when Platform is unavailable. Observe-only calls
+never block local execution.
+
+## Environment and Destination Resolution
+
+The bridge uses the shared Platform client and resolves configuration in this order.
+
+### Base URL
+
+1. `TOOL_EXECUTION_SERVICE_URL`
+2. `MAESTRO_TOOL_EXECUTION_SERVICE_URL`
+3. `MAESTRO_PLATFORM_BASE_URL`
+4. `MAESTRO_EVALOPS_BASE_URL`
+5. `EVALOPS_BASE_URL`
+
+### Access token
+
+1. `TOOL_EXECUTION_SERVICE_TOKEN`
+2. `MAESTRO_TOOL_EXECUTION_SERVICE_TOKEN`
+3. `MAESTRO_EVALOPS_ACCESS_TOKEN`
+4. `EVALOPS_TOKEN`
+5. stored EvalOps OAuth token, when present
+
+### Organization ID
+
+1. `TOOL_EXECUTION_SERVICE_ORGANIZATION_ID`
+2. `MAESTRO_TOOL_EXECUTION_ORGANIZATION_ID`
+3. `MAESTRO_EVALOPS_ORG_ID`
+4. `EVALOPS_ORGANIZATION_ID`
+5. `MAESTRO_ENTERPRISE_ORG_ID`
+6. stored EvalOps OAuth organization metadata, when present
+
+### Workspace ID
+
+1. `TOOL_EXECUTION_SERVICE_WORKSPACE_ID`
+2. `MAESTRO_TOOL_EXECUTION_WORKSPACE_ID`
+3. `MAESTRO_REMOTE_RUNNER_WORKSPACE_ID`
+4. `MAESTRO_EVALOPS_WORKSPACE_ID`
+5. `EVALOPS_WORKSPACE_ID`
+6. `MAESTRO_WORKSPACE_ID`
+
+Timeout and retry tuning can be overridden with:
+
+- `TOOL_EXECUTION_SERVICE_TIMEOUT_MS`
+- `MAESTRO_TOOL_EXECUTION_SERVICE_TIMEOUT_MS`
+- `TOOL_EXECUTION_SERVICE_MAX_ATTEMPTS`
+- `MAESTRO_TOOL_EXECUTION_SERVICE_MAX_ATTEMPTS`
+
+If the bridge cannot resolve a usable Platform destination, it returns `skip` and
+Maestro keeps local behavior.
+
+## Request Shape
+
+Each governed or observed call builds a Platform `ExecuteTool` request with:
+
+- stable linkage:
+  - `organizationId`
+  - `workspaceId`
+  - `agentId`
+  - `runId`
+  - `stepId` from the Maestro `tool_call_id`
+  - `actorId`
+  - `surface`
+  - `channelId`
+  - `correlationId`
+- a normalized tool reference for Bash or MCP
+- sanitized arguments only
+- risk level and retry policy
+- metadata carrying Maestro correlation fields such as session ID, remote-runner
+  session ID, display labels, and redaction state
+
+Observe-only result recording adds:
+
+- `maestro_local_outcome`
+- `maestro_local_output_summary`
+- `maestro_local_output_redactions`
+
+Only a short scrubbed output summary leaves Maestro. Secret-like tokens are
+redacted before the summary is sent.
+
+## Flow
+
+### Observe-only flow
+
+1. Local safety and redaction run first.
+2. The bridge classifies the call as observe-only.
+3. Maestro executes the tool locally.
+4. After completion, Maestro writes a best-effort `ExecuteTool` record with the
+   sanitized arguments and scrubbed output summary.
+5. Failure to write the observe record is logged and local execution still succeeds.
+
+### Governed flow
+
+1. Local safety and redaction run first.
+2. The bridge calls Platform `ExecuteTool` before local execution.
+3. Platform can:
+   - allow execution
+   - return `WAITING_APPROVAL`
+   - deny execution
+4. For approval waits, Maestro exposes the pending approval through its normal
+   approval surface.
+5. Approval resolution is synced back through `ResumeToolExecution`.
+6. If Platform allows the action, Maestro runs the local tool handler.
+
+## Failure Modes
+
+| Condition | Behavior |
+|-----------|----------|
+| no rollout flags | skip bridge, local-only Maestro behavior |
+| rollout enabled but no Platform config | skip bridge, local-only Maestro behavior |
+| observe-only record fails | log warning and keep local result |
+| governed preflight fails | deny the local tool call |
+| approval sync fails after an allow decision | deny the local tool call and surface the sync failure |
+| Platform returns denial | block the tool call with the Platform reason |
+
+## Event Correlation
+
+`tool_execution_start` and `tool_execution_end` events can carry:
+
+- `toolExecutionId`
+- `approvalRequestId`
+
+This lets Maestro runtime telemetry, UI timelines, and downstream Platform
+records join on the same execution.
+
+## Testing
+
+Focused coverage lives in:
+
+- `test/platform/tool-execution-client.test.ts`
+- `test/agent/tool-execution-bridge.test.ts`
+- `test/agent/tool-safety-pipeline.test.ts`
+
+The bridge tests cover:
+
+- observe-only Bash recording
+- governed MCP allow path
+- governed approval wait and resume
+- Platform denial
+- governed Platform-unavailable fail-closed behavior
+- no-config local fallback
+- observe-only degradation when Platform recording fails

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1865,6 +1865,7 @@ export class Agent {
 		});
 		recordMaestroToolCallAttempt({
 			tool_call_id: event.toolCallId,
+			tool_execution_id: event.toolExecutionId,
 			tool_name: event.toolName,
 			safe_arguments: event.args,
 			correlation: {
@@ -1938,6 +1939,7 @@ export class Agent {
 		});
 		recordMaestroToolCallCompleted({
 			tool_call_id: event.toolCallId,
+			tool_execution_id: event.toolExecutionId,
 			status: event.isError
 				? "MAESTRO_TOOL_CALL_STATUS_FAILED"
 				: "MAESTRO_TOOL_CALL_STATUS_SUCCEEDED",

--- a/src/agent/transport.ts
+++ b/src/agent/transport.ts
@@ -75,6 +75,10 @@ import type { ActionApprovalService } from "./action-approval.js";
 import { getStoredCredentials } from "./keys.js";
 import type { ToolRetryConfig, ToolRetryService } from "./tool-retry.js";
 import { createProviderStream } from "./transport/create-provider-stream.js";
+import {
+	type PlatformToolExecutionBridge,
+	getDefaultPlatformToolExecutionBridge,
+} from "./transport/tool-execution-bridge.js";
 import { createToolExecutionPromise } from "./transport/tool-execution.js";
 import {
 	type ToolSafetyVerdict,
@@ -142,6 +146,8 @@ export interface ProviderTransportOptions {
 	sessionTokenCounter?: SessionTokenCounter;
 	/** Audit logger for sensitive tool execution events */
 	auditLogger?: ToolAuditLogger;
+	/** Optional Platform ToolExecution bridge override */
+	platformToolExecutionBridge?: PlatformToolExecutionBridge | false;
 }
 
 /**
@@ -667,12 +673,18 @@ export class ProviderTransport implements AgentTransport {
 					toolCall: ToolCall,
 					message: ToolResultMessage,
 					isError: boolean,
+					metadata?: {
+						toolExecutionId?: string;
+						approvalRequestId?: string;
+					},
 				): AgentEvent[] => [
 					{ type: "message_start", message } as AgentEvent,
 					{ type: "message_end", message } as AgentEvent,
 					{
 						type: "tool_execution_end",
 						toolCallId: toolCall.id,
+						toolExecutionId: metadata?.toolExecutionId,
+						approvalRequestId: metadata?.approvalRequestId,
 						toolName: toolCall.name,
 						result: message,
 						isError,
@@ -682,6 +694,10 @@ export class ProviderTransport implements AgentTransport {
 					message: ToolResultMessage,
 					toolCall: ToolCall,
 					isError: boolean,
+					metadata?: {
+						toolExecutionId?: string;
+						approvalRequestId?: string;
+					},
 				) => {
 					try {
 						applyWorkflowStateHooks({
@@ -691,7 +707,7 @@ export class ProviderTransport implements AgentTransport {
 							isError,
 						});
 						toolResults.push(message);
-						return buildExecutionEvents(toolCall, message, isError);
+						return buildExecutionEvents(toolCall, message, isError, metadata);
 					} catch (error) {
 						if (error instanceof WorkflowStateError) {
 							const workflowErrorResult: ToolResultMessage = {
@@ -703,7 +719,12 @@ export class ProviderTransport implements AgentTransport {
 								timestamp: this.clock.now(),
 							};
 							toolResults.push(workflowErrorResult);
-							return buildExecutionEvents(toolCall, workflowErrorResult, true);
+							return buildExecutionEvents(
+								toolCall,
+								workflowErrorResult,
+								true,
+								metadata,
+							);
 						}
 						throw error;
 					}
@@ -756,6 +777,10 @@ export class ProviderTransport implements AgentTransport {
 								outcome.message,
 								next.execution.toolCall,
 								outcome.isError,
+								{
+									toolExecutionId: outcome.toolExecutionId,
+									approvalRequestId: outcome.approvalRequestId,
+								},
 							),
 						);
 						await checkSteering();
@@ -789,6 +814,11 @@ export class ProviderTransport implements AgentTransport {
 						adaptiveThresholds: this.adaptiveThresholds,
 						auditLogger: this.auditLogger,
 						approvalService: this.options.approvalService,
+						toolExecutionBridge:
+							this.options.platformToolExecutionBridge === false
+								? undefined
+								: (this.options.platformToolExecutionBridge ??
+									getDefaultPlatformToolExecutionBridge()),
 						hookService,
 						firewall,
 						rateLimitState: {
@@ -879,6 +909,12 @@ export class ProviderTransport implements AgentTransport {
 						toolRetryService: this.options.toolRetryService,
 						toolRetryConfig: this.options.toolRetryConfig,
 						clientToolService: this.options.clientToolService,
+						toolExecutionBridge:
+							this.options.platformToolExecutionBridge === false
+								? undefined
+								: (this.options.platformToolExecutionBridge ??
+									getDefaultPlatformToolExecutionBridge()),
+						toolExecutionBridgePlan: safetyVerdict.toolExecutionBridgePlan,
 						toolUpdateQueue,
 						clientToolExecPromise,
 					});
@@ -911,6 +947,10 @@ export class ProviderTransport implements AgentTransport {
 						outcome.message,
 						next.execution.toolCall,
 						outcome.isError,
+						{
+							toolExecutionId: outcome.toolExecutionId,
+							approvalRequestId: outcome.approvalRequestId,
+						},
 					)) {
 						yield event;
 					}

--- a/src/agent/transport/tool-execution-bridge.ts
+++ b/src/agent/transport/tool-execution-bridge.ts
@@ -1,0 +1,771 @@
+import {
+	MAESTRO_PLATFORM_RUNTIME_BRIDGE_KILL_SWITCH,
+	isFeatureFlagEnabled,
+	isPlatformRuntimeObserveEnabled,
+	isPlatformToolExecutionBridgeEnabled,
+} from "../../config/feature-flags.js";
+import {
+	type ExecutePlatformToolRequest,
+	type ExecutePlatformToolResponse,
+	type PlatformConnectorRef,
+	type PlatformToolExecutionRecord,
+	type PlatformToolRef,
+	type ResumePlatformToolExecutionRequest,
+	type ToolExecutionLinkage,
+	type ToolExecutionRiskLevel,
+	type ToolExecutionServiceConfig,
+	executeToolWithPlatform,
+	resolveToolExecutionServiceConfig,
+	resumeToolExecutionWithPlatform,
+} from "../../platform/tool-execution-client.js";
+import { isReadOnlyTool } from "../../tools/parallel-execution.js";
+import { createLogger } from "../../utils/logger.js";
+import type {
+	ActionApprovalDecision,
+	ActionApprovalRequest,
+} from "../action-approval.js";
+import type {
+	AgentRunConfig,
+	AgentTool,
+	ToolCall,
+	ToolResultMessage,
+} from "../types.js";
+
+const logger = createLogger("transport:tool-execution-bridge");
+
+const OBSERVE_OUTPUT_SUMMARY_MAX_LENGTH = 280;
+const OBSERVE_RESULT_FIELDS = [
+	"maestro_bridge_mode",
+	"maestro_local_outcome",
+	"maestro_local_output_summary",
+	"maestro_local_output_redactions",
+] as const;
+
+const READ_ONLY_BASH_PREFIXES = [
+	"cat",
+	"cd",
+	"df",
+	"du",
+	"echo",
+	"env",
+	"find",
+	"git branch",
+	"git diff",
+	"git log",
+	"git remote -v",
+	"git rev-parse",
+	"git show",
+	"git status",
+	"grep",
+	"head",
+	"ls",
+	"pwd",
+	"printenv",
+	"ps",
+	"rg",
+	"sed -n",
+	"tail",
+	"which",
+].map((value) => value.toLowerCase());
+
+const BASH_MUTATION_MARKERS = [
+	/\bchmod\b/u,
+	/\bchown\b/u,
+	/\bcp\b/u,
+	/\bgit\s+(add|am|apply|branch|checkout|cherry-pick|clean|commit|merge|mv|pull|push|rebase|reset|restore|revert|rm|stash|switch|tag)\b/u,
+	/\bmkdir\b/u,
+	/\bmv\b/u,
+	/\bnpm\s+(install|publish|uninstall|update|version)\b/u,
+	/\bpnpm\s+(add|install|remove|update)\b/u,
+	/\bpython\b.*-c/u,
+	/\brm\b/u,
+	/\bsed\s+-i\b/u,
+	/\btee\b/u,
+	/\btouch\b/u,
+	/\byarn\s+(add|install|remove|upgrade)\b/u,
+	/\bbun\s+(add|install|remove|update)\b/u,
+	/\bkubectl\s+(apply|create|delete|patch|replace|scale)\b/u,
+	/\bterraform\s+(apply|destroy|import)\b/u,
+	/(^|[^<])>{1,2}/u,
+] as const;
+
+export type PlatformBridgeMode = "observe" | "governed";
+
+export interface ToolExecutionBridgeMetadata {
+	toolExecutionId?: string;
+	approvalRequestId?: string;
+}
+
+export interface ObserveToolExecutionPlan {
+	kind: "observe";
+	mode: "observe";
+	classification: ToolExecutionClassification;
+	config: ToolExecutionServiceConfig;
+	request: ExecutePlatformToolRequest;
+	metadata: ToolExecutionBridgeMetadata;
+}
+
+export interface GovernedToolExecutionPlan {
+	kind: "governed";
+	mode: "governed";
+	classification: ToolExecutionClassification;
+	config: ToolExecutionServiceConfig;
+	request: ExecutePlatformToolRequest;
+	metadata: ToolExecutionBridgeMetadata;
+	resumeToken?: string;
+}
+
+export type ToolExecutionBridgePlan =
+	| ObserveToolExecutionPlan
+	| GovernedToolExecutionPlan;
+
+export type ToolExecutionBridgePreparation =
+	| {
+			status: "skip";
+	  }
+	| {
+			status: "observe";
+			plan: ObserveToolExecutionPlan;
+	  }
+	| {
+			status: "allow";
+			plan: GovernedToolExecutionPlan;
+	  }
+	| {
+			status: "wait_approval";
+			plan: GovernedToolExecutionPlan;
+			request: ActionApprovalRequest;
+	  }
+	| {
+			status: "deny";
+			plan?: GovernedToolExecutionPlan;
+			reason: string;
+	  };
+
+export type ToolExecutionBridgeApprovalResolution =
+	| {
+			status: "allow";
+			plan: GovernedToolExecutionPlan;
+	  }
+	| {
+			status: "deny";
+			plan: GovernedToolExecutionPlan;
+			reason: string;
+	  };
+
+export interface ObserveToolExecutionResult {
+	metadata: ToolExecutionBridgeMetadata;
+}
+
+export interface ToolExecutionBridgeInput {
+	cfg: AgentRunConfig;
+	toolCall: ToolCall;
+	toolDef?: AgentTool;
+	sanitizedArgs: Record<string, unknown>;
+	displayName?: string;
+	summaryLabel?: string;
+	actionDescription?: string;
+}
+
+interface ToolExecutionClassification {
+	family: "bash" | "mcp";
+	mode: PlatformBridgeMode;
+	riskLevel: ToolExecutionRiskLevel;
+	tool: PlatformToolRef;
+	connector?: PlatformConnectorRef;
+}
+
+function trimString(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function getEnvValue(names: readonly string[]): string | undefined {
+	for (const name of names) {
+		const value = trimString(process.env[name]);
+		if (value) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function buildShellCommandSummary(command: string): string {
+	const normalized = command.replace(/\s+/gu, " ").trim();
+	if (normalized.length <= 96) {
+		return normalized;
+	}
+	return `${normalized.slice(0, 93).trimEnd()}...`;
+}
+
+function isReadOnlyBashCommand(command: string): boolean {
+	const normalized = command.replace(/\s+/gu, " ").trim().toLowerCase();
+	if (!normalized) {
+		return false;
+	}
+	if (BASH_MUTATION_MARKERS.some((pattern) => pattern.test(normalized))) {
+		return false;
+	}
+	return READ_ONLY_BASH_PREFIXES.some(
+		(prefix) => normalized === prefix || normalized.startsWith(`${prefix} `),
+	);
+}
+
+function inferBashRiskLevel(command: string): ToolExecutionRiskLevel {
+	const normalized = command.toLowerCase();
+	if (
+		/\brm\s+-rf\b/u.test(normalized) ||
+		/\bgit\s+push(\s+--force|\s+-f)\b/u.test(normalized) ||
+		/\bnpm\s+publish\b/u.test(normalized) ||
+		/\bkubectl\s+delete\b/u.test(normalized) ||
+		/\bterraform\s+destroy\b/u.test(normalized)
+	) {
+		return "RISK_LEVEL_CRITICAL";
+	}
+	return isReadOnlyBashCommand(command) ? "RISK_LEVEL_LOW" : "RISK_LEVEL_HIGH";
+}
+
+function normalizeCapabilitySegment(value: string): string {
+	return value.replace(/[^a-zA-Z0-9_.-]/gu, "_");
+}
+
+function parseBridgeMcpToolName(
+	name: string,
+): { server: string; tool?: string } | null {
+	const parts = name.split("__");
+	if (parts[0] !== "mcp" || parts.length < 2) {
+		return null;
+	}
+	const server = parts[1];
+	if (!server) {
+		return null;
+	}
+	return {
+		server,
+		tool: parts.length > 2 ? parts.slice(2).join("__") : undefined,
+	};
+}
+
+function classifyToolExecution(
+	toolCall: ToolCall,
+	toolDef: AgentTool | undefined,
+	rollout: {
+		observeEnabled: boolean;
+		governedEnabled: boolean;
+	},
+): ToolExecutionClassification | null {
+	if (!rollout.observeEnabled && !rollout.governedEnabled) {
+		return null;
+	}
+
+	if (toolCall.name === "bash") {
+		const command =
+			typeof toolCall.arguments.command === "string"
+				? toolCall.arguments.command
+				: "";
+		const isReadOnly = isReadOnlyBashCommand(command);
+		const mode: PlatformBridgeMode =
+			isReadOnly || !rollout.governedEnabled ? "observe" : "governed";
+		if (mode === "observe" && !rollout.observeEnabled) {
+			return null;
+		}
+		return {
+			family: "bash",
+			mode,
+			riskLevel: inferBashRiskLevel(command),
+			tool: {
+				namespace: "maestro",
+				name: "bash",
+				version: process.env.npm_package_version,
+				capability: "maestro.tool.bash",
+				operation: command ? buildShellCommandSummary(command) : "shell",
+				idempotent: isReadOnly,
+				mutatesResource: !isReadOnly,
+			},
+		};
+	}
+
+	const mcpTool = parseBridgeMcpToolName(toolCall.name);
+	if (!mcpTool) {
+		return null;
+	}
+	const mode: PlatformBridgeMode = rollout.governedEnabled
+		? "governed"
+		: rollout.observeEnabled
+			? "observe"
+			: "observe";
+	if (mode === "observe" && !rollout.observeEnabled) {
+		return null;
+	}
+	const toolName = mcpTool.tool ?? toolCall.name;
+	const readOnly = isReadOnlyTool(toolCall.name, toolDef?.annotations);
+	return {
+		family: "mcp",
+		mode,
+		riskLevel: readOnly ? "RISK_LEVEL_MEDIUM" : "RISK_LEVEL_HIGH",
+		tool: {
+			namespace: "mcp",
+			name: toolName,
+			version: process.env.npm_package_version,
+			capability: `mcp.${normalizeCapabilitySegment(mcpTool.server)}.${normalizeCapabilitySegment(toolName)}`,
+			operation: toolName,
+			idempotent: readOnly,
+			mutatesResource: !readOnly,
+		},
+		connector: {
+			providerId: mcpTool.server,
+			resourceId: mcpTool.server,
+			resourceKind: "mcp_server",
+		},
+	};
+}
+
+function stableStringify(value: unknown): string {
+	if (Array.isArray(value)) {
+		return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+	}
+	if (value && typeof value === "object") {
+		return `{${Object.entries(value as Record<string, unknown>)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+			.join(",")}}`;
+	}
+	return JSON.stringify(value);
+}
+
+function cloneRecord(value: Record<string, unknown>): Record<string, unknown> {
+	return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
+function scrubText(value: string): { text: string; redactions: string[] } {
+	let next = value;
+	const redactions = new Set<string>();
+	for (const pattern of [
+		/\b(gh[pousr]_[A-Za-z0-9_]{20,})\b/gu,
+		/\b(Bearer\s+[A-Za-z0-9._-]{16,})\b/giu,
+		/\b([A-Za-z0-9_-]{32,})\b/gu,
+	]) {
+		if (pattern.test(next)) {
+			redactions.add("secret_like_token");
+			next = next.replace(pattern, "[REDACTED]");
+		}
+	}
+	return { text: next, redactions: [...redactions] };
+}
+
+function summarizeToolResult(result: ToolResultMessage): {
+	summary: string;
+	redactions: string[];
+} {
+	const text = result.content
+		.filter(
+			(part): part is { type: "text"; text: string } => part.type === "text",
+		)
+		.map((part) => part.text)
+		.join("\n")
+		.trim();
+	if (!text) {
+		return {
+			summary: result.isError
+				? "Tool failed without text output"
+				: "Tool completed",
+			redactions: [],
+		};
+	}
+	const firstLine = text.split(/\r?\n/u)[0]?.trim() ?? text;
+	const shortened =
+		firstLine.length > OBSERVE_OUTPUT_SUMMARY_MAX_LENGTH
+			? `${firstLine.slice(0, OBSERVE_OUTPUT_SUMMARY_MAX_LENGTH - 3).trimEnd()}...`
+			: firstLine;
+	const scrubbed = scrubText(shortened);
+	return {
+		summary: scrubbed.text,
+		redactions: scrubbed.redactions,
+	};
+}
+
+function buildLinkage(
+	cfg: AgentRunConfig,
+	toolCall: ToolCall,
+	organizationId: string | undefined,
+	workspaceId: string,
+): ToolExecutionLinkage {
+	const sessionId =
+		trimString(cfg.session?.id) ?? getEnvValue(["MAESTRO_SESSION_ID"]);
+	const agentRunId = getEnvValue(["MAESTRO_AGENT_RUN_ID"]);
+	return {
+		workspaceId,
+		...(organizationId ? { organizationId } : {}),
+		agentId:
+			getEnvValue(["MAESTRO_AGENT_ID"]) ??
+			trimString(process.env.npm_package_name) ??
+			"maestro",
+		...(agentRunId ? { runId: agentRunId } : {}),
+		objectiveId: getEnvValue(["MAESTRO_OBJECTIVE_ID"]),
+		stepId: toolCall.id,
+		actorId: trimString(cfg.user?.id) ?? getEnvValue(["MAESTRO_ACTOR_ID"]),
+		surface: getEnvValue(["MAESTRO_SURFACE"]) ?? "maestro",
+		channelId: getEnvValue(["MAESTRO_CHANNEL_ID"]),
+		correlationId: `${sessionId ?? "session"}:${toolCall.id}`,
+	};
+}
+
+function buildMetadata(
+	input: ToolExecutionBridgeInput,
+	classification: ToolExecutionClassification,
+): Record<string, string> {
+	const originalArgs = input.toolCall.arguments as Record<string, unknown>;
+	const redactedArguments =
+		stableStringify(originalArgs) !== stableStringify(input.sanitizedArgs);
+	const sessionId =
+		trimString(input.cfg.session?.id) ?? getEnvValue(["MAESTRO_SESSION_ID"]);
+	const remoteRunnerSessionId = getEnvValue([
+		"MAESTRO_REMOTE_RUNNER_SESSION_ID",
+		"MAESTRO_RUNNER_SESSION_ID",
+	]);
+	return {
+		maestro_bridge_mode: classification.mode,
+		maestro_tool_call_id: input.toolCall.id,
+		...(sessionId ? { maestro_session_id: sessionId } : {}),
+		...(remoteRunnerSessionId
+			? { maestro_remote_runner_session_id: remoteRunnerSessionId }
+			: {}),
+		...(input.displayName ? { maestro_display_name: input.displayName } : {}),
+		...(input.summaryLabel
+			? { maestro_summary_label: input.summaryLabel }
+			: {}),
+		...(input.actionDescription
+			? { maestro_action_description: input.actionDescription }
+			: {}),
+		maestro_redacted_arguments: String(redactedArguments),
+		maestro_tool_family: classification.family,
+		maestro_local_execution_authoritative: String(
+			classification.mode === "governed",
+		),
+	};
+}
+
+function buildExecuteRequest(
+	input: ToolExecutionBridgeInput,
+	config: ToolExecutionServiceConfig,
+	classification: ToolExecutionClassification,
+): ExecutePlatformToolRequest {
+	return {
+		linkage: buildLinkage(
+			input.cfg,
+			input.toolCall,
+			config.organizationId,
+			config.workspaceId ?? process.cwd(),
+		),
+		tool: classification.tool,
+		...(classification.connector
+			? { connector: classification.connector }
+			: {}),
+		arguments: cloneRecord(input.sanitizedArgs),
+		riskLevel: classification.riskLevel,
+		retryPolicy: {
+			maxAttempts: 1,
+			initialDelayMs: 0,
+			maxDelayMs: 0,
+			allowNonIdempotentRetry: false,
+		},
+		idempotencyKey: `maestro:${input.toolCall.id}`,
+		metadata: buildMetadata(input, classification),
+	};
+}
+
+function planFromResponse(
+	classification: ToolExecutionClassification,
+	config: ToolExecutionServiceConfig,
+	request: ExecutePlatformToolRequest,
+	response: ExecutePlatformToolResponse,
+): GovernedToolExecutionPlan {
+	return {
+		kind: "governed",
+		mode: "governed",
+		classification,
+		config,
+		request,
+		metadata: {
+			toolExecutionId: response.execution.id,
+			approvalRequestId: response.execution.approvalWait?.approvalRequestId,
+		},
+		resumeToken: response.execution.approvalWait?.resumeToken,
+	};
+}
+
+function waitApprovalRequest(
+	input: ToolExecutionBridgeInput,
+	plan: GovernedToolExecutionPlan,
+	execution: PlatformToolExecutionRecord,
+): ActionApprovalRequest {
+	return {
+		id:
+			execution.approvalWait?.approvalRequestId ??
+			plan.metadata.approvalRequestId ??
+			input.toolCall.id,
+		toolName: input.toolCall.name,
+		displayName: input.displayName,
+		summaryLabel: input.summaryLabel,
+		actionDescription: input.actionDescription,
+		args: input.sanitizedArgs,
+		reason:
+			execution.approvalWait?.reason ??
+			execution.errorMessage ??
+			"Approval required by Platform ToolExecution",
+	};
+}
+
+function isBridgeGloballyDisabled(): boolean {
+	return isFeatureFlagEnabled(MAESTRO_PLATFORM_RUNTIME_BRIDGE_KILL_SWITCH);
+}
+
+export interface PlatformToolExecutionBridge {
+	prepare(
+		input: ToolExecutionBridgeInput,
+		signal?: AbortSignal,
+	): Promise<ToolExecutionBridgePreparation>;
+	resolveApproval(
+		input: ToolExecutionBridgeInput,
+		plan: GovernedToolExecutionPlan,
+		decision: ActionApprovalDecision,
+		signal?: AbortSignal,
+	): Promise<ToolExecutionBridgeApprovalResolution>;
+	recordObservation(
+		plan: ObserveToolExecutionPlan,
+		result: ToolResultMessage,
+		signal?: AbortSignal,
+	): Promise<ObserveToolExecutionResult>;
+}
+
+export class DefaultPlatformToolExecutionBridge
+	implements PlatformToolExecutionBridge
+{
+	async prepare(
+		input: ToolExecutionBridgeInput,
+		signal?: AbortSignal,
+	): Promise<ToolExecutionBridgePreparation> {
+		if (isBridgeGloballyDisabled()) {
+			return { status: "skip" };
+		}
+
+		const rollout = {
+			observeEnabled:
+				isPlatformRuntimeObserveEnabled() ||
+				isPlatformToolExecutionBridgeEnabled(),
+			governedEnabled: isPlatformToolExecutionBridgeEnabled(),
+		};
+		const classification = classifyToolExecution(
+			input.toolCall,
+			input.toolDef,
+			rollout,
+		);
+		if (!classification) {
+			return { status: "skip" };
+		}
+
+		const config = await resolveToolExecutionServiceConfig();
+		if (!config) {
+			return { status: "skip" };
+		}
+
+		const request = buildExecuteRequest(input, config, classification);
+		if (classification.mode === "observe") {
+			return {
+				status: "observe",
+				plan: {
+					kind: "observe",
+					mode: "observe",
+					classification,
+					config,
+					request,
+					metadata: {},
+				},
+			};
+		}
+
+		try {
+			const response = await executeToolWithPlatform(config, request, signal);
+			const plan = planFromResponse(classification, config, request, response);
+			switch (response.execution.state) {
+				case "TOOL_EXECUTION_STATE_DENIED":
+					return {
+						status: "deny",
+						plan,
+						reason:
+							response.execution.errorMessage ??
+							"Action denied by Platform ToolExecution",
+					};
+				case "TOOL_EXECUTION_STATE_WAITING_APPROVAL":
+					return {
+						status: "wait_approval",
+						plan,
+						request: waitApprovalRequest(input, plan, response.execution),
+					};
+				default:
+					return { status: "allow", plan };
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return {
+				status: "deny",
+				reason: `Platform ToolExecution unavailable: ${message}`,
+			};
+		}
+	}
+
+	async resolveApproval(
+		input: ToolExecutionBridgeInput,
+		plan: GovernedToolExecutionPlan,
+		decision: ActionApprovalDecision,
+		signal?: AbortSignal,
+	): Promise<ToolExecutionBridgeApprovalResolution> {
+		if (!plan.resumeToken || !plan.metadata.approvalRequestId) {
+			return decision.approved
+				? { status: "allow", plan }
+				: {
+						status: "deny",
+						plan,
+						reason: decision.reason ?? "Approval denied",
+					};
+		}
+		const request: ResumePlatformToolExecutionRequest = {
+			executionId: plan.metadata.toolExecutionId ?? "",
+			approvalRequestId: plan.metadata.approvalRequestId,
+			resumeToken: plan.resumeToken,
+			approved: decision.approved,
+			decidedBy:
+				decision.resolvedBy === "user"
+					? (trimString(input.cfg.user?.id) ?? "user")
+					: "policy",
+			reason: decision.reason,
+		};
+		try {
+			const response = await resumeToolExecutionWithPlatform(
+				plan.config,
+				request,
+				signal,
+			);
+			const nextPlan: GovernedToolExecutionPlan = {
+				...plan,
+				metadata: {
+					toolExecutionId:
+						response.execution.id ?? plan.metadata.toolExecutionId,
+					approvalRequestId:
+						response.execution.approvalWait?.approvalRequestId ??
+						plan.metadata.approvalRequestId,
+				},
+			};
+			switch (response.execution.state) {
+				case "TOOL_EXECUTION_STATE_DENIED":
+				case "TOOL_EXECUTION_STATE_FAILED":
+				case "TOOL_EXECUTION_STATE_CANCELLED":
+					return {
+						status: "deny",
+						plan: nextPlan,
+						reason:
+							response.execution.errorMessage ??
+							decision.reason ??
+							"Platform ToolExecution denied the action",
+					};
+				default:
+					return { status: "allow", plan: nextPlan };
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return decision.approved
+				? {
+						status: "deny",
+						plan,
+						reason: `Platform ToolExecution decision sync failed: ${message}`,
+					}
+				: {
+						status: "deny",
+						plan,
+						reason: decision.reason ?? `Approval denied (${message})`,
+					};
+		}
+	}
+
+	async recordObservation(
+		plan: ObserveToolExecutionPlan,
+		result: ToolResultMessage,
+		signal?: AbortSignal,
+	): Promise<ObserveToolExecutionResult> {
+		const summary = summarizeToolResult(result);
+		const request: ExecutePlatformToolRequest = {
+			...plan.request,
+			metadata: {
+				...plan.request.metadata,
+				maestro_bridge_mode: "observe",
+				maestro_local_outcome: result.isError ? "failed" : "succeeded",
+				maestro_local_output_summary: summary.summary,
+				maestro_local_output_redactions:
+					summary.redactions.length > 0 ? summary.redactions.join(",") : "none",
+			},
+		};
+		try {
+			const response = await executeToolWithPlatform(
+				plan.config,
+				request,
+				signal,
+			);
+			return {
+				metadata: {
+					toolExecutionId: response.execution.id,
+					approvalRequestId: response.execution.approvalWait?.approvalRequestId,
+				},
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.warn("Failed to record observe-only tool execution", {
+				error: message,
+				toolName: plan.request.tool.name,
+				toolCallId: plan.request.metadata?.maestro_tool_call_id,
+			});
+			return { metadata: plan.metadata };
+		}
+	}
+}
+
+let defaultBridge: PlatformToolExecutionBridge | null = null;
+
+export function getDefaultPlatformToolExecutionBridge(): PlatformToolExecutionBridge {
+	if (!defaultBridge) {
+		defaultBridge = new DefaultPlatformToolExecutionBridge();
+	}
+	return defaultBridge;
+}
+
+export function resetPlatformToolExecutionBridgeForTests(): void {
+	defaultBridge = null;
+}
+
+export function buildObservedResultMetadata(
+	plan: ToolExecutionBridgePlan | undefined,
+	observation: ObserveToolExecutionResult | undefined,
+): ToolExecutionBridgeMetadata {
+	if (!plan) {
+		return observation?.metadata ?? {};
+	}
+	return {
+		toolExecutionId:
+			observation?.metadata.toolExecutionId ?? plan.metadata.toolExecutionId,
+		approvalRequestId:
+			observation?.metadata.approvalRequestId ??
+			plan.metadata.approvalRequestId,
+	};
+}
+
+export function stripObserveResultMetadata(
+	metadata: Record<string, string>,
+): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(metadata).filter(
+			([key]) =>
+				!OBSERVE_RESULT_FIELDS.includes(
+					key as (typeof OBSERVE_RESULT_FIELDS)[number],
+				),
+		),
+	);
+}

--- a/src/agent/transport/tool-execution.ts
+++ b/src/agent/transport/tool-execution.ts
@@ -27,6 +27,12 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types.js";
+import {
+	type ObserveToolExecutionPlan,
+	type PlatformToolExecutionBridge,
+	type ToolExecutionBridgePlan,
+	buildObservedResultMetadata,
+} from "./tool-execution-bridge.js";
 import type {
 	ToolExecutionOutcome,
 	ToolUpdateQueue,
@@ -60,6 +66,8 @@ export interface ToolExecutionContext {
 	toolRetryService?: ToolRetryService;
 	toolRetryConfig?: ToolRetryConfig;
 	clientToolService?: ClientToolExecutionService;
+	toolExecutionBridge?: PlatformToolExecutionBridge;
+	toolExecutionBridgePlan?: ToolExecutionBridgePlan;
 	// Concurrency
 	toolUpdateQueue: ToolUpdateQueue;
 	/** Pre-created client tool execution promise (if applicable) */
@@ -260,6 +268,8 @@ export function createToolExecutionPromise(
 		toolRetryService,
 		toolRetryConfig,
 		clientToolService,
+		toolExecutionBridge,
+		toolExecutionBridgePlan,
 	} = ctx;
 
 	const startTime = clock.now();
@@ -538,9 +548,19 @@ export function createToolExecutionPromise(
 				}
 			}
 
+			const observed =
+				toolExecutionBridge && toolExecutionBridgePlan?.kind === "observe"
+					? await toolExecutionBridge.recordObservation(
+							toolExecutionBridgePlan as ObserveToolExecutionPlan,
+							toolResultMsg,
+							signal,
+						)
+					: undefined;
+
 			return {
 				message: toolResultMsg,
 				isError: toolResultMsg.isError,
+				...buildObservedResultMetadata(toolExecutionBridgePlan, observed),
 			};
 		} catch (error: unknown) {
 			if (error instanceof Error && error.name === "AbortError") {
@@ -593,9 +613,19 @@ export function createToolExecutionPromise(
 				}
 			}
 
+			const observed =
+				toolExecutionBridge && toolExecutionBridgePlan?.kind === "observe"
+					? await toolExecutionBridge.recordObservation(
+							toolExecutionBridgePlan as ObserveToolExecutionPlan,
+							toolResultMsg,
+							signal,
+						)
+					: undefined;
+
 			return {
 				message: toolResultMsg,
 				isError: true,
+				...buildObservedResultMetadata(toolExecutionBridgePlan, observed),
 			};
 		}
 	})();

--- a/src/agent/transport/tool-safety-pipeline.ts
+++ b/src/agent/transport/tool-safety-pipeline.ts
@@ -36,6 +36,11 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 } from "../types.js";
+import type {
+	PlatformToolExecutionBridge,
+	ToolExecutionBridgeInput,
+	ToolExecutionBridgePlan,
+} from "./tool-execution-bridge.js";
 import {
 	type ToolAuditLogger,
 	buildPiiPolicyResult,
@@ -58,6 +63,7 @@ export type ToolSafetyVerdict =
 			toolDef: AgentTool;
 			events: AgentEvent[];
 			sanitizedExecutionArgs: Record<string, unknown>;
+			toolExecutionBridgePlan?: ToolExecutionBridgePlan;
 	  };
 
 export interface ToolSafetyContext {
@@ -73,6 +79,7 @@ export interface ToolSafetyContext {
 	adaptiveThresholds: AdaptiveThresholds;
 	auditLogger?: ToolAuditLogger;
 	approvalService?: ActionApprovalService;
+	toolExecutionBridge?: PlatformToolExecutionBridge;
 	hookService?: {
 		runPreToolUseHooks: (
 			toolCall: ToolCall,
@@ -106,6 +113,10 @@ export interface ToolSafetyContext {
 		message: ToolResultMessage,
 		toolCall: ToolCall,
 		isError: boolean,
+		metadata?: {
+			toolExecutionId?: string;
+			approvalRequestId?: string;
+		},
 	) => AgentEvent[];
 }
 
@@ -285,6 +296,7 @@ export async function* evaluateToolSafety(
 		workflowState,
 		auditLogger,
 		approvalService,
+		toolExecutionBridge,
 		hookService,
 		firewall,
 		emitToolResult,
@@ -450,6 +462,11 @@ export async function* evaluateToolSafety(
 	// 4. Firewall evaluation
 	const workflowSnapshot = workflowState.snapshot();
 	const toolDef = tools.find((t) => t.name === effectiveToolCall.name);
+	const describeArgs = (args: Record<string, unknown>) => ({
+		displayName: describeToolDisplayName(toolCall.name, args, toolDef),
+		summaryLabel: summarizeToolUse(toolCall.name, args, toolDef),
+		actionDescription: describeToolActivity(toolCall.name, args, toolDef),
+	});
 	const verdict = await firewall.evaluate({
 		toolName: effectiveToolCall.name,
 		args: effectiveToolCall.arguments,
@@ -539,13 +556,108 @@ export async function* evaluateToolSafety(
 		};
 	}
 
+	if (!toolDef) {
+		const errorResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: toolCall.id,
+			toolName: toolCall.name,
+			content: [
+				{
+					type: "text",
+					text: `Error: Tool "${toolCall.name}" not found`,
+				},
+			],
+			isError: true,
+			timestamp: clock.now(),
+		};
+		const errorEvents = recordEvents(
+			emitToolResult(errorResult, toolCall, true),
+		);
+		for (const event of errorEvents) {
+			yield event;
+		}
+		return {
+			verdict: { outcome: "blocked", events },
+			rateLimitUpdate: rateLimitResult.updatedState,
+		};
+	}
+
+	let toolExecutionBridgePlan: ToolExecutionBridgePlan | undefined;
+	let platformApprovalRequest:
+		| import("../action-approval.js").ActionApprovalRequest
+		| undefined;
+	let platformApprovalResolved = false;
+	const bridgeArgs = safetyMiddleware.sanitizeForLogging(
+		effectiveToolCall.arguments as Record<string, unknown>,
+	);
+	const bridgeInput: ToolExecutionBridgeInput = {
+		cfg,
+		toolCall,
+		toolDef,
+		sanitizedArgs: bridgeArgs,
+		...describeArgs(bridgeArgs),
+	};
+	if (toolExecutionBridge) {
+		const bridgeResult = await toolExecutionBridge.prepare(bridgeInput, signal);
+		switch (bridgeResult.status) {
+			case "observe":
+			case "allow":
+				toolExecutionBridgePlan = bridgeResult.plan;
+				break;
+			case "wait_approval":
+				toolExecutionBridgePlan = bridgeResult.plan;
+				platformApprovalRequest = bridgeResult.request;
+				approvalAllowed = false;
+				approvalReason = bridgeResult.request.reason;
+				break;
+			case "deny": {
+				await logToolExecutionAudit(
+					auditLogger,
+					effectiveToolCall.name,
+					bridgeArgs,
+					"denied",
+					0,
+					bridgeResult.reason,
+				);
+				const deniedResult: ToolResultMessage = {
+					role: "toolResult",
+					toolCallId: toolCall.id,
+					toolName: toolCall.name,
+					content: [{ type: "text", text: bridgeResult.reason }],
+					isError: true,
+					timestamp: clock.now(),
+				};
+				const deniedEvents = recordEvents(
+					emitToolResult(deniedResult, toolCall, true, {
+						toolExecutionId: bridgeResult.plan?.metadata.toolExecutionId,
+						approvalRequestId: bridgeResult.plan?.metadata.approvalRequestId,
+					}),
+				);
+				for (const event of deniedEvents) {
+					yield event;
+				}
+				return {
+					verdict: { outcome: "blocked", events },
+					rateLimitUpdate: rateLimitResult.updatedState,
+				};
+			}
+			default:
+				break;
+		}
+	}
+
 	// 6. Approval flow
-	if (verdict.action === "require_approval") {
+	if (verdict.action === "require_approval" || platformApprovalRequest) {
+		const localApprovalReason =
+			verdict.action === "require_approval" ? verdict.reason : undefined;
 		let permissionHookMadeDecision = false;
 		if (hookService?.runPermissionRequestHooks) {
 			const permissionHookResult = await hookService.runPermissionRequestHooks(
 				effectiveToolCall,
-				verdict.reason ?? approvalReason ?? "Approval required",
+				platformApprovalRequest?.reason ??
+					localApprovalReason ??
+					approvalReason ??
+					"Approval required",
 				signal,
 			);
 			if (permissionHookResult.updatedInput) {
@@ -567,38 +679,57 @@ export async function* evaluateToolSafety(
 			}
 		}
 
+		if (
+			permissionHookMadeDecision &&
+			toolExecutionBridge &&
+			platformApprovalRequest &&
+			toolExecutionBridgePlan?.kind === "governed"
+		) {
+			const resolution = await toolExecutionBridge.resolveApproval(
+				bridgeInput,
+				toolExecutionBridgePlan,
+				{
+					approved: approvalAllowed,
+					reason: approvalReason,
+					resolvedBy: "policy",
+				},
+				signal,
+			);
+			platformApprovalResolved = true;
+			toolExecutionBridgePlan = resolution.plan;
+			if (resolution.status === "deny") {
+				approvalAllowed = false;
+				approvalReason = resolution.reason;
+			} else {
+				approvalAllowed = true;
+				approvalReason = undefined;
+			}
+		}
+
 		if (approvalService && !permissionHookMadeDecision) {
 			const sanitizedApprovalArgs = safetyMiddleware.sanitizeForLogging(
 				effectiveToolCall.arguments as Record<string, unknown>,
 			);
-			const request = {
-				id: toolCall.id,
-				toolName: toolCall.name,
-				displayName: describeToolDisplayName(
-					toolCall.name,
-					sanitizedApprovalArgs,
-					toolDef,
-				),
-				summaryLabel: summarizeToolUse(
-					toolCall.name,
-					sanitizedApprovalArgs,
-					toolDef,
-				),
-				actionDescription: describeToolActivity(
-					toolCall.name,
-					sanitizedApprovalArgs,
-					toolDef,
-				),
-				args: sanitizedApprovalArgs,
-				reason: verdict.reason ?? "Approval required",
-			};
+			const request =
+				platformApprovalRequest ??
+				({
+					id: toolCall.id,
+					toolName: toolCall.name,
+					...describeArgs(sanitizedApprovalArgs),
+					args: sanitizedApprovalArgs,
+					reason: localApprovalReason ?? "Approval required",
+				} satisfies import("../action-approval.js").ActionApprovalRequest);
 			const shouldEmitEvents = approvalService.requiresUserInteraction();
 			if (shouldEmitEvents) {
 				yield recordEvent({ type: "action_approval_required", request });
 			}
 			recordMaestroApprovalHit({
-				approval_request_id: request.id,
-				action: request.actionDescription,
+				approval_request_id:
+					platformApprovalRequest?.id ??
+					toolExecutionBridgePlan?.metadata.approvalRequestId ??
+					request.id,
+				action:
+					request.actionDescription ?? request.summaryLabel ?? request.toolName,
 				command:
 					typeof sanitizedApprovalArgs.command === "string"
 						? sanitizedApprovalArgs.command
@@ -626,14 +757,58 @@ export async function* evaluateToolSafety(
 				});
 			}
 
+			if (
+				toolExecutionBridge &&
+				platformApprovalRequest &&
+				toolExecutionBridgePlan?.kind === "governed"
+			) {
+				const resolution = await toolExecutionBridge.resolveApproval(
+					bridgeInput,
+					toolExecutionBridgePlan,
+					decision,
+					signal,
+				);
+				platformApprovalResolved = true;
+				toolExecutionBridgePlan = resolution.plan;
+				if (resolution.status === "deny") {
+					approvalAllowed = false;
+					approvalReason = resolution.reason;
+				} else {
+					approvalAllowed = true;
+					approvalReason = undefined;
+				}
+			}
+
 			if (!decision.approved) {
 				approvalAllowed = false;
-				approvalReason = decision.reason ?? verdict.reason;
+				approvalReason = decision.reason ?? localApprovalReason;
 			}
 		}
 	}
 
 	if (!approvalAllowed) {
+		if (
+			toolExecutionBridge &&
+			platformApprovalRequest &&
+			toolExecutionBridgePlan?.kind === "governed" &&
+			!platformApprovalResolved
+		) {
+			const resolution = await toolExecutionBridge.resolveApproval(
+				bridgeInput,
+				toolExecutionBridgePlan,
+				{
+					approved: false,
+					reason: approvalReason ?? "Approval denied",
+					resolvedBy: "policy",
+				},
+				signal,
+			);
+			toolExecutionBridgePlan = resolution.plan;
+			approvalReason =
+				resolution.status === "deny"
+					? resolution.reason
+					: (approvalReason ?? "Approval denied");
+		}
 		await logToolExecutionAudit(
 			auditLogger,
 			effectiveToolCall.name,
@@ -653,7 +828,10 @@ export async function* evaluateToolSafety(
 			timestamp: clock.now(),
 		};
 		const deniedEvents = recordEvents(
-			emitToolResult(deniedResult, toolCall, true),
+			emitToolResult(deniedResult, toolCall, true, {
+				toolExecutionId: toolExecutionBridgePlan?.metadata.toolExecutionId,
+				approvalRequestId: toolExecutionBridgePlan?.metadata.approvalRequestId,
+			}),
 		);
 		for (const event of deniedEvents) {
 			yield event;
@@ -664,34 +842,7 @@ export async function* evaluateToolSafety(
 		};
 	}
 
-	// 7. Tool lookup
-	if (!toolDef) {
-		const errorResult: ToolResultMessage = {
-			role: "toolResult",
-			toolCallId: toolCall.id,
-			toolName: toolCall.name,
-			content: [
-				{
-					type: "text",
-					text: `Error: Tool "${toolCall.name}" not found`,
-				},
-			],
-			isError: true,
-			timestamp: clock.now(),
-		};
-		const errorEvents = recordEvents(
-			emitToolResult(errorResult, toolCall, true),
-		);
-		for (const event of errorEvents) {
-			yield event;
-		}
-		return {
-			verdict: { outcome: "blocked", events },
-			rateLimitUpdate: rateLimitResult.updatedState,
-		};
-	}
-
-	// 8. Argument validation
+	// 7. Argument validation
 	let validatedArgs: Record<string, unknown>;
 	try {
 		const rawArgs = validateToolArguments(toolDef, effectiveToolCall);
@@ -734,6 +885,7 @@ export async function* evaluateToolSafety(
 			toolDef,
 			events,
 			sanitizedExecutionArgs,
+			...(toolExecutionBridgePlan ? { toolExecutionBridgePlan } : {}),
 		},
 		rateLimitUpdate: rateLimitResult.updatedState,
 	};

--- a/src/agent/transport/tool-update-queue.ts
+++ b/src/agent/transport/tool-update-queue.ts
@@ -13,6 +13,8 @@ import type { AgentEvent, ToolCall, ToolResultMessage } from "../types.js";
 export interface ToolExecutionOutcome {
 	message: ToolResultMessage;
 	isError: boolean;
+	toolExecutionId?: string;
+	approvalRequestId?: string;
 }
 
 export interface PendingExecution {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1102,6 +1102,8 @@ export type AgentEvent =
 			type: "tool_execution_start";
 			/** Tool call identifier */
 			toolCallId: string;
+			/** Optional Platform ToolExecution identifier */
+			toolExecutionId?: string;
 			/** Name of the tool */
 			toolName: string;
 			/** Optional human-facing label for live UI */
@@ -1116,6 +1118,10 @@ export type AgentEvent =
 			type: "tool_execution_end";
 			/** Tool call identifier */
 			toolCallId: string;
+			/** Optional Platform ToolExecution identifier */
+			toolExecutionId?: string;
+			/** Optional approval request identifier correlated to Platform ToolExecution */
+			approvalRequestId?: string;
 			/** Name of the tool */
 			toolName: string;
 			/** Optional human-facing label for live UI */

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -24,8 +24,14 @@ export const MAESTRO_EVALOPS_MANAGED_KILL_SWITCH =
 	"platform.kill_switches.maestro.evalops_managed";
 export const MAESTRO_AUTONOMOUS_ACTIONS_KILL_SWITCH =
 	"platform.kill_switches.maestro.autonomous_actions";
+export const MAESTRO_PLATFORM_RUNTIME_BRIDGE_KILL_SWITCH =
+	"platform.kill_switches.maestro.platform_runtime_bridge";
 export const MAESTRO_DRAFT_AND_CONFIRM_DEFAULT_FLAG =
 	"maestro.agent_authority.draft_and_confirm_default";
+export const MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG =
+	"maestro.platform_runtime.agent_runtime_observe";
+export const MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG =
+	"maestro.platform_runtime.tool_execution_bridge";
 
 function getFeatureFlagsPath(): string | undefined {
 	const configured = process.env.EVALOPS_FEATURE_FLAGS_PATH?.trim();
@@ -89,6 +95,22 @@ export function areAutonomousActionsDisabled(): boolean {
 
 export function isDraftAndConfirmDefaultEnabled(): boolean {
 	return isFeatureFlagEnabled(MAESTRO_DRAFT_AND_CONFIRM_DEFAULT_FLAG);
+}
+
+export function isPlatformRuntimeBridgeDisabled(): boolean {
+	return isFeatureFlagEnabled(MAESTRO_PLATFORM_RUNTIME_BRIDGE_KILL_SWITCH);
+}
+
+export function isPlatformRuntimeObserveEnabled(): boolean {
+	return isFeatureFlagEnabled(
+		MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG,
+	);
+}
+
+export function isPlatformToolExecutionBridgeEnabled(): boolean {
+	return isFeatureFlagEnabled(
+		MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+	);
 }
 
 export function resetFeatureFlagCacheForTests(): void {

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -5,6 +5,8 @@ export const CONNECT_PROTOCOL_VERSION = "1";
 export const DEFAULT_PLATFORM_TIMEOUT_MS = 2_000;
 export const DEFAULT_PLATFORM_MAX_ATTEMPTS = 2;
 
+export type DownstreamFailureMode = "required" | "optional";
+
 export interface PlatformServiceConfig {
 	baseUrl: string;
 	token?: string;
@@ -33,6 +35,7 @@ export interface ResolvePlatformServiceConfigOptions {
 
 export interface PlatformRequestOptions {
 	serviceName: string;
+	failureMode?: DownstreamFailureMode;
 	timeoutMs: number;
 	maxAttempts?: number;
 	signal?: AbortSignal;

--- a/src/platform/core-services.ts
+++ b/src/platform/core-services.ts
@@ -11,6 +11,7 @@ export const PLATFORM_CONNECT_SERVICES = {
 	meter: "meter.v1.MeterService",
 	prompts: "prompts.v1.PromptService",
 	remoteRunner: "remoterunner.v1.RemoteRunnerService",
+	toolexecution: "toolexecution.v1.ToolExecutionService",
 } as const;
 
 export const PLATFORM_CONNECT_METHODS = {
@@ -150,6 +151,28 @@ export const PLATFORM_CONNECT_METHODS = {
 		stopRunnerSession: {
 			service: PLATFORM_CONNECT_SERVICES.remoteRunner,
 			method: "StopRunnerSession",
+		},
+	},
+	toolexecution: {
+		executeTool: {
+			service: PLATFORM_CONNECT_SERVICES.toolexecution,
+			method: "ExecuteTool",
+		},
+		getToolExecution: {
+			service: PLATFORM_CONNECT_SERVICES.toolexecution,
+			method: "GetToolExecution",
+		},
+		listToolExecutions: {
+			service: PLATFORM_CONNECT_SERVICES.toolexecution,
+			method: "ListToolExecutions",
+		},
+		recordToolExecutionOutput: {
+			service: PLATFORM_CONNECT_SERVICES.toolexecution,
+			method: "RecordToolExecutionOutput",
+		},
+		resumeToolExecution: {
+			service: PLATFORM_CONNECT_SERVICES.toolexecution,
+			method: "ResumeToolExecution",
 		},
 	},
 } as const;

--- a/src/platform/tool-execution-client.ts
+++ b/src/platform/tool-execution-client.ts
@@ -1,0 +1,452 @@
+import {
+	type PlatformServiceConfig,
+	getEnvValue,
+	postPlatformConnect,
+	resolvePlatformServiceConfig,
+	trimString,
+} from "./client.js";
+import {
+	PLATFORM_CONNECT_METHODS,
+	platformConnectMethodPath,
+	platformConnectServicePath,
+} from "./core-services.js";
+
+const DEFAULT_TIMEOUT_MS = 2_500;
+const DEFAULT_MAX_ATTEMPTS = 2;
+
+const TOOL_EXECUTION_BASE_URL_ENV_VARS = [
+	"TOOL_EXECUTION_SERVICE_URL",
+	"MAESTRO_TOOL_EXECUTION_SERVICE_URL",
+	"MAESTRO_PLATFORM_BASE_URL",
+	"MAESTRO_EVALOPS_BASE_URL",
+	"EVALOPS_BASE_URL",
+] as const;
+
+const TOOL_EXECUTION_TOKEN_ENV_VARS = [
+	"TOOL_EXECUTION_SERVICE_TOKEN",
+	"MAESTRO_TOOL_EXECUTION_SERVICE_TOKEN",
+	"MAESTRO_EVALOPS_ACCESS_TOKEN",
+	"EVALOPS_TOKEN",
+] as const;
+
+const TOOL_EXECUTION_ORGANIZATION_ENV_VARS = [
+	"TOOL_EXECUTION_SERVICE_ORGANIZATION_ID",
+	"MAESTRO_TOOL_EXECUTION_ORGANIZATION_ID",
+	"MAESTRO_EVALOPS_ORG_ID",
+	"EVALOPS_ORGANIZATION_ID",
+	"MAESTRO_ENTERPRISE_ORG_ID",
+] as const;
+
+const TOOL_EXECUTION_WORKSPACE_ENV_VARS = [
+	"TOOL_EXECUTION_SERVICE_WORKSPACE_ID",
+	"MAESTRO_TOOL_EXECUTION_WORKSPACE_ID",
+	"MAESTRO_REMOTE_RUNNER_WORKSPACE_ID",
+	"MAESTRO_EVALOPS_WORKSPACE_ID",
+	"EVALOPS_WORKSPACE_ID",
+	"MAESTRO_WORKSPACE_ID",
+] as const;
+
+const TOOL_EXECUTION_TIMEOUT_ENV_VARS = [
+	"TOOL_EXECUTION_SERVICE_TIMEOUT_MS",
+	"MAESTRO_TOOL_EXECUTION_SERVICE_TIMEOUT_MS",
+] as const;
+
+const TOOL_EXECUTION_MAX_ATTEMPTS_ENV_VARS = [
+	"TOOL_EXECUTION_SERVICE_MAX_ATTEMPTS",
+	"MAESTRO_TOOL_EXECUTION_SERVICE_MAX_ATTEMPTS",
+] as const;
+
+const EXECUTE_TOOL_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.toolexecution.executeTool,
+);
+const RESUME_TOOL_EXECUTION_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.toolexecution.resumeToolExecution,
+);
+
+export type ToolExecutionRiskLevel =
+	| "RISK_LEVEL_UNSPECIFIED"
+	| "RISK_LEVEL_LOW"
+	| "RISK_LEVEL_MEDIUM"
+	| "RISK_LEVEL_HIGH"
+	| "RISK_LEVEL_CRITICAL";
+
+export type ToolExecutionState =
+	| "TOOL_EXECUTION_STATE_UNSPECIFIED"
+	| "TOOL_EXECUTION_STATE_ACCEPTED"
+	| "TOOL_EXECUTION_STATE_POLICY_EVALUATING"
+	| "TOOL_EXECUTION_STATE_WAITING_APPROVAL"
+	| "TOOL_EXECUTION_STATE_RUNNING"
+	| "TOOL_EXECUTION_STATE_SUCCEEDED"
+	| "TOOL_EXECUTION_STATE_FAILED"
+	| "TOOL_EXECUTION_STATE_DENIED"
+	| "TOOL_EXECUTION_STATE_CANCELLED";
+
+export interface ToolExecutionLinkage {
+	workspaceId: string;
+	organizationId?: string;
+	agentId: string;
+	runId?: string;
+	objectiveId?: string;
+	stepId: string;
+	actorId?: string;
+	surface?: string;
+	channelId?: string;
+	correlationId?: string;
+}
+
+export interface PlatformToolRef {
+	namespace: string;
+	name: string;
+	version?: string;
+	capability: string;
+	operation?: string;
+	idempotent?: boolean;
+	mutatesResource?: boolean;
+}
+
+export interface PlatformConnectorRef {
+	connectionId?: string;
+	providerId?: string;
+	resourceId?: string;
+	resourceKind?: string;
+	credentialRef?: string;
+	credentialEnvironment?: string;
+}
+
+export interface PlatformToolRetryPolicy {
+	maxAttempts?: number;
+	initialDelayMs?: number;
+	maxDelayMs?: number;
+	allowNonIdempotentRetry?: boolean;
+}
+
+export interface ExecutePlatformToolRequest {
+	linkage: ToolExecutionLinkage;
+	tool: PlatformToolRef;
+	connector?: PlatformConnectorRef;
+	arguments: Record<string, unknown>;
+	riskLevel?: ToolExecutionRiskLevel;
+	retryPolicy?: PlatformToolRetryPolicy;
+	idempotencyKey: string;
+	metadata?: Record<string, string>;
+}
+
+export interface ResumePlatformToolExecutionRequest {
+	executionId: string;
+	approvalRequestId: string;
+	resumeToken: string;
+	approved: boolean;
+	decidedBy?: string;
+	reason?: string;
+}
+
+export interface PlatformApprovalWait {
+	approvalRequestId?: string;
+	resumeToken?: string;
+	reason?: string;
+}
+
+export interface PlatformToolExecutionRecord {
+	id?: string;
+	state?: ToolExecutionState;
+	errorMessage?: string;
+	approvalWait?: PlatformApprovalWait;
+}
+
+export interface ExecutePlatformToolResponse {
+	execution: PlatformToolExecutionRecord;
+	idempotentReplay: boolean;
+}
+
+export interface ResumePlatformToolExecutionResponse {
+	execution: PlatformToolExecutionRecord;
+}
+
+export interface ToolExecutionServiceConfig extends PlatformServiceConfig {}
+
+function stripTrailingSlashes(value: string): string {
+	return value.replace(/\/+$/u, "");
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+	let normalized = stripTrailingSlashes(baseUrl.trim());
+	for (const suffix of [
+		EXECUTE_TOOL_PATH,
+		RESUME_TOOL_EXECUTION_PATH,
+		platformConnectServicePath(
+			PLATFORM_CONNECT_METHODS.toolexecution.executeTool.service,
+		),
+	]) {
+		if (normalized.endsWith(suffix)) {
+			normalized = stripTrailingSlashes(normalized.slice(0, -suffix.length));
+		}
+	}
+	return normalized;
+}
+
+export async function resolveToolExecutionServiceConfig(
+	overrides: Partial<ToolExecutionServiceConfig> = {},
+): Promise<ToolExecutionServiceConfig | null> {
+	const config = await resolvePlatformServiceConfig({
+		baseUrlEnvVars: TOOL_EXECUTION_BASE_URL_ENV_VARS,
+		tokenEnvVars: TOOL_EXECUTION_TOKEN_ENV_VARS,
+		organizationEnvVars: TOOL_EXECUTION_ORGANIZATION_ENV_VARS,
+		workspaceEnvVars: TOOL_EXECUTION_WORKSPACE_ENV_VARS,
+		timeoutEnvVars: TOOL_EXECUTION_TIMEOUT_ENV_VARS,
+		maxAttemptsEnvVars: TOOL_EXECUTION_MAX_ATTEMPTS_ENV_VARS,
+		baseUrlSuffixes: [
+			EXECUTE_TOOL_PATH,
+			RESUME_TOOL_EXECUTION_PATH,
+			platformConnectServicePath(
+				PLATFORM_CONNECT_METHODS.toolexecution.executeTool.service,
+			),
+		],
+		defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+		defaultMaxAttempts: DEFAULT_MAX_ATTEMPTS,
+		requireBaseUrl: false,
+		requireOrganizationId: true,
+		requireToken: true,
+	});
+	if (!config?.baseUrl || !config.workspaceId) {
+		return null;
+	}
+	return {
+		...config,
+		baseUrl: normalizeBaseUrl(
+			trimString(overrides.baseUrl ?? config.baseUrl) ?? config.baseUrl,
+		),
+		organizationId:
+			trimString(overrides.organizationId ?? config.organizationId) ??
+			config.organizationId,
+		workspaceId:
+			trimString(overrides.workspaceId ?? config.workspaceId) ??
+			config.workspaceId,
+		token: trimString(overrides.token ?? config.token) ?? config.token,
+		timeoutMs: overrides.timeoutMs ?? config.timeoutMs,
+		maxAttempts: overrides.maxAttempts ?? config.maxAttempts,
+		teamId: trimString(overrides.teamId ?? config.teamId),
+	};
+}
+
+function firstString(
+	record: Record<string, unknown>,
+	...keys: string[]
+): string | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "string" && value.trim().length > 0) {
+			return value.trim();
+		}
+	}
+	return undefined;
+}
+
+function firstBoolean(
+	record: Record<string, unknown>,
+	...keys: string[]
+): boolean | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "boolean") {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function objectValue(
+	record: Record<string, unknown>,
+	...keys: string[]
+): Record<string, unknown> | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (value && typeof value === "object" && !Array.isArray(value)) {
+			return value as Record<string, unknown>;
+		}
+	}
+	return undefined;
+}
+
+function normalizeExecutionState(
+	value: unknown,
+): ToolExecutionState | undefined {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		return undefined;
+	}
+	return value.trim() as ToolExecutionState;
+}
+
+function normalizeApprovalWait(
+	record: Record<string, unknown> | undefined,
+): PlatformApprovalWait | undefined {
+	if (!record) {
+		return undefined;
+	}
+	const approvalRequestId = firstString(
+		record,
+		"approvalRequestId",
+		"approval_request_id",
+	);
+	const resumeToken = firstString(record, "resumeToken", "resume_token");
+	const reason = firstString(record, "reason");
+	if (!approvalRequestId && !resumeToken && !reason) {
+		return undefined;
+	}
+	return {
+		...(approvalRequestId ? { approvalRequestId } : {}),
+		...(resumeToken ? { resumeToken } : {}),
+		...(reason ? { reason } : {}),
+	};
+}
+
+function normalizeExecutionRecord(
+	record: Record<string, unknown> | undefined,
+): PlatformToolExecutionRecord {
+	if (!record) {
+		return {};
+	}
+	return {
+		id: firstString(record, "id"),
+		state: normalizeExecutionState(record.state),
+		errorMessage: firstString(record, "errorMessage", "error_message"),
+		approvalWait: normalizeApprovalWait(
+			objectValue(record, "approvalWait", "approval_wait"),
+		),
+	};
+}
+
+function stripUndefinedValues(
+	record: Record<string, unknown>,
+): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(record).filter(([, value]) => value !== undefined),
+	);
+}
+
+function normalizeExecuteToolRequest(
+	request: ExecutePlatformToolRequest,
+): Record<string, unknown> {
+	return stripUndefinedValues({
+		linkage: stripUndefinedValues({
+			workspaceId: request.linkage.workspaceId,
+			organizationId: request.linkage.organizationId,
+			agentId: request.linkage.agentId,
+			runId: request.linkage.runId,
+			objectiveId: request.linkage.objectiveId,
+			stepId: request.linkage.stepId,
+			actorId: request.linkage.actorId,
+			surface: request.linkage.surface,
+			channelId: request.linkage.channelId,
+			correlationId: request.linkage.correlationId,
+		}),
+		tool: stripUndefinedValues({
+			namespace: request.tool.namespace,
+			name: request.tool.name,
+			version: request.tool.version,
+			capability: request.tool.capability,
+			operation: request.tool.operation,
+			idempotent: request.tool.idempotent,
+			mutatesResource: request.tool.mutatesResource,
+		}),
+		connector: request.connector
+			? stripUndefinedValues({
+					connectionId: request.connector.connectionId,
+					providerId: request.connector.providerId,
+					resourceId: request.connector.resourceId,
+					resourceKind: request.connector.resourceKind,
+					credentialRef: request.connector.credentialRef,
+					credentialEnvironment: request.connector.credentialEnvironment,
+				})
+			: undefined,
+		arguments: request.arguments,
+		riskLevel: request.riskLevel,
+		retryPolicy: request.retryPolicy
+			? stripUndefinedValues({
+					maxAttempts: request.retryPolicy.maxAttempts,
+					initialDelayMs: request.retryPolicy.initialDelayMs,
+					maxDelayMs: request.retryPolicy.maxDelayMs,
+					allowNonIdempotentRetry: request.retryPolicy.allowNonIdempotentRetry,
+				})
+			: undefined,
+		idempotencyKey: request.idempotencyKey,
+		metadata: request.metadata,
+	});
+}
+
+async function parseJsonResponse(
+	response: Response,
+	serviceName: string,
+): Promise<Record<string, unknown>> {
+	const text = await response.text();
+	if (!response.ok) {
+		throw new Error(
+			`${serviceName} returned ${response.status}: ${text || response.statusText}`,
+		);
+	}
+	if (!text.trim()) {
+		throw new Error(`${serviceName} returned empty response`);
+	}
+	return JSON.parse(text) as Record<string, unknown>;
+}
+
+export async function executeToolWithPlatform(
+	config: ToolExecutionServiceConfig,
+	request: ExecutePlatformToolRequest,
+	signal?: AbortSignal,
+): Promise<ExecutePlatformToolResponse> {
+	const response = await postPlatformConnect(
+		config,
+		EXECUTE_TOOL_PATH,
+		normalizeExecuteToolRequest(request),
+		{
+			serviceName: "tool execution service",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+			signal,
+		},
+	);
+	const payload = await parseJsonResponse(response, "tool execution service");
+	return {
+		execution: normalizeExecutionRecord(objectValue(payload, "execution")),
+		idempotentReplay:
+			firstBoolean(payload, "idempotentReplay", "idempotent_replay") === true,
+	};
+}
+
+export async function resumeToolExecutionWithPlatform(
+	config: ToolExecutionServiceConfig,
+	request: ResumePlatformToolExecutionRequest,
+	signal?: AbortSignal,
+): Promise<ResumePlatformToolExecutionResponse> {
+	const response = await postPlatformConnect(
+		config,
+		RESUME_TOOL_EXECUTION_PATH,
+		stripUndefinedValues({
+			executionId: request.executionId,
+			approvalRequestId: request.approvalRequestId,
+			resumeToken: request.resumeToken,
+			approved: request.approved,
+			decidedBy: request.decidedBy,
+			reason: request.reason,
+		}),
+		{
+			serviceName: "tool execution service",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+			signal,
+		},
+	);
+	const payload = await parseJsonResponse(response, "tool execution service");
+	return {
+		execution: normalizeExecutionRecord(objectValue(payload, "execution")),
+	};
+}
+
+export function hasToolExecutionDestination(): boolean {
+	return Boolean(
+		getEnvValue(TOOL_EXECUTION_TOKEN_ENV_VARS) &&
+			getEnvValue(TOOL_EXECUTION_ORGANIZATION_ENV_VARS),
+	);
+}

--- a/test/agent/tool-execution-bridge.test.ts
+++ b/test/agent/tool-execution-bridge.test.ts
@@ -1,0 +1,482 @@
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Type } from "@sinclair/typebox";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionApprovalDecision } from "../../src/agent/action-approval.js";
+import { DefaultPlatformToolExecutionBridge } from "../../src/agent/transport/tool-execution-bridge.js";
+import type {
+	AgentRunConfig,
+	AgentTool,
+	ToolCall,
+	ToolResultMessage,
+} from "../../src/agent/types.js";
+import {
+	MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG,
+	MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+	resetFeatureFlagCacheForTests,
+} from "../../src/config/feature-flags.js";
+
+type CapturedRequest = {
+	body?: Record<string, unknown>;
+	headers: Record<string, string>;
+	method?: string;
+	pathname: string;
+	url: string;
+};
+
+function headersToRecord(
+	headers: HeadersInit | undefined,
+): Record<string, string> {
+	return Object.fromEntries(new Headers(headers).entries());
+}
+
+function parseRequestBody(
+	body: BodyInit | null | undefined,
+): Record<string, unknown> | undefined {
+	return typeof body === "string"
+		? (JSON.parse(body) as Record<string, unknown>)
+		: undefined;
+}
+
+function writeFlags(keys: string[]): string {
+	const path = join(
+		tmpdir(),
+		`maestro-tool-bridge-flags-${Date.now()}-${Math.random()}.json`,
+	);
+	writeFileSync(
+		path,
+		JSON.stringify({
+			flags: keys.map((key) => ({ key, enabled: true })),
+		}),
+	);
+	return path;
+}
+
+function baseConfig(): AgentRunConfig {
+	return {
+		systemPrompt: "",
+		tools: [],
+		model: {} as AgentRunConfig["model"],
+		session: {
+			id: "sess_1",
+			startedAt: new Date("2026-04-23T15:00:00Z"),
+		},
+		user: {
+			id: "user_1",
+			orgId: "org_evalops",
+		},
+	};
+}
+
+const okResult: ToolResultMessage = {
+	role: "toolResult",
+	toolCallId: "tc_1",
+	toolName: "bash",
+	content: [{ type: "text", text: "git status clean" }],
+	isError: false,
+	timestamp: Date.now(),
+};
+
+describe("tool execution bridge", () => {
+	let requests: CapturedRequest[];
+
+	beforeEach(() => {
+		requests = [];
+		vi.stubEnv("MAESTRO_PLATFORM_BASE_URL", "https://platform.test/");
+		vi.stubEnv("MAESTRO_EVALOPS_ACCESS_TOKEN", "evalops-token");
+		vi.stubEnv("MAESTRO_EVALOPS_ORG_ID", "org_evalops");
+		vi.stubEnv("MAESTRO_REMOTE_RUNNER_WORKSPACE_ID", "ws_evalops");
+		vi.stubEnv("MAESTRO_AGENT_RUN_ID", "run_1");
+		vi.stubEnv("MAESTRO_AGENT_ID", "maestro");
+		vi.stubEnv("MAESTRO_SURFACE", "cli");
+		vi.stubEnv("MAESTRO_SESSION_ID", "sess_1");
+		vi.stubEnv("MAESTRO_REMOTE_RUNNER_SESSION_ID", "rrs_1");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+		resetFeatureFlagCacheForTests();
+	});
+
+	it("records observe-only bash executions after local completion", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG,
+		]);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+				return new Response(
+					JSON.stringify({
+						execution: {
+							id: "texec_observe_1",
+							state: "TOOL_EXECUTION_STATE_SUCCEEDED",
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "tc_1",
+			name: "bash",
+			arguments: { command: "git status" },
+		};
+
+		const prepared = await bridge.prepare({
+			cfg: baseConfig(),
+			toolCall,
+			sanitizedArgs: { command: "git status" },
+		});
+
+		expect(prepared).toMatchObject({ status: "observe" });
+		if (prepared.status !== "observe") {
+			throw new Error("expected observe plan");
+		}
+
+		await expect(
+			bridge.recordObservation(prepared.plan, okResult),
+		).resolves.toEqual({
+			metadata: {
+				toolExecutionId: "texec_observe_1",
+				approvalRequestId: undefined,
+			},
+		});
+
+		expect(requests[0]).toMatchObject({
+			url: "https://platform.test/toolexecution.v1.ToolExecutionService/ExecuteTool",
+			body: expect.objectContaining({
+				metadata: expect.objectContaining({
+					maestro_bridge_mode: "observe",
+					maestro_local_outcome: "succeeded",
+					maestro_local_output_summary: "git status clean",
+				}),
+				tool: expect.objectContaining({
+					name: "bash",
+					namespace: "maestro",
+				}),
+			}),
+		});
+	});
+
+	it("skips the bridge when no Platform destination is configured", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+		]);
+		vi.stubEnv("MAESTRO_PLATFORM_BASE_URL", "");
+		vi.stubGlobal("fetch", vi.fn());
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		await expect(
+			bridge.prepare({
+				cfg: baseConfig(),
+				toolCall: {
+					type: "toolCall",
+					id: "tc_skip_1",
+					name: "bash",
+					arguments: { command: "git push" },
+				},
+				sanitizedArgs: { command: "git push" },
+			}),
+		).resolves.toEqual({ status: "skip" });
+
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("keeps local observe-only execution when Platform recording fails", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG,
+		]);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new Error("recording offline");
+			}),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		const prepared = await bridge.prepare({
+			cfg: baseConfig(),
+			toolCall: {
+				type: "toolCall",
+				id: "tc_observe_fail_1",
+				name: "bash",
+				arguments: { command: "git status" },
+			},
+			sanitizedArgs: { command: "git status" },
+		});
+
+		expect(prepared).toMatchObject({ status: "observe" });
+		if (prepared.status !== "observe") {
+			throw new Error("expected observe plan");
+		}
+
+		await expect(
+			bridge.recordObservation(prepared.plan, okResult),
+		).resolves.toEqual({
+			metadata: {},
+		});
+	});
+
+	it("governs MCP tool calls when the bridge flag is enabled", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+		]);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+				return new Response(
+					JSON.stringify({
+						execution: {
+							id: "texec_mcp_1",
+							state: "TOOL_EXECUTION_STATE_SUCCEEDED",
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		const mcpTool: AgentTool = {
+			name: "mcp__github__pull_request_merge",
+			description: "Merge a pull request",
+			parameters: Type.Object({ owner: Type.String(), repo: Type.String() }),
+			annotations: {
+				destructiveHint: true,
+			},
+			execute: async () => ({
+				content: [{ type: "text", text: "ok" }],
+			}),
+		};
+
+		const prepared = await bridge.prepare({
+			cfg: baseConfig(),
+			toolCall: {
+				type: "toolCall",
+				id: "tc_mcp_1",
+				name: mcpTool.name,
+				arguments: { owner: "evalops", repo: "platform" },
+			},
+			toolDef: mcpTool,
+			sanitizedArgs: { owner: "evalops", repo: "platform" },
+		});
+
+		expect(prepared).toMatchObject({
+			status: "allow",
+			plan: {
+				metadata: {
+					toolExecutionId: "texec_mcp_1",
+				},
+			},
+		});
+		expect(requests[0]?.body).toMatchObject({
+			tool: expect.objectContaining({
+				namespace: "mcp",
+				name: "pull_request_merge",
+				capability: "mcp.github.pull_request_merge",
+			}),
+			connector: expect.objectContaining({
+				providerId: "github",
+				resourceKind: "mcp_server",
+			}),
+		});
+	});
+
+	it("waits for approval and resumes governed executions", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+		]);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+				if (parsed.pathname.endsWith("/ExecuteTool")) {
+					return new Response(
+						JSON.stringify({
+							execution: {
+								id: "texec_wait_1",
+								state: "TOOL_EXECUTION_STATE_WAITING_APPROVAL",
+								approvalWait: {
+									approvalRequestId: "approval_1",
+									resumeToken: "resume_1",
+									reason: "manager approval required",
+								},
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				return new Response(
+					JSON.stringify({
+						execution: {
+							id: "texec_wait_1",
+							state: "TOOL_EXECUTION_STATE_SUCCEEDED",
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		const prepared = await bridge.prepare({
+			cfg: baseConfig(),
+			toolCall: {
+				type: "toolCall",
+				id: "tc_push_1",
+				name: "bash",
+				arguments: { command: "git push" },
+			},
+			sanitizedArgs: { command: "git push" },
+		});
+		expect(prepared).toMatchObject({
+			status: "wait_approval",
+			request: {
+				id: "approval_1",
+				reason: "manager approval required",
+			},
+		});
+		if (prepared.status !== "wait_approval") {
+			throw new Error("expected approval wait");
+		}
+
+		const decision: ActionApprovalDecision = {
+			approved: true,
+			reason: "approved in ui",
+			resolvedBy: "user",
+		};
+		await expect(
+			bridge.resolveApproval(
+				{
+					cfg: baseConfig(),
+					toolCall: {
+						type: "toolCall",
+						id: "tc_push_1",
+						name: "bash",
+						arguments: { command: "git push" },
+					},
+					sanitizedArgs: { command: "git push" },
+				},
+				prepared.plan,
+				decision,
+			),
+		).resolves.toMatchObject({
+			status: "allow",
+			plan: {
+				metadata: {
+					toolExecutionId: "texec_wait_1",
+					approvalRequestId: "approval_1",
+				},
+			},
+		});
+
+		expect(requests[1]?.pathname).toBe(
+			"/toolexecution.v1.ToolExecutionService/ResumeToolExecution",
+		);
+		expect(requests[1]?.body).toMatchObject({
+			executionId: "texec_wait_1",
+			approvalRequestId: "approval_1",
+			resumeToken: "resume_1",
+			approved: true,
+		});
+	});
+
+	it("denies governed executions when Platform rejects them", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+		]);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							execution: {
+								id: "texec_denied_1",
+								state: "TOOL_EXECUTION_STATE_DENIED",
+								errorMessage: "policy denied tool execution",
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					),
+			),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		await expect(
+			bridge.prepare({
+				cfg: baseConfig(),
+				toolCall: {
+					type: "toolCall",
+					id: "tc_denied_1",
+					name: "bash",
+					arguments: { command: "git push --force" },
+				},
+				sanitizedArgs: { command: "git push --force" },
+			}),
+		).resolves.toMatchObject({
+			status: "deny",
+			reason: "policy denied tool execution",
+		});
+	});
+
+	it("fails closed for governed executions when Platform is unavailable", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+		]);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new Error("network down");
+			}),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		await expect(
+			bridge.prepare({
+				cfg: baseConfig(),
+				toolCall: {
+					type: "toolCall",
+					id: "tc_fail_1",
+					name: "bash",
+					arguments: { command: "git push" },
+				},
+				sanitizedArgs: { command: "git push" },
+			}),
+		).resolves.toMatchObject({
+			status: "deny",
+			reason: expect.stringContaining("Platform ToolExecution unavailable"),
+		});
+	});
+});

--- a/test/config/feature-flags.test.ts
+++ b/test/config/feature-flags.test.ts
@@ -6,9 +6,15 @@ import {
 	MAESTRO_AUTONOMOUS_ACTIONS_KILL_SWITCH,
 	MAESTRO_DRAFT_AND_CONFIRM_DEFAULT_FLAG,
 	MAESTRO_EVALOPS_MANAGED_KILL_SWITCH,
+	MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG,
+	MAESTRO_PLATFORM_RUNTIME_BRIDGE_KILL_SWITCH,
+	MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
 	areAutonomousActionsDisabled,
 	isDraftAndConfirmDefaultEnabled,
 	isFeatureFlagEnabled,
+	isPlatformRuntimeBridgeDisabled,
+	isPlatformRuntimeObserveEnabled,
+	isPlatformToolExecutionBridgeEnabled,
 	resetFeatureFlagCacheForTests,
 } from "../../src/config/feature-flags.js";
 
@@ -87,5 +93,52 @@ describe("feature flags", () => {
 		process.env.EVALOPS_FEATURE_FLAGS_PATH = path;
 
 		expect(isDraftAndConfirmDefaultEnabled()).toBe(true);
+	});
+
+	it("detects the platform runtime observe and tool execution bridge flags", () => {
+		const path = join(
+			tmpdir(),
+			`maestro-feature-flags-${Date.now()}-${Math.random()}.json`,
+		);
+		writeFileSync(
+			path,
+			JSON.stringify({
+				flags: [
+					{
+						key: MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG,
+						enabled: true,
+					},
+					{
+						key: MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+						enabled: true,
+					},
+				],
+			}),
+		);
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = path;
+
+		expect(isPlatformRuntimeObserveEnabled()).toBe(true);
+		expect(isPlatformToolExecutionBridgeEnabled()).toBe(true);
+	});
+
+	it("detects the platform runtime bridge kill switch", () => {
+		const path = join(
+			tmpdir(),
+			`maestro-feature-flags-${Date.now()}-${Math.random()}.json`,
+		);
+		writeFileSync(
+			path,
+			JSON.stringify({
+				flags: [
+					{
+						key: MAESTRO_PLATFORM_RUNTIME_BRIDGE_KILL_SWITCH,
+						enabled: true,
+					},
+				],
+			}),
+		);
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = path;
+
+		expect(isPlatformRuntimeBridgeDisabled()).toBe(true);
 	});
 });

--- a/test/platform/core-services.test.ts
+++ b/test/platform/core-services.test.ts
@@ -66,6 +66,21 @@ describe("Platform core service contract names", () => {
 				PLATFORM_CONNECT_METHODS.remoteRunner.getStatus,
 			),
 		).toBe("/remoterunner.v1.RemoteRunnerService/GetStatus");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.toolexecution.executeTool,
+			),
+		).toBe("/toolexecution.v1.ToolExecutionService/ExecuteTool");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.toolexecution.resumeToolExecution,
+			),
+		).toBe("/toolexecution.v1.ToolExecutionService/ResumeToolExecution");
+		expect(
+			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.toolexecution.recordToolExecutionOutput,
+			),
+		).toBe("/toolexecution.v1.ToolExecutionService/RecordToolExecutionOutput");
 	});
 
 	it("keeps durable memory on the existing HTTP JSON route", () => {

--- a/test/platform/tool-execution-client.test.ts
+++ b/test/platform/tool-execution-client.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	executeToolWithPlatform,
+	resolveToolExecutionServiceConfig,
+	resumeToolExecutionWithPlatform,
+} from "../../src/platform/tool-execution-client.js";
+
+type CapturedRequest = {
+	body?: Record<string, unknown>;
+	headers: Record<string, string>;
+	method?: string;
+	pathname: string;
+	url: string;
+};
+
+function headersToRecord(
+	headers: HeadersInit | undefined,
+): Record<string, string> {
+	return Object.fromEntries(new Headers(headers).entries());
+}
+
+function parseRequestBody(
+	body: BodyInit | null | undefined,
+): Record<string, unknown> | undefined {
+	return typeof body === "string"
+		? (JSON.parse(body) as Record<string, unknown>)
+		: undefined;
+}
+
+describe("tool execution client", () => {
+	let requests: CapturedRequest[];
+
+	beforeEach(() => {
+		requests = [];
+		for (const name of [
+			"TOOL_EXECUTION_SERVICE_URL",
+			"MAESTRO_TOOL_EXECUTION_SERVICE_URL",
+			"MAESTRO_PLATFORM_BASE_URL",
+			"MAESTRO_EVALOPS_BASE_URL",
+			"EVALOPS_BASE_URL",
+			"TOOL_EXECUTION_SERVICE_TOKEN",
+			"MAESTRO_TOOL_EXECUTION_SERVICE_TOKEN",
+			"MAESTRO_EVALOPS_ACCESS_TOKEN",
+			"EVALOPS_TOKEN",
+			"TOOL_EXECUTION_SERVICE_ORGANIZATION_ID",
+			"MAESTRO_TOOL_EXECUTION_ORGANIZATION_ID",
+			"MAESTRO_EVALOPS_ORG_ID",
+			"EVALOPS_ORGANIZATION_ID",
+			"MAESTRO_ENTERPRISE_ORG_ID",
+			"TOOL_EXECUTION_SERVICE_WORKSPACE_ID",
+			"MAESTRO_TOOL_EXECUTION_WORKSPACE_ID",
+			"MAESTRO_REMOTE_RUNNER_WORKSPACE_ID",
+			"MAESTRO_EVALOPS_WORKSPACE_ID",
+			"EVALOPS_WORKSPACE_ID",
+			"MAESTRO_WORKSPACE_ID",
+		]) {
+			vi.stubEnv(name, "");
+		}
+		vi.stubEnv("MAESTRO_PLATFORM_BASE_URL", "https://platform.test/");
+		vi.stubEnv("MAESTRO_EVALOPS_ACCESS_TOKEN", "evalops-token");
+		vi.stubEnv("MAESTRO_EVALOPS_ORG_ID", "org_evalops");
+		vi.stubEnv("MAESTRO_REMOTE_RUNNER_WORKSPACE_ID", "ws_evalops");
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+
+				if (
+					parsed.pathname ===
+					"/toolexecution.v1.ToolExecutionService/ExecuteTool"
+				) {
+					return new Response(
+						JSON.stringify({
+							execution: {
+								id: "texec_1",
+								state: "TOOL_EXECUTION_STATE_WAITING_APPROVAL",
+								approvalWait: {
+									approvalRequestId: "approval_1",
+									resumeToken: "resume_1",
+									reason: "manager approval required",
+								},
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (
+					parsed.pathname ===
+					"/toolexecution.v1.ToolExecutionService/ResumeToolExecution"
+				) {
+					return new Response(
+						JSON.stringify({
+							execution: {
+								id: "texec_1",
+								state: "TOOL_EXECUTION_STATE_SUCCEEDED",
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				throw new Error(`Unexpected tool execution request: ${url}`);
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+	});
+
+	it("resolves shared platform configuration for tool execution", async () => {
+		await expect(resolveToolExecutionServiceConfig()).resolves.toMatchObject({
+			baseUrl: "https://platform.test",
+			token: "evalops-token",
+			organizationId: "org_evalops",
+			workspaceId: "ws_evalops",
+		});
+	});
+
+	it("executes tool requests through the shared connect catalog", async () => {
+		const config = await resolveToolExecutionServiceConfig();
+		if (!config) {
+			throw new Error("expected tool execution config");
+		}
+
+		await expect(
+			executeToolWithPlatform(config, {
+				linkage: {
+					workspaceId: "ws_evalops",
+					organizationId: "org_evalops",
+					agentId: "maestro",
+					runId: "run_1",
+					stepId: "tool_call_1",
+				},
+				tool: {
+					namespace: "maestro",
+					name: "bash",
+					capability: "maestro.tool.bash",
+					idempotent: false,
+					mutatesResource: true,
+				},
+				arguments: { command: "git push" },
+				riskLevel: "RISK_LEVEL_HIGH",
+				idempotencyKey: "maestro:tool_call_1",
+				metadata: {
+					maestro_tool_call_id: "tool_call_1",
+				},
+			}),
+		).resolves.toMatchObject({
+			execution: {
+				id: "texec_1",
+				state: "TOOL_EXECUTION_STATE_WAITING_APPROVAL",
+				approvalWait: {
+					approvalRequestId: "approval_1",
+					resumeToken: "resume_1",
+				},
+			},
+		});
+
+		expect(requests[0]).toMatchObject({
+			method: "POST",
+			url: "https://platform.test/toolexecution.v1.ToolExecutionService/ExecuteTool",
+			headers: expect.objectContaining({
+				authorization: "Bearer evalops-token",
+				"connect-protocol-version": "1",
+				"x-organization-id": "org_evalops",
+			}),
+			body: expect.objectContaining({
+				idempotencyKey: "maestro:tool_call_1",
+				riskLevel: "RISK_LEVEL_HIGH",
+				linkage: expect.objectContaining({
+					workspaceId: "ws_evalops",
+					runId: "run_1",
+					stepId: "tool_call_1",
+				}),
+				tool: expect.objectContaining({
+					namespace: "maestro",
+					name: "bash",
+				}),
+			}),
+		});
+	});
+
+	it("resumes pending approval waits through the shared connect catalog", async () => {
+		const config = await resolveToolExecutionServiceConfig();
+		if (!config) {
+			throw new Error("expected tool execution config");
+		}
+
+		await expect(
+			resumeToolExecutionWithPlatform(config, {
+				executionId: "texec_1",
+				approvalRequestId: "approval_1",
+				resumeToken: "resume_1",
+				approved: true,
+				decidedBy: "user_1",
+				reason: "approved in ui",
+			}),
+		).resolves.toMatchObject({
+			execution: {
+				id: "texec_1",
+				state: "TOOL_EXECUTION_STATE_SUCCEEDED",
+			},
+		});
+
+		expect(requests[0]?.pathname).toBe(
+			"/toolexecution.v1.ToolExecutionService/ResumeToolExecution",
+		);
+		expect(requests[0]?.body).toMatchObject({
+			executionId: "texec_1",
+			approvalRequestId: "approval_1",
+			resumeToken: "resume_1",
+			approved: true,
+			decidedBy: "user_1",
+			reason: "approved in ui",
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add the public Maestro-side Platform ToolExecution client and bridge with shared service catalog wiring
- route bash and MCP tool calls through observe-only or governed Platform flows with approval sync and correlated event metadata
- document rollout flags and destination env resolution, and add focused bridge/client tests for allow, wait, deny, skip, and degraded observe paths

## Testing
- node ./scripts/run-vitest.js --run test/platform/core-services.test.ts test/config/feature-flags.test.ts test/platform/tool-execution-client.test.ts test/agent/tool-execution-bridge.test.ts test/agent/tool-safety-pipeline.test.ts
- HUSKY=0 /Users/jonathanhaas/.npm-global/bin/bun install --frozen-lockfile
- git -c core.fsmonitor=false diff --check

Part of #73