### PR TITLE
Add hosted runner retention policy metadata

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Use this index to jump to the right guide quickly and see how the pieces connect
 - [MCP Guide](MCP_GUIDE.md) — Model Context Protocol setup and usage.
 - [Headless Protocol Reference](protocols/headless.md) — versioned JSON-over-stdio contract for Chat, TUIs, and other embedders.
 - [Hosted Runner Contract](protocols/hosted-runner-contract.md) — provider-neutral runtime contract for account-scoped remote Maestro sessions.
+- [Hosted Runner Retention](protocols/hosted-runner-retention.md) — visibility, redaction, and persistence rules for hosted-runner drain artifacts.
 
 ## Architecture & Patterns
 - [Architecture Diagram](ARCHITECTURE_DIAGRAM.md) — high-level system layout.

--- a/docs/protocols/headless.md
+++ b/docs/protocols/headless.md
@@ -24,6 +24,7 @@ Source of truth:
 - runtime message shapes: [src/cli/headless-protocol.ts](../../src/cli/headless-protocol.ts)
 - transport implementation: [src/cli/headless.ts](../../src/cli/headless.ts)
 - hosted runner contract: [docs/protocols/hosted-runner-contract.md](./hosted-runner-contract.md)
+- hosted runner retention: [docs/protocols/hosted-runner-retention.md](./hosted-runner-retention.md)
 - conformance suite: [docs/protocols/headless-conformance.md](./headless-conformance.md)
 
 Compatibility expectations:
@@ -123,6 +124,29 @@ snapshot manifest. The manifest directory comes from `--snapshot-root`,
         }
       ]
     },
+    "retention_policy": {
+      "policy_version": "evalops.remote-runner.retention.v1",
+      "managed_by": "platform",
+      "visibility": {
+        "control_plane_metadata": "operator",
+        "workspace_export": "tenant",
+        "runtime_snapshot": "internal",
+        "runtime_logs": "operator"
+      },
+      "redaction": {
+        "required_before_external_persistence": [
+          "runtime_snapshot",
+          "runtime_logs"
+        ],
+        "forbidden_plaintext": [
+          "provider_credentials",
+          "tool_secrets",
+          "attach_tokens",
+          "artifact_access_tokens",
+          "raw_environment"
+        ]
+      }
+    },
     "snapshot": {
       "protocolVersion": "2026-04-02",
       "session_id": "session_123",
@@ -154,7 +178,8 @@ but runtime flush failed before completion. Platform should treat the manifest
 as a partial handoff record, stop sending attach traffic, and decide whether to
 retry drain or terminate the pod. Maestro does not upload to GCS or require a
 Cloud Storage mount; Platform/deploy own artifact upload, retention, and any
-future resume controller behavior.
+future resume controller behavior. The visibility and redaction rules for those
+uploaded artifacts live in [Hosted Runner Retention](./hosted-runner-retention.md).
 
 The runtime flush status is the field that controls restore readiness:
 `completed` is attachable, `failed` is an interrupted restore, and `skipped`

--- a/docs/protocols/hosted-runner-contract.md
+++ b/docs/protocols/hosted-runner-contract.md
@@ -170,10 +170,13 @@ POST /.well-known/evalops/remote-runner/drain
 The manifest protocol is
 `evalops.remote-runner.snapshot-manifest.v1`. Both Rust-hosted and
 TypeScript-hosted drain paths write this same local manifest envelope, including
-the runtime flush status, workspace export contract, and headless runtime
-snapshot. Maestro does not upload to GCS, S3, Modal storage, Daytona storage, or
-any other provider store. Upload, retention, workspace artifact hydration, and
-choosing which manifest should be restored are Platform responsibilities.
+the runtime flush status, workspace export contract, headless runtime snapshot,
+and `retention_policy` metadata describing visibility and redaction classes.
+Maestro does not upload to GCS, S3, Modal storage, Daytona storage, or any
+other provider store. Upload, retention, workspace artifact hydration, and
+choosing which manifest should be restored are Platform responsibilities. See
+[Hosted Runner Retention](./hosted-runner-retention.md) for the policy rules
+that travel with the manifest.
 
 ## Rust Hosted Surface
 
@@ -333,6 +336,7 @@ startup and transport details should vary.
 
 - [Headless protocol reference](./headless.md)
 - [Headless runtime conformance](./headless-conformance.md)
+- [Hosted runner retention](./hosted-runner-retention.md)
 - [Kubernetes node isolation and NodeRestriction](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-isolation-restriction)
 - [GKE Sandbox with gVisor](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods)
 - [GKE Workload Identity Federation](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)

--- a/docs/protocols/hosted-runner-retention.md
+++ b/docs/protocols/hosted-runner-retention.md
@@ -1,0 +1,66 @@
+# Hosted Runner Retention
+
+Hosted Maestro runners write a local drain manifest so Platform can decide what
+to upload, how long to keep it, and when to delete it. This document is the
+Maestro-side contract for that handoff.
+
+Maestro does not hardcode account retention windows. Platform and deploy own
+the actual external storage durations, deletion jobs, and provider-specific
+cleanup. Maestro owns the local artifact shape, the visibility classes, and the
+set of things that must never leave the live runtime in plaintext.
+
+## Data Classes
+
+| Data class | Examples | Visibility | Rule |
+| --- | --- | --- | --- |
+| Control-plane metadata | `runner_session_id`, `workspace_id`, stop reason, timestamps, git summary | `operator` | May persist in Platform/operator systems. Do not include raw credentials, raw env dumps, or artifact access grants. |
+| Workspace export | Paths chosen by `export_paths` and the files/directories behind them | `tenant` | May persist as tenant-scoped workspace artifacts. Operator browsing should stay off by default. |
+| Runtime snapshot | `manifest.snapshot`, `runtime.session_file`, runtime cursor/state | `internal` | May exist locally in the runtime manifest, but any external copy must stay internal-only or be reduced to a redacted derivative first. |
+| Runtime logs | stdout/stderr, headless diagnostics, tool/model traces | `operator` | Persist only after redacting prompts, tool output, secret echoes, provider strings, and other sensitive payloads. |
+| Credentials and grants | Provider API keys, attach tokens, artifact access URLs, raw env values | `never persist` | Must be dropped or redacted before any external write. |
+
+## Drain Manifest Policy Block
+
+New hosted drain manifests include a `retention_policy` block with:
+
+- `policy_version`: versioned contract id for the visibility/redaction rules
+- `managed_by=platform`: external retention and deletion are Platform-owned
+- `visibility`: the allowed audience for each manifest section
+- `redaction.required_before_external_persistence`: sections that must not be
+  copied out of the live runtime verbatim
+- `redaction.forbidden_plaintext`: credential/grant classes that must never be
+  written externally in raw form
+
+This block is intentionally small. It gives Platform/deploy a stable policy
+handle without forcing Maestro to encode account-specific day counts.
+
+## Lifecycle
+
+1. Maestro writes the local drain manifest under the configured snapshot root.
+2. Platform may ingest the manifest and upload selected artifacts.
+3. External retention windows are chosen by Platform per account/profile.
+4. Platform deletes uploaded artifacts after expiry or explicit cleanup.
+5. Provider teardown removes the pod-local manifest and any unuploaded runtime
+   files.
+
+Secure or provider-backed profiles do not get a different data model. They must
+honor the same visibility classes and redaction rules before reusing the hosted
+runner contract.
+
+## Required Rules
+
+- Workspace export metadata stays bounded to the workspace root.
+- Runtime snapshots and session files are not tenant-download artifacts.
+- Raw runtime logs are not tenant-visible artifacts.
+- Credentials, attach tokens, artifact grants, and raw environment captures are
+  never valid persisted outputs.
+- Any operator-facing derivative of runtime snapshot or log data must be
+  redacted before persistence.
+
+## Follow-Through
+
+The manifest policy block is the schema-level contract. Cleanup lifecycle
+signals such as deletion succeeded, expiry applied, or cleanup failed should be
+tracked separately in runtime/control-plane events rather than inferred from the
+manifest file alone. Platform follow-through is tracked in
+`evalops/platform#853`.

--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -39,6 +39,7 @@ pub const HOSTED_RUNNER_IDENTITY_PROTOCOL_VERSION: &str = "evalops.remote-runner
 pub const HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION: &str = "evalops.remote-runner.drain.v1";
 pub const HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION: &str =
     "evalops.remote-runner.snapshot-manifest.v1";
+pub const HOSTED_RUNNER_RETENTION_POLICY_VERSION: &str = "evalops.remote-runner.retention.v1";
 
 const DEFAULT_LISTEN_HOST: &str = "0.0.0.0";
 const DEFAULT_LISTEN_PORT: u16 = 8080;
@@ -575,6 +576,8 @@ struct SnapshotManifest {
     runtime: RuntimeFlushManifest,
     workspace_export: WorkspaceExportManifest,
     snapshot: RuntimeSnapshot,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retention_policy: Option<RetentionPolicyManifest>,
 }
 
 impl SnapshotManifest {
@@ -604,6 +607,54 @@ impl SnapshotManifest {
                 resolve_workspace_path(workspace_root, None, Some(path.relative_path.as_str()))?;
         }
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RetentionPolicyManifest {
+    policy_version: String,
+    managed_by: String,
+    visibility: RetentionPolicyVisibility,
+    redaction: RetentionPolicyRedaction,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RetentionPolicyVisibility {
+    control_plane_metadata: String,
+    workspace_export: String,
+    runtime_snapshot: String,
+    runtime_logs: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RetentionPolicyRedaction {
+    required_before_external_persistence: Vec<String>,
+    forbidden_plaintext: Vec<String>,
+}
+
+fn default_retention_policy_manifest() -> RetentionPolicyManifest {
+    RetentionPolicyManifest {
+        policy_version: HOSTED_RUNNER_RETENTION_POLICY_VERSION.to_string(),
+        managed_by: "platform".to_string(),
+        visibility: RetentionPolicyVisibility {
+            control_plane_metadata: "operator".to_string(),
+            workspace_export: "tenant".to_string(),
+            runtime_snapshot: "internal".to_string(),
+            runtime_logs: "operator".to_string(),
+        },
+        redaction: RetentionPolicyRedaction {
+            required_before_external_persistence: vec![
+                "runtime_snapshot".to_string(),
+                "runtime_logs".to_string(),
+            ],
+            forbidden_plaintext: vec![
+                "provider_credentials".to_string(),
+                "tool_secrets".to_string(),
+                "attach_tokens".to_string(),
+                "artifact_access_tokens".to_string(),
+                "raw_environment".to_string(),
+            ],
+        },
     }
 }
 
@@ -2662,6 +2713,7 @@ async fn write_snapshot_manifest(
             paths: workspace_export_paths,
         },
         snapshot,
+        retention_policy: Some(default_retention_policy_manifest()),
     };
     let body_bytes = serde_json::to_vec_pretty(&manifest)
         .map_err(|error| HostedError::new(500, "runtime_failed", error.to_string()))?;
@@ -3453,6 +3505,14 @@ mod tests {
             manifest["workspace_export"]["paths"][0]["type"],
             "directory"
         );
+        assert_eq!(
+            manifest["retention_policy"]["policy_version"],
+            HOSTED_RUNNER_RETENTION_POLICY_VERSION
+        );
+        assert_eq!(
+            manifest["retention_policy"]["visibility"]["runtime_snapshot"],
+            "internal"
+        );
 
         let post_drain_identity: HostedRunnerIdentity = client
             .get(format!(
@@ -3569,6 +3629,10 @@ mod tests {
             "notes.md"
         );
         assert_eq!(manifest["workspace_export"]["paths"][0]["type"], "file");
+        assert_eq!(
+            manifest["retention_policy"]["redaction"]["required_before_external_persistence"],
+            json!(["runtime_snapshot", "runtime_logs"])
+        );
         let mut escaped_manifest = manifest.clone();
         escaped_manifest["workspace_export"]["paths"][0]["relative_path"] = json!("../secret.txt");
         let escaped_bytes = serde_json::to_vec(&escaped_manifest).expect("escaped manifest json");
@@ -3750,6 +3814,29 @@ mod tests {
                     "type": "file"
                 }]
             },
+            "retention_policy": {
+                "policy_version": HOSTED_RUNNER_RETENTION_POLICY_VERSION,
+                "managed_by": "platform",
+                "visibility": {
+                    "control_plane_metadata": "operator",
+                    "workspace_export": "tenant",
+                    "runtime_snapshot": "internal",
+                    "runtime_logs": "operator"
+                },
+                "redaction": {
+                    "required_before_external_persistence": [
+                        "runtime_snapshot",
+                        "runtime_logs"
+                    ],
+                    "forbidden_plaintext": [
+                        "provider_credentials",
+                        "tool_secrets",
+                        "attach_tokens",
+                        "artifact_access_tokens",
+                        "raw_environment"
+                    ]
+                }
+            },
             "snapshot": {
                 "protocolVersion": HEADLESS_PROTOCOL_VERSION,
                 "session_id": "session_ts",
@@ -3788,6 +3875,14 @@ mod tests {
             HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION
         );
         assert_eq!(parsed.runtime.flush_status, RuntimeFlushStatus::Completed);
+        assert_eq!(
+            parsed
+                .retention_policy
+                .as_ref()
+                .expect("retention policy")
+                .policy_version,
+            HOSTED_RUNNER_RETENTION_POLICY_VERSION
+        );
         assert_eq!(parsed.snapshot.session_id, "session_ts");
         assert_eq!(parsed.snapshot.cursor, 7);
         assert_eq!(parsed.workspace_export.paths[0].relative_path, "README.md");

--- a/src/server/handlers/hosted-runner-drain.ts
+++ b/src/server/handlers/hosted-runner-drain.ts
@@ -22,7 +22,33 @@ export const HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION =
 export const HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION =
 	"evalops.remote-runner.snapshot-manifest.v1";
 
+export const HOSTED_RUNNER_RETENTION_POLICY_VERSION =
+	"evalops.remote-runner.retention.v1";
+
 type SnapshotManifestStatus = "drained" | "interrupted";
+
+export interface HostedRunnerRetentionPolicy {
+	policy_version: typeof HOSTED_RUNNER_RETENTION_POLICY_VERSION;
+	managed_by: "platform";
+	visibility: {
+		control_plane_metadata: "operator";
+		workspace_export: "tenant";
+		runtime_snapshot: "internal";
+		runtime_logs: "operator";
+	};
+	redaction: {
+		required_before_external_persistence: Array<
+			"runtime_snapshot" | "runtime_logs"
+		>;
+		forbidden_plaintext: Array<
+			| "provider_credentials"
+			| "tool_secrets"
+			| "attach_tokens"
+			| "artifact_access_tokens"
+			| "raw_environment"
+		>;
+	};
+}
 
 export interface HostedRunnerDrainInput {
 	reason?: string;
@@ -68,6 +94,7 @@ export interface HostedRunnerSnapshotManifest {
 		paths: HostedRunnerWorkspaceExportPath[];
 	};
 	snapshot: HeadlessRuntimeSnapshot;
+	retention_policy: HostedRunnerRetentionPolicy;
 	git?: {
 		commit?: string;
 		branch?: string;
@@ -297,6 +324,32 @@ function buildHostedRunnerSnapshot(
 	};
 }
 
+function buildHostedRunnerRetentionPolicy(): HostedRunnerRetentionPolicy {
+	return {
+		policy_version: HOSTED_RUNNER_RETENTION_POLICY_VERSION,
+		managed_by: "platform",
+		visibility: {
+			control_plane_metadata: "operator",
+			workspace_export: "tenant",
+			runtime_snapshot: "internal",
+			runtime_logs: "operator",
+		},
+		redaction: {
+			required_before_external_persistence: [
+				"runtime_snapshot",
+				"runtime_logs",
+			],
+			forbidden_plaintext: [
+				"provider_credentials",
+				"tool_secrets",
+				"attach_tokens",
+				"artifact_access_tokens",
+				"raw_environment",
+			],
+		},
+	};
+}
+
 export async function drainHostedRunner(
 	input: HostedRunnerDrainInput,
 	options: DrainHostedRunnerOptions,
@@ -393,6 +446,7 @@ export async function drainHostedRunner(
 			paths: exportPaths,
 		},
 		snapshot,
+		retention_policy: buildHostedRunnerRetentionPolicy(),
 		...(git ? { git } : {}),
 	};
 

--- a/test/headless/runtime-conformance.test.ts
+++ b/test/headless/runtime-conformance.test.ts
@@ -1478,6 +1478,16 @@ function defineHeadlessRuntimeConformanceSuite(
 				maestro_session_id: "sess_conformance",
 				reason: "conformance_stop",
 				requested_by: "runtime-conformance",
+				retention_policy: {
+					policy_version: "evalops.remote-runner.retention.v1",
+					managed_by: "platform",
+					visibility: {
+						control_plane_metadata: "operator",
+						workspace_export: "tenant",
+						runtime_snapshot: "internal",
+						runtime_logs: "operator",
+					},
+				},
 			});
 			const runtimeManifest = manifest.runtime as {
 				cursor?: number;

--- a/test/server/hosted-runner-drain.test.ts
+++ b/test/server/hosted-runner-drain.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../src/cli/headless-protocol.js";
 import type { HostedRunnerContext } from "../../src/server/app-context.js";
 import {
+	HOSTED_RUNNER_RETENTION_POLICY_VERSION,
 	HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
 	drainHostedRunner,
 } from "../../src/server/handlers/hosted-runner-drain.js";
@@ -122,6 +123,29 @@ describe("hosted runner drain", () => {
 				protocol_version: HEADLESS_PROTOCOL_VERSION,
 				cursor: 7,
 			},
+			retention_policy: {
+				policy_version: HOSTED_RUNNER_RETENTION_POLICY_VERSION,
+				managed_by: "platform",
+				visibility: {
+					control_plane_metadata: "operator",
+					workspace_export: "tenant",
+					runtime_snapshot: "internal",
+					runtime_logs: "operator",
+				},
+				redaction: {
+					required_before_external_persistence: [
+						"runtime_snapshot",
+						"runtime_logs",
+					],
+					forbidden_plaintext: [
+						"provider_credentials",
+						"tool_secrets",
+						"attach_tokens",
+						"artifact_access_tokens",
+						"raw_environment",
+					],
+				},
+			},
 			snapshot,
 		});
 		expect(result?.manifest).not.toHaveProperty("manifest_version");
@@ -226,6 +250,10 @@ describe("hosted runner drain", () => {
 					is_ready: false,
 					last_status: "Drain skipped: no runtime activity was available",
 				},
+			},
+			retention_policy: {
+				policy_version: HOSTED_RUNNER_RETENTION_POLICY_VERSION,
+				managed_by: "platform",
 			},
 		});
 	});


### PR DESCRIPTION
Fixes #119
Related: evalops/platform#853

## Summary
- add hosted-runner `retention_policy` metadata to the TypeScript and Rust drain manifest shapes
- document the hosted-runner retention/redaction contract and link it from the hosted/headless protocol docs
- extend shared conformance and focused drain tests to pin the retention policy block

## Testing
- `npm run test -- test/server/hosted-runner-drain.test.ts test/headless/runtime-conformance.test.ts`
- `cargo test --manifest-path packages/tui-rs/Cargo.toml identity_and_drain_follow_runner_contract`
- `cargo test --manifest-path packages/tui-rs/Cargo.toml drain_manifest_records_runtime_cursor_after_activity`
- `cargo test --manifest-path packages/tui-rs/Cargo.toml snapshot_manifest_parser_accepts_typescript_hosted_shape`
