### PR TITLE
Preserve governed MCP outcomes in tool results

### DIFF
--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -92,6 +92,7 @@ export interface McpToolCallResult {
 		data?: string;
 		mimeType?: string;
 	}>;
+	structuredContent?: unknown;
 	isError?: boolean;
 }
 
@@ -973,6 +974,8 @@ export class McpClientManager extends EventEmitter {
 
 		return {
 			content,
+			structuredContent:
+				"structuredContent" in result ? result.structuredContent : undefined,
 			isError: typeof result.isError === "boolean" ? result.isError : undefined,
 		};
 	}

--- a/src/mcp/tool-bridge.ts
+++ b/src/mcp/tool-bridge.ts
@@ -1,15 +1,282 @@
 import type { Tool as McpTool } from "@modelcontextprotocol/sdk/types.js";
 import { type TSchema, Type } from "@sinclair/typebox";
 import type { AgentTool } from "../agent/types.js";
+import {
+	trackToolApprovalRequired,
+	trackToolBlocked,
+} from "../telemetry/security-events.js";
 import { createTool } from "../tools/tool-dsl.js";
 import { mcpManager } from "./manager.js";
-import { buildMcpToolName, parseMcpToolName } from "./names.js";
+import type { McpToolCallResult } from "./manager.js";
+import { buildMcpToolName } from "./names.js";
 
 interface McpToolDetails {
 	server: string;
 	tool: string;
 	content: unknown[];
+	structuredContent?: unknown;
 	isError?: boolean;
+	governedOutcome?: McpGovernedOutcome;
+}
+
+interface McpGovernedOutcome {
+	classification:
+		| "approval_required"
+		| "approval_pending"
+		| "authentication_required"
+		| "denied"
+		| "rate_limited";
+	decision?: string;
+	riskLevel?: string;
+	reasons?: string[];
+	approvalRequestId?: string;
+	matchedRules?: string[];
+	message?: string;
+	code?: string;
+	state?: string;
+	retryAfterMs?: number;
+	retryAfterSeconds?: number;
+}
+
+function normalizeObject(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function firstString(
+	value: Record<string, unknown>,
+	...keys: string[]
+): string | undefined {
+	for (const key of keys) {
+		const candidate = value[key];
+		if (typeof candidate === "string" && candidate.trim().length > 0) {
+			return candidate.trim();
+		}
+	}
+	return undefined;
+}
+
+function firstNumber(
+	value: Record<string, unknown>,
+	...keys: string[]
+): number | undefined {
+	for (const key of keys) {
+		const candidate = value[key];
+		if (typeof candidate === "number" && Number.isFinite(candidate)) {
+			return candidate;
+		}
+		if (typeof candidate === "string" && candidate.trim().length > 0) {
+			const parsed = Number(candidate);
+			if (Number.isFinite(parsed)) {
+				return parsed;
+			}
+		}
+	}
+	return undefined;
+}
+
+function toStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) {
+		return undefined;
+	}
+	const entries = value
+		.filter((item): item is string => typeof item === "string")
+		.map((item) => item.trim())
+		.filter(Boolean);
+	return entries.length > 0 ? entries : undefined;
+}
+
+function extractMcpTextContent(
+	content: McpToolCallResult["content"],
+): string | undefined {
+	const text = content
+		.filter((item) => item.type === "text" && typeof item.text === "string")
+		.map((item) => item.text as string)
+		.join("\n")
+		.trim();
+	return text.length > 0 ? text : undefined;
+}
+
+function parseJsonObjectFromText(
+	text: string | undefined,
+): Record<string, unknown> | null {
+	if (!text) {
+		return null;
+	}
+	const trimmed = text.trim();
+	if (!(trimmed.startsWith("{") && trimmed.endsWith("}"))) {
+		return null;
+	}
+	try {
+		return normalizeObject(JSON.parse(trimmed));
+	} catch {
+		return null;
+	}
+}
+
+function resolveGovernedPayload(
+	result: McpToolCallResult,
+): Record<string, unknown> | null {
+	return (
+		normalizeObject(result.structuredContent) ??
+		parseJsonObjectFromText(extractMcpTextContent(result.content))
+	);
+}
+
+function classifyGovernedOutcome(
+	payload: Record<string, unknown> | null,
+): McpGovernedOutcome | undefined {
+	if (!payload) {
+		return undefined;
+	}
+
+	const decision = firstString(payload, "decision")?.toLowerCase();
+	const code = firstString(payload, "code", "error_code")?.toLowerCase();
+	const state = firstString(payload, "state")?.toLowerCase();
+	const status = firstNumber(payload, "status", "status_code");
+	const approvalRequestId = firstString(
+		payload,
+		"approval_id",
+		"approvalId",
+		"approval_request_id",
+		"approvalRequestId",
+	);
+	const reasons = toStringArray(payload.reasons);
+	const matchedRules = toStringArray(
+		payload.matched_rules ?? payload.matchedRules,
+	);
+	const outcome: Omit<McpGovernedOutcome, "classification"> = {
+		decision,
+		riskLevel: firstString(payload, "risk_level", "riskLevel"),
+		reasons,
+		approvalRequestId,
+		matchedRules,
+		message: firstString(payload, "message", "detail", "error"),
+		code,
+		state,
+		retryAfterMs: firstNumber(payload, "retry_after_ms", "retryAfterMs"),
+		retryAfterSeconds: firstNumber(
+			payload,
+			"retry_after_seconds",
+			"retryAfterSeconds",
+		),
+	};
+
+	if (decision === "require_approval" || code?.includes("approval_required")) {
+		return { classification: "approval_required", ...outcome };
+	}
+	if (state === "pending" && approvalRequestId) {
+		return { classification: "approval_pending", ...outcome };
+	}
+	if (
+		code?.includes("rate_limit") ||
+		code?.includes("too_many_requests") ||
+		status === 429
+	) {
+		return { classification: "rate_limited", ...outcome };
+	}
+	if (
+		code?.includes("authentication_required") ||
+		code?.includes("unauthorized") ||
+		status === 401
+	) {
+		return { classification: "authentication_required", ...outcome };
+	}
+	if (
+		decision === "deny" ||
+		code?.includes("denied") ||
+		code?.includes("forbidden") ||
+		status === 403
+	) {
+		return { classification: "denied", ...outcome };
+	}
+	return undefined;
+}
+
+function formatGovernedOutcomeSummary(
+	outcome: McpGovernedOutcome | undefined,
+): string | undefined {
+	if (!outcome) {
+		return undefined;
+	}
+
+	const lines: string[] = [];
+	switch (outcome.classification) {
+		case "approval_required":
+			lines.push("Approval required.");
+			break;
+		case "approval_pending":
+			lines.push("Approval pending.");
+			break;
+		case "authentication_required":
+			lines.push("Authentication required.");
+			break;
+		case "rate_limited":
+			lines.push("Rate limit reached.");
+			break;
+		case "denied":
+			lines.push("Action denied.");
+			break;
+	}
+
+	if (outcome.message) {
+		lines.push(outcome.message);
+	}
+	if (outcome.reasons?.length) {
+		lines.push(`Reasons: ${outcome.reasons.join("; ")}`);
+	}
+	if (outcome.approvalRequestId) {
+		lines.push(`Approval request: ${outcome.approvalRequestId}`);
+	}
+	if (outcome.state && outcome.classification !== "approval_pending") {
+		lines.push(`State: ${outcome.state}`);
+	}
+	if (outcome.riskLevel) {
+		lines.push(`Risk level: ${outcome.riskLevel}`);
+	}
+	if (typeof outcome.retryAfterSeconds === "number") {
+		lines.push(`Retry after: ${outcome.retryAfterSeconds} seconds`);
+	} else if (typeof outcome.retryAfterMs === "number") {
+		lines.push(`Retry after: ${outcome.retryAfterMs} ms`);
+	}
+
+	return lines.join("\n");
+}
+
+function emitGovernedOutcomeTelemetry(
+	toolName: string,
+	outcome: McpGovernedOutcome | undefined,
+): void {
+	if (!outcome) {
+		return;
+	}
+
+	const reason =
+		outcome.message ??
+		outcome.reasons?.join("; ") ??
+		outcome.code ??
+		"policy event";
+
+	if (
+		outcome.classification === "approval_required" ||
+		outcome.classification === "approval_pending"
+	) {
+		trackToolApprovalRequired({
+			toolName,
+			reason,
+			source: "policy",
+		});
+		return;
+	}
+
+	trackToolBlocked({
+		toolName,
+		reason,
+		source: "policy",
+		severity:
+			outcome.classification === "authentication_required" ? "medium" : "high",
+	});
 }
 
 function convertJsonSchemaToTypebox(schema: unknown): TSchema {
@@ -90,19 +357,26 @@ export function createMcpToolWrapper(serverName: string, mcpTool: McpTool) {
 				mcpTool.name,
 				params as Record<string, unknown>,
 			);
+			const governedOutcome = classifyGovernedOutcome(
+				resolveGovernedPayload(result),
+			);
+			emitGovernedOutcomeTelemetry(mcpTool.name, governedOutcome);
 
-			const textContent = result.content
-				.filter((c) => c.type === "text" && typeof c.text === "string")
-				.map((c) => c.text as string)
-				.join("\n");
+			const output =
+				formatGovernedOutcomeSummary(governedOutcome) ??
+				extractMcpTextContent(result.content) ??
+				JSON.stringify(result.structuredContent ?? result.content, null, 2);
 
-			const output = textContent || JSON.stringify(result.content, null, 2);
-
-			return respond.text(output).detail({
+			const response = result.isError
+				? respond.error(output)
+				: respond.text(output);
+			return response.detail({
 				server: serverName,
 				tool: mcpTool.name,
 				content: result.content,
+				structuredContent: result.structuredContent,
 				isError: result.isError,
+				governedOutcome,
 			});
 		},
 	});

--- a/test/agent/mcp-governed-results.test.ts
+++ b/test/agent/mcp-governed-results.test.ts
@@ -1,0 +1,164 @@
+import type { Tool as McpTool } from "@modelcontextprotocol/sdk/types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/mcp/manager.js", () => ({
+	mcpManager: {
+		callTool: vi.fn(),
+		getAllTools: vi.fn(() => []),
+		getStatus: vi.fn(() => ({ servers: [] })),
+		readResource: vi.fn(),
+		getPrompt: vi.fn(),
+	},
+}));
+
+vi.mock("../../src/telemetry/security-events.js", () => ({
+	trackToolApprovalRequired: vi.fn(),
+	trackToolBlocked: vi.fn(),
+}));
+
+import { mcpManager } from "../../src/mcp/manager.js";
+import { createMcpToolWrapper } from "../../src/mcp/tool-bridge.js";
+import {
+	trackToolApprovalRequired,
+	trackToolBlocked,
+} from "../../src/telemetry/security-events.js";
+
+const governedTool: McpTool = {
+	name: "governed_tool",
+	description: "Platform-governed test tool",
+	inputSchema: {
+		type: "object",
+		properties: {
+			query: { type: "string" },
+		},
+	},
+};
+
+describe("MCP governed result handling", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("summarizes approval-required governed results and preserves approval metadata", async () => {
+		vi.mocked(mcpManager.callTool).mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						decision: "require_approval",
+						approval_id: "apr_123",
+						reasons: ["Needs signoff"],
+						risk_level: "high",
+					}),
+				},
+			],
+			structuredContent: {
+				decision: "require_approval",
+				approval_id: "apr_123",
+				reasons: ["Needs signoff"],
+				risk_level: "high",
+			},
+		});
+
+		const tool = createMcpToolWrapper("evalops", governedTool);
+		const result = await tool.execute("call-1", { query: "deploy" });
+
+		expect(result.isError).toBe(false);
+		expect(result.content[0]?.type).toBe("text");
+		expect(result.content[0]?.text).toContain("Approval required.");
+		expect(result.content[0]?.text).toContain("Approval request: apr_123");
+		expect(result.details).toMatchObject({
+			server: "evalops",
+			tool: "governed_tool",
+			governedOutcome: {
+				classification: "approval_required",
+				approvalRequestId: "apr_123",
+				riskLevel: "high",
+				reasons: ["Needs signoff"],
+			},
+		});
+		expect(trackToolApprovalRequired).toHaveBeenCalledWith({
+			toolName: "governed_tool",
+			reason: "Needs signoff",
+			source: "policy",
+		});
+		expect(trackToolBlocked).not.toHaveBeenCalled();
+	});
+
+	it("summarizes denied governed results and emits blocked telemetry", async () => {
+		vi.mocked(mcpManager.callTool).mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						code: "governance_denied",
+						message: "Blocked by governance policy",
+						reasons: ["External network is disabled"],
+					}),
+				},
+			],
+			structuredContent: {
+				code: "governance_denied",
+				message: "Blocked by governance policy",
+				reasons: ["External network is disabled"],
+			},
+			isError: true,
+		});
+
+		const tool = createMcpToolWrapper("evalops", governedTool);
+		const result = await tool.execute("call-2", { query: "curl example.com" });
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]?.text).toContain("Action denied.");
+		expect(result.content[0]?.text).toContain("Blocked by governance policy");
+		expect(result.details).toMatchObject({
+			governedOutcome: {
+				classification: "denied",
+				code: "governance_denied",
+				reasons: ["External network is disabled"],
+			},
+		});
+		expect(trackToolBlocked).toHaveBeenCalledWith({
+			toolName: "governed_tool",
+			reason: "Blocked by governance policy",
+			source: "policy",
+			severity: "high",
+		});
+		expect(trackToolApprovalRequired).not.toHaveBeenCalled();
+	});
+
+	it("parses text-only rate-limit payloads when structured content is unavailable", async () => {
+		vi.mocked(mcpManager.callTool).mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						code: "rate_limit_exceeded",
+						message: "Too many requests",
+						retry_after_seconds: 30,
+					}),
+				},
+			],
+			isError: true,
+		});
+
+		const tool = createMcpToolWrapper("evalops", governedTool);
+		const result = await tool.execute("call-3", { query: "burst" });
+
+		expect(result.content[0]?.text).toContain("Rate limit reached.");
+		expect(result.content[0]?.text).toContain("Retry after: 30 seconds");
+		expect(result.details).toMatchObject({
+			governedOutcome: {
+				classification: "rate_limited",
+				code: "rate_limit_exceeded",
+				retryAfterSeconds: 30,
+			},
+		});
+		expect(trackToolBlocked).toHaveBeenCalledWith({
+			toolName: "governed_tool",
+			reason: "Too many requests",
+			source: "policy",
+			severity: "high",
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- preserve MCP structuredContent in the manager so governed tool responses are not flattened away
- classify approval-required, denied, auth-required, and rate-limited MCP results into structured Maestro tool details with readable summaries
- keep remote MCP isError state intact in the wrapper and emit focused telemetry for governed policy outcomes

## Testing
- PATH=/Users/jonathanhaas/.npm-global/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/jonathanhaas/.dotfiles/bin:/Users/jonathanhaas/.dotfiles/scripts:/Users/jonathanhaas/.dotfiles/scripts/bin:/Users/jonathanhaas/.codex/tmp/arg0/codex-arg0vcQpld:/etc/profiles/per-user/jonathanhaas/bin:/opt/homebrew/opt/node@22/bin:/nix/var/nix/profiles/default/bin:/Users/jonathanhaas/.nix-profile/bin:/Users/jonathanhaas/.local/bin:/Users/jonathanhaas/bin:/run/current-system/sw/bin:/Users/jonathanhaas/.npm-global/bin:/Users/jonathanhaas/.config/zsh/plugins/fast-syntax-highlighting:/Users/jonathanhaas/.config/zsh/plugins/zsh-autosuggestions:/Users/jonathanhaas/.config/zsh/plugins/zsh-completions:/Users/jonathanhaas/.config/zsh/plugins/fzf-tab:/Users/jonathanhaas/.config/zsh/plugins/zsh-you-should-use:/Applications/Ghostty.app/Contents/MacOS node ./scripts/run-vitest.js --run test/agent/mcp-governed-results.test.ts test/agent/mcp-platform-plugin.test.ts test/agent/mcp-merge.test.ts test/agent/mcp.test.ts test/agent/mcp-tool-bridge.test.ts test/agent/mcp-tool-helpers.test.ts test/agent/mcp-manager-transports.test.ts
- PATH=/Users/jonathanhaas/.npm-global/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/jonathanhaas/.dotfiles/bin:/Users/jonathanhaas/.dotfiles/scripts:/Users/jonathanhaas/.dotfiles/scripts/bin:/Users/jonathanhaas/.codex/tmp/arg0/codex-arg0vcQpld:/etc/profiles/per-user/jonathanhaas/bin:/opt/homebrew/opt/node@22/bin:/nix/var/nix/profiles/default/bin:/Users/jonathanhaas/.nix-profile/bin:/Users/jonathanhaas/.local/bin:/Users/jonathanhaas/bin:/run/current-system/sw/bin:/Users/jonathanhaas/.npm-global/bin:/Users/jonathanhaas/.config/zsh/plugins/fast-syntax-highlighting:/Users/jonathanhaas/.config/zsh/plugins/zsh-autosuggestions:/Users/jonathanhaas/.config/zsh/plugins/zsh-completions:/Users/jonathanhaas/.config/zsh/plugins/fzf-tab:/Users/jonathanhaas/.config/zsh/plugins/zsh-you-should-use:/Applications/Ghostty.app/Contents/MacOS npm run build

Follow-up sync for: evalops/maestro-internal#1431