### PR TITLE
Promote governed tool outcome codes into execution events

### DIFF
--- a/packages/contracts/src/headless-protocol-payloads.manifest.json
+++ b/packages/contracts/src/headless-protocol-payloads.manifest.json
@@ -479,7 +479,10 @@
 			"properties": {
 				"type": { "kind": "literal", "value": "tool_end" },
 				"call_id": { "kind": "string" },
-				"success": { "kind": "boolean" }
+				"success": { "kind": "boolean" },
+				"error_code": { "kind": "string", "optional": true },
+				"approval_request_id": { "kind": "string", "optional": true },
+				"governed_outcome": { "kind": "string", "optional": true }
 			}
 		},
 		"HeadlessClientToolRequestMessageSchema": {

--- a/packages/contracts/src/headless-protocol-schemas.generated.ts
+++ b/packages/contracts/src/headless-protocol-schemas.generated.ts
@@ -413,6 +413,9 @@ export const HeadlessToolEndMessageSchema = Type.Object(
 		type: Type.Literal("tool_end"),
 		call_id: Type.String(),
 		success: Type.Boolean(),
+		error_code: Type.Optional(Type.String()),
+		approval_request_id: Type.Optional(Type.String()),
+		governed_outcome: Type.Optional(Type.String()),
 	},
 	{ additionalProperties: false },
 );

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1986,6 +1986,9 @@ export class Agent {
 			status: event.isError
 				? "MAESTRO_TOOL_CALL_STATUS_FAILED"
 				: "MAESTRO_TOOL_CALL_STATUS_SUCCEEDED",
+			approval_request_id: event.approvalRequestId,
+			governed_outcome: event.governedOutcome,
+			error_code: event.errorCode,
 			error_message: event.isError
 				? event.result.content
 						.map((part) => (part.type === "text" ? part.text : ""))

--- a/src/agent/transport.ts
+++ b/src/agent/transport.ts
@@ -108,6 +108,50 @@ import type {
 	ToolResultMessage,
 } from "./types.js";
 
+type GovernedToolOutcome =
+	| "approval_required"
+	| "approval_pending"
+	| "authentication_required"
+	| "denied"
+	| "rate_limited";
+
+function getGovernedToolResultEventMetadata(details: unknown): {
+	errorCode?: string;
+	approvalRequestId?: string;
+	governedOutcome?: GovernedToolOutcome;
+} {
+	if (!details || typeof details !== "object") {
+		return {};
+	}
+
+	const governedOutcome = (details as { governedOutcome?: unknown })
+		.governedOutcome;
+	if (!governedOutcome || typeof governedOutcome !== "object") {
+		return {};
+	}
+
+	const normalized = governedOutcome as Record<string, unknown>;
+	const classification =
+		typeof normalized.classification === "string"
+			? (normalized.classification as GovernedToolOutcome)
+			: undefined;
+	const errorCode =
+		typeof normalized.code === "string" && normalized.code.trim().length > 0
+			? normalized.code.trim()
+			: classification;
+	const approvalRequestId =
+		typeof normalized.approvalRequestId === "string" &&
+		normalized.approvalRequestId.trim().length > 0
+			? normalized.approvalRequestId.trim()
+			: undefined;
+
+	return {
+		errorCode,
+		approvalRequestId,
+		governedOutcome: classification,
+	};
+}
+
 // Re-export types for backward compatibility
 export type {
 	SessionTokenCounter,
@@ -690,19 +734,28 @@ export class ProviderTransport implements AgentTransport {
 						toolExecutionId?: string;
 						approvalRequestId?: string;
 					},
-				): AgentEvent[] => [
-					{ type: "message_start", message } as AgentEvent,
-					{ type: "message_end", message } as AgentEvent,
-					{
-						type: "tool_execution_end",
-						toolCallId: toolCall.id,
-						toolExecutionId: metadata?.toolExecutionId,
-						approvalRequestId: metadata?.approvalRequestId,
-						toolName: toolCall.name,
-						result: message,
-						isError,
-					} as AgentEvent,
-				];
+				): AgentEvent[] => {
+					const governedMetadata = getGovernedToolResultEventMetadata(
+						message.details,
+					);
+					return [
+						{ type: "message_start", message } as AgentEvent,
+						{ type: "message_end", message } as AgentEvent,
+						{
+							type: "tool_execution_end",
+							toolCallId: toolCall.id,
+							toolExecutionId: metadata?.toolExecutionId,
+							approvalRequestId:
+								metadata?.approvalRequestId ??
+								governedMetadata.approvalRequestId,
+							errorCode: governedMetadata.errorCode,
+							governedOutcome: governedMetadata.governedOutcome,
+							toolName: toolCall.name,
+							result: message,
+							isError,
+						} as AgentEvent,
+					];
+				};
 				const emitToolResult = (
 					message: ToolResultMessage,
 					toolCall: ToolCall,

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1123,6 +1123,15 @@ export type AgentEvent =
 			toolExecutionId?: string;
 			/** Optional approval request identifier correlated to Platform ToolExecution */
 			approvalRequestId?: string;
+			/** Optional stable error or outcome code for telemetry and clients */
+			errorCode?: string;
+			/** Optional governed outcome classification surfaced by the tool result */
+			governedOutcome?:
+				| "approval_required"
+				| "approval_pending"
+				| "authentication_required"
+				| "denied"
+				| "rate_limited";
 			/** Name of the tool */
 			toolName: string;
 			/** Optional human-facing label for live UI */

--- a/src/cli/headless-protocol.ts
+++ b/src/cli/headless-protocol.ts
@@ -286,6 +286,9 @@ export interface HeadlessToolEndMessage {
 	type: "tool_end";
 	call_id: string;
 	success: boolean;
+	error_code?: string;
+	approval_request_id?: string;
+	governed_outcome?: string;
 }
 
 export interface HeadlessClientToolRequestMessage {
@@ -1009,6 +1012,13 @@ export class HeadlessProtocolTranslator {
 						type: "tool_end",
 						call_id: event.toolCallId,
 						success: !event.isError,
+						...(event.errorCode ? { error_code: event.errorCode } : {}),
+						...(event.approvalRequestId
+							? { approval_request_id: event.approvalRequestId }
+							: {}),
+						...(event.governedOutcome
+							? { governed_outcome: event.governedOutcome }
+							: {}),
 					},
 				];
 			case "tool_batch_summary": {

--- a/src/cli/jsonl-writer.ts
+++ b/src/cli/jsonl-writer.ts
@@ -191,16 +191,26 @@ export function createAgentJsonlAdapter(
 					break;
 				}
 				case "tool_execution_end": {
+					const data: Record<string, unknown> = {
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+						result: event.result,
+						isError: event.isError,
+					};
+					if (event.errorCode) {
+						data.errorCode = event.errorCode;
+					}
+					if (event.approvalRequestId) {
+						data.approvalRequestId = event.approvalRequestId;
+					}
+					if (event.governedOutcome) {
+						data.governedOutcome = event.governedOutcome;
+					}
 					writer.emit({
 						type: "item",
 						subtype: "tool_result",
 						timestamp: now(),
-						data: {
-							toolCallId: event.toolCallId,
-							toolName: event.toolName,
-							result: event.result,
-							isError: event.isError,
-						},
+						data,
 					});
 					break;
 				}

--- a/src/hooks/notification-hooks.ts
+++ b/src/hooks/notification-hooks.ts
@@ -48,6 +48,9 @@ export interface NotificationPayload {
 	lastAssistantMessage?: string;
 	toolName?: string;
 	toolResult?: string;
+	toolErrorCode?: string;
+	approvalRequestId?: string;
+	governedOutcome?: string;
 	error?: string;
 }
 
@@ -401,6 +404,9 @@ export function createNotificationFromAgentEvent(
 				type: "tool-execution",
 				toolName: event.toolName,
 				toolResult: extractToolResultText(event.result),
+				toolErrorCode: event.errorCode,
+				approvalRequestId: event.approvalRequestId,
+				governedOutcome: event.governedOutcome,
 			};
 
 		case "error":

--- a/src/telemetry/maestro-event-bus.ts
+++ b/src/telemetry/maestro-event-bus.ts
@@ -172,6 +172,8 @@ export interface ToolCallResultEventData extends Record<string, unknown> {
 	correlation: MaestroCorrelation;
 	tool_call_id: string;
 	tool_execution_id?: string;
+	approval_request_id?: string;
+	governed_outcome?: string;
 	status: MaestroToolCallStatus;
 	duration?: string;
 	safe_output?: Record<string, unknown>;
@@ -276,6 +278,8 @@ export interface RecordMaestroToolCallAttemptInput {
 export interface RecordMaestroToolCallCompletedInput {
 	tool_call_id: string;
 	tool_execution_id?: string;
+	approval_request_id?: string;
+	governed_outcome?: string;
 	status: MaestroToolCallStatus;
 	duration?: string;
 	safe_output?: Record<string, unknown>;
@@ -870,6 +874,8 @@ export function recordMaestroToolCallCompleted(
 			),
 			tool_call_id: event.tool_call_id,
 			tool_execution_id: event.tool_execution_id,
+			approval_request_id: event.approval_request_id,
+			governed_outcome: event.governed_outcome,
 			status: event.status,
 			duration: event.duration,
 			safe_output: event.safe_output,

--- a/src/telemetry/turn-tracker.ts
+++ b/src/telemetry/turn-tracker.ts
@@ -126,13 +126,10 @@ export class TurnTracker {
 
 			case "tool_execution_end":
 				if (this.currentTurn && "toolCallId" in event) {
-					const success = !("error" in event) || !event.error;
-					const errorCode =
-						"error" in event && event.error
-							? typeof event.error === "string"
-								? event.error.slice(0, 50)
-								: "error"
-							: undefined;
+					const success = !event.isError;
+					const errorCode = event.isError
+						? (event.errorCode?.slice(0, 50) ?? "error")
+						: undefined;
 					const outputSize =
 						"output" in event && typeof event.output === "string"
 							? event.output.length

--- a/test/cli/headless.test.ts
+++ b/test/cli/headless.test.ts
@@ -196,6 +196,41 @@ describe("headless protocol helpers", () => {
 		]);
 	});
 
+	it("translates governed tool failures into enriched tool_end messages", () => {
+		const translator = new HeadlessProtocolTranslator();
+		const messages = translator.handleAgentEvent({
+			type: "tool_execution_end",
+			toolCallId: "call_123",
+			toolName: "bash",
+			result: {
+				role: "toolResult",
+				toolCallId: "call_123",
+				toolName: "bash",
+				content: [{ type: "text", text: "Denied by policy" }],
+				isError: true,
+				timestamp: Date.now(),
+			},
+			isError: true,
+			errorCode: "governance_denied",
+			approvalRequestId: "approval-123",
+			governedOutcome: "denied",
+		});
+
+		expect(messages).toEqual([
+			{
+				type: "tool_end",
+				call_id: "call_123",
+				success: false,
+				error_code: "governance_denied",
+				approval_request_id: "approval-123",
+				governed_outcome: "denied",
+			},
+		]);
+		for (const message of messages) {
+			expect(Value.Check(HeadlessFromAgentMessageSchema, message)).toBe(true);
+		}
+	});
+
 	it("translates approval requests into legacy and server_request messages", () => {
 		const translator = new HeadlessProtocolTranslator();
 		expect(

--- a/test/notification-hooks.test.ts
+++ b/test/notification-hooks.test.ts
@@ -271,6 +271,9 @@ describe("Notification Hooks", () => {
 					type: "tool_execution_end",
 					toolCallId: "call-123",
 					toolName: "bash",
+					errorCode: "governance_denied",
+					approvalRequestId: "approval-123",
+					governedOutcome: "denied",
 					result: {
 						role: "toolResult",
 						toolCallId: "call-123",
@@ -288,6 +291,9 @@ describe("Notification Hooks", () => {
 			expect(payload?.type).toBe("tool-execution");
 			expect(payload?.toolName).toBe("bash");
 			expect(payload?.toolResult).toBe("Command output here");
+			expect(payload?.toolErrorCode).toBe("governance_denied");
+			expect(payload?.approvalRequestId).toBe("approval-123");
+			expect(payload?.governedOutcome).toBe("denied");
 		});
 
 		it("should create payload for error event", async () => {

--- a/test/session/jsonl-writer.test.ts
+++ b/test/session/jsonl-writer.test.ts
@@ -108,4 +108,42 @@ describe("JsonlEventWriter adapter", () => {
 		emitUserTurn(writer, nextTurnId, "hello");
 		expect(stream.chunks.join("")).toMatchSnapshot();
 	});
+
+	it("includes governed tool metadata in tool results", () => {
+		adapter.handle({
+			type: "tool_execution_end",
+			toolCallId: "call-governed",
+			toolName: "bash",
+			result: {
+				...toolResult,
+				toolCallId: "call-governed",
+				toolName: "bash",
+				isError: true,
+			},
+			isError: true,
+			errorCode: "governance_denied",
+			approvalRequestId: "approval-123",
+			governedOutcome: "denied",
+		});
+
+		expect(JSON.parse(stream.chunks[0] ?? "{}")).toEqual({
+			type: "item",
+			subtype: "tool_result",
+			timestamp: "2025-01-01T00:00:00.000Z",
+			data: {
+				toolCallId: "call-governed",
+				toolName: "bash",
+				result: {
+					...toolResult,
+					toolCallId: "call-governed",
+					toolName: "bash",
+					isError: true,
+				},
+				isError: true,
+				errorCode: "governance_denied",
+				approvalRequestId: "approval-123",
+				governedOutcome: "denied",
+			},
+		});
+	});
 });

--- a/test/telemetry/turn-tracker.test.ts
+++ b/test/telemetry/turn-tracker.test.ts
@@ -304,4 +304,107 @@ describe("TurnTracker", () => {
 			costUsd: 1.1,
 		});
 	});
+
+	it("records governed tool failure codes on completed turns", () => {
+		let listener: ((event: AgentEvent) => void) | undefined;
+		const agent = {
+			state: {
+				messages: [],
+				error: undefined,
+				model: {
+					id: "test-model",
+					provider: "anthropic",
+				},
+				thinkingLevel: "off",
+			},
+			subscribe: (fn: (event: AgentEvent) => void) => {
+				listener = fn;
+				return () => {
+					listener = undefined;
+				};
+			},
+		} as unknown as Agent;
+
+		let completed:
+			| {
+					tools: Array<{
+						name: string;
+						callId: string;
+						success: boolean;
+						errorCode?: string;
+					}>;
+					toolFailureCount: number;
+			  }
+			| undefined;
+		const tracker = new TurnTracker(agent, {
+			sessionId: "session-governed-tool",
+			onTurnComplete: (event) => {
+				completed = {
+					tools: event.tools,
+					toolFailureCount: event.toolFailureCount,
+				};
+			},
+		});
+
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "done" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-20250514",
+			usage: {
+				input: 10,
+				output: 5,
+				cacheRead: 0,
+				cacheWrite: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+
+		listener?.({ type: "agent_start" });
+		listener?.({
+			type: "tool_execution_start",
+			toolCallId: "call-governed",
+			toolName: "bash",
+			args: { command: "rm -rf /tmp/demo" },
+		});
+		listener?.({
+			type: "tool_execution_end",
+			toolCallId: "call-governed",
+			toolName: "bash",
+			result: {
+				role: "toolResult",
+				toolCallId: "call-governed",
+				toolName: "bash",
+				content: [{ type: "text", text: "Denied by policy" }],
+				isError: true,
+				timestamp: Date.now(),
+			},
+			isError: true,
+			errorCode: "governance_denied",
+			governedOutcome: "denied",
+			approvalRequestId: "approval-123",
+		});
+		listener?.({ type: "message_start", message: assistantMessage });
+		listener?.({ type: "message_end", message: assistantMessage });
+		listener?.({
+			type: "agent_end",
+			messages: [assistantMessage],
+			stopReason: "stop",
+		});
+
+		tracker.dispose();
+
+		expect(completed?.tools).toEqual([
+			expect.objectContaining({
+				name: "bash",
+				callId: "call-governed",
+				success: false,
+				errorCode: "governance_denied",
+			}),
+		]);
+		expect(completed?.toolFailureCount).toBe(1);
+	});
 });


### PR DESCRIPTION
## Summary
- surface governed MCP outcome metadata on `tool_execution_end` so telemetry and downstream consumers get first-class `errorCode`, `approvalRequestId`, and `governedOutcome`
- propagate those fields through headless protocol, JSONL output, notifications, and the Maestro event bus
- fix turn tracking so failed tool executions record their actual error code instead of dropping it

## Test Plan
- `node ./scripts/run-vitest.js --run test/telemetry/turn-tracker.test.ts test/session/jsonl-writer.test.ts test/cli/headless.test.ts test/notification-hooks.test.ts`
- `bun run verify:headless-proto:sync`
- `bunx biome check packages/contracts/src/headless-protocol-payloads.manifest.json packages/contracts/src/headless-protocol-schemas.generated.ts src/agent/agent.ts src/agent/transport.ts src/agent/types.ts src/cli/headless-protocol.ts src/cli/jsonl-writer.ts src/hooks/notification-hooks.ts src/telemetry/maestro-event-bus.ts src/telemetry/turn-tracker.ts test/cli/headless.test.ts test/notification-hooks.test.ts test/session/jsonl-writer.test.ts test/telemetry/turn-tracker.test.ts`
- `npm run build`