### PR TITLE
[maestro] require hosted-runner API auth by default

### DIFF
--- a/src/cli/commands/hosted-runner.ts
+++ b/src/cli/commands/hosted-runner.ts
@@ -231,7 +231,7 @@ export function applyHostedRunnerEnvironment(config: HostedRunnerConfig): void {
 	process.env.MAESTRO_RUNNER_SESSION_ID = config.runnerSessionId;
 	process.env.MAESTRO_WORKSPACE_ROOT = config.workspaceRoot;
 	process.env.MAESTRO_PROFILE ??= "hosted-runner";
-	process.env.MAESTRO_WEB_REQUIRE_KEY ??= "0";
+	process.env.MAESTRO_WEB_REQUIRE_KEY ??= "1";
 	process.env.MAESTRO_WEB_REQUIRE_REDIS ??= "0";
 	process.env.MAESTRO_WEB_REQUIRE_CSRF ??= "0";
 	process.env.MAESTRO_AGENT_DIR ??= resolve(

--- a/test/cli/hosted-runner-command.test.ts
+++ b/test/cli/hosted-runner-command.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	applyHostedRunnerEnvironment,
 	resolveHostedRunnerConfig,
 	toHostedRunnerContext,
 } from "../../src/cli/commands/hosted-runner.js";
@@ -83,5 +84,46 @@ describe("hosted-runner command config", () => {
 		await expect(
 			resolveHostedRunnerConfig(["--runner-session-id", "mrs_123"], {}),
 		).rejects.toThrow(/workspace-root/);
+	});
+
+	it("requires API auth by default in hosted-runner mode", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const originalCwd = process.cwd();
+		const previous = {
+			MAESTRO_HOSTED_RUNNER_MODE: process.env.MAESTRO_HOSTED_RUNNER_MODE,
+			MAESTRO_RUNNER_SESSION_ID: process.env.MAESTRO_RUNNER_SESSION_ID,
+			MAESTRO_WORKSPACE_ROOT: process.env.MAESTRO_WORKSPACE_ROOT,
+			MAESTRO_PROFILE: process.env.MAESTRO_PROFILE,
+			MAESTRO_WEB_REQUIRE_KEY: process.env.MAESTRO_WEB_REQUIRE_KEY,
+			MAESTRO_WEB_REQUIRE_REDIS: process.env.MAESTRO_WEB_REQUIRE_REDIS,
+			MAESTRO_WEB_REQUIRE_CSRF: process.env.MAESTRO_WEB_REQUIRE_CSRF,
+			MAESTRO_AGENT_DIR: process.env.MAESTRO_AGENT_DIR,
+		};
+		delete process.env.MAESTRO_PROFILE;
+		delete process.env.MAESTRO_WEB_REQUIRE_KEY;
+		delete process.env.MAESTRO_WEB_REQUIRE_REDIS;
+		delete process.env.MAESTRO_WEB_REQUIRE_CSRF;
+		delete process.env.MAESTRO_AGENT_DIR;
+
+		try {
+			applyHostedRunnerEnvironment({
+				runnerSessionId: "mrs_123",
+				workspaceRoot,
+				port: 8080,
+			});
+
+			expect(process.env.MAESTRO_WEB_REQUIRE_KEY).toBe("1");
+			expect(process.env.MAESTRO_WEB_REQUIRE_REDIS).toBe("0");
+			expect(process.env.MAESTRO_WEB_REQUIRE_CSRF).toBe("0");
+		} finally {
+			process.chdir(originalCwd);
+			for (const [key, value] of Object.entries(previous)) {
+				if (value === undefined) {
+					delete process.env[key];
+				} else {
+					process.env[key] = value;
+				}
+			}
+		}
 	});
 });


### PR DESCRIPTION
### Motivation
- Hosted-runner mode previously defaulted MAESTRO_WEB_REQUIRE_KEY to "0", which disables API authentication and can expose remote unauthenticated access to tool execution when the runner is network-accessible.
- The change restores a secure default for hosted deployments by requiring API auth unless explicitly overridden.

### Description
- Change `applyHostedRunnerEnvironment` in `src/cli/commands/hosted-runner.ts` to default `MAESTRO_WEB_REQUIRE_KEY` to "1" instead of "0".
- Preserve existing defaults for `MAESTRO_WEB_REQUIRE_REDIS` and `MAESTRO_WEB_REQUIRE_CSRF` (left as "0").
- Add a regression test `test/cli/hosted-runner-command.test.ts` that calls `applyHostedRunnerEnvironment` and asserts the environment variables are set to the secure defaults, and that process env/cwd are restored after the test.
- Commit changes on the current branch with a focused message and prepare a PR with this description.

### Testing
- Ran lint via `bun run bun:lint`, which failed due to external npm registry access (`GET https://registry.npmjs.org/biome - 403`) so lint could not complete in this environment.
- Ran the full test command `npx nx run maestro:test --skip-nx-cache`, which failed due to npm registry access errors (`GET https://registry.npmjs.org/nx - 403`) so the suite could not run here.
- Executed the new unit test file with `bunx vitest --run test/cli/hosted-runner-command.test.ts`, which could not run due to registry access (`GET https://registry.npmjs.org/vitest - 403`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9707b963083268b17f86ba89dadf1)