### PR TITLE
[maestro] improve hosted remote session handoff

### DIFF
--- a/src/cli/commands/remote.ts
+++ b/src/cli/commands/remote.ts
@@ -2,6 +2,12 @@ import { headlessProtocolVersion } from "@evalops/contracts";
 import chalk from "chalk";
 import { getPackageVersion } from "../../package-metadata.js";
 import {
+	attachToRemoteRunnerSession,
+	shouldUseInteractiveRemoteAttach,
+} from "../../remote-runner/attach-client.js";
+import {
+	DEFAULT_REMOTE_RUNNER_WAIT_POLL_INTERVAL_MS,
+	DEFAULT_REMOTE_RUNNER_WAIT_TIMEOUT_MS,
 	RUNNER_ATTACH_ROLES,
 	type RunnerAttachRole,
 	type RunnerSession,
@@ -18,6 +24,7 @@ import {
 	revokeRunnerAttachToken,
 	stopRunnerSession,
 	verifyRunnerHeadlessAttach,
+	waitForRunnerSessionReady,
 } from "../../remote-runner/client.js";
 
 type RemoteFlagValue = true | string;
@@ -30,15 +37,17 @@ interface RemoteCommandOptions {
 const REMOTE_USAGE = `maestro remote <command> [options]
 
 Commands:
-  start --workspace <id> --repo <repo> --branch <branch> [--ttl 90m] [--profile standard]
+  start --workspace <id> --repo <repo> --branch <branch> [--ttl 90m] [--profile standard] [--wait] [--wait-timeout 5m] [--poll-interval 5s] [--verify]
   list --workspace <id> [--state running] [--limit 20]
   status --workspace <id>
+  get <session-id>
   events <session-id> [--after <sequence>] [--limit 50]
   extend <session-id> --ttl 2h [--idle-ttl 30m]
   stop <session-id> [--reason <text>]
-  attach <session-id> [--role controller] [--ttl 30m] [--verify]
+  attach <session-id> [--role controller] [--ttl 30m] [--verify] [--print-env]
   attach-token <session-id> [--role viewer] [--ttl 30m] [--json]
   revoke-token <session-id> <token-id>
+  target <session-id>
 
 Shared options:
   --base-url <url>       Remote runner URL (defaults to https://runner.evalops.dev)
@@ -170,6 +179,55 @@ function parseOptionalDurationMinutes(
 	return parseRemoteDurationMinutes(raw, 0);
 }
 
+function parseWaitDurationMs(
+	raw: string | undefined,
+	fallback: number,
+): number {
+	if (!raw) {
+		return fallback;
+	}
+	const value = raw.trim().toLowerCase();
+	const match = value.match(
+		/^(\d+(?:\.\d+)?)(ms|msec|millisecond|milliseconds|s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)?$/u,
+	);
+	if (!match) {
+		throw new Error(
+			`Invalid wait duration "${raw}". Use values like 5s, 30s, 5m, or 1h.`,
+		);
+	}
+	const amount = Number(match[1]);
+	const unit = match[2] ?? "s";
+	let milliseconds = amount * 1000;
+	if (unit === "ms" || unit === "msec" || unit.startsWith("millisecond")) {
+		milliseconds = amount;
+	} else if (unit.startsWith("m") && unit !== "ms" && unit !== "msec") {
+		milliseconds = amount * 60 * 1000;
+	} else if (unit.startsWith("h")) {
+		milliseconds = amount * 60 * 60 * 1000;
+	}
+	if (!Number.isFinite(milliseconds) || milliseconds < 1) {
+		throw new Error(
+			`Invalid wait duration "${raw}". Duration must resolve to at least 1ms.`,
+		);
+	}
+	return Math.round(milliseconds);
+}
+
+function formatElapsedMs(rawMs: number | undefined): string {
+	if (!rawMs || rawMs < 1000) {
+		return `${rawMs ?? 0}ms`;
+	}
+	if (rawMs < 60_000) {
+		return `${(rawMs / 1000).toFixed(rawMs % 1000 === 0 ? 0 : 1)}s`;
+	}
+	const minutes = rawMs / 60_000;
+	if (rawMs < 60 * 60_000) {
+		return `${minutes.toFixed(rawMs % 60_000 === 0 ? 0 : 1)}m`;
+	}
+	const hours = rawMs / (60 * 60_000);
+	return `${hours.toFixed(rawMs % (60 * 60_000) === 0 ? 0 : 1)}h`;
+}
+
 function parseMetadata(
 	values: readonly string[],
 ): Record<string, unknown> | undefined {
@@ -235,6 +293,20 @@ function roleValues(options: RemoteCommandOptions): RunnerAttachRole[] {
 		}
 		return value;
 	});
+}
+
+function attachConnectionRole(
+	options: RemoteCommandOptions,
+): "viewer" | "controller" {
+	return roleValues(options).every(
+		(role) => role === RUNNER_ATTACH_ROLES.VIEWER,
+	)
+		? "viewer"
+		: "controller";
+}
+
+function shouldWaitForStart(options: RemoteCommandOptions): boolean {
+	return hasFlag(options, "wait") || hasFlag(options, "verify");
 }
 
 function printJson(value: unknown): void {
@@ -379,15 +451,94 @@ async function handleStart(options: RemoteCommandOptions): Promise<void> {
 		},
 		clientOptions(options),
 	);
+	let waitResult:
+		| {
+				session: RunnerSession;
+				attempts: number;
+				elapsedMs: number;
+		  }
+		| undefined;
+	let attachResult:
+		| {
+				gatewayBaseUrl: string;
+				token: { id: string; expiresAt?: string };
+				tokenSecret: string;
+				verified?: Record<string, unknown>;
+		  }
+		| undefined;
+	if (shouldWaitForStart(options)) {
+		waitResult = await waitForRunnerSessionReady(result.session.id, {
+			...clientOptions(options),
+			timeoutMs: parseWaitDurationMs(
+				getFlag(options, "wait-timeout"),
+				DEFAULT_REMOTE_RUNNER_WAIT_TIMEOUT_MS,
+			),
+			pollIntervalMs: parseWaitDurationMs(
+				getFlag(options, "poll-interval"),
+				DEFAULT_REMOTE_RUNNER_WAIT_POLL_INTERVAL_MS,
+			),
+		});
+	}
+	if (hasFlag(options, "verify")) {
+		const minted = await mintRunnerAttachToken(
+			{
+				sessionId: result.session.id,
+				roles: roleValues(options),
+				ttlMinutes: parseRemoteDurationMinutes(
+					getFlag(options, "attach-ttl"),
+					30,
+				),
+			},
+			clientOptions(options),
+		);
+		attachResult = {
+			gatewayBaseUrl: minted.gatewayBaseUrl,
+			token: minted.token,
+			tokenSecret: minted.tokenSecret,
+			verified: await verifyRunnerHeadlessAttach({
+				gatewayBaseUrl: minted.gatewayBaseUrl,
+				tokenId: minted.token.id,
+				tokenSecret: minted.tokenSecret,
+				sessionId: result.session.id,
+				protocolVersion: headlessProtocolVersion,
+				clientVersion: getPackageVersion(),
+				takeControl: hasFlag(options, "take-control"),
+			}),
+		};
+	}
 	if (jsonFlag(options)) {
-		printJson(result);
+		printJson({
+			created: result,
+			wait: waitResult,
+			attach: attachResult,
+		});
 		return;
 	}
-	printSession(result.session);
+	printSession(waitResult?.session ?? result.session);
+	if (waitResult) {
+		console.log(
+			chalk.dim(
+				`  ready:     ${formatElapsedMs(waitResult.elapsedMs)} (${waitResult.attempts} checks)`,
+			),
+		);
+	}
 	if (result.replayed) {
 		console.log(chalk.dim("  replayed:  existing idempotent request"));
 	}
 	console.log("");
+	if (attachResult) {
+		printAttachInstructions({
+			sessionId: result.session.id,
+			gatewayBaseUrl: attachResult.gatewayBaseUrl,
+			tokenId: attachResult.token.id,
+			tokenSecret: attachResult.tokenSecret,
+			expiresAt: attachResult.token.expiresAt,
+			json: false,
+			showSecret: hasFlag(options, "show-secret"),
+			verified: attachResult.verified,
+		});
+		return;
+	}
 	console.log(chalk.dim(`Attach: maestro remote attach ${result.session.id}`));
 }
 
@@ -530,6 +681,26 @@ async function mintAttach(options: RemoteCommandOptions) {
 async function handleAttach(options: RemoteCommandOptions): Promise<void> {
 	const sessionId = options.positionals[0];
 	const minted = await mintAttach(options);
+	if (
+		shouldUseInteractiveRemoteAttach({
+			json: jsonFlag(options),
+			printEnv: hasFlag(options, "print-env"),
+			stdinIsTTY: Boolean(process.stdin.isTTY),
+			stdoutIsTTY: Boolean(process.stdout.isTTY),
+		})
+	) {
+		await attachToRemoteRunnerSession({
+			sessionId: sessionId!,
+			gatewayBaseUrl: minted.gatewayBaseUrl,
+			tokenId: minted.token.id,
+			tokenSecret: minted.tokenSecret,
+			role: attachConnectionRole(options),
+			protocolVersion: headlessProtocolVersion,
+			clientVersion: getPackageVersion(),
+			takeControl: hasFlag(options, "take-control"),
+		});
+		return;
+	}
 	let verified: Record<string, unknown> | undefined;
 	if (hasFlag(options, "verify")) {
 		verified = await verifyRunnerHeadlessAttach({

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -98,8 +98,8 @@ export function printHelp(version: string) {
   # Import a portable session log into this workspace
   maestro import ./session.json
 
-  # Start a hosted EvalOps runner session
-  maestro remote start --workspace ws_123 --repo evalops/foo --branch main --ttl 90m
+  # Start a hosted EvalOps runner session and wait for attach readiness
+  maestro remote start --workspace ws_123 --repo evalops/foo --branch main --ttl 90m --wait --verify
 
   # Run a single-session hosted runtime pod entrypoint
   maestro hosted-runner --runner-session-id mrs_abc --workspace-root /workspace --listen 0.0.0.0:8080
@@ -170,9 +170,9 @@ export function printHelp(version: string) {
   maestro memory watch [id] [ms]  Poll status/metrics continuously`,
 	)}`;
 	const remoteSection = `${sectionHeading("maestro remote")}${muted(
-		`  maestro remote start --workspace <id> --repo <repo> --branch <branch> [--ttl 90m]
+		`  maestro remote start --workspace <id> --repo <repo> --branch <branch> [--ttl 90m] [--wait] [--verify]
   maestro remote list --workspace <id> [--state running]
-  maestro remote attach <session-id> [--verify]
+  maestro remote attach <session-id> [--verify] [--print-env]
   maestro remote extend <session-id> --ttl 2h
   maestro remote stop <session-id> [--reason <text>]`,
 	)}`;

--- a/src/remote-runner/attach-client.ts
+++ b/src/remote-runner/attach-client.ts
@@ -1,0 +1,928 @@
+import { clearLine, cursorTo } from "node:readline";
+import { createInterface } from "node:readline/promises";
+import type { Readable, Writable } from "node:stream";
+import {
+	type HeadlessConnectionRole,
+	assertHeadlessRuntimeHeartbeatSnapshot,
+	assertHeadlessRuntimeStreamEnvelope,
+	assertHeadlessRuntimeSubscriptionSnapshot,
+	headlessProtocolVersion,
+} from "@evalops/contracts";
+import chalk from "chalk";
+import {
+	type HeadlessFromAgentMessage,
+	type HeadlessPendingApprovalState,
+	type HeadlessRuntimeState,
+	type HeadlessToAgentMessage,
+	applyIncomingHeadlessMessage,
+	applyOutgoingHeadlessMessage,
+	createHeadlessRuntimeState,
+} from "../cli/headless-protocol.js";
+
+const DEFAULT_ATTACH_TIMEOUT_MS = 5_000;
+const DEFAULT_CLIENT_NAME = "maestro-remote-cli";
+
+export interface RemoteRunnerAttachConnection {
+	sessionId: string;
+	connectionId: string;
+	subscriptionId: string;
+	heartbeatIntervalMs: number;
+	role: "viewer" | "controller";
+	state: HeadlessRuntimeState;
+}
+
+export interface RemoteRunnerAttachConnectInput {
+	gatewayBaseUrl: string;
+	sessionId: string;
+	tokenId: string;
+	tokenSecret: string;
+	role: "viewer" | "controller";
+	clientName?: string;
+	clientVersion?: string;
+	protocolVersion?: string;
+	takeControl?: boolean;
+	timeoutMs?: number;
+	fetchImpl?: typeof fetch;
+}
+
+export interface RemoteRunnerAttachInput
+	extends RemoteRunnerAttachConnectInput {
+	stdin?: Readable;
+	stdout?: Writable & { isTTY?: boolean };
+	stderr?: Writable & { isTTY?: boolean };
+}
+
+type ParsedSseEvent = {
+	event?: string;
+	data: string;
+};
+
+type AttachRequestContext = Pick<
+	RemoteRunnerAttachConnectInput,
+	"gatewayBaseUrl" | "tokenId" | "tokenSecret" | "timeoutMs" | "fetchImpl"
+>;
+
+function parseJsonRecord(text: string, label: string): Record<string, unknown> {
+	if (!text.trim()) {
+		return {};
+	}
+	const parsed = JSON.parse(text) as unknown;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error(`${label} returned an invalid JSON payload`);
+	}
+	return parsed as Record<string, unknown>;
+}
+
+function createAttachHeaders(input: {
+	tokenId: string;
+	tokenSecret: string;
+	connectionId?: string;
+	subscriptionId?: string;
+	accept?: string;
+	contentType?: string;
+}): Headers {
+	const headers = new Headers();
+	headers.set("Authorization", `Bearer ${input.tokenSecret}`);
+	headers.set("X-EvalOps-Runner-Attach-Token-Id", input.tokenId);
+	headers.set("Accept", input.accept ?? "application/json");
+	if (input.contentType) {
+		headers.set("Content-Type", input.contentType);
+	}
+	if (input.connectionId) {
+		headers.set("x-maestro-headless-connection-id", input.connectionId);
+	}
+	if (input.subscriptionId) {
+		headers.set("x-maestro-headless-subscriber-id", input.subscriptionId);
+	}
+	return headers;
+}
+
+async function requestJson(
+	url: string,
+	init: RequestInit,
+	input: Pick<RemoteRunnerAttachConnectInput, "timeoutMs" | "fetchImpl">,
+	label: string,
+): Promise<Record<string, unknown>> {
+	const controller = new AbortController();
+	const timeout = setTimeout(
+		() => controller.abort(new Error(`${label} timed out`)),
+		input.timeoutMs ?? DEFAULT_ATTACH_TIMEOUT_MS,
+	);
+	try {
+		const response = await (input.fetchImpl ?? fetch)(url, {
+			...init,
+			signal: controller.signal,
+		});
+		const text = await response.text();
+		if (!response.ok) {
+			throw new Error(
+				`${label} returned ${response.status}: ${text || response.statusText}`,
+			);
+		}
+		return parseJsonRecord(text, label);
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function attachCapabilities(
+	role: "viewer" | "controller",
+): { serverRequests: ["approval", "user_input", "tool_retry"] } | undefined {
+	if (role === "viewer") {
+		return undefined;
+	}
+	return {
+		serverRequests: ["approval", "user_input", "tool_retry"],
+	};
+}
+
+function clientInfo(input: RemoteRunnerAttachConnectInput) {
+	return {
+		name: input.clientName ?? DEFAULT_CLIENT_NAME,
+		version: input.clientVersion,
+	};
+}
+
+function normalizeState(value: unknown): HeadlessRuntimeState {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return createHeadlessRuntimeState();
+	}
+	return structuredClone(value as HeadlessRuntimeState);
+}
+
+function asTrimmedString(
+	record: Record<string, unknown>,
+	...keys: string[]
+): string | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "string" && value.trim().length > 0) {
+			return value.trim();
+		}
+	}
+	return undefined;
+}
+
+function parseSseEvents(buffer: string): {
+	events: ParsedSseEvent[];
+	remainder: string;
+} {
+	const normalized = buffer.replace(/\r\n/g, "\n");
+	const events: ParsedSseEvent[] = [];
+	let remainder = normalized;
+
+	while (true) {
+		const separatorIndex = remainder.indexOf("\n\n");
+		if (separatorIndex === -1) {
+			break;
+		}
+		const rawEvent = remainder.slice(0, separatorIndex);
+		remainder = remainder.slice(separatorIndex + 2);
+		if (!rawEvent.trim()) {
+			continue;
+		}
+
+		let eventType: string | undefined;
+		const dataLines: string[] = [];
+		for (const line of rawEvent.split("\n")) {
+			if (line.startsWith("event:")) {
+				eventType = line.slice(6).trim();
+				continue;
+			}
+			if (line.startsWith("data:")) {
+				dataLines.push(line.slice(5).trimStart());
+			}
+		}
+		if (dataLines.length > 0) {
+			events.push({ event: eventType, data: dataLines.join("\n") });
+		}
+	}
+
+	return { events, remainder };
+}
+
+async function sendHeadlessMessage(
+	context: AttachRequestContext & {
+		sessionId: string;
+		connectionId: string;
+		subscriptionId: string;
+	},
+	message: HeadlessToAgentMessage,
+): Promise<void> {
+	await requestJson(
+		`${context.gatewayBaseUrl}/api/headless/sessions/${encodeURIComponent(context.sessionId)}/messages`,
+		{
+			method: "POST",
+			headers: createAttachHeaders({
+				tokenId: context.tokenId,
+				tokenSecret: context.tokenSecret,
+				connectionId: context.connectionId,
+				subscriptionId: context.subscriptionId,
+				contentType: "application/json",
+			}),
+			body: JSON.stringify(message),
+		},
+		context,
+		"remote runner headless message",
+	);
+}
+
+async function heartbeatAttachConnection(
+	context: AttachRequestContext & {
+		sessionId: string;
+		connectionId: string;
+		subscriptionId: string;
+	},
+): Promise<void> {
+	const payload = await requestJson(
+		`${context.gatewayBaseUrl}/api/headless/sessions/${encodeURIComponent(context.sessionId)}/heartbeat`,
+		{
+			method: "POST",
+			headers: createAttachHeaders({
+				tokenId: context.tokenId,
+				tokenSecret: context.tokenSecret,
+				connectionId: context.connectionId,
+				subscriptionId: context.subscriptionId,
+				contentType: "application/json",
+			}),
+			body: JSON.stringify({
+				connectionId: context.connectionId,
+				subscriptionId: context.subscriptionId,
+			}),
+		},
+		context,
+		"remote runner headless heartbeat",
+	);
+	assertHeadlessRuntimeHeartbeatSnapshot(
+		payload,
+		"remote runner headless heartbeat",
+	);
+}
+
+async function disconnectAttachConnection(
+	context: AttachRequestContext & {
+		sessionId: string;
+		connectionId: string;
+		subscriptionId: string;
+	},
+): Promise<void> {
+	await requestJson(
+		`${context.gatewayBaseUrl}/api/headless/sessions/${encodeURIComponent(context.sessionId)}/disconnect`,
+		{
+			method: "POST",
+			headers: createAttachHeaders({
+				tokenId: context.tokenId,
+				tokenSecret: context.tokenSecret,
+				connectionId: context.connectionId,
+				subscriptionId: context.subscriptionId,
+				contentType: "application/json",
+			}),
+			body: JSON.stringify({
+				connectionId: context.connectionId,
+				subscriptionId: context.subscriptionId,
+			}),
+		},
+		context,
+		"remote runner headless disconnect",
+	);
+}
+
+async function streamAttachEvents(
+	context: AttachRequestContext & {
+		sessionId: string;
+		connectionId: string;
+		subscriptionId: string;
+	},
+	handlers: {
+		onMessage: (message: HeadlessFromAgentMessage) => void;
+		onReset: (snapshotState: HeadlessRuntimeState) => void;
+	},
+	signal: AbortSignal,
+): Promise<void> {
+	const response = await (context.fetchImpl ?? fetch)(
+		`${context.gatewayBaseUrl}/api/headless/sessions/${encodeURIComponent(context.sessionId)}/events?subscriptionId=${encodeURIComponent(context.subscriptionId)}`,
+		{
+			method: "GET",
+			headers: createAttachHeaders({
+				tokenId: context.tokenId,
+				tokenSecret: context.tokenSecret,
+				connectionId: context.connectionId,
+				subscriptionId: context.subscriptionId,
+				accept: "text/event-stream",
+			}),
+			signal,
+		},
+	);
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`remote runner headless events returned ${response.status}: ${
+				text || response.statusText
+			}`,
+		);
+	}
+	if (!response.body) {
+		throw new Error("remote runner headless events returned no response body");
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) {
+				break;
+			}
+			buffer += decoder.decode(value, { stream: true });
+			const parsed = parseSseEvents(buffer);
+			buffer = parsed.remainder;
+			for (const event of parsed.events) {
+				const payload = JSON.parse(event.data) as unknown;
+				assertHeadlessRuntimeStreamEnvelope(
+					payload,
+					"remote runner headless stream event",
+				);
+				switch (payload.type) {
+					case "message":
+						handlers.onMessage(payload.message as HeadlessFromAgentMessage);
+						break;
+					case "reset":
+						handlers.onReset(normalizeState(payload.snapshot.state));
+						break;
+					case "snapshot":
+						handlers.onReset(normalizeState(payload.snapshot.state));
+						break;
+					case "heartbeat":
+						break;
+				}
+			}
+		}
+	} finally {
+		void reader.cancel().catch(() => undefined);
+	}
+}
+
+export async function connectToRemoteRunnerSession(
+	input: RemoteRunnerAttachConnectInput,
+): Promise<RemoteRunnerAttachConnection> {
+	const protocolVersion = input.protocolVersion ?? headlessProtocolVersion;
+	const connectionPayload = await requestJson(
+		`${input.gatewayBaseUrl}/api/headless/connections`,
+		{
+			method: "POST",
+			headers: createAttachHeaders({
+				tokenId: input.tokenId,
+				tokenSecret: input.tokenSecret,
+				contentType: "application/json",
+			}),
+			body: JSON.stringify({
+				sessionId: input.sessionId,
+				protocolVersion,
+				clientInfo: clientInfo(input),
+				role: input.role,
+				takeControl: input.takeControl ?? false,
+				optOutNotifications: ["heartbeat"],
+				capabilities: attachCapabilities(input.role),
+			}),
+		},
+		input,
+		"remote runner headless connection",
+	);
+	const connectionId = asTrimmedString(
+		connectionPayload,
+		"connection_id",
+		"connectionId",
+	);
+	if (!connectionId) {
+		throw new Error("remote runner headless connection returned no id");
+	}
+	const runtimeSessionId =
+		asTrimmedString(connectionPayload, "session_id", "sessionId") ??
+		input.sessionId;
+
+	const subscriptionPayload = await requestJson(
+		`${input.gatewayBaseUrl}/api/headless/sessions/${encodeURIComponent(runtimeSessionId)}/subscribe`,
+		{
+			method: "POST",
+			headers: createAttachHeaders({
+				tokenId: input.tokenId,
+				tokenSecret: input.tokenSecret,
+				connectionId,
+				contentType: "application/json",
+			}),
+			body: JSON.stringify({
+				connectionId,
+				protocolVersion,
+				clientInfo: clientInfo(input),
+				role: input.role,
+				takeControl: input.takeControl ?? false,
+				optOutNotifications: ["heartbeat"],
+				capabilities: attachCapabilities(input.role),
+			}),
+		},
+		input,
+		"remote runner headless subscription",
+	);
+	assertHeadlessRuntimeSubscriptionSnapshot(
+		subscriptionPayload,
+		"remote runner headless subscription",
+	);
+
+	return {
+		sessionId:
+			subscriptionPayload.snapshot.session_id?.trim() || runtimeSessionId,
+		connectionId: subscriptionPayload.connection_id,
+		subscriptionId: subscriptionPayload.subscription_id,
+		heartbeatIntervalMs: subscriptionPayload.heartbeat_interval_ms,
+		role: subscriptionPayload.role,
+		state: normalizeState(subscriptionPayload.snapshot.state),
+	};
+}
+
+export function shouldUseInteractiveRemoteAttach(input: {
+	json: boolean;
+	printEnv: boolean;
+	stdinIsTTY: boolean;
+	stdoutIsTTY: boolean;
+}): boolean {
+	return (
+		!input.json && !input.printEnv && input.stdinIsTTY && input.stdoutIsTTY
+	);
+}
+
+class UpdateSignal {
+	private version = 0;
+	private waiter: ((value: number) => void) | null = null;
+
+	current(): number {
+		return this.version;
+	}
+
+	notify(): void {
+		this.version += 1;
+		const waiter = this.waiter;
+		this.waiter = null;
+		waiter?.(this.version);
+	}
+
+	waitForChange(previous: number): Promise<number> {
+		if (this.version !== previous) {
+			return Promise.resolve(this.version);
+		}
+		return new Promise((resolve) => {
+			this.waiter = resolve;
+		});
+	}
+}
+
+function formatRequestLabel(request: HeadlessPendingApprovalState): string {
+	return (
+		request.display_name ??
+		request.summary_label ??
+		request.action_description ??
+		request.tool
+	);
+}
+
+function summarizeArgs(args: unknown): string | undefined {
+	if (args === undefined) {
+		return undefined;
+	}
+	const serialized = JSON.stringify(args, null, 2);
+	if (!serialized) {
+		return undefined;
+	}
+	if (serialized.length <= 400) {
+		return serialized;
+	}
+	return `${serialized.slice(0, 397)}...`;
+}
+
+function pendingRequest(
+	state: HeadlessRuntimeState,
+): {
+	kind: "approval" | "user_input" | "tool_retry";
+	request: HeadlessPendingApprovalState;
+} | null {
+	if (state.pending_approvals.length > 0) {
+		return { kind: "approval", request: state.pending_approvals[0]! };
+	}
+	if (state.pending_user_inputs.length > 0) {
+		return { kind: "user_input", request: state.pending_user_inputs[0]! };
+	}
+	if (state.pending_tool_retries.length > 0) {
+		return { kind: "tool_retry", request: state.pending_tool_retries[0]! };
+	}
+	return null;
+}
+
+function clearPromptLine(stdout: Writable & { isTTY?: boolean }): void {
+	if (!stdout.isTTY) {
+		return;
+	}
+	clearLine(stdout, 0);
+	cursorTo(stdout, 0);
+}
+
+export async function attachToRemoteRunnerSession(
+	input: RemoteRunnerAttachInput,
+): Promise<void> {
+	const stdout =
+		(input.stdout as (Writable & { isTTY?: boolean }) | undefined) ??
+		(process.stdout as Writable & { isTTY?: boolean });
+	const stderr =
+		(input.stderr as (Writable & { isTTY?: boolean }) | undefined) ??
+		(process.stderr as Writable & { isTTY?: boolean });
+	const stdin =
+		(input.stdin as Readable | undefined) ?? (process.stdin as Readable);
+	const rl = createInterface({
+		input: stdin,
+		output: stdout,
+		terminal: Boolean(
+			(stdin as Readable & { isTTY?: boolean }).isTTY && stdout.isTTY,
+		),
+	});
+
+	let state = createHeadlessRuntimeState();
+	const updates = new UpdateSignal();
+	let closeRequested = false;
+	let streamError: Error | null = null;
+	let visibleResponseOpen = false;
+	let responseEndsWithNewline = true;
+
+	const ensureAssistantBreak = () => {
+		if (visibleResponseOpen && !responseEndsWithNewline) {
+			stdout.write("\n");
+			responseEndsWithNewline = true;
+		}
+	};
+
+	const writeLine = (message = "") => {
+		ensureAssistantBreak();
+		clearPromptLine(stdout);
+		stdout.write(`${message}\n`);
+	};
+
+	const beginAssistantOutput = () => {
+		if (!visibleResponseOpen) {
+			clearPromptLine(stdout);
+			stdout.write(chalk.bold("assistant> "));
+			visibleResponseOpen = true;
+			responseEndsWithNewline = false;
+		}
+	};
+
+	const printAssistantChunk = (content: string) => {
+		if (!content) {
+			return;
+		}
+		beginAssistantOutput();
+		stdout.write(content);
+		responseEndsWithNewline = content.endsWith("\n");
+	};
+
+	const printStatus = () => {
+		writeLine(chalk.bold(`Remote session ${input.sessionId}`));
+		writeLine(`  role: ${input.role}`);
+		writeLine(`  ready: ${state.is_ready ? "yes" : "no"}`);
+		writeLine(`  responding: ${state.is_responding ? "yes" : "no"}`);
+		writeLine(`  model: ${state.model ?? "-"}`);
+		writeLine(`  provider: ${state.provider ?? "-"}`);
+		writeLine(`  cwd: ${state.cwd ?? "-"}`);
+		writeLine(`  git: ${state.git_branch ?? "-"}`);
+		writeLine(`  approvals: ${state.pending_approvals.length}`);
+		writeLine(`  user input: ${state.pending_user_inputs.length}`);
+		writeLine(`  tool retries: ${state.pending_tool_retries.length}`);
+		writeLine(`  active tools: ${state.active_tools.length}`);
+	};
+
+	const connection = await connectToRemoteRunnerSession(input);
+	state = connection.state;
+	writeLine(
+		chalk.bold(
+			`Attached to ${connection.sessionId} as ${connection.role === "viewer" ? "viewer" : "controller"}`,
+		),
+	);
+	if (connection.role === "controller") {
+		writeLine(
+			chalk.dim(
+				"Enter a prompt below. Use /status, /help, or /exit. Press Ctrl+C to interrupt an active response.",
+			),
+		);
+	} else {
+		writeLine(chalk.dim("Viewer mode is read-only. Use /status or /exit."));
+	}
+
+	const attachContext = {
+		gatewayBaseUrl: input.gatewayBaseUrl,
+		tokenId: input.tokenId,
+		tokenSecret: input.tokenSecret,
+		timeoutMs: input.timeoutMs,
+		fetchImpl: input.fetchImpl,
+		sessionId: connection.sessionId,
+		connectionId: connection.connectionId,
+		subscriptionId: connection.subscriptionId,
+	};
+
+	const streamAbort = new AbortController();
+	const streamPromise = streamAttachEvents(
+		attachContext,
+		{
+			onMessage: (message) => {
+				applyIncomingHeadlessMessage(state, message);
+				switch (message.type) {
+					case "response_start":
+						visibleResponseOpen = false;
+						responseEndsWithNewline = true;
+						break;
+					case "response_chunk":
+						if (!message.is_thinking) {
+							printAssistantChunk(message.content);
+						}
+						break;
+					case "response_end":
+						ensureAssistantBreak();
+						visibleResponseOpen = false;
+						break;
+					case "status":
+						writeLine(chalk.dim(message.message));
+						break;
+					case "error":
+						writeLine(chalk.red(message.message));
+						break;
+					case "compaction":
+						writeLine(
+							chalk.dim(`Compacted remote history: ${message.summary}`),
+						);
+						break;
+					default:
+						break;
+				}
+				updates.notify();
+			},
+			onReset: (snapshotState) => {
+				state = snapshotState;
+				writeLine(chalk.dim("Remote session state resynced from snapshot."));
+				updates.notify();
+			},
+		},
+		streamAbort.signal,
+	).catch((error) => {
+		if (!streamAbort.signal.aborted) {
+			streamError = error instanceof Error ? error : new Error(String(error));
+			updates.notify();
+		}
+	});
+
+	const heartbeatTimer = setInterval(
+		() => {
+			if (closeRequested) {
+				return;
+			}
+			void heartbeatAttachConnection(attachContext).catch((error) => {
+				streamError = error instanceof Error ? error : new Error(String(error));
+				updates.notify();
+			});
+		},
+		Math.max(1_000, Math.floor(connection.heartbeatIntervalMs / 2)),
+	);
+	heartbeatTimer.unref();
+
+	const sendInteractiveMessage = async (message: HeadlessToAgentMessage) => {
+		await sendHeadlessMessage(attachContext, message);
+		applyOutgoingHeadlessMessage(state, message);
+		updates.notify();
+	};
+
+	const handleCommand = async (line: string): Promise<boolean> => {
+		switch (line.trim()) {
+			case "/help":
+				writeLine("Commands: /status, /interrupt, /exit");
+				return true;
+			case "/status":
+				printStatus();
+				return true;
+			case "/interrupt":
+				if (connection.role !== "controller") {
+					writeLine(chalk.yellow("Viewer mode cannot interrupt the session."));
+					return true;
+				}
+				if (!state.is_responding) {
+					writeLine(chalk.dim("No active response to interrupt."));
+					return true;
+				}
+				await sendInteractiveMessage({ type: "interrupt" });
+				writeLine(chalk.dim("Interrupt sent."));
+				return true;
+			case "/exit":
+			case "/quit":
+				closeRequested = true;
+				updates.notify();
+				return true;
+			default:
+				if (line.startsWith("/")) {
+					writeLine(chalk.yellow(`Unknown command: ${line}`));
+					return true;
+				}
+				return false;
+		}
+	};
+
+	const handleApproval = async (request: HeadlessPendingApprovalState) => {
+		writeLine(
+			chalk.yellow(`Approval required: ${formatRequestLabel(request)}`),
+		);
+		const summary = summarizeArgs(request.args);
+		if (summary) {
+			writeLine(chalk.dim(summary));
+		}
+		while (!closeRequested) {
+			const answer = (await rl.question("Approve? [y/N]: ")).trim();
+			if (await handleCommand(answer)) {
+				continue;
+			}
+			const approved = /^(y|yes)$/iu.test(answer);
+			if (request.request_id) {
+				await sendInteractiveMessage({
+					type: "server_request_response",
+					request_id: request.request_id,
+					request_type: "approval",
+					approved,
+					result: approved
+						? {
+								success: true,
+								output: "Approved by remote attach client",
+							}
+						: {
+								success: false,
+								output: "",
+								error: "Denied by remote attach client",
+							},
+				});
+			} else {
+				await sendInteractiveMessage({
+					type: "tool_response",
+					call_id: request.call_id,
+					approved,
+					result: approved
+						? {
+								success: true,
+								output: "Approved by remote attach client",
+							}
+						: {
+								success: false,
+								output: "",
+								error: "Denied by remote attach client",
+							},
+				});
+			}
+			return;
+		}
+	};
+
+	const handleUserInput = async (request: HeadlessPendingApprovalState) => {
+		writeLine(chalk.yellow(`Input requested: ${formatRequestLabel(request)}`));
+		const summary = summarizeArgs(request.args);
+		if (summary) {
+			writeLine(chalk.dim(summary));
+		}
+		while (!closeRequested) {
+			const answer = await rl.question("Reply: ");
+			if (await handleCommand(answer.trim())) {
+				continue;
+			}
+			if (request.request_id) {
+				await sendInteractiveMessage({
+					type: "server_request_response",
+					request_id: request.request_id,
+					request_type: "user_input",
+					content: [{ type: "text", text: answer }],
+					is_error: false,
+				});
+			} else {
+				await sendInteractiveMessage({
+					type: "client_tool_result",
+					call_id: request.call_id,
+					content: [{ type: "text", text: answer }],
+					is_error: false,
+				});
+			}
+			return;
+		}
+	};
+
+	const handleToolRetry = async (request: HeadlessPendingApprovalState) => {
+		writeLine(
+			chalk.yellow(`Tool retry requested: ${formatRequestLabel(request)}`),
+		);
+		const summary = summarizeArgs(request.args);
+		if (summary) {
+			writeLine(chalk.dim(summary));
+		}
+		while (!closeRequested) {
+			const answer = (await rl.question("Decision [retry/skip/abort]: "))
+				.trim()
+				.toLowerCase();
+			if (await handleCommand(answer)) {
+				continue;
+			}
+			if (!["retry", "skip", "abort"].includes(answer)) {
+				writeLine(chalk.yellow("Enter retry, skip, or abort."));
+				continue;
+			}
+			await sendInteractiveMessage({
+				type: "server_request_response",
+				request_id: request.request_id ?? request.call_id,
+				request_type: "tool_retry",
+				decision_action: answer as "retry" | "skip" | "abort",
+			});
+			return;
+		}
+	};
+
+	const sigintHandler = () => {
+		if (
+			connection.role === "controller" &&
+			state.is_responding &&
+			!closeRequested
+		) {
+			void sendInteractiveMessage({ type: "interrupt" }).catch((error) => {
+				streamError = error instanceof Error ? error : new Error(String(error));
+				updates.notify();
+			});
+			writeLine(chalk.dim("Interrupt sent."));
+			return;
+		}
+		closeRequested = true;
+		updates.notify();
+	};
+
+	rl.on("SIGINT", sigintHandler);
+
+	try {
+		let version = updates.current();
+		while (!closeRequested) {
+			if (streamError) {
+				throw streamError;
+			}
+
+			if (connection.role === "controller") {
+				const next = pendingRequest(state);
+				if (next) {
+					switch (next.kind) {
+						case "approval":
+							await handleApproval(next.request);
+							break;
+						case "user_input":
+							await handleUserInput(next.request);
+							break;
+						case "tool_retry":
+							await handleToolRetry(next.request);
+							break;
+					}
+					version = updates.current();
+					continue;
+				}
+			}
+
+			if (state.is_responding || !state.is_ready) {
+				version = await updates.waitForChange(version);
+				continue;
+			}
+
+			const prompt = connection.role === "controller" ? "remote> " : "viewer> ";
+			const line = await rl.question(prompt);
+			if (await handleCommand(line.trim())) {
+				version = updates.current();
+				continue;
+			}
+			if (connection.role !== "controller") {
+				writeLine(chalk.yellow("Viewer mode is read-only."));
+				version = updates.current();
+				continue;
+			}
+			if (!line.trim()) {
+				version = updates.current();
+				continue;
+			}
+			await sendInteractiveMessage({
+				type: "prompt",
+				content: line,
+			});
+			version = updates.current();
+		}
+	} finally {
+		clearInterval(heartbeatTimer);
+		streamAbort.abort();
+		rl.close();
+		try {
+			await disconnectAttachConnection(attachContext);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			stderr.write(`${message}\n`);
+		}
+		await streamPromise.catch(() => undefined);
+	}
+}

--- a/src/remote-runner/client.ts
+++ b/src/remote-runner/client.ts
@@ -18,6 +18,8 @@ import { fetchDownstream } from "../utils/downstream-http.js";
 export const DEFAULT_REMOTE_RUNNER_BASE_URL = "https://runner.evalops.dev";
 const DEFAULT_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_ATTEMPTS = 2;
+export const DEFAULT_REMOTE_RUNNER_WAIT_TIMEOUT_MS = 5 * 60 * 1000;
+export const DEFAULT_REMOTE_RUNNER_WAIT_POLL_INTERVAL_MS = 5_000;
 
 const CREATE_RUNNER_SESSION_PATH = platformConnectMethodPath(
 	PLATFORM_CONNECT_METHODS.remoteRunner.createRunnerSession,
@@ -243,6 +245,34 @@ export interface RemoteRunnerStatus {
 	service?: string;
 	workspaceId?: string;
 	downstreamPolicy?: string;
+}
+
+export interface WaitForRunnerSessionReadyOptions
+	extends RemoteRunnerClientOptions {
+	timeoutMs?: number;
+	pollIntervalMs?: number;
+}
+
+export class WaitForRunnerSessionReadyError extends Error {
+	readonly code: "timeout" | "terminal_state";
+	readonly elapsedMs: number;
+	readonly attempts: number;
+	readonly session?: RunnerSession;
+
+	constructor(input: {
+		message: string;
+		code: "timeout" | "terminal_state";
+		elapsedMs: number;
+		attempts: number;
+		session?: RunnerSession;
+	}) {
+		super(input.message);
+		this.name = "WaitForRunnerSessionReadyError";
+		this.code = input.code;
+		this.elapsedMs = input.elapsedMs;
+		this.attempts = input.attempts;
+		this.session = input.session;
+	}
 }
 
 function firstString(
@@ -500,6 +530,35 @@ function normalizeState(
 		throw new Error(`Unknown runner session state: ${state}`);
 	}
 	return matched;
+}
+
+function stateMatches(
+	state: RunnerSessionState | string | undefined,
+	expected: readonly RunnerSessionState[],
+): boolean {
+	if (!state) {
+		return false;
+	}
+	try {
+		return expected.includes(normalizeState(state));
+	} catch {
+		return false;
+	}
+}
+
+function describeState(state: RunnerSessionState | string | undefined): string {
+	return (
+		state
+			?.replace(/^RUNNER_SESSION_STATE_/u, "")
+			.toLowerCase()
+			.replaceAll("_", "-") ?? "unknown"
+	);
+}
+
+function waitDelay(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
 }
 
 function normalizeConfig(
@@ -869,6 +928,83 @@ export async function getRemoteRunnerStatus(
 			),
 		}),
 	);
+}
+
+export async function waitForRunnerSessionReady(
+	sessionId: string,
+	options: WaitForRunnerSessionReadyOptions = {},
+): Promise<{
+	session: RunnerSession;
+	attempts: number;
+	elapsedMs: number;
+}> {
+	const timeoutMs = options.timeoutMs ?? DEFAULT_REMOTE_RUNNER_WAIT_TIMEOUT_MS;
+	const pollIntervalMs =
+		options.pollIntervalMs ?? DEFAULT_REMOTE_RUNNER_WAIT_POLL_INTERVAL_MS;
+	if (!Number.isFinite(timeoutMs) || timeoutMs < 1) {
+		throw new Error("Remote runner wait timeout must be at least 1ms");
+	}
+	if (!Number.isFinite(pollIntervalMs) || pollIntervalMs < 0) {
+		throw new Error("Remote runner poll interval must be 0ms or greater");
+	}
+
+	const readyStates = [
+		RUNNER_SESSION_STATES.RUNNING,
+		RUNNER_SESSION_STATES.IDLE,
+	] as const;
+	const terminalStates = [
+		RUNNER_SESSION_STATES.STOPPED,
+		RUNNER_SESSION_STATES.EXPIRED,
+		RUNNER_SESSION_STATES.FAILED,
+		RUNNER_SESSION_STATES.LOST,
+	] as const;
+
+	const startedAt = Date.now();
+	let attempts = 0;
+	let lastSession: RunnerSession | undefined;
+
+	while (true) {
+		attempts += 1;
+		lastSession = await getRunnerSession(sessionId, options);
+		const elapsedMs = Date.now() - startedAt;
+
+		if (stateMatches(lastSession.state, readyStates)) {
+			return {
+				session: lastSession,
+				attempts,
+				elapsedMs,
+			};
+		}
+
+		if (stateMatches(lastSession.state, terminalStates)) {
+			const stopReason = lastSession.stopReason?.trim();
+			throw new WaitForRunnerSessionReadyError({
+				message: stopReason
+					? `Remote runner session ${sessionId} entered terminal state ${describeState(lastSession.state)}: ${stopReason}`
+					: `Remote runner session ${sessionId} entered terminal state ${describeState(lastSession.state)}`,
+				code: "terminal_state",
+				elapsedMs,
+				attempts,
+				session: lastSession,
+			});
+		}
+
+		if (elapsedMs >= timeoutMs) {
+			throw new WaitForRunnerSessionReadyError({
+				message: `Timed out after ${timeoutMs}ms waiting for remote runner session ${sessionId} to become ready (last state: ${describeState(lastSession.state)})`,
+				code: "timeout",
+				elapsedMs,
+				attempts,
+				session: lastSession,
+			});
+		}
+
+		const remainingMs = timeoutMs - elapsedMs;
+		const sleepMs = Math.min(pollIntervalMs, remainingMs);
+		if (sleepMs > 0) {
+			await waitDelay(sleepMs);
+		}
+	}
 }
 
 export async function verifyRunnerHeadlessAttach(input: {

--- a/test/cli/remote-command.test.ts
+++ b/test/cli/remote-command.test.ts
@@ -1,7 +1,59 @@
-import { describe, expect, it } from "vitest";
-import { parseRemoteDurationMinutes } from "../../src/cli/commands/remote.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/remote-runner/client.js", async () => {
+	const actual = await vi.importActual<
+		typeof import("../../src/remote-runner/client.js")
+	>("../../src/remote-runner/client.js");
+	return {
+		...actual,
+		createRunnerSession: vi.fn(),
+		waitForRunnerSessionReady: vi.fn(),
+		mintRunnerAttachToken: vi.fn(),
+		verifyRunnerHeadlessAttach: vi.fn(),
+	};
+});
+
+vi.mock("../../src/remote-runner/attach-client.js", () => ({
+	attachToRemoteRunnerSession: vi.fn(),
+	shouldUseInteractiveRemoteAttach: vi.fn(),
+}));
+
+import {
+	handleRemoteCommand,
+	parseRemoteDurationMinutes,
+} from "../../src/cli/commands/remote.js";
+import {
+	attachToRemoteRunnerSession,
+	shouldUseInteractiveRemoteAttach,
+} from "../../src/remote-runner/attach-client.js";
+import {
+	RUNNER_SESSION_STATES,
+	createRunnerSession,
+	mintRunnerAttachToken,
+	verifyRunnerHeadlessAttach,
+	waitForRunnerSessionReady,
+} from "../../src/remote-runner/client.js";
 
 describe("remote command helpers", () => {
+	const stdinTty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+	const stdoutTty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(shouldUseInteractiveRemoteAttach).mockReturnValue(false);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		process.exitCode = undefined;
+		if (stdinTty) {
+			Object.defineProperty(process.stdin, "isTTY", stdinTty);
+		}
+		if (stdoutTty) {
+			Object.defineProperty(process.stdout, "isTTY", stdoutTty);
+		}
+	});
+
 	it("parses runner TTL values as whole minutes", () => {
 		expect(parseRemoteDurationMinutes("90m", 1)).toBe(90);
 		expect(parseRemoteDurationMinutes("2h", 1)).toBe(120);
@@ -15,6 +67,171 @@ describe("remote command helpers", () => {
 		);
 		expect(() => parseRemoteDurationMinutes("soon", 1)).toThrow(
 			"Invalid duration",
+		);
+	});
+
+	it("waits for readiness and verifies attach during remote start", async () => {
+		vi.mocked(shouldUseInteractiveRemoteAttach).mockReturnValue(false);
+		vi.mocked(createRunnerSession).mockResolvedValue({
+			session: {
+				id: "mrs_start_1",
+				workspaceId: "ws_evalops",
+				state: RUNNER_SESSION_STATES.REQUESTED,
+				runnerProfile: "standard",
+				repoUrl: "evalops/foo",
+				branch: "main",
+			},
+			events: [],
+			replayed: false,
+		});
+		vi.mocked(waitForRunnerSessionReady).mockResolvedValue({
+			session: {
+				id: "mrs_start_1",
+				workspaceId: "ws_evalops",
+				state: RUNNER_SESSION_STATES.RUNNING,
+				runnerProfile: "standard",
+				repoUrl: "evalops/foo",
+				branch: "main",
+			},
+			attempts: 2,
+			elapsedMs: 8_000,
+		});
+		vi.mocked(mintRunnerAttachToken).mockResolvedValue({
+			token: {
+				id: "rat_start_1",
+				sessionId: "mrs_start_1",
+				expiresAt: "2026-04-23T20:00:00Z",
+			},
+			tokenSecret: "runner-secret",
+			gatewayBaseUrl:
+				"https://runner.test/v1/runner-sessions/mrs_start_1/headless",
+		});
+		vi.mocked(verifyRunnerHeadlessAttach).mockResolvedValue({
+			sessionId: "sess_runtime_1",
+			connectionId: "conn_1",
+			heartbeatIntervalMs: 30_000,
+			role: "controller",
+		});
+
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+		const errorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+
+		await handleRemoteCommand("start", [
+			"--workspace",
+			"ws_evalops",
+			"--repo",
+			"evalops/foo",
+			"--branch",
+			"main",
+			"--wait",
+			"--wait-timeout",
+			"2m",
+			"--poll-interval",
+			"5s",
+			"--verify",
+			"--show-secret",
+		]);
+
+		expect(errorSpy).not.toHaveBeenCalled();
+		expect(waitForRunnerSessionReady).toHaveBeenCalledWith(
+			"mrs_start_1",
+			expect.objectContaining({
+				workspaceId: "ws_evalops",
+				timeoutMs: 120_000,
+				pollIntervalMs: 5_000,
+			}),
+		);
+		expect(mintRunnerAttachToken).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId: "mrs_start_1",
+				ttlMinutes: 30,
+			}),
+			expect.objectContaining({
+				workspaceId: "ws_evalops",
+			}),
+		);
+		expect(verifyRunnerHeadlessAttach).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId: "mrs_start_1",
+			}),
+		);
+		expect(logSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Remote runner attach token minted"),
+		);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("launches the live attach client for interactive TTY sessions", async () => {
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: true,
+			configurable: true,
+		});
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: true,
+			configurable: true,
+		});
+		vi.mocked(shouldUseInteractiveRemoteAttach).mockReturnValue(true);
+		vi.mocked(mintRunnerAttachToken).mockResolvedValue({
+			token: {
+				id: "rat_attach_1",
+				sessionId: "mrs_attach_1",
+				expiresAt: "2026-04-23T20:00:00Z",
+			},
+			tokenSecret: "runner-secret",
+			gatewayBaseUrl:
+				"https://runner.test/v1/runner-sessions/mrs_attach_1/headless",
+		});
+
+		await handleRemoteCommand("attach", ["mrs_attach_1"]);
+
+		expect(shouldUseInteractiveRemoteAttach).toHaveBeenCalledWith({
+			json: false,
+			printEnv: false,
+			stdinIsTTY: true,
+			stdoutIsTTY: true,
+		});
+		expect(attachToRemoteRunnerSession).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sessionId: "mrs_attach_1",
+				gatewayBaseUrl:
+					"https://runner.test/v1/runner-sessions/mrs_attach_1/headless",
+				tokenId: "rat_attach_1",
+				tokenSecret: "runner-secret",
+				role: "controller",
+			}),
+		);
+		expect(verifyRunnerHeadlessAttach).not.toHaveBeenCalled();
+	});
+
+	it("keeps the env handoff path for non-interactive attach", async () => {
+		Object.defineProperty(process.stdin, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+		vi.mocked(shouldUseInteractiveRemoteAttach).mockReturnValue(false);
+		vi.mocked(mintRunnerAttachToken).mockResolvedValue({
+			token: {
+				id: "rat_attach_2",
+				sessionId: "mrs_attach_2",
+				expiresAt: "2026-04-23T20:00:00Z",
+			},
+			tokenSecret: "runner-secret-2",
+			gatewayBaseUrl:
+				"https://runner.test/v1/runner-sessions/mrs_attach_2/headless",
+		});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		await handleRemoteCommand("attach", ["mrs_attach_2"]);
+
+		expect(attachToRemoteRunnerSession).not.toHaveBeenCalled();
+		expect(logSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Remote runner attach token minted"),
 		);
 	});
 });

--- a/test/remote-runner/attach-client.test.ts
+++ b/test/remote-runner/attach-client.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHeadlessRuntimeState } from "../../src/cli/headless-protocol.js";
+import {
+	connectToRemoteRunnerSession,
+	shouldUseInteractiveRemoteAttach,
+} from "../../src/remote-runner/attach-client.js";
+
+type CapturedRequest = {
+	body?: Record<string, unknown>;
+	headers: Record<string, string>;
+	method?: string;
+	pathname: string;
+	url: string;
+};
+
+function headersToRecord(
+	headers: HeadersInit | undefined,
+): Record<string, string> {
+	return Object.fromEntries(new Headers(headers).entries());
+}
+
+function parseRequestBody(
+	body: BodyInit | null | undefined,
+): Record<string, unknown> | undefined {
+	return typeof body === "string"
+		? (JSON.parse(body) as Record<string, unknown>)
+		: undefined;
+}
+
+describe("remote runner attach client", () => {
+	let requests: CapturedRequest[];
+
+	beforeEach(() => {
+		requests = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+
+				if (parsed.pathname.endsWith("/api/headless/connections")) {
+					return new Response(
+						JSON.stringify({
+							session_id: "sess_runtime_1",
+							connection_id: "conn_1",
+							heartbeat_interval_ms: 30000,
+							role: "controller",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (parsed.pathname.endsWith("/subscribe")) {
+					return new Response(
+						JSON.stringify({
+							connection_id: "conn_1",
+							subscription_id: "sub_1",
+							role: requests[0]?.body?.role ?? "controller",
+							controller_lease_granted: true,
+							controller_subscription_id: "sub_1",
+							controller_connection_id: "conn_1",
+							lease_expires_at: "2026-04-23T20:00:00Z",
+							heartbeat_interval_ms: 30000,
+							snapshot: {
+								protocolVersion: "2026-04-02",
+								session_id: "sess_runtime_1",
+								cursor: 0,
+								last_init: null,
+								state: createHeadlessRuntimeState(),
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				throw new Error(`Unexpected attach-client request: ${url}`);
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("creates a controller connection and explicit subscription", async () => {
+		await expect(
+			connectToRemoteRunnerSession({
+				gatewayBaseUrl:
+					"https://runner.test/v1/runner-sessions/mrs_attach_1/headless",
+				sessionId: "mrs_attach_1",
+				tokenId: "rat_1",
+				tokenSecret: "runner-secret",
+				role: "controller",
+				clientVersion: "0.10.8",
+			}),
+		).resolves.toMatchObject({
+			sessionId: "sess_runtime_1",
+			connectionId: "conn_1",
+			subscriptionId: "sub_1",
+			heartbeatIntervalMs: 30000,
+			role: "controller",
+		});
+
+		expect(requests[0]).toMatchObject({
+			method: "POST",
+			url: "https://runner.test/v1/runner-sessions/mrs_attach_1/headless/api/headless/connections",
+			headers: expect.objectContaining({
+				authorization: "Bearer runner-secret",
+				"x-evalops-runner-attach-token-id": "rat_1",
+			}),
+			body: expect.objectContaining({
+				sessionId: "mrs_attach_1",
+				role: "controller",
+				optOutNotifications: ["heartbeat"],
+				capabilities: {
+					serverRequests: ["approval", "user_input", "tool_retry"],
+				},
+			}),
+		});
+		expect(requests[1]).toMatchObject({
+			method: "POST",
+			url: "https://runner.test/v1/runner-sessions/mrs_attach_1/headless/api/headless/sessions/sess_runtime_1/subscribe",
+			headers: expect.objectContaining({
+				authorization: "Bearer runner-secret",
+				"x-evalops-runner-attach-token-id": "rat_1",
+				"x-maestro-headless-connection-id": "conn_1",
+			}),
+			body: expect.objectContaining({
+				connectionId: "conn_1",
+				role: "controller",
+			}),
+		});
+	});
+
+	it("keeps viewer attach capabilities read-only", async () => {
+		await connectToRemoteRunnerSession({
+			gatewayBaseUrl:
+				"https://runner.test/v1/runner-sessions/mrs_attach_2/headless",
+			sessionId: "mrs_attach_2",
+			tokenId: "rat_2",
+			tokenSecret: "runner-secret-2",
+			role: "viewer",
+		});
+
+		expect(requests[0]?.body?.capabilities).toBeUndefined();
+		expect(requests[1]?.body?.capabilities).toBeUndefined();
+	});
+
+	it("only uses the live attach client for interactive tty sessions", () => {
+		expect(
+			shouldUseInteractiveRemoteAttach({
+				json: false,
+				printEnv: false,
+				stdinIsTTY: true,
+				stdoutIsTTY: true,
+			}),
+		).toBe(true);
+		expect(
+			shouldUseInteractiveRemoteAttach({
+				json: true,
+				printEnv: false,
+				stdinIsTTY: true,
+				stdoutIsTTY: true,
+			}),
+		).toBe(false);
+		expect(
+			shouldUseInteractiveRemoteAttach({
+				json: false,
+				printEnv: true,
+				stdinIsTTY: true,
+				stdoutIsTTY: true,
+			}),
+		).toBe(false);
+	});
+});

--- a/test/remote-runner/client.test.ts
+++ b/test/remote-runner/client.test.ts
@@ -6,6 +6,7 @@ import {
 	listRunnerSessions,
 	mintRunnerAttachToken,
 	verifyRunnerHeadlessAttach,
+	waitForRunnerSessionReady,
 } from "../../src/remote-runner/client.js";
 
 type CapturedRequest = {
@@ -32,9 +33,11 @@ function parseRequestBody(
 
 describe("remote runner client", () => {
 	let requests: CapturedRequest[];
+	let getRunnerSessionResponses: Array<Record<string, unknown>>;
 
 	beforeEach(() => {
 		requests = [];
+		getRunnerSessionResponses = [];
 		for (const name of [
 			"MAESTRO_REMOTE_RUNNER_URL",
 			"REMOTE_RUNNER_SERVICE_URL",
@@ -75,6 +78,25 @@ describe("remote runner client", () => {
 					url,
 				};
 				requests.push(request);
+
+				if (
+					parsed.pathname ===
+					"/remoterunner.v1.RemoteRunnerService/GetRunnerSession"
+				) {
+					const next =
+						getRunnerSessionResponses.shift() ??
+						({
+							session: {
+								id: request.body?.sessionId ?? "mrs_get_1",
+								workspaceId: "ws_evalops",
+								state: RUNNER_SESSION_STATES.RUNNING,
+							},
+						} satisfies Record<string, unknown>);
+					return new Response(JSON.stringify(next), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
 
 				if (
 					parsed.pathname ===
@@ -165,6 +187,7 @@ describe("remote runner client", () => {
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.unstubAllEnvs();
 		vi.unstubAllGlobals();
 	});
@@ -296,5 +319,95 @@ describe("remote runner client", () => {
 				role: "controller",
 			}),
 		});
+	});
+
+	it("waits for runner sessions to become ready", async () => {
+		getRunnerSessionResponses.push(
+			{
+				session: {
+					id: "mrs_wait_1",
+					workspaceId: "ws_evalops",
+					state: RUNNER_SESSION_STATES.REQUESTED,
+				},
+			},
+			{
+				session: {
+					id: "mrs_wait_1",
+					workspaceId: "ws_evalops",
+					state: RUNNER_SESSION_STATES.PROVISIONING,
+				},
+			},
+			{
+				session: {
+					id: "mrs_wait_1",
+					workspaceId: "ws_evalops",
+					state: RUNNER_SESSION_STATES.RUNNING,
+				},
+			},
+		);
+
+		await expect(
+			waitForRunnerSessionReady("mrs_wait_1", {
+				pollIntervalMs: 0,
+				timeoutMs: 10_000,
+			}),
+		).resolves.toMatchObject({
+			session: {
+				id: "mrs_wait_1",
+				state: RUNNER_SESSION_STATES.RUNNING,
+			},
+			attempts: 3,
+		});
+	});
+
+	it("fails fast when the runner session enters a terminal state", async () => {
+		getRunnerSessionResponses.push({
+			session: {
+				id: "mrs_wait_failed",
+				workspaceId: "ws_evalops",
+				state: RUNNER_SESSION_STATES.FAILED,
+				stopReason: "image pull backoff",
+			},
+		});
+
+		await expect(
+			waitForRunnerSessionReady("mrs_wait_failed", {
+				pollIntervalMs: 0,
+				timeoutMs: 10_000,
+			}),
+		).rejects.toThrow(
+			"Remote runner session mrs_wait_failed entered terminal state failed: image pull backoff",
+		);
+	});
+
+	it("times out when the runner session never becomes ready", async () => {
+		vi.useFakeTimers();
+		getRunnerSessionResponses.push(
+			{
+				session: {
+					id: "mrs_wait_timeout",
+					workspaceId: "ws_evalops",
+					state: RUNNER_SESSION_STATES.REQUESTED,
+				},
+			},
+			{
+				session: {
+					id: "mrs_wait_timeout",
+					workspaceId: "ws_evalops",
+					state: RUNNER_SESSION_STATES.REQUESTED,
+				},
+			},
+		);
+
+		const waitPromise = waitForRunnerSessionReady("mrs_wait_timeout", {
+			pollIntervalMs: 5,
+			timeoutMs: 5,
+		});
+		const assertion = expect(waitPromise).rejects.toThrow(
+			"Timed out after 5ms waiting for remote runner session mrs_wait_timeout to become ready",
+		);
+		await vi.advanceTimersByTimeAsync(5);
+		await assertion;
+		vi.useRealTimers();
 	});
 });


### PR DESCRIPTION
## Summary
- add the remote-runner readiness wait helpers and wire `maestro remote start --wait/--verify` into a real hosted-session bring-up path
- add an interactive `maestro remote attach` client that opens a live headless session instead of only printing env handoff details
- cover the new wait/verify and attach flows with focused remote-runner and CLI tests

Closes #124

## Validation
- `npm test -- test/remote-runner/client.test.ts test/remote-runner/attach-client.test.ts test/cli/remote-command.test.ts`
- `bunx biome check src/cli/commands/remote.ts src/cli/help.ts src/remote-runner/client.ts src/remote-runner/attach-client.ts test/cli/remote-command.test.ts test/remote-runner/client.test.ts test/remote-runner/attach-client.test.ts`
- `git diff --check`

## Notes
- `npm run build` in this worktree still hits unrelated pre-existing dependency/type issues in `src/auth/totp.ts`, `src/telemetry/maestro-event-bus.ts`, and `src/utils/document-extractor.ts`; the changed remote-runner files were validated with the focused test/lint pass above.