### PR TITLE
[maestro] fix remote attach formatting

### DIFF
--- a/src/remote-runner/attach-client.ts
+++ b/src/remote-runner/attach-client.ts
@@ -500,9 +500,7 @@ function summarizeArgs(args: unknown): string | undefined {
 	return `${serialized.slice(0, 397)}...`;
 }
 
-function pendingRequest(
-	state: HeadlessRuntimeState,
-): {
+function pendingRequest(state: HeadlessRuntimeState): {
 	kind: "approval" | "user_input" | "tool_retry";
 	request: HeadlessPendingApprovalState;
 } | null {


### PR DESCRIPTION
## Summary
- fix the remaining Biome formatting failure in `src/remote-runner/attach-client.ts` after evalops/maestro#127 merged
- keep the change scoped to the `pendingRequest(...)` signature that `pr-checks` flagged

Follow-up to #127.

## Validation
- `bunx biome check src/remote-runner/attach-client.ts`
- `npm test -- test/remote-runner/client.test.ts test/remote-runner/attach-client.test.ts test/cli/remote-command.test.ts`
- `git diff --check`
