### PR TITLE
[maestro] surface selected skill identity in telemetry

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -1988,6 +1988,7 @@ export class Agent {
 			status: event.isError
 				? "MAESTRO_TOOL_CALL_STATUS_FAILED"
 				: "MAESTRO_TOOL_CALL_STATUS_SUCCEEDED",
+			skill_metadata: event.skillMetadata,
 			approval_request_id: event.approvalRequestId,
 			governed_outcome: event.governedOutcome,
 			error_code: event.errorCode,

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -40,6 +40,7 @@ import {
 	resolvePromptLoadedProjectDocPaths,
 } from "../config/index.js";
 import type { SessionEntry } from "../session/types.js";
+import { getSkillArtifactMetadataFromDetails } from "../skills/artifact-metadata.js";
 import { readTool } from "../tools/read.js";
 import { createLogger } from "../utils/logger.js";
 import { expandUserPath } from "../utils/path-validation.js";
@@ -1059,6 +1060,7 @@ async function collectRecentSkillRestoreMessages(
 
 		let skillName: string | null = null;
 		let content: (TextContent | ImageContent)[] | null = null;
+		let skillMetadata: ReturnType<typeof getSkillArtifactMetadataFromDetails>;
 
 		if (
 			message.role === "toolResult" &&
@@ -1070,6 +1072,7 @@ async function collectRecentSkillRestoreMessages(
 				message.content,
 				SKILL_RESTORE_MAX_TOKENS_PER_SKILL,
 			);
+			skillMetadata = getSkillArtifactMetadataFromDetails(message.details);
 		} else if (
 			message.role === "hookMessage" &&
 			message.customType === "skill" &&
@@ -1124,7 +1127,11 @@ async function collectRecentSkillRestoreMessages(
 				"skill",
 				content,
 				false,
-				{ name: skillName, source: "tool" },
+				{
+					name: skillName,
+					source: "tool",
+					skillMetadata,
+				},
 				new Date().toISOString(),
 			),
 		);

--- a/src/agent/transport.ts
+++ b/src/agent/transport.ts
@@ -68,6 +68,10 @@ import {
 	applyWorkflowStateHooks,
 	isWorkflowTrackedTool,
 } from "../safety/workflow-state.js";
+import {
+	type SkillArtifactMetadata,
+	getSkillArtifactMetadataFromDetails,
+} from "../skills/artifact-metadata.js";
 import { getOptimalConcurrency } from "../tools/parallel-execution.js";
 import { trackUsage } from "../tracking/cost-tracker.js";
 import { getTrainingHeaders } from "../training.js";
@@ -149,6 +153,14 @@ function getGovernedToolResultEventMetadata(details: unknown): {
 		errorCode,
 		approvalRequestId,
 		governedOutcome: classification,
+	};
+}
+
+function getSkillToolResultEventMetadata(details: unknown): {
+	skillMetadata?: SkillArtifactMetadata;
+} {
+	return {
+		skillMetadata: getSkillArtifactMetadataFromDetails(details),
 	};
 }
 
@@ -738,6 +750,9 @@ export class ProviderTransport implements AgentTransport {
 					const governedMetadata = getGovernedToolResultEventMetadata(
 						message.details,
 					);
+					const skillMetadata = getSkillToolResultEventMetadata(
+						message.details,
+					).skillMetadata;
 					return [
 						{ type: "message_start", message } as AgentEvent,
 						{ type: "message_end", message } as AgentEvent,
@@ -750,6 +765,7 @@ export class ProviderTransport implements AgentTransport {
 								governedMetadata.approvalRequestId,
 							errorCode: governedMetadata.errorCode,
 							governedOutcome: governedMetadata.governedOutcome,
+							skillMetadata,
 							toolName: toolCall.name,
 							result: message,
 							isError,

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -33,6 +33,7 @@
 
 import type { TSchema } from "@sinclair/typebox";
 import type { PromptMetadata } from "../prompts/types.js";
+import type { SkillArtifactMetadata } from "../skills/artifact-metadata.js";
 import type { CheckpointProfiler } from "../utils/checkpoint-profiler.js";
 import type {
 	ActionApprovalDecision,
@@ -1132,6 +1133,8 @@ export type AgentEvent =
 				| "authentication_required"
 				| "denied"
 				| "rate_limited";
+			/** Optional selected skill artifact metadata surfaced by the tool result */
+			skillMetadata?: SkillArtifactMetadata;
 			/** Name of the tool */
 			toolName: string;
 			/** Optional human-facing label for live UI */

--- a/src/cli/jsonl-writer.ts
+++ b/src/cli/jsonl-writer.ts
@@ -206,6 +206,9 @@ export function createAgentJsonlAdapter(
 					if (event.governedOutcome) {
 						data.governedOutcome = event.governedOutcome;
 					}
+					if (event.skillMetadata) {
+						data.skillMetadata = event.skillMetadata;
+					}
 					writer.emit({
 						type: "item",
 						subtype: "tool_result",

--- a/src/hooks/notification-hooks.ts
+++ b/src/hooks/notification-hooks.ts
@@ -25,6 +25,7 @@ import { join } from "node:path";
 import type { AgentEvent, AppMessage } from "../agent/types.js";
 import { PATHS } from "../config/constants.js";
 import { getTimeSinceLastUserInteraction } from "../interaction/user-interaction.js";
+import type { SkillArtifactMetadata } from "../skills/artifact-metadata.js";
 import { createLogger } from "../utils/logger.js";
 import type { SessionHookService } from "./session-integration.js";
 
@@ -51,6 +52,7 @@ export interface NotificationPayload {
 	toolErrorCode?: string;
 	approvalRequestId?: string;
 	governedOutcome?: string;
+	skillMetadata?: SkillArtifactMetadata;
 	error?: string;
 }
 
@@ -407,6 +409,7 @@ export function createNotificationFromAgentEvent(
 				toolErrorCode: event.errorCode,
 				approvalRequestId: event.approvalRequestId,
 				governedOutcome: event.governedOutcome,
+				skillMetadata: event.skillMetadata,
 			};
 
 		case "error":

--- a/src/skills/artifact-metadata.ts
+++ b/src/skills/artifact-metadata.ts
@@ -1,0 +1,120 @@
+import { createHash } from "node:crypto";
+import type { LoadedSkill } from "./loader.js";
+
+export type SkillArtifactSource = LoadedSkill["sourceType"];
+
+export interface SkillArtifactMetadata {
+	name: string;
+	hash: string;
+	source: SkillArtifactSource;
+	artifactId?: string;
+	version?: string;
+	sourcePath?: string;
+	scope?: string;
+	workspaceId?: string;
+	ownerId?: string;
+}
+
+function hashSkillContent(content: string): string {
+	return createHash("sha256").update(content).digest("hex");
+}
+
+function readMetadataValue(
+	metadata: Record<string, string> | undefined,
+	key: string,
+): string | undefined {
+	const value = metadata?.[key]?.trim();
+	return value ? value : undefined;
+}
+
+function normalizeSkillArtifactMetadata(
+	value: unknown,
+): SkillArtifactMetadata | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const candidate = value as Record<string, unknown>;
+	if (
+		typeof candidate.name !== "string" ||
+		candidate.name.trim().length === 0 ||
+		typeof candidate.hash !== "string" ||
+		candidate.hash.trim().length === 0 ||
+		typeof candidate.source !== "string" ||
+		candidate.source.trim().length === 0
+	) {
+		return undefined;
+	}
+
+	return {
+		name: candidate.name.trim(),
+		hash: candidate.hash.trim(),
+		source: candidate.source.trim() as SkillArtifactSource,
+		...(typeof candidate.artifactId === "string" &&
+		candidate.artifactId.trim().length > 0
+			? { artifactId: candidate.artifactId.trim() }
+			: {}),
+		...(typeof candidate.version === "string" &&
+		candidate.version.trim().length > 0
+			? { version: candidate.version.trim() }
+			: {}),
+		...(typeof candidate.sourcePath === "string" &&
+		candidate.sourcePath.trim().length > 0
+			? { sourcePath: candidate.sourcePath.trim() }
+			: {}),
+		...(typeof candidate.scope === "string" && candidate.scope.trim().length > 0
+			? { scope: candidate.scope.trim() }
+			: {}),
+		...(typeof candidate.workspaceId === "string" &&
+		candidate.workspaceId.trim().length > 0
+			? { workspaceId: candidate.workspaceId.trim() }
+			: {}),
+		...(typeof candidate.ownerId === "string" &&
+		candidate.ownerId.trim().length > 0
+			? { ownerId: candidate.ownerId.trim() }
+			: {}),
+	};
+}
+
+export function buildSkillArtifactMetadata(
+	skill: LoadedSkill,
+): SkillArtifactMetadata {
+	return {
+		name: skill.name,
+		hash: hashSkillContent(skill.content),
+		source: skill.sourceType,
+		...(readMetadataValue(skill.metadata, "skillServiceId")
+			? { artifactId: readMetadataValue(skill.metadata, "skillServiceId") }
+			: {}),
+		...((readMetadataValue(skill.metadata, "currentVersion") ??
+		readMetadataValue(skill.metadata, "version") ??
+		skill.version)
+			? {
+					version:
+						readMetadataValue(skill.metadata, "currentVersion") ??
+						readMetadataValue(skill.metadata, "version") ??
+						skill.version,
+				}
+			: {}),
+		...(skill.sourcePath ? { sourcePath: skill.sourcePath } : {}),
+		...(readMetadataValue(skill.metadata, "scope")
+			? { scope: readMetadataValue(skill.metadata, "scope") }
+			: {}),
+		...(readMetadataValue(skill.metadata, "workspaceId")
+			? { workspaceId: readMetadataValue(skill.metadata, "workspaceId") }
+			: {}),
+		...(readMetadataValue(skill.metadata, "ownerId")
+			? { ownerId: readMetadataValue(skill.metadata, "ownerId") }
+			: {}),
+	};
+}
+
+export function getSkillArtifactMetadataFromDetails(
+	details: unknown,
+): SkillArtifactMetadata | undefined {
+	if (!details || typeof details !== "object" || Array.isArray(details)) {
+		return undefined;
+	}
+	return normalizeSkillArtifactMetadata(
+		(details as { skillMetadata?: unknown }).skillMetadata,
+	);
+}

--- a/src/skills/tool.ts
+++ b/src/skills/tool.ts
@@ -8,6 +8,7 @@
 import { Type } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "../agent/types.js";
 import { createLogger } from "../utils/logger.js";
+import { buildSkillArtifactMetadata } from "./artifact-metadata.js";
 import {
 	type LoadedSkill,
 	findSkill,
@@ -192,6 +193,9 @@ Available skills can be listed by calling this tool with skill="list".`,
 
 			return {
 				content: [{ type: "text", text }],
+				details: {
+					skillMetadata: buildSkillArtifactMetadata(skill),
+				},
 			};
 		},
 	};

--- a/src/telemetry/maestro-event-bus.ts
+++ b/src/telemetry/maestro-event-bus.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { JetStreamClient, NatsConnection } from "nats";
 import type { PromptMetadata } from "../prompts/types.js";
+import type { SkillArtifactMetadata } from "../skills/artifact-metadata.js";
 import {
 	MaestroBusEventType,
 	getMaestroBusEventCatalogEntry,
@@ -157,6 +158,7 @@ export interface ToolCallAttemptEventData extends Record<string, unknown> {
 	tool_call_id: string;
 	tool_execution_id?: string;
 	prompt_metadata?: PromptMetadata;
+	skill_metadata?: SkillArtifactMetadata;
 	tool_namespace?: string;
 	tool_name: string;
 	tool_version?: string;
@@ -175,6 +177,7 @@ export interface ToolCallResultEventData extends Record<string, unknown> {
 	tool_call_id: string;
 	tool_execution_id?: string;
 	prompt_metadata?: PromptMetadata;
+	skill_metadata?: SkillArtifactMetadata;
 	approval_request_id?: string;
 	governed_outcome?: string;
 	status: MaestroToolCallStatus;
@@ -271,6 +274,7 @@ export interface RecordMaestroToolCallAttemptInput {
 	tool_call_id: string;
 	tool_execution_id?: string;
 	prompt_metadata?: PromptMetadata;
+	skill_metadata?: SkillArtifactMetadata;
 	tool_namespace?: string;
 	tool_name: string;
 	tool_version?: string;
@@ -290,6 +294,7 @@ export interface RecordMaestroToolCallCompletedInput {
 	tool_call_id: string;
 	tool_execution_id?: string;
 	prompt_metadata?: PromptMetadata;
+	skill_metadata?: SkillArtifactMetadata;
 	approval_request_id?: string;
 	governed_outcome?: string;
 	status: MaestroToolCallStatus;
@@ -865,6 +870,7 @@ export function recordMaestroToolCallAttempt(
 			tool_call_id: event.tool_call_id,
 			tool_execution_id: event.tool_execution_id,
 			prompt_metadata: event.prompt_metadata,
+			skill_metadata: event.skill_metadata,
 			tool_namespace: event.tool_namespace,
 			tool_name: event.tool_name,
 			tool_version: event.tool_version,
@@ -895,6 +901,7 @@ export function recordMaestroToolCallCompleted(
 			tool_call_id: event.tool_call_id,
 			tool_execution_id: event.tool_execution_id,
 			prompt_metadata: event.prompt_metadata,
+			skill_metadata: event.skill_metadata,
 			approval_request_id: event.approval_request_id,
 			governed_outcome: event.governed_outcome,
 			status: event.status,

--- a/src/telemetry/meter-service-client.ts
+++ b/src/telemetry/meter-service-client.ts
@@ -88,6 +88,16 @@ function trimRecord(
 	);
 }
 
+function joinMetadataValues(
+	values: Array<string | undefined> | undefined,
+): string | undefined {
+	if (!values) {
+		return undefined;
+	}
+	const filtered = values.map((value) => value?.trim()).filter(Boolean);
+	return filtered.length > 0 ? filtered.join(",") : undefined;
+}
+
 function toNonNegativeInt(value: number | undefined): number {
 	if (typeof value !== "number" || !Number.isFinite(value)) {
 		return 0;
@@ -116,6 +126,21 @@ function buildMetadata(event: CanonicalTurnEvent): Record<string, string> {
 		promptVersionId: event.promptMetadata?.versionId,
 		promptHash: event.promptMetadata?.hash,
 		promptSource: event.promptMetadata?.source,
+		skillNames: joinMetadataValues(
+			event.skillMetadata?.map((skill) => skill.name),
+		),
+		skillArtifactIds: joinMetadataValues(
+			event.skillMetadata?.map((skill) => skill.artifactId),
+		),
+		skillVersions: joinMetadataValues(
+			event.skillMetadata?.map((skill) => skill.version),
+		),
+		skillHashes: joinMetadataValues(
+			event.skillMetadata?.map((skill) => skill.hash),
+		),
+		skillSources: joinMetadataValues(
+			event.skillMetadata?.map((skill) => skill.source),
+		),
 	});
 }
 

--- a/src/telemetry/turn-tracker.ts
+++ b/src/telemetry/turn-tracker.ts
@@ -141,6 +141,7 @@ export class TurnTracker {
 						outputSize,
 						errorCode,
 					);
+					this.currentTurn.recordSkillMetadata(event.skillMetadata);
 				}
 				break;
 

--- a/src/telemetry/wide-events.ts
+++ b/src/telemetry/wide-events.ts
@@ -14,6 +14,7 @@
 
 import { randomUUID } from "node:crypto";
 import type { PromptMetadata } from "../prompts/types.js";
+import type { SkillArtifactMetadata } from "../skills/artifact-metadata.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -69,6 +70,7 @@ export interface CanonicalTurnEvent {
 	// ─── Model Context ──────────────────────────────────────────────────────
 	model: ModelInfo;
 	promptMetadata?: PromptMetadata;
+	skillMetadata?: SkillArtifactMetadata[];
 
 	// ─── Timing ─────────────────────────────────────────────────────────────
 	totalDurationMs: number;
@@ -185,6 +187,7 @@ export class TurnCollector {
 		thinkingLevel: "off",
 	};
 	private promptMetadata?: PromptMetadata;
+	private readonly skillMetadata = new Map<string, SkillArtifactMetadata>();
 	private tools: Map<
 		string,
 		{ name: string; callId: string; startTime: number; inputSizeBytes?: number }
@@ -231,6 +234,26 @@ export class TurnCollector {
 
 	setPromptMetadata(promptMetadata: PromptMetadata | undefined): this {
 		this.promptMetadata = promptMetadata;
+		return this;
+	}
+
+	recordSkillMetadata(skillMetadata: SkillArtifactMetadata | undefined): this {
+		if (!skillMetadata) {
+			return this;
+		}
+		const key = [
+			skillMetadata.artifactId,
+			skillMetadata.source,
+			skillMetadata.name,
+			skillMetadata.version,
+			skillMetadata.hash,
+		]
+			.filter(Boolean)
+			.join(":");
+		if (!key) {
+			return this;
+		}
+		this.skillMetadata.set(key, skillMetadata);
 		return this;
 	}
 
@@ -384,6 +407,10 @@ export class TurnCollector {
 			// Model
 			model: this.model,
 			promptMetadata: this.promptMetadata,
+			skillMetadata:
+				this.skillMetadata.size > 0
+					? [...this.skillMetadata.values()]
+					: undefined,
 
 			// Timing
 			totalDurationMs: Math.round(totalDurationMs),

--- a/test/notification-hooks.test.ts
+++ b/test/notification-hooks.test.ts
@@ -274,6 +274,12 @@ describe("Notification Hooks", () => {
 					errorCode: "governance_denied",
 					approvalRequestId: "approval-123",
 					governedOutcome: "denied",
+					skillMetadata: {
+						name: "incident-review",
+						artifactId: "skill_remote_1",
+						hash: "hash_skill_123",
+						source: "service",
+					},
 					result: {
 						role: "toolResult",
 						toolCallId: "call-123",
@@ -294,6 +300,12 @@ describe("Notification Hooks", () => {
 			expect(payload?.toolErrorCode).toBe("governance_denied");
 			expect(payload?.approvalRequestId).toBe("approval-123");
 			expect(payload?.governedOutcome).toBe("denied");
+			expect(payload?.skillMetadata).toEqual({
+				name: "incident-review",
+				artifactId: "skill_remote_1",
+				hash: "hash_skill_123",
+				source: "service",
+			});
 		});
 
 		it("should create payload for error event", async () => {

--- a/test/session/jsonl-writer.test.ts
+++ b/test/session/jsonl-writer.test.ts
@@ -146,4 +146,48 @@ describe("JsonlEventWriter adapter", () => {
 			},
 		});
 	});
+
+	it("includes selected skill metadata in tool results", () => {
+		adapter.handle({
+			type: "tool_execution_end",
+			toolCallId: "call-skill",
+			toolName: "Skill",
+			result: {
+				...toolResult,
+				toolCallId: "call-skill",
+				toolName: "Skill",
+			},
+			isError: false,
+			skillMetadata: {
+				name: "incident-review",
+				artifactId: "skill_remote_1",
+				version: "3",
+				hash: "hash_skill_123",
+				source: "service",
+			},
+		});
+
+		expect(JSON.parse(stream.chunks[0] ?? "{}")).toEqual({
+			type: "item",
+			subtype: "tool_result",
+			timestamp: "2025-01-01T00:00:00.000Z",
+			data: {
+				toolCallId: "call-skill",
+				toolName: "Skill",
+				result: {
+					...toolResult,
+					toolCallId: "call-skill",
+					toolName: "Skill",
+				},
+				isError: false,
+				skillMetadata: {
+					name: "incident-review",
+					artifactId: "skill_remote_1",
+					version: "3",
+					hash: "hash_skill_123",
+					source: "service",
+				},
+			},
+		});
+	});
 });

--- a/test/skills/tool.test.ts
+++ b/test/skills/tool.test.ts
@@ -155,12 +155,28 @@ ${content}
 			const tool = createSkillTool(testDir, { includeSystem: false });
 			const result = await tool.execute("test-3", { skill: "my-skill" });
 			const text = getResultText(result);
+			const skillMetadata = (
+				result.details as
+					| {
+							skillMetadata?: {
+								name: string;
+								hash: string;
+								source: string;
+							};
+					  }
+					| undefined
+			)?.skillMetadata;
 
 			expect(result.isError).toBeUndefined();
 			expect(text).toContain("# Skill: my-skill");
 			expect(text).toContain("> Test skill");
 			expect(text).toContain("# Instructions");
 			expect(text).toContain("Do this.");
+			expect(skillMetadata).toMatchObject({
+				name: "my-skill",
+				source: "project",
+			});
+			expect(skillMetadata?.hash).toMatch(/^[a-f0-9]{64}$/u);
 		});
 
 		it("loads skill case-insensitively", async () => {
@@ -229,11 +245,30 @@ ${content}
 				skill: "incident-review",
 			});
 			const text = getResultText(result);
+			const skillMetadata = (
+				result.details as
+					| {
+							skillMetadata?: {
+								name: string;
+								artifactId?: string;
+								version?: string;
+								source: string;
+								scope?: string;
+							};
+					  }
+					| undefined
+			)?.skillMetadata;
 
 			expect(result.isError).toBeUndefined();
 			expect(text).toContain("# Skill: incident-review");
 			expect(text).toContain("> Review incident reports");
 			expect(text).toContain("Summarize impact and remediation.");
+			expect(skillMetadata).toMatchObject({
+				name: "incident-review",
+				artifactId: "remote-1",
+				source: "service",
+				scope: "workspace",
+			});
 		});
 
 		it("falls back to local skills when the optional skills service fails", async () => {

--- a/test/telemetry/maestro-event-bus.test.ts
+++ b/test/telemetry/maestro-event-bus.test.ts
@@ -6,6 +6,7 @@ import {
 	getMaestroEventBusStatus,
 	publishMaestroCloudEvent,
 	recordMaestroPromptVariantSelected,
+	recordMaestroToolCallCompleted,
 	resolveMaestroEventBusConfig,
 	setMaestroEventBusTransportForTests,
 } from "../../src/telemetry/maestro-event-bus.js";
@@ -115,6 +116,45 @@ describe("maestro event bus", () => {
 					source: "service",
 				},
 				selected_at: "2026-04-23T17:00:00.000Z",
+			},
+		});
+	});
+
+	it("publishes tool completion CloudEvents with selected skill identity", async () => {
+		const published: Array<{ subject: string; payload: string }> = [];
+		setMaestroEventBusTransportForTests({
+			async publish(subject, payload) {
+				published.push({ subject, payload });
+			},
+		});
+
+		recordMaestroToolCallCompleted({
+			tool_call_id: "tool_1",
+			status: "MAESTRO_TOOL_CALL_STATUS_SUCCEEDED",
+			skill_metadata: {
+				name: "incident-review",
+				artifactId: "skill_remote_1",
+				version: "3",
+				hash: "hash_skill_123",
+				source: "service",
+			},
+			completed_at: "2026-04-23T18:00:00.000Z",
+			env: { MAESTRO_EVENT_BUS_URL: "nats://bus.example:4222" },
+		});
+
+		await Promise.resolve();
+
+		expect(published).toHaveLength(1);
+		expect(JSON.parse(published[0]?.payload ?? "{}")).toMatchObject({
+			type: "maestro.events.tool_call.completed",
+			data: {
+				tool_call_id: "tool_1",
+				skill_metadata: {
+					name: "incident-review",
+					artifactId: "skill_remote_1",
+					version: "3",
+					source: "service",
+				},
 			},
 		});
 	});

--- a/test/telemetry/meter-service-client.test.ts
+++ b/test/telemetry/meter-service-client.test.ts
@@ -22,6 +22,13 @@ function createCanonicalTurnEvent() {
 			hash: "hash_123",
 			source: "service",
 		})
+		.recordSkillMetadata({
+			name: "incident-review",
+			artifactId: "skill_remote_1",
+			version: "3",
+			hash: "hash_skill_123",
+			source: "service",
+		})
 		.setSandboxMode("docker")
 		.setApprovalMode("auto")
 		.setMcpServers(["context7"]);
@@ -94,6 +101,11 @@ describe("meter telemetry client", () => {
 					promptVersionId: "ver_9",
 					promptHash: "hash_123",
 					promptSource: "service",
+					skillNames: "incident-review",
+					skillArtifactIds: "skill_remote_1",
+					skillVersions: "3",
+					skillHashes: "hash_skill_123",
+					skillSources: "service",
 				},
 				data: event,
 				metrics: {

--- a/test/telemetry/turn-tracker.test.ts
+++ b/test/telemetry/turn-tracker.test.ts
@@ -489,4 +489,105 @@ describe("TurnTracker", () => {
 			source: "service",
 		});
 	});
+
+	it("attaches skill artifact identity to completed turns", () => {
+		let listener: ((event: AgentEvent) => void) | undefined;
+		const agent = {
+			state: {
+				messages: [],
+				error: undefined,
+				model: {
+					id: "test-model",
+					provider: "anthropic",
+				},
+				thinkingLevel: "off",
+			},
+			subscribe: (fn: (event: AgentEvent) => void) => {
+				listener = fn;
+				return () => {
+					listener = undefined;
+				};
+			},
+		} as unknown as Agent;
+
+		let completed:
+			| {
+					skillMetadata?: Array<{
+						name: string;
+						artifactId?: string;
+						source: string;
+					}>;
+			  }
+			| undefined;
+		const tracker = new TurnTracker(agent, {
+			sessionId: "session-skill-metadata",
+			onTurnComplete: (event) => {
+				completed = {
+					skillMetadata: event.skillMetadata,
+				};
+			},
+		});
+
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "done" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-20250514",
+			usage: {
+				input: 10,
+				output: 5,
+				cacheRead: 0,
+				cacheWrite: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+
+		listener?.({ type: "agent_start" });
+		listener?.({
+			type: "tool_execution_start",
+			toolCallId: "call-skill",
+			toolName: "Skill",
+			args: { skill: "incident-review" },
+		});
+		listener?.({
+			type: "tool_execution_end",
+			toolCallId: "call-skill",
+			toolName: "Skill",
+			skillMetadata: {
+				name: "incident-review",
+				artifactId: "skill_remote_1",
+				hash: "hash_skill_123",
+				source: "service",
+			},
+			result: {
+				role: "toolResult",
+				toolCallId: "call-skill",
+				toolName: "Skill",
+				content: [{ type: "text", text: "# Skill: incident-review" }],
+				isError: false,
+				timestamp: Date.now(),
+			},
+			isError: false,
+		});
+		listener?.({ type: "message_start", message: assistantMessage });
+		listener?.({ type: "message_end", message: assistantMessage });
+		listener?.({
+			type: "agent_end",
+			messages: [assistantMessage],
+			stopReason: "stop",
+		});
+
+		tracker.dispose();
+
+		expect(completed?.skillMetadata).toEqual([
+			expect.objectContaining({
+				name: "incident-review",
+				artifactId: "skill_remote_1",
+				source: "service",
+			}),
+		]);
+	});
 });

--- a/test/telemetry/wide-events.test.ts
+++ b/test/telemetry/wide-events.test.ts
@@ -137,6 +137,36 @@ describe("TurnCollector", () => {
 		});
 	});
 
+	it("records selected skill artifact identity on canonical turn events", () => {
+		const collector = new TurnCollector("session-123", 1);
+
+		collector.recordSkillMetadata({
+			name: "incident-review",
+			artifactId: "skill_remote_1",
+			version: "3",
+			hash: "hash_skill_123",
+			source: "service",
+			scope: "workspace",
+		});
+
+		const event = collector.complete(
+			"success",
+			{ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			0,
+		);
+
+		expect(event.skillMetadata).toEqual([
+			{
+				name: "incident-review",
+				artifactId: "skill_remote_1",
+				version: "3",
+				hash: "hash_skill_123",
+				source: "service",
+				scope: "workspace",
+			},
+		]);
+	});
+
 	it("records error details", () => {
 		const collector = new TurnCollector("session-123", 1);
 


### PR DESCRIPTION
## Summary
- attach exact selected-skill artifact metadata to successful `Skill` tool results
- lift that metadata into `tool_execution_end`, tool-call CloudEvents, canonical turns, meter metadata, JSONL, notifications, and compaction skill-restore hooks
- add focused coverage for local/service skill loads plus the telemetry surfaces that consume selected skill identity

## Validation
- node ./scripts/run-vitest.js --run test/skills/tool.test.ts test/telemetry/wide-events.test.ts test/telemetry/turn-tracker.test.ts test/telemetry/meter-service-client.test.ts test/telemetry/maestro-event-bus.test.ts test/session/jsonl-writer.test.ts test/notification-hooks.test.ts
- bunx biome check src/skills/tool.ts src/skills/artifact-metadata.ts src/agent/types.ts src/agent/transport.ts src/agent/agent.ts src/telemetry/maestro-event-bus.ts src/telemetry/wide-events.ts src/telemetry/turn-tracker.ts src/telemetry/meter-service-client.ts src/cli/jsonl-writer.ts src/hooks/notification-hooks.ts src/agent/compaction.ts test/skills/tool.test.ts test/telemetry/wide-events.test.ts test/telemetry/turn-tracker.test.ts test/telemetry/meter-service-client.test.ts test/telemetry/maestro-event-bus.test.ts test/session/jsonl-writer.test.ts test/notification-hooks.test.ts
- npm run build