### PR TITLE
Use verified principals for hosted session scope

### DIFF
--- a/src/server/authz.ts
+++ b/src/server/authz.ts
@@ -17,6 +17,28 @@ const JWT_JWKS_URL = process.env.MAESTRO_JWT_JWKS_URL?.trim() || null;
 const JWT_AUDIENCE = process.env.MAESTRO_JWT_AUD?.trim() || undefined;
 const JWT_ISSUER = process.env.MAESTRO_JWT_ISS?.trim() || undefined;
 const JWT_ALG = process.env.MAESTRO_JWT_ALG?.trim() || "HS256";
+const REQUEST_PRINCIPAL = Symbol("maestro.requestPrincipal");
+
+export type AuthMethod = "anon" | "api_key" | "jwt" | "shared_token";
+
+export interface VerifiedRequestPrincipal {
+	authMethod: AuthMethod;
+	subject: string;
+	scopeKey: string;
+	userId?: string;
+	workspaceId?: string;
+	orgId?: string;
+	teamId?: string;
+	tokenId?: string;
+	keyId?: string;
+	roles: string[];
+	scopes: string[];
+	claims?: Record<string, unknown>;
+}
+
+type RequestWithPrincipal = IncomingMessage & {
+	[REQUEST_PRINCIPAL]?: VerifiedRequestPrincipal | null;
+};
 
 function base64UrlDecode(input: string): string {
 	return Buffer.from(
@@ -44,6 +66,157 @@ function verifySharedToken(token: string): string | null {
 	const expected = hmac.digest("hex");
 	if (!secureCompare(providedSig, expected)) return null;
 	return userId;
+}
+
+function hasConfiguredAuth(): boolean {
+	return Boolean(WEB_API_KEY || SHARED_SECRET || JWT_SECRET || JWT_JWKS_URL);
+}
+
+function sanitizePrincipalPart(value: string): string {
+	return value
+		.trim()
+		.replace(/[^a-zA-Z0-9._-]/g, "_")
+		.slice(0, 32);
+}
+
+function getStringClaim(
+	payload: JWTPayload,
+	...names: string[]
+): string | undefined {
+	for (const name of names) {
+		const raw = payload[name];
+		if (typeof raw !== "string") continue;
+		const trimmed = raw.trim();
+		if (trimmed) return trimmed;
+	}
+	return undefined;
+}
+
+function getStringListClaim(payload: JWTPayload, ...names: string[]): string[] {
+	for (const name of names) {
+		const raw = payload[name];
+		if (Array.isArray(raw)) {
+			return raw
+				.filter((value): value is string => typeof value === "string")
+				.map((value) => value.trim())
+				.filter(Boolean);
+		}
+		if (typeof raw === "string") {
+			return raw
+				.split(/[,\s]+/)
+				.map((value) => value.trim())
+				.filter(Boolean);
+		}
+	}
+	return [];
+}
+
+function buildScopeKey(parts: string[]): string {
+	const normalized = parts
+		.map((value) => sanitizePrincipalPart(value))
+		.filter(Boolean);
+	if (normalized.length === 0) {
+		return "anon";
+	}
+	const joined = normalized.join("__");
+	if (joined.length <= 64) {
+		return joined;
+	}
+	const digest = createHash("sha256").update(joined).digest("hex").slice(0, 24);
+	return `principal_${digest}`;
+}
+
+function setVerifiedRequestPrincipal(
+	req: IncomingMessage,
+	principal: VerifiedRequestPrincipal | null,
+): VerifiedRequestPrincipal | null {
+	const request = req as RequestWithPrincipal;
+	request[REQUEST_PRINCIPAL] = principal;
+	return principal;
+}
+
+function createAnonymousPrincipal(): VerifiedRequestPrincipal {
+	return {
+		authMethod: "anon",
+		subject: "anon",
+		scopeKey: "anon",
+		roles: [],
+		scopes: [],
+	};
+}
+
+function createSharedTokenPrincipal(userId: string): VerifiedRequestPrincipal {
+	const subject = `user:${userId}`;
+	return {
+		authMethod: "shared_token",
+		subject,
+		scopeKey: buildScopeKey([subject]),
+		userId,
+		roles: [],
+		scopes: [],
+	};
+}
+
+function createApiKeyPrincipal(token: string): VerifiedRequestPrincipal {
+	const keyId = createHash("sha256").update(token).digest("hex").slice(0, 16);
+	const subject = `key:${keyId}`;
+	return {
+		authMethod: "api_key",
+		subject,
+		scopeKey: buildScopeKey([subject]),
+		keyId,
+		roles: [],
+		scopes: [],
+	};
+}
+
+function createJwtPrincipal(payload: JWTPayload): VerifiedRequestPrincipal {
+	const userId = payload.sub?.trim();
+	if (!userId) {
+		throw new Error("JWT principal requires sub");
+	}
+	const workspaceId = getStringClaim(
+		payload,
+		"workspace_id",
+		"workspaceId",
+		"wid",
+	);
+	const orgId = getStringClaim(
+		payload,
+		"org_id",
+		"orgId",
+		"organization_id",
+		"organizationId",
+		"tenant_id",
+		"tenantId",
+	);
+	const teamId = getStringClaim(payload, "team_id", "teamId");
+	const subject = `user:${userId}`;
+	const scopeParts = [
+		workspaceId ? `workspace_${workspaceId}` : null,
+		orgId ? `org_${orgId}` : null,
+		teamId ? `team_${teamId}` : null,
+		`user_${userId}`,
+	].filter((value): value is string => Boolean(value));
+	return {
+		authMethod: "jwt",
+		subject,
+		scopeKey: buildScopeKey(scopeParts),
+		userId,
+		workspaceId,
+		orgId,
+		teamId,
+		tokenId: getStringClaim(payload, "jti"),
+		roles: getStringListClaim(payload, "roles", "role"),
+		scopes: getStringListClaim(payload, "scopes", "scope"),
+		claims: { ...payload },
+	};
+}
+
+export function getVerifiedRequestPrincipal(
+	req: IncomingMessage,
+): VerifiedRequestPrincipal | null {
+	return (req as RequestWithPrincipal)[REQUEST_PRINCIPAL] ?? null;
 }
 
 async function verifyJwt(token: string): Promise<JWTPayload | null> {
@@ -78,19 +251,45 @@ async function verifyJwt(token: string): Promise<JWTPayload | null> {
 export async function checkApiAuth(req: IncomingMessage): Promise<{
 	ok: boolean;
 	error?: string;
+	principal?: VerifiedRequestPrincipal;
 }> {
+	const cachedPrincipal = getVerifiedRequestPrincipal(req);
+	if (cachedPrincipal) {
+		return { ok: true, principal: cachedPrincipal };
+	}
 	const bearer = getRequestToken(req);
 	const jwtPayload = bearer ? await verifyJwt(bearer) : null;
 	const userId = bearer ? verifySharedToken(bearer) : null;
-	if (userId) return { ok: true };
-	if (jwtPayload?.sub) return { ok: true };
-	if (WEB_API_KEY) {
-		if (bearer && secureCompare(bearer, WEB_API_KEY)) {
-			return { ok: true };
-		}
+	if (userId) {
+		const principal = setVerifiedRequestPrincipal(
+			req,
+			createSharedTokenPrincipal(userId),
+		);
+		return { ok: true, principal: principal ?? undefined };
+	}
+	if (jwtPayload?.sub) {
+		const principal = setVerifiedRequestPrincipal(
+			req,
+			createJwtPrincipal(jwtPayload),
+		);
+		return { ok: true, principal: principal ?? undefined };
+	}
+	if (WEB_API_KEY && bearer && secureCompare(bearer, WEB_API_KEY)) {
+		const principal = setVerifiedRequestPrincipal(
+			req,
+			createApiKeyPrincipal(bearer),
+		);
+		return { ok: true, principal: principal ?? undefined };
+	}
+	if (hasConfiguredAuth()) {
+		setVerifiedRequestPrincipal(req, null);
 		return { ok: false, error: "Unauthorized" };
 	}
-	return { ok: true };
+	const principal = setVerifiedRequestPrincipal(
+		req,
+		createAnonymousPrincipal(),
+	);
+	return { ok: true, principal: principal ?? undefined };
 }
 
 export async function requireApiAuth(
@@ -156,6 +355,10 @@ export function requireCsrf(
 
 // Derive a stable subject key from provided token (API key) for per-user scoping
 export function getAuthSubject(req: IncomingMessage): string {
+	const principal = getVerifiedRequestPrincipal(req);
+	if (principal) {
+		return principal.subject;
+	}
 	const token = getRequestToken(req);
 	// Attempt JWT verification synchronously not possible; so use hash of token + prefix
 	if (token && SHARED_SECRET) {
@@ -165,4 +368,12 @@ export function getAuthSubject(req: IncomingMessage): string {
 	if (!token) return "anon";
 	const digest = createHash("sha256").update(token).digest("hex");
 	return `key:${digest.slice(0, 16)}`;
+}
+
+export function getAuthScopeKey(req: IncomingMessage): string {
+	const principal = getVerifiedRequestPrincipal(req);
+	if (principal) {
+		return principal.scopeKey;
+	}
+	return getAuthSubject(req);
 }

--- a/src/server/authz.ts
+++ b/src/server/authz.ts
@@ -73,10 +73,7 @@ function hasConfiguredAuth(): boolean {
 }
 
 function sanitizePrincipalPart(value: string): string {
-	return value
-		.trim()
-		.replace(/[^a-zA-Z0-9._-]/g, "_")
-		.slice(0, 32);
+	return value.trim().replace(/[^a-zA-Z0-9._-]/g, "_");
 }
 
 function getStringClaim(

--- a/src/server/handlers/headless-sessions.ts
+++ b/src/server/handlers/headless-sessions.ts
@@ -18,7 +18,7 @@ import {
 	normalizeApprovalMode,
 	resolveApprovalModeForRequest,
 } from "../approval-mode-store.js";
-import { getAuthSubject } from "../authz.js";
+import { getAuthScopeKey, getAuthSubject } from "../authz.js";
 import type {
 	HeadlessRuntimeConnectionSnapshot,
 	HeadlessRuntimeHeartbeatSnapshot,
@@ -274,7 +274,7 @@ function parseOptOutNotifications(
 }
 
 function getScopeKey(req: IncomingMessage): string {
-	return getAuthSubject(req);
+	return getAuthScopeKey(req);
 }
 
 function ensureHostedRunnerCanUseSession(

--- a/src/server/server-middlewares.ts
+++ b/src/server/server-middlewares.ts
@@ -2,15 +2,11 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { parse } from "node:url";
 import { createLogger } from "../utils/logger.js";
 import { getArtifactAccessGrantFromRequest } from "./artifact-access.js";
+import { checkApiAuth } from "./authz.js";
 import { isOverloaded, logRequest } from "./logger.js";
 import type { Middleware } from "./middleware.js";
 import type { RateLimiter, TieredRateLimiter } from "./rate-limiter.js";
-import {
-	authenticateRequest,
-	getRequestHeader,
-	secureCompare,
-	sendJson,
-} from "./server-utils.js";
+import { getRequestHeader, secureCompare, sendJson } from "./server-utils.js";
 
 const logger = createLogger("middleware:ip-access");
 
@@ -207,9 +203,11 @@ export function createAuthMiddleware(
 	corsHeaders: Record<string, string>,
 	requireApiKey = false,
 ): Middleware {
-	return (req, res, next) => {
+	return async (req, res, next) => {
 		const pathname = getPathname(req);
-		if (pathname.startsWith("/api")) {
+		const requiresAuthBoundary =
+			pathname.startsWith("/api") || pathname === "/debug/z";
+		if (requiresAuthBoundary) {
 			const missingKey = !apiKey || apiKey.length === 0;
 
 			// No key provided
@@ -228,14 +226,36 @@ export function createAuthMiddleware(
 					return;
 				}
 				// Requirement off and no key: allow through.
+				const auth = await checkApiAuth(req);
+				if (!auth.ok) {
+					sendJson(
+						res,
+						401,
+						{ error: auth.error || "Unauthorized" },
+						corsHeaders,
+						req,
+					);
+					return;
+				}
 				return next();
 			}
 
 			// Key provided: validate it.
-			if (getArtifactAccessGrantFromRequest(req)) {
+			if (
+				pathname.startsWith("/api") &&
+				getArtifactAccessGrantFromRequest(req)
+			) {
 				return next();
 			}
-			if (!authenticateRequest(req, res, corsHeaders, apiKey)) {
+			const auth = await checkApiAuth(req);
+			if (!auth.ok) {
+				sendJson(
+					res,
+					401,
+					{ error: auth.error || "Unauthorized" },
+					corsHeaders,
+					req,
+				);
 				return;
 			}
 		}

--- a/src/server/session-scope.ts
+++ b/src/server/session-scope.ts
@@ -7,7 +7,7 @@ import {
 	sanitizeSessionScope,
 } from "../session/scope.js";
 import { getArtifactAccessGrantFromRequest } from "./artifact-access.js";
-import { getAuthSubject } from "./authz.js";
+import { getAuthScopeKey, getAuthSubject } from "./authz.js";
 import { HostedSessionManager } from "./hosted-session-manager.js";
 import { getRequestToken } from "./server-utils.js";
 
@@ -31,9 +31,9 @@ export function resolveSessionScope(req: IncomingMessage): string | null {
 		return artifactAccess.scope ?? null;
 	}
 	if (!getRequestToken(req)) return null;
-	const subject = getAuthSubject(req);
-	if (!subject) return null;
-	return sanitizeSessionScope(subject) || null;
+	const scopeKey = getAuthScopeKey(req);
+	if (!scopeKey) return null;
+	return sanitizeSessionScope(scopeKey) || null;
 }
 
 export function createSessionManagerForRequest(

--- a/test/db/hosted-session-storage.integration.test.ts
+++ b/test/db/hosted-session-storage.integration.test.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import type { IncomingMessage } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { SignJWT } from "jose";
 import postgres from "postgres";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentState, AppMessage } from "../../src/agent/types.js";
@@ -95,6 +96,25 @@ function createScopedRequest(token: string): IncomingMessage {
 		headers: { authorization: `Bearer ${token}` },
 		socket: { remoteAddress: "127.0.0.1" },
 	} as unknown as IncomingMessage;
+}
+
+async function createJwtToken(
+	secret: string,
+	claims: {
+		sub: string;
+		workspaceId: string;
+		orgId?: string;
+		jti?: string;
+	},
+): Promise<string> {
+	return new SignJWT({
+		workspace_id: claims.workspaceId,
+		...(claims.orgId ? { org_id: claims.orgId } : {}),
+		...(claims.jti ? { jti: claims.jti } : {}),
+	})
+		.setProtectedHeader({ alg: "HS256" })
+		.setSubject(claims.sub)
+		.sign(new TextEncoder().encode(secret));
 }
 
 function countJsonlFiles(root: string): number {
@@ -255,6 +275,81 @@ describeDb("hosted session database storage", () => {
 		} finally {
 			await verify.end();
 		}
+	});
+
+	it("reuses hosted database sessions across JWT rotation within the same workspace", async () => {
+		process.env.MAESTRO_JWT_SECRET = "test-jwt-secret-should-be-long-enough";
+
+		const { migrate } = await import("../../src/db/migrate.js");
+		await expect(migrate()).resolves.toBe(7);
+
+		const { checkApiAuth } = await import("../../src/server/authz.js");
+		const { createWebSessionManagerForRequest } = await import(
+			"../../src/server/session-scope.js"
+		);
+		const { isHostedSessionManager } = await import(
+			"../../src/server/hosted-session-manager.js"
+		);
+
+		const tokenA = await createJwtToken(process.env.MAESTRO_JWT_SECRET!, {
+			sub: "user-123",
+			workspaceId: "workspace-7",
+			orgId: "org-9",
+			jti: "jwt-a",
+		});
+		const tokenB = await createJwtToken(process.env.MAESTRO_JWT_SECRET!, {
+			sub: "user-123",
+			workspaceId: "workspace-7",
+			orgId: "org-9",
+			jti: "jwt-b",
+		});
+		const tokenOtherWorkspace = await createJwtToken(
+			process.env.MAESTRO_JWT_SECRET!,
+			{
+				sub: "user-123",
+				workspaceId: "workspace-99",
+				orgId: "org-9",
+				jti: "jwt-c",
+			},
+		);
+
+		const requestA = createScopedRequest(tokenA);
+		const requestB = createScopedRequest(tokenB);
+		const requestOtherWorkspace = createScopedRequest(tokenOtherWorkspace);
+
+		await expect(checkApiAuth(requestA)).resolves.toMatchObject({ ok: true });
+		await expect(checkApiAuth(requestB)).resolves.toMatchObject({ ok: true });
+		await expect(checkApiAuth(requestOtherWorkspace)).resolves.toMatchObject({
+			ok: true,
+		});
+
+		const managerA = createWebSessionManagerForRequest(requestA, false);
+		expect(isHostedSessionManager(managerA)).toBe(true);
+		const state = createMockState([
+			userMessage("Keep this hosted session scoped to the verified workspace."),
+		]);
+		managerA.startSession(state, { subject: "user:user-123" });
+		await managerA.flush();
+		const sessionId = managerA.getSessionId();
+
+		const managerB = createWebSessionManagerForRequest(requestB, false);
+		expect(isHostedSessionManager(managerB)).toBe(true);
+		if (!isHostedSessionManager(managerB)) {
+			throw new Error("expected hosted session manager");
+		}
+		await expect(managerB.resumeSession(sessionId)).resolves.toBe(true);
+
+		const managerOtherWorkspace = createWebSessionManagerForRequest(
+			requestOtherWorkspace,
+			false,
+		);
+		expect(isHostedSessionManager(managerOtherWorkspace)).toBe(true);
+		if (!isHostedSessionManager(managerOtherWorkspace)) {
+			throw new Error("expected hosted session manager");
+		}
+		await expect(managerOtherWorkspace.resumeSession(sessionId)).resolves.toBe(
+			false,
+		);
 	});
 
 	it("emits prompt selection telemetry for hosted session starts", async () => {

--- a/test/server/authz-principal.test.ts
+++ b/test/server/authz-principal.test.ts
@@ -1,0 +1,280 @@
+/**
+ * @vitest-environment node
+ */
+
+import { createHmac } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { SignJWT } from "jose";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalEnv = { ...process.env };
+
+function createRequest(
+	headers: Record<string, string> = {},
+	url = "/api/sessions",
+): IncomingMessage {
+	return {
+		headers: {
+			host: "localhost",
+			...headers,
+		},
+		url,
+		method: "GET",
+	} as unknown as IncomingMessage;
+}
+
+function createSharedToken(userId: string, secret: string): string {
+	const encodedUser = Buffer.from(userId, "utf-8").toString("base64url");
+	const signature = createHmac("sha256", secret).update(userId).digest("hex");
+	return `${encodedUser}.${signature}`;
+}
+
+async function createJwtToken(
+	secret: string,
+	claims: {
+		sub: string;
+		workspaceId?: string;
+		orgId?: string;
+		teamId?: string;
+		jti?: string;
+		scope?: string;
+		roles?: string[];
+	},
+): Promise<string> {
+	const jwt = new SignJWT({
+		...(claims.workspaceId ? { workspace_id: claims.workspaceId } : {}),
+		...(claims.orgId ? { org_id: claims.orgId } : {}),
+		...(claims.teamId ? { team_id: claims.teamId } : {}),
+		...(claims.jti ? { jti: claims.jti } : {}),
+		...(claims.scope ? { scope: claims.scope } : {}),
+		...(claims.roles ? { roles: claims.roles } : {}),
+	})
+		.setProtectedHeader({ alg: "HS256" })
+		.setSubject(claims.sub);
+	return jwt.sign(new TextEncoder().encode(secret));
+}
+
+function createResponse(): ServerResponse & {
+	statusCode?: number;
+	body: string;
+} {
+	return {
+		body: "",
+		writeHead(statusCode: number) {
+			this.statusCode = statusCode;
+			return this;
+		},
+		end(chunk?: string) {
+			this.body += chunk ?? "";
+			return this;
+		},
+	} as unknown as ServerResponse & { statusCode?: number; body: string };
+}
+
+afterEach(() => {
+	process.env = { ...originalEnv };
+	vi.resetModules();
+});
+
+describe("verified request principals", () => {
+	it("uses verified JWT claims for subject and hosted session scope", async () => {
+		process.env = {
+			...originalEnv,
+			MAESTRO_JWT_SECRET: "test-jwt-secret-should-be-long-enough",
+			MAESTRO_SESSION_SCOPE: "auth",
+		};
+		vi.resetModules();
+		const { checkApiAuth, getAuthScopeKey, getAuthSubject } = await import(
+			"../../src/server/authz.js"
+		);
+		const { resolveSessionScope } = await import(
+			"../../src/server/session-scope.js"
+		);
+		const token = await createJwtToken(process.env.MAESTRO_JWT_SECRET!, {
+			sub: "user-123",
+			workspaceId: "workspace-7",
+			orgId: "org-9",
+			jti: "jwt-1",
+			scope: "sessions:read sessions:write",
+			roles: ["member"],
+		});
+		const req = createRequest({ authorization: `Bearer ${token}` });
+
+		const result = await checkApiAuth(req);
+
+		expect(result).toMatchObject({
+			ok: true,
+			principal: {
+				authMethod: "jwt",
+				subject: "user:user-123",
+				workspaceId: "workspace-7",
+				orgId: "org-9",
+				tokenId: "jwt-1",
+				scopes: ["sessions:read", "sessions:write"],
+				roles: ["member"],
+			},
+		});
+		expect(getAuthSubject(req)).toBe("user:user-123");
+		expect(getAuthScopeKey(req)).toBe(
+			"workspace_workspace-7__org_org-9__user_user-123",
+		);
+		expect(resolveSessionScope(req)).toBe(
+			"workspace_workspace-7__org_org-9__user_user-123",
+		);
+	});
+
+	it("keeps hosted session scope stable across JWT rotation for the same user and workspace", async () => {
+		process.env = {
+			...originalEnv,
+			MAESTRO_JWT_SECRET: "test-jwt-secret-should-be-long-enough",
+			MAESTRO_SESSION_SCOPE: "auth",
+		};
+		vi.resetModules();
+		const { checkApiAuth, getAuthScopeKey } = await import(
+			"../../src/server/authz.js"
+		);
+		const tokenA = await createJwtToken(process.env.MAESTRO_JWT_SECRET!, {
+			sub: "user-123",
+			workspaceId: "workspace-7",
+			orgId: "org-9",
+			jti: "jwt-a",
+		});
+		const tokenB = await createJwtToken(process.env.MAESTRO_JWT_SECRET!, {
+			sub: "user-123",
+			workspaceId: "workspace-7",
+			orgId: "org-9",
+			jti: "jwt-b",
+		});
+		const tokenOtherWorkspace = await createJwtToken(
+			process.env.MAESTRO_JWT_SECRET!,
+			{
+				sub: "user-123",
+				workspaceId: "workspace-99",
+				orgId: "org-9",
+				jti: "jwt-c",
+			},
+		);
+		const reqA = createRequest({ authorization: `Bearer ${tokenA}` });
+		const reqB = createRequest({ authorization: `Bearer ${tokenB}` });
+		const reqOtherWorkspace = createRequest({
+			authorization: `Bearer ${tokenOtherWorkspace}`,
+		});
+
+		await checkApiAuth(reqA);
+		await checkApiAuth(reqB);
+		await checkApiAuth(reqOtherWorkspace);
+
+		expect(getAuthScopeKey(reqA)).toBe(getAuthScopeKey(reqB));
+		expect(getAuthScopeKey(reqA)).not.toBe(getAuthScopeKey(reqOtherWorkspace));
+	});
+
+	it("keeps shared-secret tokens scoped by durable user identity", async () => {
+		process.env = {
+			...originalEnv,
+			MAESTRO_AUTH_SHARED_SECRET: "shared-secret",
+			MAESTRO_SESSION_SCOPE: "auth",
+		};
+		vi.resetModules();
+		const { checkApiAuth, getAuthScopeKey, getAuthSubject } = await import(
+			"../../src/server/authz.js"
+		);
+		const { resolveSessionScope } = await import(
+			"../../src/server/session-scope.js"
+		);
+		const token = createSharedToken(
+			"alice",
+			process.env.MAESTRO_AUTH_SHARED_SECRET!,
+		);
+		const req = createRequest({ authorization: `Bearer ${token}` });
+
+		await checkApiAuth(req);
+
+		expect(getAuthSubject(req)).toBe("user:alice");
+		expect(getAuthScopeKey(req)).toBe("user_alice");
+		expect(resolveSessionScope(req)).toBe("user_alice");
+	});
+
+	it("treats the web API key as a single-user scoped principal", async () => {
+		process.env = {
+			...originalEnv,
+			MAESTRO_WEB_API_KEY: "maestro-web-api-key",
+			MAESTRO_SESSION_SCOPE: "auth",
+		};
+		vi.resetModules();
+		const { checkApiAuth, getAuthScopeKey, getAuthSubject } = await import(
+			"../../src/server/authz.js"
+		);
+		const reqA = createRequest({
+			authorization: `Bearer ${process.env.MAESTRO_WEB_API_KEY}`,
+		});
+		const reqB = createRequest({
+			"x-composer-api-key": process.env.MAESTRO_WEB_API_KEY!,
+		});
+
+		await checkApiAuth(reqA);
+		await checkApiAuth(reqB);
+
+		expect(getAuthSubject(reqA)).toMatch(/^key:[a-f0-9]{16}$/);
+		expect(getAuthScopeKey(reqA)).toBe(getAuthScopeKey(reqB));
+	});
+
+	it("rejects invalid bearer tokens when auth is configured", async () => {
+		process.env = {
+			...originalEnv,
+			MAESTRO_JWT_SECRET: "test-jwt-secret-should-be-long-enough",
+		};
+		vi.resetModules();
+		const { checkApiAuth } = await import("../../src/server/authz.js");
+		const req = createRequest({ authorization: "Bearer definitely-not-a-jwt" });
+
+		const result = await checkApiAuth(req);
+
+		expect(result).toEqual({ ok: false, error: "Unauthorized" });
+	});
+
+	it("applies the authenticated boundary to /debug/z when auth is configured", async () => {
+		process.env = {
+			...originalEnv,
+			MAESTRO_JWT_SECRET: "test-jwt-secret-should-be-long-enough",
+			MAESTRO_WEB_REQUIRE_KEY: "0",
+		};
+		vi.resetModules();
+		const { createAuthMiddleware } = await import(
+			"../../src/server/server-middlewares.js"
+		);
+		const req = createRequest({}, "/debug/z");
+		const res = createResponse();
+		const next = vi.fn();
+
+		await createAuthMiddleware(null, {}, false)(req, res, next);
+
+		expect(next).not.toHaveBeenCalled();
+		expect(res.statusCode).toBe(401);
+		expect(res.body).toContain("Unauthorized");
+	});
+
+	it("keeps local unauthenticated requests explicitly anonymous", async () => {
+		process.env = {
+			...originalEnv,
+			MAESTRO_SESSION_SCOPE: "auth",
+		};
+		vi.resetModules();
+		const { checkApiAuth, getAuthScopeKey, getAuthSubject } = await import(
+			"../../src/server/authz.js"
+		);
+		const { resolveSessionScope } = await import(
+			"../../src/server/session-scope.js"
+		);
+		const req = createRequest();
+
+		const result = await checkApiAuth(req);
+
+		expect(result).toMatchObject({
+			ok: true,
+			principal: { authMethod: "anon", subject: "anon", scopeKey: "anon" },
+		});
+		expect(getAuthSubject(req)).toBe("anon");
+		expect(getAuthScopeKey(req)).toBe("anon");
+		expect(resolveSessionScope(req)).toBeNull();
+	});
+});

--- a/test/server/authz-principal.test.ts
+++ b/test/server/authz-principal.test.ts
@@ -168,6 +168,40 @@ describe("verified request principals", () => {
 		expect(getAuthScopeKey(reqA)).not.toBe(getAuthScopeKey(reqOtherWorkspace));
 	});
 
+	it("does not collapse long workspace identifiers that only differ after the old truncation boundary", async () => {
+		process.env = {
+			...originalEnv,
+			MAESTRO_JWT_SECRET: "test-jwt-secret-should-be-long-enough",
+			MAESTRO_SESSION_SCOPE: "auth",
+		};
+		vi.resetModules();
+		const { checkApiAuth, getAuthScopeKey } = await import(
+			"../../src/server/authz.js"
+		);
+		const sharedPrefix = "workspace-1234567890abcdef1234567890";
+		const tokenA = await createJwtToken(process.env.MAESTRO_JWT_SECRET!, {
+			sub: "user-1234567890abcdef1234567890",
+			workspaceId: `${sharedPrefix}AAAAAA`,
+			orgId: "org-1234567890abcdef1234567890",
+			jti: "jwt-a",
+		});
+		const tokenB = await createJwtToken(process.env.MAESTRO_JWT_SECRET!, {
+			sub: "user-1234567890abcdef1234567890",
+			workspaceId: `${sharedPrefix}BBBBBB`,
+			orgId: "org-1234567890abcdef1234567890",
+			jti: "jwt-b",
+		});
+		const reqA = createRequest({ authorization: `Bearer ${tokenA}` });
+		const reqB = createRequest({ authorization: `Bearer ${tokenB}` });
+
+		await checkApiAuth(reqA);
+		await checkApiAuth(reqB);
+
+		expect(getAuthScopeKey(reqA)).toMatch(/^principal_[a-f0-9]{24}$/);
+		expect(getAuthScopeKey(reqB)).toMatch(/^principal_[a-f0-9]{24}$/);
+		expect(getAuthScopeKey(reqA)).not.toBe(getAuthScopeKey(reqB));
+	});
+
 	it("keeps shared-secret tokens scoped by durable user identity", async () => {
 		process.env = {
 			...originalEnv,


### PR DESCRIPTION
## Summary
- cache a verified request principal after JWT, shared-token, or web API key auth and use it for auth subject/scope derivation
- scope hosted sessions and headless runtimes by verified workspace/org/user claims instead of bearer-token hashes, while preserving explicit local anon mode
- apply the authenticated boundary to `/debug/z` when auth is configured and add focused auth/session coverage plus hosted-session reuse coverage

Closes #79.

## Testing
- `export PATH="/private/tmp/bun-1.3.6/bin:$PATH" && npm test -- test/server/authz-principal.test.ts test/db/hosted-session-storage.integration.test.ts test/web/headless-sessions.test.ts test/web/chat-handler.test.ts test/web/approvals-handler.test.ts test/web/api-client-websocket.test.ts`
- `export PATH="/private/tmp/bun-1.3.6/bin:$PATH" && bunx biome check src/server/authz.ts src/server/session-scope.ts src/server/server-middlewares.ts src/server/handlers/headless-sessions.ts test/server/authz-principal.test.ts test/db/hosted-session-storage.integration.test.ts`
- `git diff --check`
