### PR TITLE
[maestro] emit selected skill eval signals

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -88,6 +88,7 @@ import {
 } from "../lsp/diagnostic-repair.js";
 import type { SkillArtifactMetadata } from "../skills/artifact-metadata.js";
 import {
+	recordMaestroEvalScored,
 	recordMaestroSkillInvoked,
 	recordMaestroSkillOutcome,
 	recordMaestroToolCallAttempt,
@@ -138,6 +139,66 @@ import type {
 } from "./types.js";
 
 const logger = createLogger("agent");
+
+type ToolEvaluationSummary = {
+	score?: number;
+	threshold?: number;
+	passed?: boolean;
+	rationale?: string;
+	assertionCount?: number;
+};
+
+function getToolEvaluationSummary(
+	details: unknown,
+): ToolEvaluationSummary | undefined {
+	if (!details || typeof details !== "object" || Array.isArray(details)) {
+		return undefined;
+	}
+
+	const normalized = details as {
+		evaluation?: unknown;
+		assertions?: unknown;
+	};
+	if (
+		!normalized.evaluation ||
+		typeof normalized.evaluation !== "object" ||
+		Array.isArray(normalized.evaluation)
+	) {
+		return undefined;
+	}
+
+	const evaluation = normalized.evaluation as Record<string, unknown>;
+	const summary: ToolEvaluationSummary = {};
+	if (
+		typeof evaluation.score === "number" &&
+		Number.isFinite(evaluation.score)
+	) {
+		summary.score = evaluation.score;
+	}
+	if (
+		typeof evaluation.threshold === "number" &&
+		Number.isFinite(evaluation.threshold)
+	) {
+		summary.threshold = evaluation.threshold;
+	}
+	if (typeof evaluation.passed === "boolean") {
+		summary.passed = evaluation.passed;
+	}
+	if (
+		typeof evaluation.rationale === "string" &&
+		evaluation.rationale.trim().length > 0
+	) {
+		summary.rationale = evaluation.rationale.trim();
+	}
+	if (
+		Array.isArray(normalized.assertions) &&
+		normalized.assertions.length > 0
+	) {
+		summary.assertionCount = normalized.assertions.length;
+	}
+
+	return Object.keys(summary).length > 0 ? summary : undefined;
+}
 
 /**
  * Default message transformer that converts app messages to LLM-ready format.
@@ -2044,6 +2105,7 @@ export class Agent {
 				});
 			}
 		}
+		this.publishCurrentTurnEvalScores(event);
 		this.handleDiagnosticDeltaToolResult(event);
 		if (!pending) {
 			return;
@@ -2086,6 +2148,36 @@ export class Agent {
 			return;
 		}
 		this.currentTurnSkillSelections.set(key, selection);
+	}
+
+	private publishCurrentTurnEvalScores(
+		event: Extract<AgentEvent, { type: "tool_execution_end" }>,
+	): void {
+		const evaluation = getToolEvaluationSummary(event.result.details);
+		if (!evaluation || this.currentTurnSkillSelections.size === 0) {
+			return;
+		}
+
+		const scoredAt = new Date(event.result.timestamp).toISOString();
+		for (const selection of this.currentTurnSkillSelections.values()) {
+			recordMaestroEvalScored({
+				prompt_metadata: this._state.promptMetadata,
+				skill_metadata: selection.skillMetadata,
+				tool_call_id: event.toolCallId,
+				tool_execution_id: event.toolExecutionId,
+				tool_name: event.toolName,
+				score: evaluation.score,
+				threshold: evaluation.threshold,
+				passed: evaluation.passed,
+				rationale: evaluation.rationale,
+				assertion_count: evaluation.assertionCount,
+				correlation: {
+					session_id: this._state.session?.id,
+					agent_run_step_id: event.toolCallId,
+				},
+				scored_at: scoredAt,
+			});
+		}
 	}
 
 	private publishCurrentTurnSkillOutcomes(options: {

--- a/src/telemetry/maestro-event-bus.ts
+++ b/src/telemetry/maestro-event-bus.ts
@@ -249,6 +249,21 @@ export interface SkillOutcomeEventData extends Record<string, unknown> {
 	outcome_at: string;
 }
 
+export interface EvalScoredEventData extends Record<string, unknown> {
+	correlation: MaestroCorrelation;
+	prompt_metadata?: PromptMetadata;
+	skill_metadata?: SkillArtifactMetadata;
+	tool_call_id: string;
+	tool_execution_id?: string;
+	tool_name?: string;
+	score?: number;
+	threshold?: number;
+	passed?: boolean;
+	rationale?: string;
+	assertion_count?: number;
+	scored_at: string;
+}
+
 export interface MaestroEventBusTransport {
 	publish(subject: string, payload: string): Promise<void>;
 	close?(): Promise<void>;
@@ -364,6 +379,22 @@ export interface RecordMaestroSkillOutcomeInput {
 	stop_reason?: string;
 	correlation?: Partial<MaestroCorrelation>;
 	outcome_at?: string;
+	env?: Env;
+}
+
+export interface RecordMaestroEvalScoredInput {
+	prompt_metadata?: PromptMetadata;
+	skill_metadata?: SkillArtifactMetadata;
+	tool_call_id: string;
+	tool_execution_id?: string;
+	tool_name?: string;
+	score?: number;
+	threshold?: number;
+	passed?: boolean;
+	rationale?: string;
+	assertion_count?: number;
+	correlation?: Partial<MaestroCorrelation>;
+	scored_at?: string;
 	env?: Env;
 }
 
@@ -1033,6 +1064,33 @@ export function recordMaestroSkillOutcome(
 			outcome_at: outcomeAt,
 		},
 		{ env: event.env, time: outcomeAt },
+	);
+}
+
+export function recordMaestroEvalScored(
+	event: RecordMaestroEvalScoredInput,
+): void {
+	const scoredAt = event.scored_at ?? new Date().toISOString();
+	void publishMaestroCloudEvent<EvalScoredEventData>(
+		MaestroBusEventType.EvalScored,
+		{
+			correlation: mergeCorrelation(
+				resolveMaestroEventBusConfig(event.env).defaultCorrelation,
+				event.correlation,
+			),
+			prompt_metadata: event.prompt_metadata,
+			skill_metadata: event.skill_metadata,
+			tool_call_id: event.tool_call_id,
+			tool_execution_id: event.tool_execution_id,
+			tool_name: event.tool_name,
+			score: event.score,
+			threshold: event.threshold,
+			passed: event.passed,
+			rationale: event.rationale,
+			assertion_count: event.assertion_count,
+			scored_at: scoredAt,
+		},
+		{ env: event.env, time: scoredAt },
 	);
 }
 

--- a/test/agent/skill-outcome-telemetry.test.ts
+++ b/test/agent/skill-outcome-telemetry.test.ts
@@ -58,6 +58,36 @@ function createAssistantToolCallMessage(toolCallId: string): AssistantMessage {
 	};
 }
 
+function createAssistantGenericToolCallMessage(
+	toolCallId: string,
+	name: string,
+	arguments_: Record<string, unknown>,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{
+				type: "toolCall",
+				id: toolCallId,
+				name,
+				arguments: arguments_,
+			},
+		],
+		api: "openai-completions",
+		provider: "mock",
+		model: "mock-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	};
+}
+
 function createAssistantTextMessage(text: string): AssistantMessage {
 	return {
 		role: "assistant",
@@ -88,8 +118,37 @@ function createSkillToolResult(toolCallId: string): ToolResultMessage {
 	};
 }
 
+function createEvaluatedToolResult(toolCallId: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "Bash",
+		content: [{ type: "text", text: "bash completed" }],
+		details: {
+			evaluation: {
+				score: 0.82,
+				threshold: 0.9,
+				passed: false,
+				rationale: "formatting checks failed",
+			},
+			assertions: [
+				{
+					name: "formatting",
+					passed: false,
+					score: 0.82,
+				},
+			],
+		},
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
 class SkillSelectionTransport implements AgentTransport {
-	constructor(private readonly shouldFailAfterSelection = false) {}
+	constructor(
+		private readonly shouldFailAfterSelection = false,
+		private readonly shouldEmitEvaluation = false,
+	) {}
 
 	async *continue(): AsyncGenerator<AgentEvent, void, unknown> {}
 
@@ -130,6 +189,35 @@ class SkillSelectionTransport implements AgentTransport {
 			result: toolResult,
 			isError: false,
 		};
+
+		if (this.shouldEmitEvaluation) {
+			const evalToolCallId = "tool-eval-1";
+			const evalToolCallMessage = createAssistantGenericToolCallMessage(
+				evalToolCallId,
+				"Bash",
+				{ command: "npm test" },
+			);
+			yield { type: "message_start", message: evalToolCallMessage };
+			yield { type: "message_end", message: evalToolCallMessage };
+			yield {
+				type: "tool_execution_start",
+				toolCallId: evalToolCallId,
+				toolName: "Bash",
+				args: { command: "npm test" },
+			};
+
+			const evalResult = createEvaluatedToolResult(evalToolCallId);
+			yield { type: "message_start", message: evalResult };
+			yield { type: "message_end", message: evalResult };
+			yield {
+				type: "tool_execution_end",
+				toolCallId: evalToolCallId,
+				toolName: "Bash",
+				toolExecutionId: "exec_eval_1",
+				result: evalResult,
+				isError: false,
+			};
+		}
 
 		if (this.shouldFailAfterSelection) {
 			throw new Error("turn blew up");
@@ -217,6 +305,68 @@ describe("skill outcome telemetry", () => {
 				skill_metadata: {
 					name: "incident-review",
 					artifactId: "skill_remote_1",
+				},
+			},
+		});
+	});
+
+	it("publishes eval scored events with selected skill identity", async () => {
+		const published: Array<{ subject: string; payload: string }> = [];
+		process.env.MAESTRO_EVENT_BUS_URL = "nats://bus.example:4222";
+		setMaestroEventBusTransportForTests({
+			async publish(subject, payload) {
+				published.push({ subject, payload });
+			},
+		});
+
+		const agent = new Agent({
+			transport: new SkillSelectionTransport(false, true),
+			initialState: {
+				model: mockModel,
+				tools: [],
+				session: {
+					id: "session_123",
+					startedAt: new Date("2026-04-23T18:00:00.000Z"),
+				},
+				promptMetadata: {
+					name: "maestro-system",
+					label: "production",
+					surface: "maestro",
+					version: 9,
+					versionId: "ver_9",
+					hash: "hash_prompt_123",
+					source: "service",
+				},
+			},
+		});
+
+		await agent.prompt("load the incident review skill and evaluate the run");
+
+		const payloads = published.map(({ payload }) => JSON.parse(payload));
+		expect(payloads.map((payload) => payload.type)).toContain(
+			"maestro.events.eval.scored",
+		);
+		expect(
+			payloads.find((payload) => payload.type === "maestro.events.eval.scored"),
+		).toMatchObject({
+			data: {
+				tool_call_id: "tool-eval-1",
+				tool_execution_id: "exec_eval_1",
+				tool_name: "Bash",
+				score: 0.82,
+				threshold: 0.9,
+				passed: false,
+				rationale: "formatting checks failed",
+				assertion_count: 1,
+				prompt_metadata: {
+					name: "maestro-system",
+					versionId: "ver_9",
+				},
+				skill_metadata: {
+					name: "incident-review",
+					artifactId: "skill_remote_1",
+					version: "3",
+					source: "service",
 				},
 			},
 		});

--- a/test/telemetry/maestro-event-bus.test.ts
+++ b/test/telemetry/maestro-event-bus.test.ts
@@ -5,6 +5,7 @@ import {
 	closeMaestroEventBusTransport,
 	getMaestroEventBusStatus,
 	publishMaestroCloudEvent,
+	recordMaestroEvalScored,
 	recordMaestroPromptVariantSelected,
 	recordMaestroSkillInvoked,
 	recordMaestroSkillOutcome,
@@ -231,6 +232,71 @@ describe("maestro event bus", () => {
 				tool_call_id: "tool_skill_1",
 				turn_status: "error",
 				error_message: "turn failed",
+				skill_metadata: {
+					name: "incident-review",
+					artifactId: "skill_remote_1",
+					source: "service",
+				},
+			},
+		});
+	});
+
+	it("publishes eval scored CloudEvents with prompt and skill identity", async () => {
+		const published: Array<{ subject: string; payload: string }> = [];
+		setMaestroEventBusTransportForTests({
+			async publish(subject, payload) {
+				published.push({ subject, payload });
+			},
+		});
+
+		recordMaestroEvalScored({
+			tool_call_id: "tool_eval_1",
+			tool_execution_id: "exec_eval_1",
+			tool_name: "Bash",
+			score: 0.82,
+			threshold: 0.9,
+			passed: false,
+			rationale: "formatting checks failed",
+			assertion_count: 1,
+			prompt_metadata: {
+				name: "maestro-system",
+				label: "prod",
+				surface: "maestro",
+				version: 9,
+				versionId: "ver_9",
+				hash: "hash_prompt_123",
+				source: "service",
+			},
+			skill_metadata: {
+				name: "incident-review",
+				artifactId: "skill_remote_1",
+				version: "3",
+				hash: "hash_skill_123",
+				source: "service",
+			},
+			scored_at: "2026-04-23T18:15:00.000Z",
+			env: { MAESTRO_EVENT_BUS_URL: "nats://bus.example:4222" },
+		});
+
+		await Promise.resolve();
+
+		expect(published).toHaveLength(1);
+		expect(JSON.parse(published[0]?.payload ?? "{}")).toMatchObject({
+			type: "maestro.events.eval.scored",
+			data: {
+				tool_call_id: "tool_eval_1",
+				tool_execution_id: "exec_eval_1",
+				tool_name: "Bash",
+				score: 0.82,
+				threshold: 0.9,
+				passed: false,
+				rationale: "formatting checks failed",
+				assertion_count: 1,
+				prompt_metadata: {
+					name: "maestro-system",
+					versionId: "ver_9",
+					source: "service",
+				},
 				skill_metadata: {
 					name: "incident-review",
 					artifactId: "skill_remote_1",


### PR DESCRIPTION
## Summary
- emit `maestro.events.eval.scored` when a tool result carries hook evaluation details
- attach selected skill identity and prompt metadata to those eval signals so Maestro can close the learning loop on the exact chosen artifact
- cover the event bus payload and end-to-end selected-skill telemetry path with focused tests

## Testing
- node ./scripts/run-vitest.js --run test/telemetry/maestro-event-bus.test.ts test/agent/skill-outcome-telemetry.test.ts
- bun run bun:lint
- npm run build
- npx nx run maestro:test --skip-nx-cache

Closes #75
