### PR TITLE
Add structured hosted runtime ownership errors

### DIFF
--- a/docs/protocols/hosted-runner-contract.md
+++ b/docs/protocols/hosted-runner-contract.md
@@ -235,6 +235,14 @@ Retryable HTTP failures should use `503` and `Retry-After` where they pass
 through HTTP. Permanent authorization and owner failures should not be retried
 without a fresh attach token or a new runtime owner.
 
+Hosted runner ownership failures should include a machine-readable
+`runtime_owned_elsewhere` code in the JSON error body. TypeScript web-hosted
+runners expose it as `error_type` and a `google.rpc.ErrorInfo` detail with
+`reason=runtime_owned_elsewhere`, plus routing metadata such as
+`runner_session_id`, `owner_instance_id`, `maestro_session_id`, and
+`requested_maestro_session_id`. Gateways and clients must key off that code
+rather than matching human error text.
+
 ## Provider Notes
 
 These notes are intentionally non-contractual. They describe useful provider

--- a/packages/tui-rs/src/headless/remote_transport.rs
+++ b/packages/tui-rs/src/headless/remote_transport.rs
@@ -1477,6 +1477,10 @@ fn classify_remote_status(
 ) -> (bool, RemoteErrorKind) {
     let trimmed_body = body.trim();
 
+    if body_has_remote_error_code(trimmed_body, "runtime_owned_elsewhere") {
+        return (false, RemoteErrorKind::OwnershipConflict);
+    }
+
     if trimmed_body.contains("Headless connection not found") {
         return (
             !matches!(kind, RemoteRequestKind::Bootstrap),
@@ -1540,6 +1544,26 @@ fn classify_remote_status(
         ),
     };
     (retryable, RemoteErrorKind::Other)
+}
+
+fn body_has_remote_error_code(body: &str, expected: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    if value.get("error_type").and_then(|value| value.as_str()) == Some(expected) {
+        return true;
+    }
+    if value.get("code").and_then(|value| value.as_str()) == Some(expected) {
+        return true;
+    }
+    value
+        .get("details")
+        .and_then(|value| value.as_array())
+        .is_some_and(|details| {
+            details.iter().any(|detail| {
+                detail.get("reason").and_then(|value| value.as_str()) == Some(expected)
+            })
+        })
 }
 
 async fn response_status_error(
@@ -2910,6 +2934,26 @@ mod tests {
                 r#"{"error":"Controller lease is already held by another connection"}"#,
             ),
             (false, RemoteErrorKind::ControllerLeaseConflict)
+        );
+    }
+
+    #[test]
+    fn retryability_classifies_structured_runtime_owner_mismatches() {
+        assert_eq!(
+            classify_remote_status(
+                StatusCode::CONFLICT,
+                RemoteRequestKind::Subscribe,
+                r#"{"error":"Hosted runner is bound to Maestro session sess_owner","code":"ALREADY_EXISTS","error_type":"runtime_owned_elsewhere"}"#,
+            ),
+            (false, RemoteErrorKind::OwnershipConflict)
+        );
+        assert_eq!(
+            classify_remote_status(
+                StatusCode::CONFLICT,
+                RemoteRequestKind::Heartbeat,
+                r#"{"error":"Hosted runner is bound to Maestro session sess_owner","code":"ALREADY_EXISTS","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"runtime_owned_elsewhere","domain":"maestro.hosted_runner","metadata":{"owner_instance_id":"pod-a","maestro_session_id":"sess_owner"}}]}"#,
+            ),
+            (false, RemoteErrorKind::OwnershipConflict)
         );
     }
 

--- a/src/server/handlers/headless-sessions.ts
+++ b/src/server/handlers/headless-sessions.ts
@@ -279,6 +279,38 @@ function getScopeKey(req: IncomingMessage): string {
 	return getAuthScopeKey(req);
 }
 
+function hostedRunnerOwnershipError(
+	context: WebServerContext,
+	message: string,
+	metadata: Record<string, string | undefined>,
+): ApiError {
+	const hostedRunner = context.hostedRunner;
+	const detailMetadata: Record<string, string> = {};
+	for (const [key, value] of Object.entries({
+		runner_session_id: hostedRunner?.runnerSessionId,
+		owner_instance_id: hostedRunner?.ownerInstanceId,
+		workspace_id: hostedRunner?.workspaceId,
+		agent_run_id: hostedRunner?.agentRunId,
+		...metadata,
+	})) {
+		if (value) {
+			detailMetadata[key] = value;
+		}
+	}
+	return new ApiError(
+		409,
+		message,
+		[
+			{
+				reason: "runtime_owned_elsewhere",
+				domain: "maestro.hosted_runner",
+				metadata: detailMetadata,
+			},
+		],
+		"runtime_owned_elsewhere",
+	);
+}
+
 function ensureHostedRunnerCanUseSession(
 	context: WebServerContext,
 	requestedSessionId: string | undefined,
@@ -294,15 +326,22 @@ function ensureHostedRunnerCanUseSession(
 		return;
 	}
 	if (!requestedSessionId) {
-		throw new ApiError(
-			409,
+		throw hostedRunnerOwnershipError(
+			context,
 			`Hosted runner is already bound to Maestro session ${activeSessionId}`,
+			{
+				maestro_session_id: activeSessionId,
+			},
 		);
 	}
 	if (requestedSessionId !== activeSessionId) {
-		throw new ApiError(
-			409,
+		throw hostedRunnerOwnershipError(
+			context,
 			`Hosted runner is bound to Maestro session ${activeSessionId}`,
+			{
+				maestro_session_id: activeSessionId,
+				requested_maestro_session_id: requestedSessionId,
+			},
 		);
 	}
 }
@@ -319,9 +358,13 @@ function claimHostedRunnerSession(
 		hostedRunner.activeMaestroSessionId ??
 		hostedRunner.configuredMaestroSessionId;
 	if (activeSessionId && activeSessionId !== sessionId) {
-		throw new ApiError(
-			409,
+		throw hostedRunnerOwnershipError(
+			context,
 			`Hosted runner is bound to Maestro session ${activeSessionId}`,
+			{
+				maestro_session_id: activeSessionId,
+				requested_maestro_session_id: sessionId,
+			},
 		);
 	}
 	hostedRunner.activeMaestroSessionId = sessionId;
@@ -544,6 +587,7 @@ function getRuntime(
 	if (!sessionId) {
 		throw new ApiError(400, "Missing headless session id");
 	}
+	ensureHostedRunnerCanUseSession(context, sessionId);
 	const runtime = context.headlessRuntimeService.getRuntime(
 		getScopeKey(req),
 		sessionId,

--- a/src/server/server-utils.ts
+++ b/src/server/server-utils.ts
@@ -13,6 +13,7 @@ export class ApiError extends StatusError {
 		public statusCode: number,
 		message: string,
 		details: Record<string, unknown>[] = [],
+		public errorType?: string,
 	) {
 		let code = Code.UNKNOWN;
 		switch (statusCode) {
@@ -315,6 +316,10 @@ export function respondWithApiError(
 		{
 			error: status.message,
 			code: Code[status.code],
+			error_type:
+				error instanceof ApiError && error.errorType
+					? error.errorType
+					: undefined,
 			details: status.details.length ? status.details : undefined,
 			maestro: isComposerError(error)
 				? {

--- a/test/web/headless-sessions.test.ts
+++ b/test/web/headless-sessions.test.ts
@@ -33,6 +33,7 @@ import {
 	handleHeadlessSessionDisconnect,
 	handleHeadlessSessionEvents,
 	handleHeadlessSessionMessage,
+	handleHeadlessSessionState,
 	handleHeadlessSessionSubscribe,
 	handleHeadlessSessionUnsubscribe,
 } from "../../src/server/handlers/headless-sessions.js";
@@ -42,7 +43,10 @@ import {
 	type HeadlessRuntimeStreamEnvelope,
 } from "../../src/server/headless-runtime-service.js";
 import { serverRequestManager } from "../../src/server/server-request-manager.js";
-import { ApiError } from "../../src/server/server-utils.js";
+import {
+	ApiError,
+	respondWithApiError,
+} from "../../src/server/server-utils.js";
 import { createSessionManagerForRequest } from "../../src/server/session-scope.js";
 import { ServerRequestToolRetryService } from "../../src/server/tool-retry-service.js";
 import { SessionManager } from "../../src/session/manager.js";
@@ -2838,6 +2842,144 @@ describe("headless session handlers", () => {
 		} finally {
 			await rm(hostedWorkspaceRoot, { recursive: true, force: true });
 			await rm(requestedWorkspaceRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("returns structured runtime owner errors for hosted session mismatches", async () => {
+		const workspaceRoot = await mkdtemp(
+			join(tmpdir(), "maestro-headless-hosted-owner-"),
+		);
+		try {
+			const context = createContext({
+				hostedRunner: {
+					enabled: true,
+					runnerSessionId: "mrs_test",
+					ownerInstanceId: "pod-a",
+					workspaceRoot,
+					workspaceId: "ws_1",
+					agentRunId: "run_1",
+					activeMaestroSessionId: "session_owner",
+				},
+			});
+			const req = createJsonRequest("POST", "/api/headless/sessions", {
+				model: TEST_MODEL.id,
+				sessionId: "session_other",
+			});
+			const res = new MockResponse();
+			res.req = req;
+
+			let caught: unknown;
+			try {
+				await handleHeadlessSessionCreate(
+					req,
+					res as unknown as ServerResponse,
+					context,
+				);
+			} catch (error) {
+				caught = error;
+			}
+
+			expect(caught).toBeInstanceOf(ApiError);
+			expect((caught as ApiError).errorType).toBe("runtime_owned_elsewhere");
+
+			const errorRes = new MockResponse();
+			errorRes.req = req;
+			respondWithApiError(
+				errorRes as unknown as ServerResponse,
+				caught,
+				500,
+				{},
+				req,
+			);
+
+			expect(errorRes.statusCode).toBe(409);
+			expect(JSON.parse(errorRes.body)).toMatchObject({
+				error: "Hosted runner is bound to Maestro session session_owner",
+				code: "ALREADY_EXISTS",
+				error_type: "runtime_owned_elsewhere",
+				details: [
+					{
+						reason: "runtime_owned_elsewhere",
+						domain: "maestro.hosted_runner",
+						metadata: {
+							runner_session_id: "mrs_test",
+							owner_instance_id: "pod-a",
+							workspace_id: "ws_1",
+							agent_run_id: "run_1",
+							maestro_session_id: "session_owner",
+							requested_maestro_session_id: "session_other",
+						},
+					},
+				],
+			});
+		} finally {
+			await rm(workspaceRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("reports runtime owner errors before local runtime lookup", async () => {
+		const workspaceRoot = await mkdtemp(
+			join(tmpdir(), "maestro-headless-hosted-owner-"),
+		);
+		try {
+			const context = createContext({
+				hostedRunner: {
+					enabled: true,
+					runnerSessionId: "mrs_test",
+					ownerInstanceId: "pod-a",
+					workspaceRoot,
+					activeMaestroSessionId: "session_owner",
+				},
+			});
+			const req = createJsonRequest(
+				"GET",
+				"/api/headless/sessions/session_other/state",
+			);
+			const res = new MockResponse();
+			res.req = req;
+
+			let caught: unknown;
+			try {
+				handleHeadlessSessionState(
+					req,
+					res as unknown as ServerResponse,
+					context,
+					{
+						id: "session_other",
+					},
+				);
+			} catch (error) {
+				caught = error;
+			}
+
+			expect(caught).toBeInstanceOf(ApiError);
+
+			const errorRes = new MockResponse();
+			errorRes.req = req;
+			respondWithApiError(
+				errorRes as unknown as ServerResponse,
+				caught,
+				500,
+				{},
+				req,
+			);
+
+			expect(errorRes.statusCode).toBe(409);
+			expect(JSON.parse(errorRes.body)).toMatchObject({
+				error_type: "runtime_owned_elsewhere",
+				details: [
+					{
+						reason: "runtime_owned_elsewhere",
+						metadata: {
+							owner_instance_id: "pod-a",
+							maestro_session_id: "session_owner",
+							requested_maestro_session_id: "session_other",
+						},
+					},
+				],
+			});
+		} finally {
+			await rm(workspaceRoot, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
## Summary
- return typed `runtime_owned_elsewhere` API errors for hosted runner session-owner mismatches, including ErrorInfo routing metadata
- classify structured `runtime_owned_elsewhere` responses in the Rust remote transport instead of relying on human error text
- document the hosted-runner ownership error envelope for gateways and clients

## Test plan
- `npm test -- test/web/headless-sessions.test.ts`
- `cargo test --manifest-path packages/tui-rs/Cargo.toml headless::remote_transport`
- `cargo fmt --manifest-path packages/tui-rs/Cargo.toml --check`
- `bunx biome check src/server/server-utils.ts src/server/handlers/headless-sessions.ts test/web/headless-sessions.test.ts docs/protocols/hosted-runner-contract.md`
- `git diff --check`

Closes part of #78. Updates #76.