### PR TITLE
Guard multi-replica headless Helm routing

### DIFF
--- a/deploy/helm/maestro/templates/_helpers.tpl
+++ b/deploy/helm/maestro/templates/_helpers.tpl
@@ -52,3 +52,23 @@ Service account name
 {{- include "maestro.fullname" . }}
 {{- end }}
 {{- end }}
+
+{{/*
+Validate process-local headless runtime routing before rendering workload
+resources. Multi-replica web/headless deployments need sticky sessions or a
+durable owner router; otherwise clients can land on a pod that does not own the
+runtime state for /api/headless/* or /api/chat/ws.
+*/}}
+{{- define "maestro.validateHeadlessRuntimeRouting" -}}
+{{- $replicas := int (default 1 .Values.replicaCount) -}}
+{{- $headlessRuntime := default dict (get .Values "headlessRuntime") -}}
+{{- $routing := default dict (get $headlessRuntime "routing") -}}
+{{- $routingMode := default "single-replica" (get $routing "mode") -}}
+{{- $validModes := list "single-replica" "sticky-session" "durable-owner" -}}
+{{- if not (has $routingMode $validModes) -}}
+{{- fail (printf "headlessRuntime.routing.mode must be one of %s, got %q" (join ", " $validModes) $routingMode) -}}
+{{- end -}}
+{{- if and (gt $replicas 1) (eq $routingMode "single-replica") -}}
+{{- fail "replicaCount > 1 requires headlessRuntime.routing.mode to be sticky-session or durable-owner so /api/headless/* and /api/chat/ws stay on the owning runtime pod" -}}
+{{- end -}}
+{{- end }}

--- a/deploy/helm/maestro/templates/deployment.yaml
+++ b/deploy/helm/maestro/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "maestro.validateHeadlessRuntimeRouting" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/maestro/values.yaml
+++ b/deploy/helm/maestro/values.yaml
@@ -1,4 +1,12 @@
-replicaCount: 2
+replicaCount: 1
+
+headlessRuntime:
+  routing:
+    # single-replica keeps headless runtime ownership, SSE replay, connection
+    # leases, and utility state local to one Maestro pod. Use sticky-session
+    # only when ingress pins /api/headless/* and /api/chat/ws to one pod, or
+    # durable-owner when Platform routes by a durable runtime-owner record.
+    mode: single-replica
 
 image:
   repository: ghcr.io/evalops/maestro

--- a/docs/protocols/hosted-runner-contract.md
+++ b/docs/protocols/hosted-runner-contract.md
@@ -92,6 +92,15 @@ The response is intentionally sparse:
 If Platform expects an owner generation, it must compare
 `owner_instance_id` before proxying attach traffic.
 
+The Maestro Helm chart defaults to `replicaCount=1` with
+`headlessRuntime.routing.mode=single-replica` because the TypeScript
+web/headless runtime keeps session ownership, connection leases, event replay,
+and utility operation state in-process. A chart render with `replicaCount > 1`
+must declare either `headlessRuntime.routing.mode=sticky-session` for ingress
+affinity on `/api/headless/*` and `/api/chat/ws`, or
+`headlessRuntime.routing.mode=durable-owner` for a gateway backed by durable
+runtime-owner records.
+
 ## Attach Surface
 
 All providers expose the same HTTP headless surface:

--- a/test/deploy/helm-maestro.test.ts
+++ b/test/deploy/helm-maestro.test.ts
@@ -1,0 +1,53 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const chartPath = resolve(repoRoot, "deploy/helm/maestro");
+const hasHelm =
+	spawnSync("helm", ["version", "--short"], { encoding: "utf8" }).status === 0;
+const helmIt = hasHelm ? it : it.skip;
+
+function renderChart(args: string[] = []) {
+	return spawnSync("helm", ["template", "maestro", chartPath, ...args], {
+		cwd: repoRoot,
+		encoding: "utf8",
+	});
+}
+
+describe("maestro Helm chart", () => {
+	helmIt(
+		"renders one replica by default for process-local headless routing",
+		() => {
+			const result = renderChart();
+
+			expect(result.status).toBe(0);
+			expect(result.stdout).toMatch(/replicas:\s+1/);
+		},
+	);
+
+	helmIt("rejects multi-replica process-local headless routing", () => {
+		const result = renderChart(["--set", "replicaCount=2"]);
+
+		expect(result.status).not.toBe(0);
+		expect(`${result.stderr}\n${result.stdout}`).toContain(
+			"replicaCount > 1 requires headlessRuntime.routing.mode",
+		);
+	});
+
+	helmIt(
+		"allows multi-replica deployments when sticky routing is declared",
+		() => {
+			const result = renderChart([
+				"--set",
+				"replicaCount=2",
+				"--set",
+				"headlessRuntime.routing.mode=sticky-session",
+			]);
+
+			expect(result.status).toBe(0);
+			expect(result.stdout).toMatch(/replicas:\s+2/);
+		},
+	);
+});


### PR DESCRIPTION
## Summary
- default the Maestro Helm chart to one replica for process-local headless runtime routing
- fail chart rendering when `replicaCount > 1` is used without `sticky-session` or `durable-owner` routing mode
- document the routing modes and add Helm render tests for default, rejected, and sticky-routed cases

## Test plan
- `npm test -- test/deploy/helm-maestro.test.ts`
- `helm lint deploy/helm/maestro`
- `helm template maestro deploy/helm/maestro`
- `helm template maestro deploy/helm/maestro --set replicaCount=2 --set headlessRuntime.routing.mode=durable-owner`
- `bunx biome check deploy/helm/maestro/values.yaml deploy/helm/maestro/templates/_helpers.tpl deploy/helm/maestro/templates/deployment.yaml docs/protocols/hosted-runner-contract.md test/deploy/helm-maestro.test.ts`
- `git diff --check`

Closes another part of #78. Updates #76.