### PR TITLE
Harden Maestro Helm runtime defaults

### DIFF
--- a/deploy/helm/maestro/templates/_helpers.tpl
+++ b/deploy/helm/maestro/templates/_helpers.tpl
@@ -42,12 +42,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Service account name
 */}}
 {{- define "maestro.serviceAccountName" -}}
-{{- if .Values.serviceAccount }}
-{{- if .Values.serviceAccount.name }}
+{{- if and .Values.serviceAccount .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
-{{- else }}
-{{- include "maestro.fullname" . }}
-{{- end }}
 {{- else }}
 {{- include "maestro.fullname" . }}
 {{- end }}
@@ -60,7 +56,12 @@ durable owner router; otherwise clients can land on a pod that does not own the
 runtime state for /api/headless/* or /api/chat/ws.
 */}}
 {{- define "maestro.validateHeadlessRuntimeRouting" -}}
+{{- $autoscaling := default dict (get .Values "autoscaling") -}}
+{{- $autoscalingEnabled := default false (get $autoscaling "enabled") -}}
 {{- $replicas := int (default 1 .Values.replicaCount) -}}
+{{- if $autoscalingEnabled -}}
+{{- $replicas = int (default 1 (get $autoscaling "maxReplicas")) -}}
+{{- end -}}
 {{- $headlessRuntime := default dict (get .Values "headlessRuntime") -}}
 {{- $routing := default dict (get $headlessRuntime "routing") -}}
 {{- $routingMode := default "single-replica" (get $routing "mode") -}}
@@ -69,6 +70,6 @@ runtime state for /api/headless/* or /api/chat/ws.
 {{- fail (printf "headlessRuntime.routing.mode must be one of %s, got %q" (join ", " $validModes) $routingMode) -}}
 {{- end -}}
 {{- if and (gt $replicas 1) (eq $routingMode "single-replica") -}}
-{{- fail "replicaCount > 1 requires headlessRuntime.routing.mode to be sticky-session or durable-owner so /api/headless/* and /api/chat/ws stay on the owning runtime pod" -}}
+{{- fail "replicaCount or autoscaling.maxReplicas > 1 requires headlessRuntime.routing.mode to be sticky-session or durable-owner so /api/headless/* and /api/chat/ws stay on the owning runtime pod" -}}
 {{- end -}}
 {{- end }}

--- a/deploy/helm/maestro/templates/deployment.yaml
+++ b/deploy/helm/maestro/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "maestro.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "maestro.selectorLabels" . | nindent 6 }}
@@ -14,12 +16,34 @@ spec:
     metadata:
       labels:
         {{- include "maestro.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "maestro.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.writableTmp.enabled }}
+      volumes:
+        - name: tmp
+          emptyDir:
+            {{- if .Values.writableTmp.sizeLimit }}
+            sizeLimit: {{ .Values.writableTmp.sizeLimit }}
+            {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -33,6 +57,15 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- if .Values.writableTmp.enabled }}
+          volumeMounts:
+            - name: tmp
+              mountPath: {{ .Values.writableTmp.mountPath }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -45,5 +78,10 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- if .Values.gracefulShutdown.enabled }}
+          lifecycle:
+            preStop:
+              {{- toYaml .Values.gracefulShutdown.preStop | nindent 14 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/maestro/templates/hpa.yaml
+++ b/deploy/helm/maestro/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "maestro.fullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "maestro.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/maestro/templates/pdb.yaml
+++ b/deploy/helm/maestro/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "maestro.fullname" . }}
+  labels:
+    {{- include "maestro.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "maestro.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/maestro/templates/serviceaccount.yaml
+++ b/deploy/helm/maestro/templates/serviceaccount.yaml
@@ -1,6 +1,13 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "maestro.serviceAccountName" . }}
   labels:
     {{- include "maestro.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/helm/maestro/values.yaml
+++ b/deploy/helm/maestro/values.yaml
@@ -1,5 +1,11 @@
 replicaCount: 1
 
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
 headlessRuntime:
   routing:
     # single-replica keeps headless runtime ownership, SSE replay, connection
@@ -17,6 +23,59 @@ service:
   type: ClusterIP
   port: 8080
 
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
+
+writableTmp:
+  enabled: true
+  sizeLimit: 1Gi
+  mountPath: /tmp
+
+terminationGracePeriodSeconds: 45
+
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  failureThreshold: 18
+  periodSeconds: 5
+
+gracefulShutdown:
+  enabled: true
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - sleep 5
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
 resources:
   requests:
     cpu: 500m
@@ -26,7 +85,10 @@ resources:
     memory: 2Gi
 
 env:
+  HOME: "/tmp"
   IDENTITY_URL: ""
   KEYS_URL: ""
   LLM_GATEWAY_URL: ""
   MEMORY_URL: ""
+  TMPDIR: "/tmp"
+  XDG_CACHE_HOME: "/tmp/.cache"

--- a/test/deploy/helm-maestro.test.ts
+++ b/test/deploy/helm-maestro.test.ts
@@ -27,14 +27,60 @@ describe("maestro Helm chart", () => {
 		},
 	);
 
+	helmIt("renders production security and disruption defaults", () => {
+		const result = renderChart();
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("kind: PodDisruptionBudget");
+		expect(result.stdout).toMatch(/automountServiceAccountToken:\s+false/);
+		expect(result.stdout).toMatch(/terminationGracePeriodSeconds:\s+45/);
+		expect(result.stdout).toMatch(/runAsUser:\s+1001/);
+		expect(result.stdout).toMatch(/runAsGroup:\s+1001/);
+		expect(result.stdout).toMatch(/readOnlyRootFilesystem:\s+true/);
+		expect(result.stdout).toContain("emptyDir:");
+		expect(result.stdout).toMatch(/mountPath:\s+\/tmp/);
+		expect(result.stdout).toContain("name: HOME");
+		expect(result.stdout).toContain("name: XDG_CACHE_HOME");
+		expect(result.stdout).toContain("startupProbe:");
+		expect(result.stdout).toContain("preStop:");
+	});
+
+	helmIt("can render an HPA without a fixed deployment replica count", () => {
+		const result = renderChart([
+			"--set",
+			"autoscaling.enabled=true",
+			"--set",
+			"headlessRuntime.routing.mode=sticky-session",
+			"--set",
+			"autoscaling.maxReplicas=4",
+		]);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("kind: HorizontalPodAutoscaler");
+		expect(result.stdout).toMatch(/maxReplicas:\s+4/);
+		expect(result.stdout).not.toMatch(/replicas:\s+1/);
+	});
+
 	helmIt("rejects multi-replica process-local headless routing", () => {
 		const result = renderChart(["--set", "replicaCount=2"]);
 
 		expect(result.status).not.toBe(0);
 		expect(`${result.stderr}\n${result.stdout}`).toContain(
-			"replicaCount > 1 requires headlessRuntime.routing.mode",
+			"replicaCount or autoscaling.maxReplicas > 1 requires headlessRuntime.routing.mode",
 		);
 	});
+
+	helmIt(
+		"rejects autoscaling above one replica without routed ownership",
+		() => {
+			const result = renderChart(["--set", "autoscaling.enabled=true"]);
+
+			expect(result.status).not.toBe(0);
+			expect(`${result.stderr}\n${result.stdout}`).toContain(
+				"replicaCount or autoscaling.maxReplicas > 1 requires headlessRuntime.routing.mode",
+			);
+		},
+	);
 
 	helmIt(
 		"allows multi-replica deployments when sticky routing is declared",


### PR DESCRIPTION
## Summary
- add production-shaped pod defaults for the Maestro Helm chart: service account control, restricted security context, writable /tmp, startup probe, graceful shutdown, and pod disruption budget
- add optional HPA support with a template guard that refuses multi-replica hosted runtime deployments unless an explicit routing mode is configured
- expand Helm chart tests around secure defaults, autoscaling, and routing guard behavior

Fixes #80

## Test plan
- `helm template maestro deploy/helm/maestro`
- `helm template maestro deploy/helm/maestro --set autoscaling.enabled=true --set autoscaling.maxReplicas=3` rejects without routing
- `helm template maestro deploy/helm/maestro --set autoscaling.enabled=true --set autoscaling.maxReplicas=4 --set headlessRuntime.routing.mode=sticky-session`
- `helm lint deploy/helm/maestro`
- `bunx biome check test/deploy/helm-maestro.test.ts`
- `npm test -- test/deploy/helm-maestro.test.ts`
- `git diff --check`