### PR TITLE
Fix missed Maestro review feedback

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -2276,7 +2276,7 @@ export class Agent {
 
 		const baseTurnStatus = options.aborted
 			? "aborted"
-			: this._state.error
+			: this._state.error !== undefined
 				? "error"
 				: undefined;
 

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -1096,6 +1096,7 @@ async function collectRecentSkillRestoreMessages(
 					? details.name
 					: extractSkillRestoreName(message.content);
 			content = message.content;
+			skillMetadata = getSkillArtifactMetadataFromDetails(message.details);
 		}
 
 		if (!skillName || !content || seenSkillNames.has(skillName)) {

--- a/src/remote-runner/client.ts
+++ b/src/remote-runner/client.ts
@@ -248,7 +248,8 @@ export interface RemoteRunnerStatus {
 }
 
 export interface WaitForRunnerSessionReadyOptions
-	extends RemoteRunnerClientOptions {
+	extends Omit<RemoteRunnerClientOptions, "timeoutMs"> {
+	requestTimeoutMs?: number;
 	timeoutMs?: number;
 	pollIntervalMs?: number;
 }
@@ -947,6 +948,16 @@ export async function waitForRunnerSessionReady(
 	if (!Number.isFinite(pollIntervalMs) || pollIntervalMs < 0) {
 		throw new Error("Remote runner poll interval must be 0ms or greater");
 	}
+	const {
+		pollIntervalMs: _pollIntervalMs,
+		requestTimeoutMs,
+		timeoutMs: _waitTimeoutMs,
+		...requestOptions
+	} = options;
+	const getSessionOptions: RemoteRunnerClientOptions = {
+		...requestOptions,
+		...(requestTimeoutMs !== undefined ? { timeoutMs: requestTimeoutMs } : {}),
+	};
 
 	const readyStates = [
 		RUNNER_SESSION_STATES.RUNNING,
@@ -965,7 +976,7 @@ export async function waitForRunnerSessionReady(
 
 	while (true) {
 		attempts += 1;
-		lastSession = await getRunnerSession(sessionId, options);
+		lastSession = await getRunnerSession(sessionId, getSessionOptions);
 		const elapsedMs = Date.now() - startedAt;
 
 		if (stateMatches(lastSession.state, readyStates)) {

--- a/src/server/authz.ts
+++ b/src/server/authz.ts
@@ -240,7 +240,7 @@ async function verifyJwt(token: string): Promise<JWTPayload | null> {
 			});
 			payload = verified.payload;
 		}
-		if (!payload.sub) return null;
+		if (typeof payload.sub !== "string" || !payload.sub.trim()) return null;
 		// basic exp/nbf checks handled by jose
 		return payload;
 	} catch {
@@ -274,7 +274,7 @@ export async function checkApiAuth(
 		);
 		return { ok: true, principal: principal ?? undefined };
 	}
-	if (jwtPayload?.sub) {
+	if (jwtPayload) {
 		const principal = setVerifiedRequestPrincipal(
 			req,
 			createJwtPrincipal(jwtPayload),

--- a/src/telemetry/meter-service-client.ts
+++ b/src/telemetry/meter-service-client.ts
@@ -94,8 +94,8 @@ function joinMetadataValues(
 	if (!values) {
 		return undefined;
 	}
-	const filtered = values.map((value) => value?.trim()).filter(Boolean);
-	return filtered.length > 0 ? filtered.join(",") : undefined;
+	const normalized = values.map((value) => value?.trim() ?? "");
+	return normalized.some(Boolean) ? normalized.join(",") : undefined;
 }
 
 function toNonNegativeInt(value: number | undefined): number {

--- a/test/agent/perform-compaction.test.ts
+++ b/test/agent/perform-compaction.test.ts
@@ -267,13 +267,18 @@ function createActiveSkillHookMessage(name = "debug"): AppMessage {
 function createRestoredSkillHookMessage(
 	name = "reviewer",
 	content = "# Skill: reviewer\n\n> Review specialist\n\n## Instructions\n\nInspect the diff for regressions.",
+	skillMetadata?: Record<string, unknown>,
 ): AppMessage {
 	return {
 		role: "hookMessage",
 		customType: "skill",
 		content: [{ type: "text", text: content.replaceAll("reviewer", name) }],
 		display: false,
-		details: { name, source: "tool" },
+		details: {
+			name,
+			source: "tool",
+			...(skillMetadata ? { skillMetadata } : {}),
+		},
 		timestamp: Date.now(),
 	};
 }
@@ -2289,6 +2294,48 @@ Current plan contents:
 		expect(JSON.stringify(restoredSkillMessages[0]?.content)).toContain(
 			"Inspect the diff for regressions.",
 		);
+	});
+
+	it("preserves restored tool skill metadata across repeated compactions", async () => {
+		const messages = buildConversation(10);
+		messages.splice(
+			2,
+			0,
+			createRestoredSkillHookMessage(
+				"reviewer",
+				"# Skill: reviewer\n\n> Review specialist\n\n## Instructions\n\nInspect the diff for regressions.",
+				{
+					name: "reviewer",
+					artifactId: "skill_remote_reviewer",
+					version: "2",
+					hash: "hash_reviewer",
+					source: "service",
+				},
+			),
+		);
+		const agent = createMockAgentWithoutAppendMessage(messages);
+		const sessionManager = createMockSessionManager();
+
+		const result = await performCompaction({ agent, sessionManager });
+
+		expect(result.success).toBe(true);
+		const restoredSkillMessage = getReplacedMessages(agent).find(
+			(message) =>
+				message.role === "hookMessage" && message.customType === "skill",
+		);
+		expect(restoredSkillMessage).toMatchObject({
+			details: {
+				name: "reviewer",
+				source: "tool",
+				skillMetadata: {
+					name: "reviewer",
+					artifactId: "skill_remote_reviewer",
+					version: "2",
+					hash: "hash_reviewer",
+					source: "service",
+				},
+			},
+		});
 	});
 
 	it("refreshes stale kept-tail tool skill context across repeated compactions", async () => {

--- a/test/agent/skill-outcome-telemetry.test.ts
+++ b/test/agent/skill-outcome-telemetry.test.ts
@@ -154,6 +154,7 @@ class SkillSelectionTransport implements AgentTransport {
 			toolExecutionId: string;
 			skillMetadata: SkillArtifactMetadata;
 		}> = [],
+		private readonly failureMessage = "turn blew up",
 	) {}
 
 	async *continue(): AsyncGenerator<AgentEvent, void, unknown> {}
@@ -253,7 +254,7 @@ class SkillSelectionTransport implements AgentTransport {
 		}
 
 		if (this.shouldFailAfterSelection) {
-			throw new Error("turn blew up");
+			throw new Error(this.failureMessage);
 		}
 
 		const finalMessage = createAssistantTextMessage("Done");
@@ -538,6 +539,43 @@ describe("skill outcome telemetry", () => {
 					name: "incident-review",
 					artifactId: "skill_remote_1",
 				},
+			},
+		});
+	});
+
+	it("publishes failed skill outcomes for empty error messages", async () => {
+		const published: Array<{ subject: string; payload: string }> = [];
+		process.env.MAESTRO_EVENT_BUS_URL = "nats://bus.example:4222";
+		setMaestroEventBusTransportForTests({
+			async publish(subject, payload) {
+				published.push({ subject, payload });
+			},
+		});
+
+		const agent = new Agent({
+			transport: new SkillSelectionTransport(true, false, [], ""),
+			initialState: {
+				model: mockModel,
+				tools: [],
+				session: {
+					id: "session_123",
+					startedAt: new Date("2026-04-23T18:00:00.000Z"),
+				},
+			},
+		});
+
+		await expect(
+			agent.prompt("load the incident review skill"),
+		).rejects.toThrow(Error);
+
+		const skillOutcome = published
+			.map(({ payload }) => JSON.parse(payload))
+			.find((payload) => payload.type === "maestro.events.skill.failed");
+		expect(skillOutcome).toMatchObject({
+			data: {
+				turn_status: "error",
+				error_category: "runtime",
+				error_message: "",
 			},
 		});
 	});

--- a/test/remote-runner/client.test.ts
+++ b/test/remote-runner/client.test.ts
@@ -360,6 +360,43 @@ describe("remote runner client", () => {
 		});
 	});
 
+	it("does not use the total wait timeout as the per-request timeout", async () => {
+		vi.useFakeTimers();
+		const aborts: string[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async (_input: RequestInfo | URL, init?: RequestInit) =>
+					new Promise<Response>((_resolve, reject) => {
+						init?.signal?.addEventListener(
+							"abort",
+							() => {
+								aborts.push("aborted");
+								const error = new Error("aborted");
+								error.name = "AbortError";
+								reject(error);
+							},
+							{ once: true },
+						);
+					}),
+			),
+		);
+
+		const waitPromise = waitForRunnerSessionReady("mrs_wait_request_timeout", {
+			maxAttempts: 1,
+			pollIntervalMs: 0,
+			timeoutMs: 10_000,
+		});
+		const assertion = expect(waitPromise).rejects.toThrow(
+			"remote runner service request timed out after 5000ms",
+		);
+
+		await vi.advanceTimersByTimeAsync(4_999);
+		expect(aborts).toEqual([]);
+		await vi.advanceTimersByTimeAsync(1);
+		await assertion;
+	});
+
 	it("fails fast when the runner session enters a terminal state", async () => {
 		getRunnerSessionResponses.push({
 			session: {

--- a/test/server/authz-principal.test.ts
+++ b/test/server/authz-principal.test.ts
@@ -266,6 +266,24 @@ describe("verified request principals", () => {
 		expect(result).toEqual({ ok: false, error: "Unauthorized" });
 	});
 
+	it("rejects JWTs with whitespace-only subjects without throwing", async () => {
+		process.env = {
+			...originalEnv,
+			MAESTRO_JWT_SECRET: "test-jwt-secret-should-be-long-enough",
+		};
+		vi.resetModules();
+		const { checkApiAuth } = await import("../../src/server/authz.js");
+		const token = await createJwtToken(process.env.MAESTRO_JWT_SECRET!, {
+			sub: "   ",
+		});
+		const req = createRequest({ authorization: `Bearer ${token}` });
+
+		await expect(checkApiAuth(req)).resolves.toEqual({
+			ok: false,
+			error: "Unauthorized",
+		});
+	});
+
 	it("applies the authenticated boundary to /debug/z when auth is configured", async () => {
 		process.env = {
 			...originalEnv,

--- a/test/telemetry/meter-service-client.test.ts
+++ b/test/telemetry/meter-service-client.test.ts
@@ -131,6 +131,44 @@ describe("meter telemetry client", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
+	it("keeps skill metadata arrays positionally aligned", async () => {
+		const event = {
+			...createCanonicalTurnEvent(),
+			skillMetadata: [
+				{
+					name: "incident-review",
+					artifactId: "skill_remote_1",
+					version: "3",
+					hash: "hash_skill_123",
+					source: "service",
+				},
+				{
+					name: "local-debug",
+					version: "1",
+					hash: "hash_skill_456",
+					source: "filesystem",
+				},
+			],
+		};
+		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+			expect(JSON.parse(String(init?.body ?? "{}")).metadata).toMatchObject({
+				skillNames: "incident-review,local-debug",
+				skillArtifactIds: "skill_remote_1,",
+				skillVersions: "3,1",
+				skillHashes: "hash_skill_123,hash_skill_456",
+				skillSources: "service,filesystem",
+			});
+			return new Response(JSON.stringify({ event: { id: "wide_event_1" } }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(mirrorCanonicalTurnEventToMeter(event)).resolves.toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it.each([
 		"/meter.v1.MeterService/QueryWideEvents",
 		"/meter.v1.MeterService/GetEventDashboard",


### PR DESCRIPTION
## Summary
- reject whitespace-only JWT subjects cleanly and keep empty runtime errors classified as failed skill outcomes
- preserve restored skill metadata through repeated compactions and keep meter skill metadata arrays positionally aligned
- keep remote-runner wait timeout separate from per-request polling timeout

## Test plan
- `bunx biome check src/server/authz.ts src/agent/agent.ts src/agent/compaction.ts src/telemetry/meter-service-client.ts src/remote-runner/client.ts test/server/authz-principal.test.ts test/agent/skill-outcome-telemetry.test.ts test/agent/perform-compaction.test.ts test/telemetry/meter-service-client.test.ts test/remote-runner/client.test.ts`
- `npm test -- test/server/authz-principal.test.ts test/agent/skill-outcome-telemetry.test.ts test/agent/perform-compaction.test.ts test/telemetry/meter-service-client.test.ts test/remote-runner/client.test.ts`
- `bunx tsc -p tsconfig.build.json --noEmit`
- commit hook: Guardian, full Biome, lint:evals, build, compile
- `git diff --check`