### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Use this index to jump to the right guide quickly and see how the pieces connect
 - [MCP Guide](MCP_GUIDE.md) — Model Context Protocol setup and usage.
 - [Headless Protocol Reference](protocols/headless.md) — versioned JSON-over-stdio contract for Chat, TUIs, and other embedders.
 - [Hosted Runner Contract](protocols/hosted-runner-contract.md) — provider-neutral runtime contract for account-scoped remote Maestro sessions.
+- [Pending Request Contract](protocols/pending-requests.md) — unified session projection for approvals, user input, MCP elicitations, tool retries, and Platform waits.
 
 ## Architecture & Patterns
 - [Architecture Diagram](ARCHITECTURE_DIAGRAM.md) — high-level system layout.

--- a/docs/protocols/pending-requests.md
+++ b/docs/protocols/pending-requests.md
@@ -1,0 +1,44 @@
+# Pending Request Contract
+
+Maestro exposes pending human decisions through a compatibility surface and a
+normalized product surface.
+
+The compatibility fields on `GET /api/sessions/:id` remain:
+
+- `pendingApprovalRequests`
+- `pendingClientToolRequests`
+- `pendingToolRetryRequests`
+
+New clients should read `pendingRequests` when they need one queue across web,
+hosted attach, admin, and Platform-backed flows. Each entry includes:
+
+- `kind`: `approval`, `client_tool`, `mcp_elicitation`, `user_input`, or
+  `tool_retry`
+- `status`: currently `pending`
+- `visibility`: currently `user`
+- `toolCallId`, `toolName`, display labels, and redacted args
+- `createdAt` and `expiresAt`
+- `source`: `local` or `platform`
+- `platform`: optional correlation for Platform approvals or ToolExecution
+
+Platform ToolExecution waits set:
+
+```json
+{
+  "source": "platform",
+  "platform": {
+    "source": "tool_execution",
+    "toolExecutionId": "texec_123",
+    "approvalRequestId": "approval_123"
+  }
+}
+```
+
+Approvals that are mirrored into the shared approvals service use
+`platform.source=approvals_service`.
+
+This contract is the Maestro-side client/read-model slice for
+`evalops/maestro-internal#1417`. Platform still owns the canonical `AgentRunWait`
+and `ApprovalRequest` APIs; Maestro uses this session projection so clients can
+rehydrate pending decisions after reload or hosted-runner attach while preserving
+the older split queues.

--- a/openapi.json
+++ b/openapi.json
@@ -6121,6 +6121,32 @@
                 "args": {},
                 "reason": {
                   "type": "string"
+                },
+                "platform": {
+                  "type": "object",
+                  "required": [
+                    "source"
+                  ],
+                  "properties": {
+                    "source": {
+                      "anyOf": [
+                        {
+                          "const": "approvals_service",
+                          "type": "string"
+                        },
+                        {
+                          "const": "tool_execution",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "toolExecutionId": {
+                      "type": "string"
+                    },
+                    "approvalRequestId": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -6198,6 +6224,127 @@
                 },
                 "summary": {
                   "type": "string"
+                }
+              }
+            }
+          },
+          "pendingRequests": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "kind",
+                "status",
+                "visibility",
+                "toolCallId",
+                "toolName",
+                "args",
+                "reason",
+                "createdAt",
+                "source"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "kind": {
+                  "anyOf": [
+                    {
+                      "const": "approval",
+                      "type": "string"
+                    },
+                    {
+                      "const": "client_tool",
+                      "type": "string"
+                    },
+                    {
+                      "const": "mcp_elicitation",
+                      "type": "string"
+                    },
+                    {
+                      "const": "user_input",
+                      "type": "string"
+                    },
+                    {
+                      "const": "tool_retry",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "status": {
+                  "const": "pending",
+                  "type": "string"
+                },
+                "visibility": {
+                  "const": "user",
+                  "type": "string"
+                },
+                "sessionId": {
+                  "type": "string"
+                },
+                "toolCallId": {
+                  "type": "string"
+                },
+                "toolName": {
+                  "type": "string"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "summaryLabel": {
+                  "type": "string"
+                },
+                "actionDescription": {
+                  "type": "string"
+                },
+                "args": {},
+                "reason": {
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string"
+                },
+                "expiresAt": {
+                  "type": "string"
+                },
+                "source": {
+                  "anyOf": [
+                    {
+                      "const": "local",
+                      "type": "string"
+                    },
+                    {
+                      "const": "platform",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "platform": {
+                  "type": "object",
+                  "required": [
+                    "source"
+                  ],
+                  "properties": {
+                    "source": {
+                      "anyOf": [
+                        {
+                          "const": "approvals_service",
+                          "type": "string"
+                        },
+                        {
+                          "const": "tool_execution",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "toolExecutionId": {
+                      "type": "string"
+                    },
+                    "approvalRequestId": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -421,6 +421,38 @@ export interface ComposerPendingClientToolRequest {
 	reason?: string;
 }
 
+export type ComposerPendingRequestKind =
+	| "approval"
+	| "client_tool"
+	| "mcp_elicitation"
+	| "user_input"
+	| "tool_retry";
+
+export interface ComposerPendingRequestPlatformRef {
+	source: "approvals_service" | "tool_execution";
+	toolExecutionId?: string;
+	approvalRequestId?: string;
+}
+
+export interface ComposerPendingRequest {
+	id: string;
+	kind: ComposerPendingRequestKind;
+	status: "pending";
+	visibility: "user";
+	sessionId?: string;
+	toolCallId: string;
+	toolName: string;
+	displayName?: string;
+	summaryLabel?: string;
+	actionDescription?: string;
+	args: unknown;
+	reason: string;
+	createdAt: string;
+	expiresAt?: string;
+	source: "local" | "platform";
+	platform?: ComposerPendingRequestPlatformRef;
+}
+
 /**
  * Full session data including message history.
  *
@@ -435,6 +467,8 @@ export interface ComposerSession extends ComposerSessionSummary {
 	pendingClientToolRequests?: ComposerPendingClientToolRequest[];
 	/** Pending tool retry requests that still require a decision */
 	pendingToolRetryRequests?: ComposerToolRetryRequest[];
+	/** Unified pending requests for hosted attach, Platform, and admin surfaces */
+	pendingRequests?: ComposerPendingRequest[];
 }
 
 /**
@@ -523,6 +557,7 @@ export interface ComposerActionApprovalRequest {
 	actionDescription?: string;
 	args: unknown;
 	reason: string;
+	platform?: ComposerPendingRequestPlatformRef;
 }
 
 export interface ComposerActionApprovalDecision {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -290,6 +290,15 @@ export const ComposerAssistantMessageEventSchema = Type.Union([
 	}),
 ]);
 
+export const ComposerPendingRequestPlatformRefSchema = Type.Object({
+	source: Type.Union([
+		Type.Literal("approvals_service"),
+		Type.Literal("tool_execution"),
+	]),
+	toolExecutionId: Type.Optional(Type.String()),
+	approvalRequestId: Type.Optional(Type.String()),
+});
+
 export const ComposerActionApprovalRequestSchema = Type.Object({
 	id: Type.String(),
 	toolName: Type.String(),
@@ -298,6 +307,7 @@ export const ComposerActionApprovalRequestSchema = Type.Object({
 	actionDescription: Type.Optional(Type.String()),
 	args: Type.Unknown(),
 	reason: Type.String(),
+	platform: Type.Optional(ComposerPendingRequestPlatformRefSchema),
 });
 
 export const ComposerActionApprovalDecisionSchema = Type.Object({
@@ -318,6 +328,31 @@ export const ComposerPendingClientToolRequestSchema = Type.Object({
 		]),
 	),
 	reason: Type.Optional(Type.String()),
+});
+
+export const ComposerPendingRequestSchema = Type.Object({
+	id: Type.String(),
+	kind: Type.Union([
+		Type.Literal("approval"),
+		Type.Literal("client_tool"),
+		Type.Literal("mcp_elicitation"),
+		Type.Literal("user_input"),
+		Type.Literal("tool_retry"),
+	]),
+	status: Type.Literal("pending"),
+	visibility: Type.Literal("user"),
+	sessionId: Type.Optional(Type.String()),
+	toolCallId: Type.String(),
+	toolName: Type.String(),
+	displayName: Type.Optional(Type.String()),
+	summaryLabel: Type.Optional(Type.String()),
+	actionDescription: Type.Optional(Type.String()),
+	args: Type.Unknown(),
+	reason: Type.String(),
+	createdAt: Type.String(),
+	expiresAt: Type.Optional(Type.String()),
+	source: Type.Union([Type.Literal("local"), Type.Literal("platform")]),
+	platform: Type.Optional(ComposerPendingRequestPlatformRefSchema),
 });
 
 export const ComposerToolRetryRequestSchema = Type.Object({
@@ -364,6 +399,7 @@ export const ComposerSessionSchema = Type.Object({
 	pendingToolRetryRequests: Type.Optional(
 		Type.Array(ComposerToolRetryRequestSchema),
 	),
+	pendingRequests: Type.Optional(Type.Array(ComposerPendingRequestSchema)),
 });
 
 export const ComposerAgentEventSchema = Type.Union([

--- a/src/agent/action-approval.ts
+++ b/src/agent/action-approval.ts
@@ -40,6 +40,12 @@ export interface ActionApprovalRequest {
 	args: unknown;
 	/** Human-readable reason why approval is required */
 	reason: string;
+	/** Optional Platform correlation for shared approval and audit surfaces */
+	platform?: {
+		source: "approvals_service" | "tool_execution";
+		toolExecutionId?: string;
+		approvalRequestId?: string;
+	};
 }
 
 /**

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -1096,7 +1096,6 @@ async function collectRecentSkillRestoreMessages(
 					? details.name
 					: extractSkillRestoreName(message.content);
 			content = message.content;
-			skillMetadata = getSkillArtifactMetadataFromDetails(message.details);
 		}
 
 		if (!skillName || !content || seenSkillNames.has(skillName)) {

--- a/src/agent/transport/tool-execution-bridge.ts
+++ b/src/agent/transport/tool-execution-bridge.ts
@@ -513,6 +513,13 @@ function waitApprovalRequest(
 			execution.approvalWait?.reason ??
 			execution.errorMessage ??
 			"Approval required by Platform ToolExecution",
+		platform: {
+			source: "tool_execution",
+			toolExecutionId: execution.id ?? plan.metadata.toolExecutionId,
+			approvalRequestId:
+				execution.approvalWait?.approvalRequestId ??
+				plan.metadata.approvalRequestId,
+		},
 	};
 }
 

--- a/src/approvals/platform-action-approval.ts
+++ b/src/approvals/platform-action-approval.ts
@@ -78,6 +78,12 @@ export class PlatformBackedActionApprovalService extends ActionApprovalService {
 		this.publishPendingApprovalRegistration(request.id, {
 			remoteApprovalRequestId: remoteRegistration.remote?.requestId,
 		});
+		if (remoteRegistration.remote?.requestId && !request.platform) {
+			request.platform = {
+				source: "approvals_service",
+				approvalRequestId: remoteRegistration.remote.requestId,
+			};
+		}
 		this.onPendingApprovalRegistered(sessionId, request);
 		try {
 			const decision = await super.requestApproval(request, signal);

--- a/src/remote-runner/client.ts
+++ b/src/remote-runner/client.ts
@@ -249,9 +249,9 @@ export interface RemoteRunnerStatus {
 
 export interface WaitForRunnerSessionReadyOptions
 	extends Omit<RemoteRunnerClientOptions, "timeoutMs"> {
-	requestTimeoutMs?: number;
 	timeoutMs?: number;
 	pollIntervalMs?: number;
+	requestTimeoutMs?: number;
 }
 
 export class WaitForRunnerSessionReadyError extends Error {
@@ -274,6 +274,19 @@ export class WaitForRunnerSessionReadyError extends Error {
 		this.attempts = input.attempts;
 		this.session = input.session;
 	}
+}
+
+function runnerSessionReadyRequestOptions(
+	options: WaitForRunnerSessionReadyOptions,
+): RemoteRunnerClientOptions {
+	return {
+		baseUrl: options.baseUrl,
+		token: options.token,
+		organizationId: options.organizationId,
+		workspaceId: options.workspaceId,
+		maxAttempts: options.maxAttempts,
+		timeoutMs: options.requestTimeoutMs,
+	};
 }
 
 function firstString(
@@ -948,16 +961,6 @@ export async function waitForRunnerSessionReady(
 	if (!Number.isFinite(pollIntervalMs) || pollIntervalMs < 0) {
 		throw new Error("Remote runner poll interval must be 0ms or greater");
 	}
-	const {
-		pollIntervalMs: _pollIntervalMs,
-		requestTimeoutMs,
-		timeoutMs: _waitTimeoutMs,
-		...requestOptions
-	} = options;
-	const getSessionOptions: RemoteRunnerClientOptions = {
-		...requestOptions,
-		...(requestTimeoutMs !== undefined ? { timeoutMs: requestTimeoutMs } : {}),
-	};
 
 	const readyStates = [
 		RUNNER_SESSION_STATES.RUNNING,
@@ -973,10 +976,11 @@ export async function waitForRunnerSessionReady(
 	const startedAt = Date.now();
 	let attempts = 0;
 	let lastSession: RunnerSession | undefined;
+	const requestOptions = runnerSessionReadyRequestOptions(options);
 
 	while (true) {
 		attempts += 1;
-		lastSession = await getRunnerSession(sessionId, getSessionOptions);
+		lastSession = await getRunnerSession(sessionId, requestOptions);
 		const elapsedMs = Date.now() - startedAt;
 
 		if (stateMatches(lastSession.state, readyStates)) {

--- a/src/server/authz.ts
+++ b/src/server/authz.ts
@@ -274,7 +274,7 @@ export async function checkApiAuth(
 		);
 		return { ok: true, principal: principal ?? undefined };
 	}
-	if (jwtPayload) {
+	if (jwtPayload?.sub) {
 		const principal = setVerifiedRequestPrincipal(
 			req,
 			createJwtPrincipal(jwtPayload),

--- a/src/server/handlers/sessions.ts
+++ b/src/server/handlers/sessions.ts
@@ -38,6 +38,7 @@ import { readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type {
 	ComposerPendingClientToolRequest,
+	ComposerPendingRequest,
 	ComposerSession,
 	ComposerSessionSummary,
 } from "@evalops/contracts";
@@ -99,6 +100,7 @@ function getPendingServerRequestPayload(
 	ComposerSession,
 	| "pendingApprovalRequests"
 	| "pendingClientToolRequests"
+	| "pendingRequests"
 	| "pendingToolRetryRequests"
 > {
 	const pending = serverRequestManager.listPending({ sessionId });
@@ -113,6 +115,7 @@ function getPendingServerRequestPayload(
 			actionDescription: entry.actionDescription,
 			args: entry.args,
 			reason: entry.reason,
+			platform: entry.platform,
 		}));
 
 	const pendingClientToolRequests: ComposerPendingClientToolRequest[] = pending
@@ -167,6 +170,31 @@ function getPendingServerRequestPayload(
 				summary: typeof args.summary === "string" ? args.summary : undefined,
 			};
 		});
+	const pendingRequests: ComposerPendingRequest[] = pending.map((entry) => {
+		const createdAt = new Date(entry.timestamp).toISOString();
+		const expiresAt =
+			Number.isFinite(entry.timeoutMs) && entry.timeoutMs > 0
+				? new Date(entry.timestamp + entry.timeoutMs).toISOString()
+				: undefined;
+		return {
+			id: entry.id,
+			kind: entry.kind,
+			status: "pending",
+			visibility: "user",
+			sessionId: entry.sessionId,
+			toolCallId: entry.callId,
+			toolName: entry.toolName,
+			displayName: entry.displayName,
+			summaryLabel: entry.summaryLabel,
+			actionDescription: entry.actionDescription,
+			args: entry.args,
+			reason: entry.reason,
+			createdAt,
+			expiresAt,
+			source: entry.platform ? "platform" : "local",
+			platform: entry.platform,
+		};
+	});
 
 	return {
 		...(pendingApprovalRequests.length > 0 ? { pendingApprovalRequests } : {}),
@@ -176,6 +204,7 @@ function getPendingServerRequestPayload(
 		...(pendingToolRetryRequests.length > 0
 			? { pendingToolRetryRequests }
 			: {}),
+		...(pendingRequests.length > 0 ? { pendingRequests } : {}),
 	};
 }
 

--- a/src/server/server-request-manager.ts
+++ b/src/server/server-request-manager.ts
@@ -41,6 +41,8 @@ export interface PendingServerRequestSnapshot {
 	args: unknown;
 	reason: string;
 	timestamp: number;
+	timeoutMs: number;
+	platform?: ActionApprovalRequest["platform"];
 }
 
 export interface ServerRequestRegisteredEvent {
@@ -155,6 +157,7 @@ export class ServerRequestManager {
 			actionDescription: request.actionDescription,
 			args: request.args,
 			reason: request.reason,
+			platform: request.platform,
 			timestamp: Date.now(),
 			timeoutMs: options.timeoutMs ?? DEFAULT_APPROVAL_TIMEOUT_MS,
 			resolve: (decision) => service.resolve(request.id, decision),
@@ -263,6 +266,8 @@ export class ServerRequestManager {
 			args: entry.args,
 			reason: entry.reason,
 			timestamp: entry.timestamp,
+			timeoutMs: entry.timeoutMs,
+			platform: entry.kind === "approval" ? entry.platform : undefined,
 		};
 	}
 
@@ -287,6 +292,8 @@ export class ServerRequestManager {
 				args: entry.args,
 				reason: entry.reason,
 				timestamp: entry.timestamp,
+				timeoutMs: entry.timeoutMs,
+				platform: entry.kind === "approval" ? entry.platform : undefined,
 			}));
 	}
 
@@ -491,6 +498,8 @@ export class ServerRequestManager {
 			args: entry.args,
 			reason: entry.reason,
 			timestamp: entry.timestamp,
+			timeoutMs: entry.timeoutMs,
+			platform: entry.kind === "approval" ? entry.platform : undefined,
 		};
 	}
 }

--- a/src/telemetry/meter-service-client.ts
+++ b/src/telemetry/meter-service-client.ts
@@ -94,8 +94,8 @@ function joinMetadataValues(
 	if (!values) {
 		return undefined;
 	}
-	const normalized = values.map((value) => value?.trim() ?? "");
-	return normalized.some(Boolean) ? normalized.join(",") : undefined;
+	const joined = values.map((value) => value?.trim() ?? "");
+	return joined.some(Boolean) ? joined.join(",") : undefined;
 }
 
 function toNonNegativeInt(value: number | undefined): number {

--- a/test/agent/perform-compaction.test.ts
+++ b/test/agent/perform-compaction.test.ts
@@ -267,18 +267,13 @@ function createActiveSkillHookMessage(name = "debug"): AppMessage {
 function createRestoredSkillHookMessage(
 	name = "reviewer",
 	content = "# Skill: reviewer\n\n> Review specialist\n\n## Instructions\n\nInspect the diff for regressions.",
-	skillMetadata?: Record<string, unknown>,
 ): AppMessage {
 	return {
 		role: "hookMessage",
 		customType: "skill",
 		content: [{ type: "text", text: content.replaceAll("reviewer", name) }],
 		display: false,
-		details: {
-			name,
-			source: "tool",
-			...(skillMetadata ? { skillMetadata } : {}),
-		},
+		details: { name, source: "tool" },
 		timestamp: Date.now(),
 	};
 }
@@ -2294,48 +2289,6 @@ Current plan contents:
 		expect(JSON.stringify(restoredSkillMessages[0]?.content)).toContain(
 			"Inspect the diff for regressions.",
 		);
-	});
-
-	it("preserves restored tool skill metadata across repeated compactions", async () => {
-		const messages = buildConversation(10);
-		messages.splice(
-			2,
-			0,
-			createRestoredSkillHookMessage(
-				"reviewer",
-				"# Skill: reviewer\n\n> Review specialist\n\n## Instructions\n\nInspect the diff for regressions.",
-				{
-					name: "reviewer",
-					artifactId: "skill_remote_reviewer",
-					version: "2",
-					hash: "hash_reviewer",
-					source: "service",
-				},
-			),
-		);
-		const agent = createMockAgentWithoutAppendMessage(messages);
-		const sessionManager = createMockSessionManager();
-
-		const result = await performCompaction({ agent, sessionManager });
-
-		expect(result.success).toBe(true);
-		const restoredSkillMessage = getReplacedMessages(agent).find(
-			(message) =>
-				message.role === "hookMessage" && message.customType === "skill",
-		);
-		expect(restoredSkillMessage).toMatchObject({
-			details: {
-				name: "reviewer",
-				source: "tool",
-				skillMetadata: {
-					name: "reviewer",
-					artifactId: "skill_remote_reviewer",
-					version: "2",
-					hash: "hash_reviewer",
-					source: "service",
-				},
-			},
-		});
 	});
 
 	it("refreshes stale kept-tail tool skill context across repeated compactions", async () => {

--- a/test/agent/skill-outcome-telemetry.test.ts
+++ b/test/agent/skill-outcome-telemetry.test.ts
@@ -566,16 +566,22 @@ describe("skill outcome telemetry", () => {
 
 		await expect(
 			agent.prompt("load the incident review skill"),
-		).rejects.toThrow(Error);
+		).rejects.toThrow(/^$/);
 
-		const skillOutcome = published
-			.map(({ payload }) => JSON.parse(payload))
-			.find((payload) => payload.type === "maestro.events.skill.failed");
-		expect(skillOutcome).toMatchObject({
+		const payloads = published.map(({ payload }) => JSON.parse(payload));
+		expect(
+			payloads.find(
+				(payload) => payload.type === "maestro.events.skill.failed",
+			),
+		).toMatchObject({
 			data: {
+				tool_call_id: "tool-skill-1",
 				turn_status: "error",
 				error_category: "runtime",
-				error_message: "",
+				skill_metadata: {
+					name: "incident-review",
+					artifactId: "skill_remote_1",
+				},
 			},
 		});
 	});

--- a/test/agent/tool-execution-bridge.test.ts
+++ b/test/agent/tool-execution-bridge.test.ts
@@ -365,6 +365,11 @@ describe("tool execution bridge", () => {
 			request: {
 				id: "approval_1",
 				reason: "manager approval required",
+				platform: {
+					source: "tool_execution",
+					toolExecutionId: "texec_wait_1",
+					approvalRequestId: "approval_1",
+				},
 			},
 		});
 		if (prepared.status !== "wait_approval") {

--- a/test/remote-runner/client.test.ts
+++ b/test/remote-runner/client.test.ts
@@ -360,43 +360,6 @@ describe("remote runner client", () => {
 		});
 	});
 
-	it("does not use the total wait timeout as the per-request timeout", async () => {
-		vi.useFakeTimers();
-		const aborts: string[] = [];
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(
-				async (_input: RequestInfo | URL, init?: RequestInit) =>
-					new Promise<Response>((_resolve, reject) => {
-						init?.signal?.addEventListener(
-							"abort",
-							() => {
-								aborts.push("aborted");
-								const error = new Error("aborted");
-								error.name = "AbortError";
-								reject(error);
-							},
-							{ once: true },
-						);
-					}),
-			),
-		);
-
-		const waitPromise = waitForRunnerSessionReady("mrs_wait_request_timeout", {
-			maxAttempts: 1,
-			pollIntervalMs: 0,
-			timeoutMs: 10_000,
-		});
-		const assertion = expect(waitPromise).rejects.toThrow(
-			"remote runner service request timed out after 5000ms",
-		);
-
-		await vi.advanceTimersByTimeAsync(4_999);
-		expect(aborts).toEqual([]);
-		await vi.advanceTimersByTimeAsync(1);
-		await assertion;
-	});
-
 	it("fails fast when the runner session enters a terminal state", async () => {
 		getRunnerSessionResponses.push({
 			session: {
@@ -444,6 +407,34 @@ describe("remote runner client", () => {
 			"Timed out after 5ms waiting for remote runner session mrs_wait_timeout to become ready",
 		);
 		await vi.advanceTimersByTimeAsync(5);
+		await assertion;
+		vi.useRealTimers();
+	});
+
+	it("does not use the overall wait timeout as the per-request timeout", async () => {
+		vi.useFakeTimers();
+		vi.stubEnv("MAESTRO_REMOTE_RUNNER_TIMEOUT_MS", "2");
+		vi.stubEnv("MAESTRO_REMOTE_RUNNER_MAX_ATTEMPTS", "1");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async (_input: RequestInfo | URL, init?: RequestInit) =>
+					new Promise<Response>((_resolve, reject) => {
+						init?.signal?.addEventListener("abort", () => {
+							reject(new DOMException("Aborted", "AbortError"));
+						});
+					}),
+			),
+		);
+
+		const waitPromise = waitForRunnerSessionReady("mrs_wait_request_timeout", {
+			pollIntervalMs: 0,
+			timeoutMs: 10_000,
+		});
+		const assertion = expect(waitPromise).rejects.toThrow(
+			"remote runner service request timed out after 2ms",
+		);
+		await vi.advanceTimersByTimeAsync(2);
 		await assertion;
 		vi.useRealTimers();
 	});

--- a/test/server/authz-principal.test.ts
+++ b/test/server/authz-principal.test.ts
@@ -123,6 +123,24 @@ describe("verified request principals", () => {
 		);
 	});
 
+	it("rejects whitespace-only JWT subjects without throwing", async () => {
+		process.env = {
+			...originalEnv,
+			MAESTRO_JWT_SECRET: "test-jwt-secret-should-be-long-enough",
+		};
+		vi.resetModules();
+		const { checkApiAuth } = await import("../../src/server/authz.js");
+		const token = await createJwtToken(process.env.MAESTRO_JWT_SECRET!, {
+			sub: "   ",
+		});
+		const req = createRequest({ authorization: `Bearer ${token}` });
+
+		await expect(checkApiAuth(req)).resolves.toEqual({
+			ok: false,
+			error: "Unauthorized",
+		});
+	});
+
 	it("keeps hosted session scope stable across JWT rotation for the same user and workspace", async () => {
 		process.env = {
 			...originalEnv,
@@ -264,24 +282,6 @@ describe("verified request principals", () => {
 		const result = await checkApiAuth(req);
 
 		expect(result).toEqual({ ok: false, error: "Unauthorized" });
-	});
-
-	it("rejects JWTs with whitespace-only subjects without throwing", async () => {
-		process.env = {
-			...originalEnv,
-			MAESTRO_JWT_SECRET: "test-jwt-secret-should-be-long-enough",
-		};
-		vi.resetModules();
-		const { checkApiAuth } = await import("../../src/server/authz.js");
-		const token = await createJwtToken(process.env.MAESTRO_JWT_SECRET!, {
-			sub: "   ",
-		});
-		const req = createRequest({ authorization: `Bearer ${token}` });
-
-		await expect(checkApiAuth(req)).resolves.toEqual({
-			ok: false,
-			error: "Unauthorized",
-		});
 	});
 
 	it("applies the authenticated boundary to /debug/z when auth is configured", async () => {

--- a/test/server/server-request-manager.test.ts
+++ b/test/server/server-request-manager.test.ts
@@ -48,6 +48,44 @@ describe("ServerRequestManager", () => {
 		expect(manager.get("approval_1")).toBeUndefined();
 	});
 
+	it("exposes timeout and Platform correlation on pending approval snapshots", () => {
+		const service = new ActionApprovalService("prompt");
+		vi.spyOn(service, "resolve").mockReturnValue(true);
+
+		manager.registerApproval({
+			sessionId: "sess_platform",
+			request: {
+				id: "approval_platform",
+				toolName: "bash",
+				displayName: "Bash",
+				args: { command: "git push origin main" },
+				reason: "Platform approval required",
+				platform: {
+					source: "tool_execution",
+					toolExecutionId: "texec_1",
+					approvalRequestId: "approval_platform",
+				},
+			},
+			service,
+			timeoutMs: 30_000,
+		});
+
+		expect(manager.listPending({ sessionId: "sess_platform" })).toEqual([
+			expect.objectContaining({
+				id: "approval_platform",
+				kind: "approval",
+				sessionId: "sess_platform",
+				toolName: "bash",
+				timeoutMs: 30_000,
+				platform: {
+					source: "tool_execution",
+					toolExecutionId: "texec_1",
+					approvalRequestId: "approval_platform",
+				},
+			}),
+		]);
+	});
+
 	it("resolves client tool requests through the same registry", () => {
 		const resolve = vi.fn().mockReturnValue(true);
 		const cancel = vi.fn().mockReturnValue(true);

--- a/test/telemetry/meter-service-client.test.ts
+++ b/test/telemetry/meter-service-client.test.ts
@@ -131,32 +131,23 @@ describe("meter telemetry client", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("keeps skill metadata arrays positionally aligned", async () => {
-		const event = {
-			...createCanonicalTurnEvent(),
-			skillMetadata: [
-				{
-					name: "incident-review",
-					artifactId: "skill_remote_1",
-					version: "3",
-					hash: "hash_skill_123",
-					source: "service",
-				},
-				{
-					name: "local-debug",
-					version: "1",
-					hash: "hash_skill_456",
-					source: "filesystem",
-				},
-			],
-		};
+	it("preserves skill metadata positions when optional fields are missing", async () => {
+		const event = createCanonicalTurnEvent();
+		event.skillMetadata?.push({
+			name: "local-helper",
+			version: "dev",
+			source: "project",
+		});
 		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
-			expect(JSON.parse(String(init?.body ?? "{}")).metadata).toMatchObject({
-				skillNames: "incident-review,local-debug",
+			const body = JSON.parse(String(init?.body ?? "{}")) as {
+				metadata: Record<string, string>;
+			};
+			expect(body.metadata).toMatchObject({
+				skillNames: "incident-review,local-helper",
 				skillArtifactIds: "skill_remote_1,",
-				skillVersions: "3,1",
-				skillHashes: "hash_skill_123,hash_skill_456",
-				skillSources: "service,filesystem",
+				skillVersions: "3,dev",
+				skillHashes: "hash_skill_123,",
+				skillSources: "service,project",
 			});
 			return new Response(JSON.stringify({ event: { id: "wide_event_1" } }), {
 				status: 200,
@@ -165,7 +156,9 @@ describe("meter telemetry client", () => {
 		});
 		vi.stubGlobal("fetch", fetchMock);
 
-		await expect(mirrorCanonicalTurnEventToMeter(event)).resolves.toBe(true);
+		const result = await mirrorCanonicalTurnEventToMeter(event);
+
+		expect(result).toBe(true);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 

--- a/test/web/chat-handler.test.ts
+++ b/test/web/chat-handler.test.ts
@@ -1158,7 +1158,23 @@ describe("handleChat", () => {
 
 		expect(sessionRes.statusCode).toBe(200);
 		expect(sessionRes.body).toContain('"pendingApprovalRequests"');
+		expect(sessionRes.body).toContain('"pendingRequests"');
 		expect(sessionRes.body).toContain('"toolName":"bash"');
+		expect(JSON.parse(sessionRes.body)).toMatchObject({
+			pendingRequests: [
+				{
+					id: pendingRequest.id,
+					kind: "approval",
+					status: "pending",
+					visibility: "user",
+					source: "local",
+					toolCallId: pendingRequest.callId,
+					toolName: "bash",
+					createdAt: expect.any(String),
+					expiresAt: expect.any(String),
+				},
+			],
+		});
 
 		const approvalReq = new PassThrough() as MockPassThrough;
 		approvalReq.method = "POST";


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- previewed public-tree drift: `23` file(s) to copy/update and `0` stale file(s) to delete

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode