### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/pending-requests.md
+++ b/docs/protocols/pending-requests.md
@@ -42,3 +42,8 @@ This contract is the Maestro-side client/read-model slice for
 and `ApprovalRequest` APIs; Maestro uses this session projection so clients can
 rehydrate pending decisions after reload or hosted-runner attach while preserving
 the older split queues.
+
+Web clients should merge `pendingRequests` with the legacy split queues during
+the rollout. When the same request appears in both surfaces, prefer the
+normalized `pendingRequests` entry so Platform correlation fields and refreshed
+display metadata survive attach/reload recovery.

--- a/packages/web/src/components/composer-chat-approvals.test.ts
+++ b/packages/web/src/components/composer-chat-approvals.test.ts
@@ -87,6 +87,74 @@ describe("ComposerChatApprovals", () => {
 		);
 	});
 
+	it("restores Platform approvals from normalized pending requests", () => {
+		const { approvals, state } = createApprovalsHarness();
+
+		approvals.restorePendingRequests({
+			pendingApprovalRequests: [
+				{
+					id: "approval-1",
+					toolName: "bash",
+					args: { command: "old" },
+					reason: "Legacy projection",
+				},
+			],
+			pendingRequests: [
+				{
+					id: "approval-1",
+					kind: "approval",
+					status: "pending",
+					visibility: "user",
+					sessionId: "session-1",
+					toolCallId: "approval-1",
+					toolName: "bash",
+					displayName: "Run shell command",
+					summaryLabel: "Needs command approval",
+					actionDescription: "npm test",
+					args: { command: "npm test" },
+					reason: "Platform approval wait",
+					createdAt: "2026-04-23T23:00:00.000Z",
+					source: "platform",
+					platform: {
+						source: "tool_execution",
+						toolExecutionId: "texec-1",
+						approvalRequestId: "approval-1",
+					},
+				},
+				{
+					id: "user-1",
+					kind: "user_input",
+					status: "pending",
+					visibility: "user",
+					sessionId: "session-1",
+					toolCallId: "user-call-1",
+					toolName: "ask_user",
+					args: { questions: [] },
+					reason: "Not an approval",
+					createdAt: "2026-04-23T23:00:01.000Z",
+					source: "platform",
+				},
+			],
+		});
+
+		expect(state.pendingApprovalQueue).toEqual([
+			{
+				id: "approval-1",
+				toolName: "bash",
+				displayName: "Run shell command",
+				summaryLabel: "Needs command approval",
+				actionDescription: "npm test",
+				args: { command: "npm test" },
+				reason: "Platform approval wait",
+				platform: {
+					source: "tool_execution",
+					toolExecutionId: "texec-1",
+					approvalRequestId: "approval-1",
+				},
+			},
+		]);
+	});
+
 	it("stores stricter-server notices when approval mode resolves down", () => {
 		const { approvals, showToast, state } = createApprovalsHarness();
 

--- a/packages/web/src/components/composer-chat-approvals.ts
+++ b/packages/web/src/components/composer-chat-approvals.ts
@@ -1,6 +1,7 @@
 import type {
 	ComposerActionApprovalRequest,
 	ComposerApprovalMode,
+	ComposerPendingRequest,
 } from "@evalops/contracts";
 import type { ApiClient, Session } from "../services/api-client.js";
 
@@ -29,6 +30,44 @@ export type ComposerApprovalStatusUpdate = {
 	notify?: boolean;
 	sessionId?: string | null;
 };
+
+function approvalFromPendingRequest(
+	request: ComposerPendingRequest,
+): ComposerActionApprovalRequest | null {
+	if (request.kind !== "approval") {
+		return null;
+	}
+	return {
+		id: request.id,
+		toolName: request.toolName,
+		displayName: request.displayName,
+		summaryLabel: request.summaryLabel,
+		actionDescription: request.actionDescription,
+		args: request.args,
+		reason: request.reason,
+		platform: request.platform,
+	};
+}
+
+function mergeApprovalRequests(
+	session: Pick<Session, "pendingApprovalRequests" | "pendingRequests">,
+): ComposerActionApprovalRequest[] {
+	const merged = new Map<string, ComposerActionApprovalRequest>();
+	if (Array.isArray(session.pendingApprovalRequests)) {
+		for (const request of session.pendingApprovalRequests) {
+			merged.set(request.id, request);
+		}
+	}
+	if (Array.isArray(session.pendingRequests)) {
+		for (const request of session.pendingRequests) {
+			const approval = approvalFromPendingRequest(request);
+			if (approval) {
+				merged.set(approval.id, approval);
+			}
+		}
+	}
+	return [...merged.values()];
+}
 
 export class ComposerChatApprovals {
 	private approvalModeNoticeSessionId: string | null = null;
@@ -84,11 +123,11 @@ export class ComposerChatApprovals {
 		});
 	}
 
-	restorePendingRequests(session: Pick<Session, "pendingApprovalRequests">) {
+	restorePendingRequests(
+		session: Pick<Session, "pendingApprovalRequests" | "pendingRequests">,
+	) {
 		this.setState({
-			pendingApprovalQueue: Array.isArray(session.pendingApprovalRequests)
-				? [...session.pendingApprovalRequests]
-				: [],
+			pendingApprovalQueue: mergeApprovalRequests(session),
 			approvalSubmitting: false,
 		});
 	}

--- a/packages/web/src/components/composer-chat-client-requests.test.ts
+++ b/packages/web/src/components/composer-chat-client-requests.test.ts
@@ -125,6 +125,158 @@ describe("ComposerChatClientRequests", () => {
 		]);
 	});
 
+	it("restores normalized pending requests when split queues are absent", () => {
+		const { clientRequests, state } = createClientRequestHarness();
+
+		const replayable = clientRequests.restorePendingRequests({
+			pendingRequests: [
+				{
+					id: "retry-1",
+					kind: "tool_retry",
+					status: "pending",
+					visibility: "user",
+					sessionId: "session-1",
+					toolCallId: "tool-call-1",
+					toolName: "bash",
+					args: {
+						tool_call_id: "tool-call-1",
+						args: { command: "npm test" },
+						error_message: "exit 1",
+						attempt: 2,
+						max_attempts: 3,
+						summary: "Tests failed",
+					},
+					reason: "Tests failed",
+					createdAt: "2026-04-23T23:00:00.000Z",
+					source: "local",
+				},
+				{
+					id: "mcp-1",
+					kind: "mcp_elicitation",
+					status: "pending",
+					visibility: "user",
+					sessionId: "session-1",
+					toolCallId: "mcp-call-1",
+					toolName: "mcp_elicitation",
+					args: { prompt: "project" },
+					reason: "MCP server requested more input",
+					createdAt: "2026-04-23T23:00:01.000Z",
+					source: "platform",
+					platform: {
+						source: "tool_execution",
+						toolExecutionId: "texec-1",
+					},
+				},
+				{
+					id: "user-1",
+					kind: "user_input",
+					status: "pending",
+					visibility: "user",
+					sessionId: "session-1",
+					toolCallId: "user-call-1",
+					toolName: "ask_user",
+					args: { questions: [{ header: "Mode" }] },
+					reason: "Agent requested structured user input",
+					createdAt: "2026-04-23T23:00:02.000Z",
+					source: "platform",
+				},
+				{
+					id: "artifact-1",
+					kind: "client_tool",
+					status: "pending",
+					visibility: "user",
+					sessionId: "session-1",
+					toolCallId: "artifact-call-1",
+					toolName: "artifacts",
+					args: { command: "list" },
+					reason: "Client tool requires local execution",
+					createdAt: "2026-04-23T23:00:03.000Z",
+					source: "local",
+				},
+			],
+		});
+
+		expect(state.pendingToolRetryQueue).toEqual([
+			{
+				id: "retry-1",
+				toolCallId: "tool-call-1",
+				toolName: "bash",
+				args: { command: "npm test" },
+				errorMessage: "exit 1",
+				attempt: 2,
+				maxAttempts: 3,
+				summary: "Tests failed",
+			},
+		]);
+		expect(state.pendingMcpElicitationQueue).toEqual([
+			{
+				toolCallId: "mcp-call-1",
+				toolName: "mcp_elicitation",
+				args: { prompt: "project" },
+				kind: "mcp_elicitation",
+				reason: "MCP server requested more input",
+			},
+		]);
+		expect(state.pendingUserInputQueue).toEqual([
+			{
+				toolCallId: "user-call-1",
+				toolName: "ask_user",
+				args: { questions: [{ header: "Mode" }] },
+				kind: "user_input",
+				reason: "Agent requested structured user input",
+			},
+		]);
+		expect(replayable).toEqual([
+			{
+				toolCallId: "artifact-call-1",
+				toolName: "artifacts",
+				args: { command: "list" },
+				kind: "client_tool",
+				reason: "Client tool requires local execution",
+			},
+		]);
+	});
+
+	it("lets normalized pending requests refresh legacy queue entries", () => {
+		const { clientRequests, state } = createClientRequestHarness();
+
+		clientRequests.restorePendingRequests({
+			pendingClientToolRequests: [
+				{
+					toolCallId: "user-call-1",
+					toolName: "ask_user",
+					args: { questions: [{ header: "Old" }] },
+					kind: "user_input",
+				},
+			],
+			pendingRequests: [
+				{
+					id: "user-1",
+					kind: "user_input",
+					status: "pending",
+					visibility: "user",
+					sessionId: "session-1",
+					toolCallId: "user-call-1",
+					toolName: "ask_user",
+					args: { questions: [{ header: "Latest" }] },
+					reason: "Latest Platform wait projection",
+					createdAt: "2026-04-23T23:00:00.000Z",
+					source: "platform",
+				},
+			],
+		});
+
+		expect(state.pendingUserInputQueue).toEqual([
+			{
+				toolCallId: "user-call-1",
+				toolName: "ask_user",
+				args: { questions: [{ header: "Latest" }] },
+				kind: "user_input",
+				reason: "Latest Platform wait projection",
+			},
+		]);
+	});
+
 	it("submits MCP elicitation responses and clears the queue", async () => {
 		const { apiClient, clientRequests, showToast, state } =
 			createClientRequestHarness();

--- a/packages/web/src/components/composer-chat-client-requests.ts
+++ b/packages/web/src/components/composer-chat-client-requests.ts
@@ -1,5 +1,6 @@
 import type {
 	ComposerPendingClientToolRequest,
+	ComposerPendingRequest,
 	ComposerToolRetryRequest,
 } from "@evalops/contracts";
 import type { ApiClient, Session } from "../services/api-client.js";
@@ -32,6 +33,105 @@ function isMcpElicitationRequest(
 	return (
 		request.kind === "mcp_elicitation" || request.toolName === "mcp_elicitation"
 	);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+	return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function clientToolRequestFromPendingRequest(
+	request: ComposerPendingRequest,
+): ComposerPendingClientToolRequest | null {
+	if (
+		request.kind !== "client_tool" &&
+		request.kind !== "mcp_elicitation" &&
+		request.kind !== "user_input"
+	) {
+		return null;
+	}
+	return {
+		toolCallId: request.toolCallId,
+		toolName: request.toolName,
+		args: request.args,
+		kind: request.kind,
+		reason: request.reason,
+	};
+}
+
+function toolRetryRequestFromPendingRequest(
+	request: ComposerPendingRequest,
+): ComposerToolRetryRequest | null {
+	if (request.kind !== "tool_retry") {
+		return null;
+	}
+	const args = isRecord(request.args) ? request.args : {};
+	return {
+		id: request.id,
+		toolCallId:
+			typeof args.tool_call_id === "string"
+				? args.tool_call_id
+				: request.toolCallId,
+		toolName: request.toolName,
+		args: hasOwn(args, "args") ? args.args : request.args,
+		errorMessage:
+			typeof args.error_message === "string"
+				? args.error_message
+				: request.reason,
+		attempt:
+			typeof args.attempt === "number" && Number.isFinite(args.attempt)
+				? args.attempt
+				: 1,
+		maxAttempts:
+			typeof args.max_attempts === "number" &&
+			Number.isFinite(args.max_attempts)
+				? args.max_attempts
+				: undefined,
+		summary: typeof args.summary === "string" ? args.summary : undefined,
+	};
+}
+
+function mergeClientToolRequests(
+	session: Pick<Session, "pendingClientToolRequests" | "pendingRequests">,
+): ComposerPendingClientToolRequest[] {
+	const merged = new Map<string, ComposerPendingClientToolRequest>();
+	if (Array.isArray(session.pendingClientToolRequests)) {
+		for (const request of session.pendingClientToolRequests) {
+			merged.set(request.toolCallId, request);
+		}
+	}
+	if (Array.isArray(session.pendingRequests)) {
+		for (const request of session.pendingRequests) {
+			const clientToolRequest = clientToolRequestFromPendingRequest(request);
+			if (clientToolRequest) {
+				merged.set(clientToolRequest.toolCallId, clientToolRequest);
+			}
+		}
+	}
+	return [...merged.values()];
+}
+
+function mergeToolRetryRequests(
+	session: Pick<Session, "pendingToolRetryRequests" | "pendingRequests">,
+): ComposerToolRetryRequest[] {
+	const merged = new Map<string, ComposerToolRetryRequest>();
+	if (Array.isArray(session.pendingToolRetryRequests)) {
+		for (const request of session.pendingToolRetryRequests) {
+			merged.set(request.id, request);
+		}
+	}
+	if (Array.isArray(session.pendingRequests)) {
+		for (const request of session.pendingRequests) {
+			const toolRetryRequest = toolRetryRequestFromPendingRequest(request);
+			if (toolRetryRequest) {
+				merged.set(toolRetryRequest.id, toolRetryRequest);
+			}
+		}
+	}
+	return [...merged.values()];
 }
 
 export class ComposerChatClientRequests {
@@ -143,18 +243,14 @@ export class ComposerChatClientRequests {
 	restorePendingRequests(
 		session: Pick<
 			Session,
-			"pendingToolRetryRequests" | "pendingClientToolRequests"
+			| "pendingToolRetryRequests"
+			| "pendingClientToolRequests"
+			| "pendingRequests"
 		>,
 	): ComposerPendingClientToolRequest[] {
-		const pendingClientToolRequests = Array.isArray(
-			session.pendingClientToolRequests,
-		)
-			? [...session.pendingClientToolRequests]
-			: [];
+		const pendingClientToolRequests = mergeClientToolRequests(session);
 		this.setState({
-			pendingToolRetryQueue: Array.isArray(session.pendingToolRetryRequests)
-				? [...session.pendingToolRetryRequests]
-				: [],
+			pendingToolRetryQueue: mergeToolRetryRequests(session),
 			toolRetrySubmitting: false,
 			pendingMcpElicitationQueue: pendingClientToolRequests.filter(
 				isMcpElicitationRequest,

--- a/test/web/composer-chat-session-pending-requests.test.ts
+++ b/test/web/composer-chat-session-pending-requests.test.ts
@@ -187,6 +187,141 @@ describe("composer-chat session pending request restore", () => {
 		expect(sendClientToolResult).not.toHaveBeenCalled();
 	});
 
+	it("rehydrates pending queues from normalized pendingRequests after attach", async () => {
+		const element = createChat();
+		const sendClientToolResult = vi.fn().mockResolvedValue({ success: true });
+		element.apiClient = {
+			createSession: vi.fn(),
+			getSession: vi.fn().mockResolvedValue({
+				id: "session-platform",
+				messages: [],
+				pendingRequests: [
+					{
+						id: "approval-platform",
+						kind: "approval",
+						status: "pending",
+						visibility: "user",
+						sessionId: "session-platform",
+						toolCallId: "approval-platform",
+						toolName: "bash",
+						displayName: "Run shell command",
+						summaryLabel: "Needs command approval",
+						actionDescription: "npm test",
+						args: { command: "npm test" },
+						reason: "Platform approval wait",
+						createdAt: "2026-04-23T23:00:00.000Z",
+						source: "platform",
+						platform: {
+							source: "tool_execution",
+							toolExecutionId: "texec-1",
+							approvalRequestId: "approval-platform",
+						},
+					},
+					{
+						id: "retry-platform",
+						kind: "tool_retry",
+						status: "pending",
+						visibility: "user",
+						sessionId: "session-platform",
+						toolCallId: "tool-call-platform",
+						toolName: "read",
+						args: {
+							tool_call_id: "tool-call-platform",
+							args: { file: "README.md" },
+							error_message: "timed out",
+							attempt: 2,
+						},
+						reason: "timed out",
+						createdAt: "2026-04-23T23:00:01.000Z",
+						source: "local",
+					},
+					{
+						id: "user-platform",
+						kind: "user_input",
+						status: "pending",
+						visibility: "user",
+						sessionId: "session-platform",
+						toolCallId: "client-call-platform",
+						toolName: "ask_user",
+						args: {
+							questions: [
+								{
+									header: "Mode",
+									question: "How should we proceed?",
+									options: [
+										{
+											label: "Continue",
+											description: "Keep going",
+										},
+									],
+								},
+							],
+						},
+						reason: "Agent requested structured user input",
+						createdAt: "2026-04-23T23:00:02.000Z",
+						source: "platform",
+					},
+				],
+			}),
+			sendClientToolResult,
+		};
+
+		await element.selectSession("session-platform");
+		await flushAsyncWork();
+
+		expect(element.pendingApprovalQueue).toEqual([
+			{
+				id: "approval-platform",
+				toolName: "bash",
+				displayName: "Run shell command",
+				summaryLabel: "Needs command approval",
+				actionDescription: "npm test",
+				args: { command: "npm test" },
+				reason: "Platform approval wait",
+				platform: {
+					source: "tool_execution",
+					toolExecutionId: "texec-1",
+					approvalRequestId: "approval-platform",
+				},
+			},
+		]);
+		expect(element.pendingToolRetryQueue).toEqual([
+			{
+				id: "retry-platform",
+				toolCallId: "tool-call-platform",
+				toolName: "read",
+				args: { file: "README.md" },
+				errorMessage: "timed out",
+				attempt: 2,
+				maxAttempts: undefined,
+				summary: undefined,
+			},
+		]);
+		expect(element.pendingUserInputQueue).toEqual([
+			{
+				toolCallId: "client-call-platform",
+				toolName: "ask_user",
+				args: {
+					questions: [
+						{
+							header: "Mode",
+							question: "How should we proceed?",
+							options: [
+								{
+									label: "Continue",
+									description: "Keep going",
+								},
+							],
+						},
+					],
+				},
+				kind: "user_input",
+				reason: "Agent requested structured user input",
+			},
+		]);
+		expect(sendClientToolResult).not.toHaveBeenCalled();
+	});
+
 	it("restores pending queues after the current-session update cycle runs", async () => {
 		const element = createChat();
 		let flushedSessionUpdate = false;


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode