### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/pending-requests.md
+++ b/docs/protocols/pending-requests.md
@@ -46,4 +46,7 @@ the older split queues.
 Web clients should merge `pendingRequests` with the legacy split queues during
 the rollout. When the same request appears in both surfaces, prefer the
 normalized `pendingRequests` entry so Platform correlation fields and refreshed
-display metadata survive attach/reload recovery.
+display metadata survive attach/reload recovery. Client UI surfaces should also
+preserve `source`, `createdAt`, and `expiresAt` from the normalized entry so
+users can tell whether a wait is Platform-backed and whether it is close to or
+past timeout.

--- a/packages/web/src/components/composer-approval.ts
+++ b/packages/web/src/components/composer-approval.ts
@@ -5,6 +5,7 @@
 import type { ComposerActionApprovalRequest } from "@evalops/contracts";
 import { LitElement, css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { formatPendingRequestStatus } from "./pending-request-metadata.js";
 
 @customElement("composer-approval")
 export class ComposerApproval extends LitElement {
@@ -420,10 +421,12 @@ export class ComposerApproval extends LitElement {
 	private getQueueSubtitle(): string {
 		const total = Math.max(this.queueLength, this.request ? 1 : 0);
 		const remaining = Math.max(total - 1, 0);
-		if (remaining === 0) {
-			return "No other pending approvals";
-		}
-		return `${remaining} more approval${remaining === 1 ? "" : "s"} waiting`;
+		const queueStatus =
+			remaining === 0
+				? "No other pending approvals"
+				: `${remaining} more approval${remaining === 1 ? "" : "s"} waiting`;
+		const requestStatus = formatPendingRequestStatus(this.request);
+		return [queueStatus, requestStatus].filter(Boolean).join(" • ");
 	}
 
 	private handleApprove() {

--- a/packages/web/src/components/composer-chat-approvals.test.ts
+++ b/packages/web/src/components/composer-chat-approvals.test.ts
@@ -137,7 +137,7 @@ describe("ComposerChatApprovals", () => {
 			],
 		});
 
-		expect(state.pendingApprovalQueue).toEqual([
+		expect(state.pendingApprovalQueue).toMatchObject([
 			{
 				id: "approval-1",
 				toolName: "bash",
@@ -150,6 +150,15 @@ describe("ComposerChatApprovals", () => {
 					source: "tool_execution",
 					toolExecutionId: "texec-1",
 					approvalRequestId: "approval-1",
+				},
+				pendingRequest: {
+					source: "platform",
+					createdAt: "2026-04-23T23:00:00.000Z",
+					platform: {
+						source: "tool_execution",
+						toolExecutionId: "texec-1",
+						approvalRequestId: "approval-1",
+					},
 				},
 			},
 		]);

--- a/packages/web/src/components/composer-chat-approvals.ts
+++ b/packages/web/src/components/composer-chat-approvals.ts
@@ -4,6 +4,7 @@ import type {
 	ComposerPendingRequest,
 } from "@evalops/contracts";
 import type { ApiClient, Session } from "../services/api-client.js";
+import { attachPendingRequestMetadata } from "./pending-request-metadata.js";
 
 type ToastType = "success" | "error" | "info";
 
@@ -37,16 +38,19 @@ function approvalFromPendingRequest(
 	if (request.kind !== "approval") {
 		return null;
 	}
-	return {
-		id: request.id,
-		toolName: request.toolName,
-		displayName: request.displayName,
-		summaryLabel: request.summaryLabel,
-		actionDescription: request.actionDescription,
-		args: request.args,
-		reason: request.reason,
-		platform: request.platform,
-	};
+	return attachPendingRequestMetadata(
+		{
+			id: request.id,
+			toolName: request.toolName,
+			displayName: request.displayName,
+			summaryLabel: request.summaryLabel,
+			actionDescription: request.actionDescription,
+			args: request.args,
+			reason: request.reason,
+			platform: request.platform,
+		},
+		request,
+	);
 }
 
 function mergeApprovalRequests(

--- a/packages/web/src/components/composer-chat-client-requests.test.ts
+++ b/packages/web/src/components/composer-chat-client-requests.test.ts
@@ -196,7 +196,7 @@ describe("ComposerChatClientRequests", () => {
 			],
 		});
 
-		expect(state.pendingToolRetryQueue).toEqual([
+		expect(state.pendingToolRetryQueue).toMatchObject([
 			{
 				id: "retry-1",
 				toolCallId: "tool-call-1",
@@ -206,33 +206,53 @@ describe("ComposerChatClientRequests", () => {
 				attempt: 2,
 				maxAttempts: 3,
 				summary: "Tests failed",
+				pendingRequest: {
+					source: "local",
+					createdAt: "2026-04-23T23:00:00.000Z",
+				},
 			},
 		]);
-		expect(state.pendingMcpElicitationQueue).toEqual([
+		expect(state.pendingMcpElicitationQueue).toMatchObject([
 			{
 				toolCallId: "mcp-call-1",
 				toolName: "mcp_elicitation",
 				args: { prompt: "project" },
 				kind: "mcp_elicitation",
 				reason: "MCP server requested more input",
+				pendingRequest: {
+					source: "platform",
+					createdAt: "2026-04-23T23:00:01.000Z",
+					platform: {
+						source: "tool_execution",
+						toolExecutionId: "texec-1",
+					},
+				},
 			},
 		]);
-		expect(state.pendingUserInputQueue).toEqual([
+		expect(state.pendingUserInputQueue).toMatchObject([
 			{
 				toolCallId: "user-call-1",
 				toolName: "ask_user",
 				args: { questions: [{ header: "Mode" }] },
 				kind: "user_input",
 				reason: "Agent requested structured user input",
+				pendingRequest: {
+					source: "platform",
+					createdAt: "2026-04-23T23:00:02.000Z",
+				},
 			},
 		]);
-		expect(replayable).toEqual([
+		expect(replayable).toMatchObject([
 			{
 				toolCallId: "artifact-call-1",
 				toolName: "artifacts",
 				args: { command: "list" },
 				kind: "client_tool",
 				reason: "Client tool requires local execution",
+				pendingRequest: {
+					source: "local",
+					createdAt: "2026-04-23T23:00:03.000Z",
+				},
 			},
 		]);
 	});
@@ -266,13 +286,17 @@ describe("ComposerChatClientRequests", () => {
 			],
 		});
 
-		expect(state.pendingUserInputQueue).toEqual([
+		expect(state.pendingUserInputQueue).toMatchObject([
 			{
 				toolCallId: "user-call-1",
 				toolName: "ask_user",
 				args: { questions: [{ header: "Latest" }] },
 				kind: "user_input",
 				reason: "Latest Platform wait projection",
+				pendingRequest: {
+					source: "platform",
+					createdAt: "2026-04-23T23:00:00.000Z",
+				},
 			},
 		]);
 	});

--- a/packages/web/src/components/composer-chat-client-requests.ts
+++ b/packages/web/src/components/composer-chat-client-requests.ts
@@ -4,6 +4,7 @@ import type {
 	ComposerToolRetryRequest,
 } from "@evalops/contracts";
 import type { ApiClient, Session } from "../services/api-client.js";
+import { attachPendingRequestMetadata } from "./pending-request-metadata.js";
 
 type ToastType = "success" | "error" | "info";
 
@@ -53,13 +54,16 @@ function clientToolRequestFromPendingRequest(
 	) {
 		return null;
 	}
-	return {
-		toolCallId: request.toolCallId,
-		toolName: request.toolName,
-		args: request.args,
-		kind: request.kind,
-		reason: request.reason,
-	};
+	return attachPendingRequestMetadata(
+		{
+			toolCallId: request.toolCallId,
+			toolName: request.toolName,
+			args: request.args,
+			kind: request.kind,
+			reason: request.reason,
+		},
+		request,
+	);
 }
 
 function toolRetryRequestFromPendingRequest(
@@ -69,29 +73,32 @@ function toolRetryRequestFromPendingRequest(
 		return null;
 	}
 	const args = isRecord(request.args) ? request.args : {};
-	return {
-		id: request.id,
-		toolCallId:
-			typeof args.tool_call_id === "string"
-				? args.tool_call_id
-				: request.toolCallId,
-		toolName: request.toolName,
-		args: hasOwn(args, "args") ? args.args : request.args,
-		errorMessage:
-			typeof args.error_message === "string"
-				? args.error_message
-				: request.reason,
-		attempt:
-			typeof args.attempt === "number" && Number.isFinite(args.attempt)
-				? args.attempt
-				: 1,
-		maxAttempts:
-			typeof args.max_attempts === "number" &&
-			Number.isFinite(args.max_attempts)
-				? args.max_attempts
-				: undefined,
-		summary: typeof args.summary === "string" ? args.summary : undefined,
-	};
+	return attachPendingRequestMetadata(
+		{
+			id: request.id,
+			toolCallId:
+				typeof args.tool_call_id === "string"
+					? args.tool_call_id
+					: request.toolCallId,
+			toolName: request.toolName,
+			args: hasOwn(args, "args") ? args.args : request.args,
+			errorMessage:
+				typeof args.error_message === "string"
+					? args.error_message
+					: request.reason,
+			attempt:
+				typeof args.attempt === "number" && Number.isFinite(args.attempt)
+					? args.attempt
+					: 1,
+			maxAttempts:
+				typeof args.max_attempts === "number" &&
+				Number.isFinite(args.max_attempts)
+					? args.max_attempts
+					: undefined,
+			summary: typeof args.summary === "string" ? args.summary : undefined,
+		},
+		request,
+	);
 }
 
 function mergeClientToolRequests(

--- a/packages/web/src/components/composer-mcp-elicitation.ts
+++ b/packages/web/src/components/composer-mcp-elicitation.ts
@@ -5,6 +5,7 @@
 import type { ComposerPendingClientToolRequest } from "@evalops/contracts";
 import { LitElement, type PropertyValues, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { formatPendingRequestStatus } from "./pending-request-metadata.js";
 
 type PrimitiveValue = string | number | boolean | string[];
 
@@ -997,6 +998,7 @@ export class ComposerMcpElicitation extends LitElement {
 
 		const parsed = parseMcpElicitationRequest(this.request.args);
 		const waitingCount = Math.max(0, this.queueLength - 1);
+		const pendingStatus = formatPendingRequestStatus(this.request);
 
 		return html`
 			<div class="overlay">
@@ -1027,6 +1029,7 @@ export class ComposerMcpElicitation extends LitElement {
 										? html`<br />${waitingCount} more MCP request${waitingCount === 1 ? "" : "s"} waiting.`
 										: nothing
 								}
+								${pendingStatus ? html`<br />${pendingStatus}` : nothing}
 							</div>
 						</div>
 

--- a/packages/web/src/components/composer-tool-retry.ts
+++ b/packages/web/src/components/composer-tool-retry.ts
@@ -5,6 +5,7 @@
 import type { ComposerToolRetryRequest } from "@evalops/contracts";
 import { LitElement, css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { formatPendingRequestStatus } from "./pending-request-metadata.js";
 
 @customElement("composer-tool-retry")
 export class ComposerToolRetry extends LitElement {
@@ -318,10 +319,12 @@ export class ComposerToolRetry extends LitElement {
 	private getQueueSubtitle(): string {
 		const total = Math.max(this.queueLength, this.request ? 1 : 0);
 		const remaining = Math.max(total - 1, 0);
-		if (remaining === 0) {
-			return "No other pending retry decisions";
-		}
-		return `${remaining} more retry decision${remaining === 1 ? "" : "s"} waiting`;
+		const queueStatus =
+			remaining === 0
+				? "No other pending retry decisions"
+				: `${remaining} more retry decision${remaining === 1 ? "" : "s"} waiting`;
+		const requestStatus = formatPendingRequestStatus(this.request);
+		return [queueStatus, requestStatus].filter(Boolean).join(" • ");
 	}
 
 	private getToolTitle(): string {

--- a/packages/web/src/components/composer-user-input.ts
+++ b/packages/web/src/components/composer-user-input.ts
@@ -5,6 +5,7 @@
 import type { ComposerPendingClientToolRequest } from "@evalops/contracts";
 import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { formatPendingRequestStatus } from "./pending-request-metadata.js";
 
 type AskUserOptionPreviewKind = "markdown" | "text" | "diff";
 
@@ -500,10 +501,12 @@ export class ComposerUserInput extends LitElement {
 	}
 
 	private getQueueSubtitle(): string {
-		if (this.queueLength <= 1) {
-			return "This agent run is waiting for your structured response.";
-		}
-		return `${this.queueLength - 1} more input request${this.queueLength === 2 ? "" : "s"} waiting behind this one.`;
+		const queueStatus =
+			this.queueLength <= 1
+				? "This agent run is waiting for your structured response."
+				: `${this.queueLength - 1} more input request${this.queueLength === 2 ? "" : "s"} waiting behind this one.`;
+		const requestStatus = formatPendingRequestStatus(this.request);
+		return [queueStatus, requestStatus].filter(Boolean).join(" • ");
 	}
 
 	private toggleOption(

--- a/packages/web/src/components/pending-request-metadata.ts
+++ b/packages/web/src/components/pending-request-metadata.ts
@@ -1,0 +1,91 @@
+import type {
+	ComposerPendingRequest,
+	ComposerPendingRequestPlatformRef,
+} from "@evalops/contracts";
+
+export interface PendingRequestUiMetadata {
+	source: ComposerPendingRequest["source"];
+	createdAt?: string;
+	expiresAt?: string;
+	platform?: ComposerPendingRequestPlatformRef;
+}
+
+interface PendingRequestCarrier {
+	pendingRequest?: PendingRequestUiMetadata;
+}
+
+export function attachPendingRequestMetadata<T extends object>(
+	value: T,
+	request: ComposerPendingRequest,
+): T & PendingRequestCarrier {
+	return {
+		...value,
+		pendingRequest: {
+			source: request.source,
+			createdAt: request.createdAt,
+			expiresAt: request.expiresAt,
+			platform: request.platform,
+		},
+	};
+}
+
+export function getPendingRequestMetadata(
+	value: unknown,
+): PendingRequestUiMetadata | null {
+	if (!value || typeof value !== "object") {
+		return null;
+	}
+	const metadata = (value as PendingRequestCarrier).pendingRequest;
+	if (!metadata) {
+		return null;
+	}
+	return metadata;
+}
+
+function formatRelativeTime(ms: number): string {
+	const absoluteMs = Math.abs(ms);
+	if (absoluteMs < 60_000) {
+		return ms <= 0 ? "less than 1 minute ago" : "in less than 1 minute";
+	}
+	const minutes = Math.round(absoluteMs / 60_000);
+	if (minutes < 60) {
+		return ms < 0
+			? `${minutes} minute${minutes === 1 ? "" : "s"} ago`
+			: `in ${minutes} minute${minutes === 1 ? "" : "s"}`;
+	}
+	const hours = Math.round(absoluteMs / 3_600_000);
+	if (hours < 24) {
+		return ms < 0
+			? `${hours} hour${hours === 1 ? "" : "s"} ago`
+			: `in ${hours} hour${hours === 1 ? "" : "s"}`;
+	}
+	const days = Math.round(absoluteMs / 86_400_000);
+	return ms < 0
+		? `${days} day${days === 1 ? "" : "s"} ago`
+		: `in ${days} day${days === 1 ? "" : "s"}`;
+}
+
+export function formatPendingRequestStatus(
+	value: unknown,
+	nowMs = Date.now(),
+): string | null {
+	const metadata = getPendingRequestMetadata(value);
+	if (!metadata) {
+		return null;
+	}
+	const parts = [
+		metadata.source === "platform" ? "Platform wait" : "Local wait",
+	];
+	if (metadata.expiresAt) {
+		const expiresAtMs = Date.parse(metadata.expiresAt);
+		if (Number.isFinite(expiresAtMs)) {
+			const deltaMs = expiresAtMs - nowMs;
+			parts.push(
+				deltaMs <= 0
+					? `Timed out ${formatRelativeTime(deltaMs)}`
+					: `Expires ${formatRelativeTime(deltaMs)}`,
+			);
+		}
+	}
+	return parts.join(" • ");
+}

--- a/test/web/composer-approval.test.ts
+++ b/test/web/composer-approval.test.ts
@@ -56,6 +56,7 @@ describe("composer-approval", () => {
 				toolName: string;
 				args: Record<string, unknown>;
 				reason: string;
+				pendingRequest?: Record<string, unknown>;
 			};
 			queueLength: number;
 			updateComplete?: Promise<void>;
@@ -71,6 +72,11 @@ describe("composer-approval", () => {
 				cwd: "/tmp/demo",
 			},
 			reason: "Potentially dangerous shell command",
+			pendingRequest: {
+				source: "platform",
+				createdAt: new Date().toISOString(),
+				expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
+			},
 		};
 		el.queueLength = 3;
 
@@ -80,6 +86,8 @@ describe("composer-approval", () => {
 		const text = (el.shadowRoot?.textContent ?? "").replace(/\s+/g, " ");
 		expect(text).toContain("Approval 1 of 3");
 		expect(text).toContain("2 more approvals waiting");
+		expect(text).toContain("Platform wait");
+		expect(text).toContain("Expires");
 		expect(text).toContain("Action execute");
 		expect(text).toContain("Shell mode enabled");
 		expect(text).toContain("cwd:");

--- a/test/web/composer-chat-session-pending-requests.test.ts
+++ b/test/web/composer-chat-session-pending-requests.test.ts
@@ -269,7 +269,7 @@ describe("composer-chat session pending request restore", () => {
 		await element.selectSession("session-platform");
 		await flushAsyncWork();
 
-		expect(element.pendingApprovalQueue).toEqual([
+		expect(element.pendingApprovalQueue).toMatchObject([
 			{
 				id: "approval-platform",
 				toolName: "bash",
@@ -283,9 +283,18 @@ describe("composer-chat session pending request restore", () => {
 					toolExecutionId: "texec-1",
 					approvalRequestId: "approval-platform",
 				},
+				pendingRequest: {
+					source: "platform",
+					createdAt: "2026-04-23T23:00:00.000Z",
+					platform: {
+						source: "tool_execution",
+						toolExecutionId: "texec-1",
+						approvalRequestId: "approval-platform",
+					},
+				},
 			},
 		]);
-		expect(element.pendingToolRetryQueue).toEqual([
+		expect(element.pendingToolRetryQueue).toMatchObject([
 			{
 				id: "retry-platform",
 				toolCallId: "tool-call-platform",
@@ -295,9 +304,13 @@ describe("composer-chat session pending request restore", () => {
 				attempt: 2,
 				maxAttempts: undefined,
 				summary: undefined,
+				pendingRequest: {
+					source: "local",
+					createdAt: "2026-04-23T23:00:01.000Z",
+				},
 			},
 		]);
-		expect(element.pendingUserInputQueue).toEqual([
+		expect(element.pendingUserInputQueue).toMatchObject([
 			{
 				toolCallId: "client-call-platform",
 				toolName: "ask_user",
@@ -317,6 +330,10 @@ describe("composer-chat session pending request restore", () => {
 				},
 				kind: "user_input",
 				reason: "Agent requested structured user input",
+				pendingRequest: {
+					source: "platform",
+					createdAt: "2026-04-23T23:00:02.000Z",
+				},
 			},
 		]);
 		expect(sendClientToolResult).not.toHaveBeenCalled();

--- a/test/web/composer-mcp-elicitation.test.ts
+++ b/test/web/composer-mcp-elicitation.test.ts
@@ -18,6 +18,7 @@ describe("composer-mcp-elicitation", () => {
 				toolName: string;
 				kind: "mcp_elicitation";
 				args: Record<string, unknown>;
+				pendingRequest?: Record<string, unknown>;
 			};
 			updateComplete?: Promise<void>;
 		};
@@ -53,6 +54,11 @@ describe("composer-mcp-elicitation", () => {
 					required: ["project", "flavor"],
 				},
 			},
+			pendingRequest: {
+				source: "platform",
+				createdAt: new Date().toISOString(),
+				expiresAt: new Date(Date.now() + 6 * 60 * 1000).toISOString(),
+			},
 		};
 		el.queueLength = 2;
 
@@ -65,6 +71,8 @@ describe("composer-mcp-elicitation", () => {
 		const text = (el.shadowRoot?.textContent ?? "").replace(/\s+/g, " ");
 		expect(text).toContain("MCP Elicitation");
 		expect(text).toContain("Request 1 of 2");
+		expect(text).toContain("Platform wait");
+		expect(text).toContain("Expires");
 		expect(text).toContain("Provide the project details");
 
 		const projectInput = el.shadowRoot?.querySelector(

--- a/test/web/composer-tool-retry.test.ts
+++ b/test/web/composer-tool-retry.test.ts
@@ -8,6 +8,45 @@ afterEach(() => {
 });
 
 describe("composer-tool-retry", () => {
+	it("renders queue source and timeout metadata", async () => {
+		const el = document.createElement("composer-tool-retry") as HTMLElement & {
+			request: {
+				id: string;
+				toolCallId: string;
+				toolName: string;
+				args: Record<string, unknown>;
+				errorMessage: string;
+				attempt: number;
+				pendingRequest?: Record<string, unknown>;
+			};
+			queueLength: number;
+			updateComplete?: Promise<void>;
+		};
+
+		el.request = {
+			id: "retry-1",
+			toolCallId: "tool-call-1",
+			toolName: "bash",
+			args: { command: "npm test" },
+			errorMessage: "exit 1",
+			attempt: 2,
+			pendingRequest: {
+				source: "local",
+				createdAt: new Date().toISOString(),
+				expiresAt: new Date(Date.now() + 3 * 60 * 1000).toISOString(),
+			},
+		};
+		el.queueLength = 1;
+
+		document.body.appendChild(el);
+		await el.updateComplete;
+
+		const text = (el.shadowRoot?.textContent ?? "").replace(/\s+/g, " ");
+		expect(text).toContain("Retry request 1 of 1");
+		expect(text).toContain("Local wait");
+		expect(text).toContain("Expires");
+	});
+
 	it("ignores global Enter and Escape keys when no retry request is active", async () => {
 		const el = document.createElement("composer-tool-retry") as HTMLElement & {
 			updateComplete?: Promise<void>;

--- a/test/web/composer-user-input.test.ts
+++ b/test/web/composer-user-input.test.ts
@@ -15,6 +15,7 @@ describe("composer-user-input", () => {
 				toolName: string;
 				args: Record<string, unknown>;
 				kind: "user_input";
+				pendingRequest?: Record<string, unknown>;
 			};
 			queueLength: number;
 			updateComplete?: Promise<void>;
@@ -47,6 +48,11 @@ describe("composer-user-input", () => {
 					},
 				],
 			},
+			pendingRequest: {
+				source: "platform",
+				createdAt: new Date().toISOString(),
+				expiresAt: new Date(Date.now() + 4 * 60 * 1000).toISOString(),
+			},
 		};
 		el.queueLength = 2;
 
@@ -56,6 +62,11 @@ describe("composer-user-input", () => {
 		const text = (el.shadowRoot?.textContent ?? "").replace(/\s+/g, " ");
 		expect(text).toContain("Input 1 of 2");
 		expect(text).toContain("1 more input request waiting");
+		expect(text).toContain(
+			"1 more input request waiting behind this one. \u2022 Platform wait",
+		);
+		expect(text).toContain("Platform wait");
+		expect(text).toContain("Expires");
 		expect(text).toContain("Which schema library should we use?");
 		expect(text).toContain("Zod patch");
 		expect(text).toContain("diff --git a/package.json b/package.json");

--- a/test/web/pending-request-metadata.test.ts
+++ b/test/web/pending-request-metadata.test.ts
@@ -1,0 +1,62 @@
+import type { ComposerPendingRequest } from "@evalops/contracts";
+import { describe, expect, it } from "vitest";
+import {
+	attachPendingRequestMetadata,
+	formatPendingRequestStatus,
+} from "../../packages/web/src/components/pending-request-metadata.js";
+
+function pendingRequest(expiresAt: string): ComposerPendingRequest {
+	return {
+		id: "approval-1",
+		kind: "approval",
+		status: "pending",
+		visibility: "user",
+		toolCallId: "tool-call-1",
+		toolName: "bash",
+		args: { command: "echo hi" },
+		reason: "Needs approval",
+		createdAt: "2026-04-24T00:00:00.000Z",
+		expiresAt,
+		source: "platform",
+	};
+}
+
+describe("pending request metadata", () => {
+	it("formats exact-expiry waits as timed out in the past", () => {
+		const nowMs = Date.parse("2026-04-24T00:05:00.000Z");
+		const value = attachPendingRequestMetadata(
+			{},
+			pendingRequest(new Date(nowMs).toISOString()),
+		);
+
+		const status = formatPendingRequestStatus(value, nowMs);
+
+		expect(status).toContain("Platform wait");
+		expect(status).toContain("Timed out less than 1 minute ago");
+		expect(status).not.toContain("Timed out in");
+	});
+
+	it("keeps future expirations phrased as upcoming", () => {
+		const nowMs = Date.parse("2026-04-24T00:05:00.000Z");
+		const value = attachPendingRequestMetadata(
+			{},
+			pendingRequest(new Date(nowMs + 1).toISOString()),
+		);
+
+		expect(formatPendingRequestStatus(value, nowMs)).toContain(
+			"Expires in less than 1 minute",
+		);
+	});
+
+	it("rounds hours from the original duration", () => {
+		const nowMs = Date.parse("2026-04-24T00:05:00.000Z");
+		const value = attachPendingRequestMetadata(
+			{},
+			pendingRequest(new Date(nowMs + 89.5 * 60_000).toISOString()),
+		);
+
+		expect(formatPendingRequestStatus(value, nowMs)).toContain(
+			"Expires in 1 hour",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- previewed public-tree drift: `15` file(s) to copy/update and `0` stale file(s) to delete

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode