### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2203,6 +2203,31 @@
         }
       }
     },
+    "/api/pending-requests/{requestId}/resume": {
+      "post": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
     "/api/chat/approval": {
       "post": {
         "summary": "Auto-generated from route definition",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -428,6 +428,22 @@ export type ComposerPendingRequestKind =
 	| "user_input"
 	| "tool_retry";
 
+export type ComposerPendingRequestResolution =
+	| "approved"
+	| "denied"
+	| "completed"
+	| "failed"
+	| "answered"
+	| "retried"
+	| "skipped"
+	| "aborted"
+	| "cancelled";
+
+export type ComposerPendingRequestPlatformOperation =
+	| "ResolveApproval"
+	| "ResumeToolExecution"
+	| "ResumeRun";
+
 export interface ComposerPendingRequestPlatformRef {
 	source: "approvals_service" | "tool_execution";
 	toolExecutionId?: string;
@@ -451,6 +467,33 @@ export interface ComposerPendingRequest {
 	expiresAt?: string;
 	source: "local" | "platform";
 	platform?: ComposerPendingRequestPlatformRef;
+}
+
+export type ComposerClientToolResultContent =
+	| ComposerTextContent
+	| ComposerImageContent;
+
+export interface ComposerPendingRequestResumeRequest {
+	kind?: ComposerPendingRequestKind;
+	sessionId?: string;
+	decision?: "approved" | "denied";
+	action?: "retry" | "skip" | "abort";
+	content?: ComposerClientToolResultContent[];
+	isError?: boolean;
+	reason?: string;
+}
+
+export interface ComposerPendingRequestResumeResponse {
+	success: true;
+	request: {
+		id: string;
+		kind: ComposerPendingRequestKind;
+		sessionId?: string;
+		resolution: ComposerPendingRequestResolution;
+		source: "local" | "platform";
+		platform?: ComposerPendingRequestPlatformRef;
+		platformOperation?: ComposerPendingRequestPlatformOperation;
+	};
 }
 
 /**

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -355,6 +355,76 @@ export const ComposerPendingRequestSchema = Type.Object({
 	platform: Type.Optional(ComposerPendingRequestPlatformRefSchema),
 });
 
+export const ComposerPendingRequestResolutionSchema = Type.Union([
+	Type.Literal("approved"),
+	Type.Literal("denied"),
+	Type.Literal("completed"),
+	Type.Literal("failed"),
+	Type.Literal("answered"),
+	Type.Literal("retried"),
+	Type.Literal("skipped"),
+	Type.Literal("aborted"),
+	Type.Literal("cancelled"),
+]);
+
+export const ComposerPendingRequestPlatformOperationSchema = Type.Union([
+	Type.Literal("ResolveApproval"),
+	Type.Literal("ResumeToolExecution"),
+	Type.Literal("ResumeRun"),
+]);
+
+export const ComposerClientToolResultContentSchema = Type.Union([
+	ComposerTextContentSchema,
+	ComposerImageContentSchema,
+]);
+
+export const ComposerPendingRequestResumeRequestSchema = Type.Object({
+	kind: Type.Optional(
+		Type.Union([
+			Type.Literal("approval"),
+			Type.Literal("client_tool"),
+			Type.Literal("mcp_elicitation"),
+			Type.Literal("user_input"),
+			Type.Literal("tool_retry"),
+		]),
+	),
+	sessionId: Type.Optional(Type.String()),
+	decision: Type.Optional(
+		Type.Union([Type.Literal("approved"), Type.Literal("denied")]),
+	),
+	action: Type.Optional(
+		Type.Union([
+			Type.Literal("retry"),
+			Type.Literal("skip"),
+			Type.Literal("abort"),
+		]),
+	),
+	content: Type.Optional(Type.Array(ComposerClientToolResultContentSchema)),
+	isError: Type.Optional(Type.Boolean()),
+	reason: Type.Optional(Type.String()),
+});
+
+export const ComposerPendingRequestResumeResponseSchema = Type.Object({
+	success: Type.Literal(true),
+	request: Type.Object({
+		id: Type.String(),
+		kind: Type.Union([
+			Type.Literal("approval"),
+			Type.Literal("client_tool"),
+			Type.Literal("mcp_elicitation"),
+			Type.Literal("user_input"),
+			Type.Literal("tool_retry"),
+		]),
+		sessionId: Type.Optional(Type.String()),
+		resolution: ComposerPendingRequestResolutionSchema,
+		source: Type.Union([Type.Literal("local"), Type.Literal("platform")]),
+		platform: Type.Optional(ComposerPendingRequestPlatformRefSchema),
+		platformOperation: Type.Optional(
+			ComposerPendingRequestPlatformOperationSchema,
+		),
+	}),
+});
+
 export const ComposerToolRetryRequestSchema = Type.Object({
 	id: Type.String(),
 	toolCallId: Type.String(),

--- a/packages/contracts/src/validators.ts
+++ b/packages/contracts/src/validators.ts
@@ -40,6 +40,8 @@ import {
 	ComposerMessageSchema,
 	ComposerModelListResponseSchema,
 	ComposerModelSchema,
+	ComposerPendingRequestResumeRequestSchema,
+	ComposerPendingRequestResumeResponseSchema,
 	ComposerPlanActionResponseSchema,
 	ComposerPlanRequestSchema,
 	ComposerPlanStatusResponseSchema,
@@ -371,6 +373,16 @@ export const isComposerSession = (
 	value: unknown,
 ): value is Static<typeof ComposerSessionSchema> =>
 	Value.Check(ComposerSessionSchema, value);
+
+export const isComposerPendingRequestResumeRequest = (
+	value: unknown,
+): value is Static<typeof ComposerPendingRequestResumeRequestSchema> =>
+	Value.Check(ComposerPendingRequestResumeRequestSchema, value);
+
+export const isComposerPendingRequestResumeResponse = (
+	value: unknown,
+): value is Static<typeof ComposerPendingRequestResumeResponseSchema> =>
+	Value.Check(ComposerPendingRequestResumeResponseSchema, value);
 
 export const isComposerSessionListResponse = (
 	value: unknown,

--- a/packages/web/src/services/api-client.ts
+++ b/packages/web/src/services/api-client.ts
@@ -71,6 +71,8 @@ import {
 	isComposerGuardianStatusResponse,
 	isComposerModel,
 	isComposerModelListResponse,
+	isComposerPendingRequestResumeRequest,
+	isComposerPendingRequestResumeResponse,
 	isComposerPlanActionResponse,
 	isComposerPlanStatusResponse,
 	isComposerSession,
@@ -104,6 +106,8 @@ import type {
 	ComposerGuardianStatusResponse,
 	ComposerMessage,
 	ComposerModel,
+	ComposerPendingRequestResumeRequest,
+	ComposerPendingRequestResumeResponse,
 	ComposerPlanActionResponse,
 	ComposerPlanStatusResponse,
 	ComposerProjectOnboardingState,
@@ -1633,10 +1637,10 @@ export class ApiClient {
 		>;
 		isError: boolean;
 	}): Promise<void> {
-		await this.tryFallbackFetch(
-			"/api/chat/client-tool-result",
-			this.buildJsonRequestInit("POST", input),
-		);
+		await this.resumePendingRequest(input.toolCallId, {
+			content: input.content,
+			isError: input.isError,
+		});
 	}
 
 	async submitApprovalDecision(input: {
@@ -1644,11 +1648,11 @@ export class ApiClient {
 		decision: "approved" | "denied";
 		reason?: string;
 	}): Promise<{ success: boolean }> {
-		return await this.fetchJsonRequestWithFallback<{ success: boolean }>(
-			"/api/chat/approval",
-			"POST",
-			input,
-		);
+		return await this.resumePendingRequest(input.requestId, {
+			kind: "approval",
+			decision: input.decision,
+			reason: input.reason,
+		});
 	}
 
 	async submitToolRetryDecision(input: {
@@ -1656,11 +1660,37 @@ export class ApiClient {
 		action: "retry" | "skip" | "abort";
 		reason?: string;
 	}): Promise<{ success: boolean }> {
-		return await this.fetchJsonRequestWithFallback<{ success: boolean }>(
-			"/api/chat/tool-retry",
-			"POST",
-			input,
-		);
+		return await this.resumePendingRequest(input.requestId, {
+			kind: "tool_retry",
+			action: input.action,
+			reason: input.reason,
+		});
+	}
+
+	async resumePendingRequest(
+		requestId: string,
+		input: ComposerPendingRequestResumeRequest,
+	): Promise<ComposerPendingRequestResumeResponse> {
+		if (
+			VALIDATE_API_RESPONSES &&
+			!isComposerPendingRequestResumeRequest(input)
+		) {
+			throw new Error("Invalid pending request resume request payload");
+		}
+
+		const data =
+			await this.fetchJsonRequestWithFallback<ComposerPendingRequestResumeResponse>(
+				`/api/pending-requests/${encodeURIComponent(requestId)}/resume`,
+				"POST",
+				input,
+			);
+		if (
+			VALIDATE_API_RESPONSES &&
+			!isComposerPendingRequestResumeResponse(data)
+		) {
+			throw new Error("Invalid pending request resume response payload");
+		}
+		return data;
 	}
 
 	/**

--- a/src/server/handlers/pending-requests.ts
+++ b/src/server/handlers/pending-requests.ts
@@ -1,0 +1,225 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+	type ComposerPendingRequestKind,
+	type ComposerPendingRequestPlatformOperation,
+	type ComposerPendingRequestResolution,
+	type ComposerPendingRequestResumeRequest,
+	ComposerPendingRequestResumeRequestSchema,
+	type ComposerPendingRequestResumeResponse,
+} from "@evalops/contracts";
+import type { WebServerContext } from "../app-context.js";
+import {
+	type PendingServerRequestSnapshot,
+	serverRequestManager,
+} from "../server-request-manager.js";
+import { ApiError, respondWithApiError, sendJson } from "../server-utils.js";
+import { parseAndValidateJson } from "../validation.js";
+
+type PendingRequestRouteParams = {
+	requestId?: string;
+};
+
+function decodeRequestId(params: PendingRequestRouteParams): string {
+	const raw = params.requestId?.trim();
+	if (!raw) {
+		throw new ApiError(400, "Pending request id is required");
+	}
+	try {
+		return decodeURIComponent(raw);
+	} catch {
+		throw new ApiError(400, "Pending request id is invalid");
+	}
+}
+
+function assertRequestKind(
+	actual: ComposerPendingRequestKind,
+	expected: ComposerPendingRequestKind | undefined,
+): void {
+	if (expected && expected !== actual) {
+		throw new ApiError(
+			400,
+			`Pending request ${expected} resolver cannot resume ${actual} request`,
+		);
+	}
+}
+
+function assertSessionMatch(
+	request: PendingServerRequestSnapshot,
+	sessionId: string | undefined,
+): void {
+	if (sessionId && request.sessionId && sessionId !== request.sessionId) {
+		throw new ApiError(404, "Pending request not found for session");
+	}
+}
+
+function requireApprovalDecision(
+	input: ComposerPendingRequestResumeRequest,
+): "approved" | "denied" {
+	if (input.decision !== "approved" && input.decision !== "denied") {
+		throw new ApiError(400, "Approval resume requires decision");
+	}
+	return input.decision;
+}
+
+function requireRetryAction(
+	input: ComposerPendingRequestResumeRequest,
+): "retry" | "skip" | "abort" {
+	if (
+		input.action !== "retry" &&
+		input.action !== "skip" &&
+		input.action !== "abort"
+	) {
+		throw new ApiError(400, "Tool retry resume requires action");
+	}
+	return input.action;
+}
+
+function requireClientToolContent(
+	input: ComposerPendingRequestResumeRequest,
+): NonNullable<ComposerPendingRequestResumeRequest["content"]> {
+	if (!Array.isArray(input.content)) {
+		throw new ApiError(400, "Client request resume requires content");
+	}
+	return input.content;
+}
+
+function resolutionForClientRequest(
+	kind: PendingServerRequestSnapshot["kind"],
+	isError: boolean,
+): ComposerPendingRequestResolution {
+	if (isError) {
+		return "failed";
+	}
+	if (kind === "mcp_elicitation" || kind === "user_input") {
+		return "answered";
+	}
+	return "completed";
+}
+
+function platformOperationFor(
+	request: PendingServerRequestSnapshot,
+): ComposerPendingRequestPlatformOperation | undefined {
+	if (!request.platform) {
+		return undefined;
+	}
+	if (request.kind === "approval") {
+		return request.platform.source === "tool_execution"
+			? "ResumeToolExecution"
+			: "ResolveApproval";
+	}
+	if (
+		request.kind === "client_tool" ||
+		request.kind === "mcp_elicitation" ||
+		request.kind === "user_input"
+	) {
+		return "ResumeRun";
+	}
+	return undefined;
+}
+
+function responseFor(
+	request: PendingServerRequestSnapshot,
+	resolution: ComposerPendingRequestResolution,
+): ComposerPendingRequestResumeResponse {
+	return {
+		success: true,
+		request: {
+			id: request.id,
+			kind: request.kind,
+			sessionId: request.sessionId,
+			resolution,
+			source: request.platform ? "platform" : "local",
+			platform: request.platform,
+			platformOperation: platformOperationFor(request),
+		},
+	};
+}
+
+export async function handlePendingRequestResume(
+	req: IncomingMessage,
+	res: ServerResponse,
+	context: WebServerContext,
+	params: PendingRequestRouteParams,
+) {
+	const { corsHeaders } = context;
+
+	try {
+		if (req.method !== "POST") {
+			res.writeHead(405, corsHeaders);
+			res.end();
+			return;
+		}
+
+		const requestId = decodeRequestId(params);
+		const input =
+			await parseAndValidateJson<ComposerPendingRequestResumeRequest>(
+				req,
+				ComposerPendingRequestResumeRequestSchema,
+			);
+		const pendingRequest = serverRequestManager.get(requestId);
+		if (!pendingRequest) {
+			throw new ApiError(404, "Pending request not found or already resolved");
+		}
+
+		assertRequestKind(pendingRequest.kind, input.kind);
+		assertSessionMatch(pendingRequest, input.sessionId);
+
+		let resolved = false;
+		let resolution: ComposerPendingRequestResolution;
+
+		switch (pendingRequest.kind) {
+			case "approval": {
+				const decision = requireApprovalDecision(input);
+				resolved = serverRequestManager.resolveApproval(requestId, {
+					approved: decision === "approved",
+					reason: input.reason,
+					resolvedBy: "user",
+				});
+				resolution = decision;
+				break;
+			}
+			case "tool_retry": {
+				const action = requireRetryAction(input);
+				resolved = serverRequestManager.resolveToolRetry(requestId, {
+					action,
+					reason: input.reason,
+					resolvedBy: "user",
+				});
+				resolution =
+					action === "retry"
+						? "retried"
+						: action === "skip"
+							? "skipped"
+							: "aborted";
+				break;
+			}
+			case "client_tool":
+			case "mcp_elicitation":
+			case "user_input": {
+				const content = requireClientToolContent(input);
+				const isError = input.isError === true;
+				resolved = serverRequestManager.resolveClientTool(
+					requestId,
+					content,
+					isError,
+				);
+				resolution = resolutionForClientRequest(pendingRequest.kind, isError);
+				break;
+			}
+		}
+
+		if (!resolved) {
+			throw new ApiError(404, "Pending request not found or already resolved");
+		}
+
+		sendJson(
+			res,
+			200,
+			responseFor(pendingRequest, resolution),
+			corsHeaders,
+			req,
+		);
+	} catch (error) {
+		respondWithApiError(res, error, 400, corsHeaders, req);
+	}
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -61,6 +61,7 @@ import { handleMode } from "./handlers/mode.js";
 import { handleModel, handleModels } from "./handlers/models.js";
 import { handleOllama } from "./handlers/ollama.js";
 import { handlePackageStatus } from "./handlers/package.js";
+import { handlePendingRequestResume } from "./handlers/pending-requests.js";
 import { handlePlan } from "./handlers/plan.js";
 import { handlePolicyValidate } from "./handlers/policy.js";
 import { handlePreview } from "./handlers/preview.js";
@@ -745,6 +746,12 @@ export function createRoutes(context: WebServerContext): Route[] {
 			method: "POST",
 			path: "/api/chat",
 			handler: async (req, res) => handleChat(req, res, context),
+		},
+		{
+			method: "POST",
+			path: "/api/pending-requests/:requestId/resume",
+			handler: (req, res, params) =>
+				handlePendingRequestResume(req, res, context, params),
 		},
 		{
 			method: "POST",

--- a/test/web/api-client-approvals.test.ts
+++ b/test/web/api-client-approvals.test.ts
@@ -48,12 +48,23 @@ describe("ApiClient approvals", () => {
 		expect(headers.get("x-composer-csrf")).toBe("csrf-token");
 	});
 
-	it("posts approval decisions to the chat approval endpoint", async () => {
+	it("posts approval decisions to the unified pending request resume endpoint", async () => {
 		global.fetch = vi.fn().mockResolvedValue(
-			new Response(JSON.stringify({ success: true }), {
-				status: 200,
-				headers: { "content-type": "application/json" },
-			}),
+			new Response(
+				JSON.stringify({
+					success: true,
+					request: {
+						id: "req_123",
+						kind: "approval",
+						resolution: "approved",
+						source: "local",
+					},
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			),
 		);
 
 		const api = new ApiClient("http://localhost:8080", {
@@ -71,21 +82,32 @@ describe("ApiClient approvals", () => {
 		expect(global.fetch).toHaveBeenCalled();
 		const [url, init] = vi.mocked(global.fetch).mock.calls[0] ?? [];
 		const headers = new Headers((init as RequestInit).headers);
-		expect(String(url)).toContain("/api/chat/approval");
+		expect(String(url)).toContain("/api/pending-requests/req_123/resume");
 		expect((init as RequestInit).body).toBe(
-			JSON.stringify({ requestId: "req_123", decision: "approved" }),
+			JSON.stringify({ kind: "approval", decision: "approved" }),
 		);
 		expect(headers.get("authorization")).toBe("Bearer access-token");
 		expect(headers.get("x-composer-api-key")).toBe("api-key");
 		expect(headers.get("x-composer-csrf")).toBe("csrf-token");
 	});
 
-	it("posts tool retry decisions to the chat tool-retry endpoint", async () => {
+	it("posts tool retry decisions to the unified pending request resume endpoint", async () => {
 		global.fetch = vi.fn().mockResolvedValue(
-			new Response(JSON.stringify({ success: true }), {
-				status: 200,
-				headers: { "content-type": "application/json" },
-			}),
+			new Response(
+				JSON.stringify({
+					success: true,
+					request: {
+						id: "retry_123",
+						kind: "tool_retry",
+						resolution: "retried",
+						source: "local",
+					},
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			),
 		);
 
 		const api = new ApiClient("http://localhost:8080", {
@@ -104,10 +126,10 @@ describe("ApiClient approvals", () => {
 		expect(global.fetch).toHaveBeenCalled();
 		const [url, init] = vi.mocked(global.fetch).mock.calls[0] ?? [];
 		const headers = new Headers((init as RequestInit).headers);
-		expect(String(url)).toContain("/api/chat/tool-retry");
+		expect(String(url)).toContain("/api/pending-requests/retry_123/resume");
 		expect((init as RequestInit).body).toBe(
 			JSON.stringify({
-				requestId: "retry_123",
+				kind: "tool_retry",
 				action: "retry",
 				reason: "Try again",
 			}),
@@ -115,5 +137,42 @@ describe("ApiClient approvals", () => {
 		expect(headers.get("authorization")).toBe("Bearer access-token");
 		expect(headers.get("x-composer-api-key")).toBe("api-key");
 		expect(headers.get("x-composer-csrf")).toBe("csrf-token");
+	});
+
+	it("posts client tool results to the unified pending request resume endpoint", async () => {
+		global.fetch = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					success: true,
+					request: {
+						id: "tool_call_123",
+						kind: "user_input",
+						resolution: "answered",
+						source: "local",
+					},
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			),
+		);
+
+		const api = new ApiClient("http://localhost:8080");
+		await api.sendClientToolResult({
+			toolCallId: "tool_call_123",
+			content: [{ type: "text", text: "done" }],
+			isError: false,
+		});
+
+		expect(global.fetch).toHaveBeenCalled();
+		const [url, init] = vi.mocked(global.fetch).mock.calls[0] ?? [];
+		expect(String(url)).toContain("/api/pending-requests/tool_call_123/resume");
+		expect((init as RequestInit).body).toBe(
+			JSON.stringify({
+				content: [{ type: "text", text: "done" }],
+				isError: false,
+			}),
+		);
 	});
 });

--- a/test/web/pending-request-resume-handler.test.ts
+++ b/test/web/pending-request-resume-handler.test.ts
@@ -1,0 +1,221 @@
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ActionApprovalService } from "../../src/agent/action-approval.js";
+import { ToolRetryService } from "../../src/agent/tool-retry.js";
+import type { WebServerContext } from "../../src/server/app-context.js";
+import { handlePendingRequestResume } from "../../src/server/handlers/pending-requests.js";
+import { serverRequestManager } from "../../src/server/server-request-manager.js";
+
+const cors = { "Access-Control-Allow-Origin": "*" };
+
+interface MockResponse {
+	statusCode: number;
+	headers: Record<string, string | number>;
+	body: string;
+	writableEnded: boolean;
+	writeHead(status: number, headers?: Record<string, string | number>): void;
+	write(chunk: string | Buffer): void;
+	end(chunk?: string | Buffer): void;
+}
+
+interface MockRequest extends PassThrough {
+	method: string;
+	url: string;
+	headers: Record<string, string>;
+}
+
+function makeReq(body: unknown): MockRequest {
+	const req = new PassThrough() as MockRequest;
+	req.method = "POST";
+	req.url = "/api/pending-requests/request/resume";
+	req.headers = {};
+	req.end(JSON.stringify(body));
+	return req;
+}
+
+function makeRes(): MockResponse {
+	return {
+		statusCode: 200,
+		headers: {},
+		body: "",
+		writableEnded: false,
+		writeHead(status: number, headers?: Record<string, string | number>) {
+			this.statusCode = status;
+			this.headers = headers ?? {};
+		},
+		write(chunk: string | Buffer) {
+			this.body += chunk.toString();
+		},
+		end(chunk?: string | Buffer) {
+			if (chunk) this.write(chunk);
+			this.writableEnded = true;
+		},
+	};
+}
+
+async function resume(requestId: string, body: unknown) {
+	const req = makeReq(body);
+	const res = makeRes();
+	await handlePendingRequestResume(
+		req,
+		res,
+		{ corsHeaders: cors } as WebServerContext,
+		{ requestId: encodeURIComponent(requestId) },
+	);
+	return res;
+}
+
+describe("handlePendingRequestResume", () => {
+	afterEach(() => {
+		for (const request of serverRequestManager.listPending()) {
+			serverRequestManager.cancel(request.id, "test cleanup", "runtime");
+		}
+		vi.restoreAllMocks();
+	});
+
+	it("resumes Platform-backed approvals through the unified endpoint", async () => {
+		const service = new ActionApprovalService("prompt");
+		const resolve = vi.spyOn(service, "resolve").mockReturnValue(true);
+		serverRequestManager.registerApproval({
+			sessionId: "session-platform",
+			request: {
+				id: "approval-platform",
+				toolName: "bash",
+				args: { command: "deploy" },
+				reason: "Needs approval",
+				platform: {
+					source: "tool_execution",
+					toolExecutionId: "texec-1",
+					approvalRequestId: "approval-platform",
+				},
+			},
+			service,
+		});
+
+		const res = await resume("approval-platform", {
+			kind: "approval",
+			sessionId: "session-platform",
+			decision: "approved",
+			reason: "Looks good",
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.body)).toEqual({
+			success: true,
+			request: {
+				id: "approval-platform",
+				kind: "approval",
+				sessionId: "session-platform",
+				resolution: "approved",
+				source: "platform",
+				platform: {
+					source: "tool_execution",
+					toolExecutionId: "texec-1",
+					approvalRequestId: "approval-platform",
+				},
+				platformOperation: "ResumeToolExecution",
+			},
+		});
+		expect(resolve).toHaveBeenCalledWith("approval-platform", {
+			approved: true,
+			reason: "Looks good",
+			resolvedBy: "user",
+		});
+		expect(serverRequestManager.get("approval-platform")).toBeUndefined();
+	});
+
+	it("resumes client-side prompts without the caller knowing the legacy endpoint", async () => {
+		const resolve = vi.fn().mockReturnValue(true);
+		serverRequestManager.registerClientTool({
+			id: "ask-user-1",
+			sessionId: "session-client",
+			toolName: "ask_user",
+			args: { question: "Continue?" },
+			kind: "user_input",
+			resolve,
+			cancel: vi.fn().mockReturnValue(true),
+		});
+
+		const res = await resume("ask-user-1", {
+			sessionId: "session-client",
+			content: [{ type: "text", text: "Yes" }],
+			isError: false,
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.body)).toEqual({
+			success: true,
+			request: {
+				id: "ask-user-1",
+				kind: "user_input",
+				sessionId: "session-client",
+				resolution: "answered",
+				source: "local",
+			},
+		});
+		expect(resolve).toHaveBeenCalledWith(
+			[{ type: "text", text: "Yes" }],
+			false,
+		);
+	});
+
+	it("resumes tool retry requests from the same endpoint", async () => {
+		const service = new ToolRetryService("prompt");
+		const retry = vi.spyOn(service, "retry").mockReturnValue(true);
+		serverRequestManager.registerToolRetry({
+			sessionId: "session-retry",
+			request: {
+				id: "retry-1",
+				toolCallId: "tool-call-1",
+				toolName: "bash",
+				args: { command: "make test" },
+				errorMessage: "Timed out",
+				attempt: 1,
+			},
+			service,
+		});
+
+		const res = await resume("retry-1", {
+			kind: "tool_retry",
+			action: "retry",
+			reason: "Try again",
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.body).request).toMatchObject({
+			id: "retry-1",
+			kind: "tool_retry",
+			sessionId: "session-retry",
+			resolution: "retried",
+			source: "local",
+		});
+		expect(retry).toHaveBeenCalledWith("retry-1", "Try again", "user");
+	});
+
+	it("rejects resume attempts for a different session", async () => {
+		const service = new ActionApprovalService("prompt");
+		vi.spyOn(service, "resolve").mockReturnValue(true);
+		serverRequestManager.registerApproval({
+			sessionId: "session-owner",
+			request: {
+				id: "approval-owner",
+				toolName: "bash",
+				args: {},
+				reason: "Needs approval",
+			},
+			service,
+		});
+
+		const res = await resume("approval-owner", {
+			kind: "approval",
+			sessionId: "session-other",
+			decision: "approved",
+		});
+
+		expect(res.statusCode).toBe(404);
+		expect(JSON.parse(res.body)).toMatchObject({
+			error: "Pending request not found for session",
+		});
+		expect(serverRequestManager.get("approval-owner")).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- previewed public-tree drift: `9` file(s) to copy/update and `0` stale file(s) to delete

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode