### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2524,6 +2524,31 @@
         ]
       }
     },
+    "/api/sessions/{id}/timeline": {
+      "get": {
+        "summary": "Auto-generated from route definition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "ComposerApiKey": []
+          }
+        ]
+      }
+    },
     "/api/sessions": {
       "get": {
         "summary": "List sessions",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -496,6 +496,67 @@ export interface ComposerPendingRequestResumeResponse {
 	};
 }
 
+export type ComposerRunTimelineVisibility = "user" | "admin" | "audit";
+
+export type ComposerRunTimelineSource = "local" | "platform";
+
+export type ComposerRunTimelineEventType =
+	| "session.started"
+	| "session.updated"
+	| "message.user"
+	| "message.assistant"
+	| "tool.requested"
+	| "tool.completed"
+	| "tool.failed"
+	| "wait.pending"
+	| "compaction.created"
+	| "branch.created"
+	| "model.changed"
+	| "thinking.changed"
+	| "custom.event";
+
+export type ComposerRunTimelineStatus =
+	| "pending"
+	| "running"
+	| "completed"
+	| "failed"
+	| "approved"
+	| "denied"
+	| "info";
+
+export interface ComposerRunTimelineItem {
+	id: string;
+	sessionId: string;
+	timestamp: string;
+	type: ComposerRunTimelineEventType;
+	title: string;
+	visibility: ComposerRunTimelineVisibility;
+	source: ComposerRunTimelineSource;
+	status?: ComposerRunTimelineStatus;
+	summary?: string;
+	role?: ComposerRole;
+	toolCallId?: string;
+	toolName?: string;
+	pendingRequestId?: string;
+	pendingRequestKind?: ComposerPendingRequestKind;
+	approvalRequestId?: string;
+	toolExecutionId?: string;
+	artifactId?: string;
+	remoteRunnerSessionId?: string;
+	platform?: ComposerPendingRequestPlatformRef;
+	platformOperation?: ComposerPendingRequestPlatformOperation;
+	metadata?: Record<string, unknown>;
+}
+
+export interface ComposerRunTimelineResponse {
+	sessionId: string;
+	source: ComposerRunTimelineSource;
+	generatedAt: string;
+	platformBacked: boolean;
+	pendingRequestCount: number;
+	items: ComposerRunTimelineItem[];
+}
+
 /**
  * Full session data including message history.
  *

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -425,6 +425,86 @@ export const ComposerPendingRequestResumeResponseSchema = Type.Object({
 	}),
 });
 
+export const ComposerRunTimelineVisibilitySchema = Type.Union([
+	Type.Literal("user"),
+	Type.Literal("admin"),
+	Type.Literal("audit"),
+]);
+
+export const ComposerRunTimelineSourceSchema = Type.Union([
+	Type.Literal("local"),
+	Type.Literal("platform"),
+]);
+
+export const ComposerRunTimelineEventTypeSchema = Type.Union([
+	Type.Literal("session.started"),
+	Type.Literal("session.updated"),
+	Type.Literal("message.user"),
+	Type.Literal("message.assistant"),
+	Type.Literal("tool.requested"),
+	Type.Literal("tool.completed"),
+	Type.Literal("tool.failed"),
+	Type.Literal("wait.pending"),
+	Type.Literal("compaction.created"),
+	Type.Literal("branch.created"),
+	Type.Literal("model.changed"),
+	Type.Literal("thinking.changed"),
+	Type.Literal("custom.event"),
+]);
+
+export const ComposerRunTimelineStatusSchema = Type.Union([
+	Type.Literal("pending"),
+	Type.Literal("running"),
+	Type.Literal("completed"),
+	Type.Literal("failed"),
+	Type.Literal("approved"),
+	Type.Literal("denied"),
+	Type.Literal("info"),
+]);
+
+export const ComposerRunTimelineItemSchema = Type.Object({
+	id: Type.String(),
+	sessionId: Type.String(),
+	timestamp: Type.String(),
+	type: ComposerRunTimelineEventTypeSchema,
+	title: Type.String(),
+	visibility: ComposerRunTimelineVisibilitySchema,
+	source: ComposerRunTimelineSourceSchema,
+	status: Type.Optional(ComposerRunTimelineStatusSchema),
+	summary: Type.Optional(Type.String()),
+	role: Type.Optional(ComposerRoleSchema),
+	toolCallId: Type.Optional(Type.String()),
+	toolName: Type.Optional(Type.String()),
+	pendingRequestId: Type.Optional(Type.String()),
+	pendingRequestKind: Type.Optional(
+		Type.Union([
+			Type.Literal("approval"),
+			Type.Literal("client_tool"),
+			Type.Literal("mcp_elicitation"),
+			Type.Literal("user_input"),
+			Type.Literal("tool_retry"),
+		]),
+	),
+	approvalRequestId: Type.Optional(Type.String()),
+	toolExecutionId: Type.Optional(Type.String()),
+	artifactId: Type.Optional(Type.String()),
+	remoteRunnerSessionId: Type.Optional(Type.String()),
+	platform: Type.Optional(ComposerPendingRequestPlatformRefSchema),
+	platformOperation: Type.Optional(
+		ComposerPendingRequestPlatformOperationSchema,
+	),
+	metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+
+export const ComposerRunTimelineResponseSchema = Type.Object({
+	sessionId: Type.String(),
+	source: ComposerRunTimelineSourceSchema,
+	generatedAt: Type.String(),
+	platformBacked: Type.Boolean(),
+	pendingRequestCount: Type.Number(),
+	items: Type.Array(ComposerRunTimelineItemSchema),
+});
+
 export const ComposerToolRetryRequestSchema = Type.Object({
 	id: Type.String(),
 	toolCallId: Type.String(),

--- a/packages/contracts/src/validators.ts
+++ b/packages/contracts/src/validators.ts
@@ -45,6 +45,7 @@ import {
 	ComposerPlanActionResponseSchema,
 	ComposerPlanRequestSchema,
 	ComposerPlanStatusResponseSchema,
+	ComposerRunTimelineResponseSchema,
 	ComposerSessionListResponseSchema,
 	ComposerSessionSchema,
 	ComposerSessionSummarySchema,
@@ -383,6 +384,11 @@ export const isComposerPendingRequestResumeResponse = (
 	value: unknown,
 ): value is Static<typeof ComposerPendingRequestResumeResponseSchema> =>
 	Value.Check(ComposerPendingRequestResumeResponseSchema, value);
+
+export const isComposerRunTimelineResponse = (
+	value: unknown,
+): value is Static<typeof ComposerRunTimelineResponseSchema> =>
+	Value.Check(ComposerRunTimelineResponseSchema, value);
 
 export const isComposerSessionListResponse = (
 	value: unknown,

--- a/packages/web/src/services/api-client.ts
+++ b/packages/web/src/services/api-client.ts
@@ -75,6 +75,7 @@ import {
 	isComposerPendingRequestResumeResponse,
 	isComposerPlanActionResponse,
 	isComposerPlanStatusResponse,
+	isComposerRunTimelineResponse,
 	isComposerSession,
 	isComposerSessionListResponse,
 	isComposerSessionSummary,
@@ -113,6 +114,7 @@ import type {
 	ComposerProjectOnboardingState,
 	ComposerPromptSuggestionRequest,
 	ComposerPromptSuggestionResponse,
+	ComposerRunTimelineResponse,
 	ComposerSession,
 	ComposerSessionSummary,
 	ComposerToolCall,
@@ -167,6 +169,8 @@ export type Model = ComposerModel;
 export type Session = ComposerSession;
 
 export type SessionSummary = ComposerSessionSummary;
+
+export type RunTimelineResponse = ComposerRunTimelineResponse;
 
 export type ChatRequest = ComposerChatRequest;
 
@@ -1888,6 +1892,19 @@ export class ApiClient {
 			throw new Error("Invalid session payload");
 		}
 		return data as Session;
+	}
+
+	/**
+	 * Get the run timeline for a specific session.
+	 */
+	async getSessionTimeline(sessionId: string): Promise<RunTimelineResponse> {
+		const data = await this.fetchJsonWithFallback(
+			`/api/sessions/${encodeURIComponent(sessionId)}/timeline`,
+		);
+		if (VALIDATE_API_RESPONSES && !isComposerRunTimelineResponse(data)) {
+			throw new Error("Invalid session timeline payload");
+		}
+		return data as RunTimelineResponse;
 	}
 
 	/**

--- a/src/server/handlers/session-timeline.ts
+++ b/src/server/handlers/session-timeline.ts
@@ -1,0 +1,70 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ComposerRunTimelineResponse } from "@evalops/contracts";
+import { safeReadSessionEntries } from "../../session/session-context.js";
+import { getAuthSubject } from "../authz.js";
+import { getPendingComposerRequests } from "../pending-request-payload.js";
+import { ApiError, respondWithApiError, sendJson } from "../server-utils.js";
+import { createWebSessionManagerForRequest } from "../session-scope.js";
+import { buildComposerRunTimeline } from "../session-timeline.js";
+import { sessionIdPattern, verifySessionOwnership } from "./sessions.js";
+
+interface SessionTimelineParams {
+	id?: string;
+}
+
+function requireSessionId(params: SessionTimelineParams): string {
+	const sessionId = params.id?.trim();
+	if (!sessionId || !sessionIdPattern.test(sessionId)) {
+		throw new ApiError(400, "Invalid session id");
+	}
+	return sessionId;
+}
+
+export async function handleSessionTimeline(
+	req: IncomingMessage,
+	res: ServerResponse,
+	params: SessionTimelineParams,
+	cors: Record<string, string>,
+): Promise<void> {
+	try {
+		if (req.method !== "GET") {
+			res.writeHead(405, cors);
+			res.end();
+			return;
+		}
+
+		const sessionId = requireSessionId(params);
+		const sessionManager = createWebSessionManagerForRequest(req, true);
+		const session = await sessionManager.loadSession(sessionId);
+		if (!session) {
+			throw new ApiError(404, "Session not found");
+		}
+
+		const subject = getAuthSubject(req);
+		if (!verifySessionOwnership(session, subject)) {
+			throw new ApiError(403, "Access denied: session belongs to another user");
+		}
+
+		const sessionPath = sessionManager.getSessionFileById(sessionId);
+		const entries = sessionPath ? safeReadSessionEntries(sessionPath) : [];
+		const pendingRequests = getPendingComposerRequests(session.id);
+		const responseBody: ComposerRunTimelineResponse = buildComposerRunTimeline({
+			sessionId: session.id,
+			entries,
+			messages: session.messages || [],
+			pendingRequests,
+		});
+
+		sendJson(res, 200, responseBody, cors, req);
+	} catch (error) {
+		if (!respondWithApiError(res, error, 500, cors, req)) {
+			sendJson(
+				res,
+				500,
+				{ error: "Failed to load session timeline" },
+				cors,
+				req,
+			);
+		}
+	}
+}

--- a/src/server/handlers/sessions.ts
+++ b/src/server/handlers/sessions.ts
@@ -10,6 +10,7 @@
  * |--------|------|-------------|
  * | GET | `/api/sessions` | List all sessions with pagination |
  * | GET | `/api/sessions/:id` | Get a specific session with messages |
+ * | GET | `/api/sessions/:id/timeline` | Get a redacted run timeline |
  * | POST | `/api/sessions` | Create a new session |
  * | PATCH | `/api/sessions/:id` | Update session metadata (title, tags, favorite) |
  * | DELETE | `/api/sessions/:id` | Delete a session |
@@ -37,8 +38,6 @@ import crypto from "node:crypto";
 import { readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type {
-	ComposerPendingClientToolRequest,
-	ComposerPendingRequest,
 	ComposerSession,
 	ComposerSessionSummary,
 } from "@evalops/contracts";
@@ -51,7 +50,7 @@ import type { SessionEntry } from "../../session/types.js";
 import { createLogger } from "../../utils/logger.js";
 import { getAuthSubject } from "../authz.js";
 import { isHostedSessionManager } from "../hosted-session-manager.js";
-import { serverRequestManager } from "../server-request-manager.js";
+import { getPendingServerRequestPayload } from "../pending-request-payload.js";
 import {
 	buildContentDisposition,
 	readJsonBody,
@@ -91,122 +90,8 @@ export type {
 } from "./session-share-store.js";
 
 const logger = createLogger("sessions-handler");
-const sessionIdPattern = /^[a-zA-Z0-9._-]+$/;
+export const sessionIdPattern = /^[a-zA-Z0-9._-]+$/;
 const attachmentIdPattern = /^[a-zA-Z0-9._-]+$/;
-
-function getPendingServerRequestPayload(
-	sessionId: string,
-): Pick<
-	ComposerSession,
-	| "pendingApprovalRequests"
-	| "pendingClientToolRequests"
-	| "pendingRequests"
-	| "pendingToolRetryRequests"
-> {
-	const pending = serverRequestManager.listPending({ sessionId });
-
-	const pendingApprovalRequests = pending
-		.filter((entry) => entry.kind === "approval")
-		.map((entry) => ({
-			id: entry.id,
-			toolName: entry.toolName,
-			displayName: entry.displayName,
-			summaryLabel: entry.summaryLabel,
-			actionDescription: entry.actionDescription,
-			args: entry.args,
-			reason: entry.reason,
-			platform: entry.platform,
-		}));
-
-	const pendingClientToolRequests: ComposerPendingClientToolRequest[] = pending
-		.filter(
-			(
-				entry,
-			): entry is typeof entry & {
-				kind: "client_tool" | "mcp_elicitation" | "user_input";
-			} =>
-				entry.kind === "client_tool" ||
-				entry.kind === "mcp_elicitation" ||
-				entry.kind === "user_input",
-		)
-		.map((entry) => ({
-			toolCallId: entry.callId,
-			toolName: entry.toolName,
-			args: entry.args,
-			kind: entry.kind,
-			reason: entry.reason,
-		}));
-
-	const pendingToolRetryRequests = pending
-		.filter((entry) => entry.kind === "tool_retry")
-		.map((entry) => {
-			const args =
-				entry.args &&
-				typeof entry.args === "object" &&
-				!Array.isArray(entry.args)
-					? (entry.args as Record<string, unknown>)
-					: {};
-			return {
-				id: entry.id,
-				toolCallId:
-					typeof args.tool_call_id === "string"
-						? args.tool_call_id
-						: entry.callId,
-				toolName: entry.toolName,
-				args: args.args,
-				errorMessage:
-					typeof args.error_message === "string"
-						? args.error_message
-						: entry.reason,
-				attempt:
-					typeof args.attempt === "number" && Number.isFinite(args.attempt)
-						? args.attempt
-						: 1,
-				maxAttempts:
-					typeof args.max_attempts === "number" &&
-					Number.isFinite(args.max_attempts)
-						? args.max_attempts
-						: undefined,
-				summary: typeof args.summary === "string" ? args.summary : undefined,
-			};
-		});
-	const pendingRequests: ComposerPendingRequest[] = pending.map((entry) => {
-		const createdAt = new Date(entry.timestamp).toISOString();
-		const expiresAt =
-			Number.isFinite(entry.timeoutMs) && entry.timeoutMs > 0
-				? new Date(entry.timestamp + entry.timeoutMs).toISOString()
-				: undefined;
-		return {
-			id: entry.id,
-			kind: entry.kind,
-			status: "pending",
-			visibility: "user",
-			sessionId: entry.sessionId,
-			toolCallId: entry.callId,
-			toolName: entry.toolName,
-			displayName: entry.displayName,
-			summaryLabel: entry.summaryLabel,
-			actionDescription: entry.actionDescription,
-			args: entry.args,
-			reason: entry.reason,
-			createdAt,
-			expiresAt,
-			source: entry.platform ? "platform" : "local",
-			platform: entry.platform,
-		};
-	});
-
-	return {
-		...(pendingApprovalRequests.length > 0 ? { pendingApprovalRequests } : {}),
-		...(pendingClientToolRequests.length > 0
-			? { pendingClientToolRequests }
-			: {}),
-		...(pendingToolRetryRequests.length > 0
-			? { pendingToolRetryRequests }
-			: {}),
-		...(pendingRequests.length > 0 ? { pendingRequests } : {}),
-	};
-}
 
 function sendSensitiveContentBlockedResponse(
 	req: IncomingMessage,
@@ -234,7 +119,7 @@ function sendSensitiveContentBlockedResponse(
  *
  * Returns true if access is allowed, false otherwise.
  */
-function verifySessionOwnership(
+export function verifySessionOwnership(
 	session: { owner?: unknown; subject?: unknown },
 	subject: string,
 ): boolean {

--- a/src/server/pending-request-payload.ts
+++ b/src/server/pending-request-payload.ts
@@ -1,0 +1,137 @@
+import type {
+	ComposerPendingClientToolRequest,
+	ComposerPendingRequest,
+	ComposerSession,
+} from "@evalops/contracts";
+import {
+	type PendingServerRequestSnapshot,
+	serverRequestManager,
+} from "./server-request-manager.js";
+
+function mapPendingComposerRequests(
+	pending: PendingServerRequestSnapshot[],
+): ComposerPendingRequest[] {
+	return pending.map((entry) => {
+		const createdAt = new Date(entry.timestamp).toISOString();
+		const expiresAt =
+			Number.isFinite(entry.timeoutMs) && entry.timeoutMs > 0
+				? new Date(entry.timestamp + entry.timeoutMs).toISOString()
+				: undefined;
+		return {
+			id: entry.id,
+			kind: entry.kind,
+			status: "pending",
+			visibility: "user",
+			sessionId: entry.sessionId,
+			toolCallId: entry.callId,
+			toolName: entry.toolName,
+			displayName: entry.displayName,
+			summaryLabel: entry.summaryLabel,
+			actionDescription: entry.actionDescription,
+			args: entry.args,
+			reason: entry.reason,
+			createdAt,
+			expiresAt,
+			source: entry.platform ? "platform" : "local",
+			platform: entry.platform,
+		};
+	});
+}
+
+export function getPendingComposerRequests(
+	sessionId: string,
+): ComposerPendingRequest[] {
+	return mapPendingComposerRequests(
+		serverRequestManager.listPending({ sessionId }),
+	);
+}
+
+export function getPendingServerRequestPayload(
+	sessionId: string,
+): Pick<
+	ComposerSession,
+	| "pendingApprovalRequests"
+	| "pendingClientToolRequests"
+	| "pendingRequests"
+	| "pendingToolRetryRequests"
+> {
+	const pending = serverRequestManager.listPending({ sessionId });
+
+	const pendingApprovalRequests = pending
+		.filter((entry) => entry.kind === "approval")
+		.map((entry) => ({
+			id: entry.id,
+			toolName: entry.toolName,
+			displayName: entry.displayName,
+			summaryLabel: entry.summaryLabel,
+			actionDescription: entry.actionDescription,
+			args: entry.args,
+			reason: entry.reason,
+			platform: entry.platform,
+		}));
+
+	const pendingClientToolRequests: ComposerPendingClientToolRequest[] = pending
+		.filter(
+			(
+				entry,
+			): entry is typeof entry & {
+				kind: "client_tool" | "mcp_elicitation" | "user_input";
+			} =>
+				entry.kind === "client_tool" ||
+				entry.kind === "mcp_elicitation" ||
+				entry.kind === "user_input",
+		)
+		.map((entry) => ({
+			toolCallId: entry.callId,
+			toolName: entry.toolName,
+			args: entry.args,
+			kind: entry.kind,
+			reason: entry.reason,
+		}));
+
+	const pendingToolRetryRequests = pending
+		.filter((entry) => entry.kind === "tool_retry")
+		.map((entry) => {
+			const args =
+				entry.args &&
+				typeof entry.args === "object" &&
+				!Array.isArray(entry.args)
+					? (entry.args as Record<string, unknown>)
+					: {};
+			return {
+				id: entry.id,
+				toolCallId:
+					typeof args.tool_call_id === "string"
+						? args.tool_call_id
+						: entry.callId,
+				toolName: entry.toolName,
+				args: args.args,
+				errorMessage:
+					typeof args.error_message === "string"
+						? args.error_message
+						: entry.reason,
+				attempt:
+					typeof args.attempt === "number" && Number.isFinite(args.attempt)
+						? args.attempt
+						: 1,
+				maxAttempts:
+					typeof args.max_attempts === "number" &&
+					Number.isFinite(args.max_attempts)
+						? args.max_attempts
+						: undefined,
+				summary: typeof args.summary === "string" ? args.summary : undefined,
+			};
+		});
+	const pendingRequests = mapPendingComposerRequests(pending);
+
+	return {
+		...(pendingApprovalRequests.length > 0 ? { pendingApprovalRequests } : {}),
+		...(pendingClientToolRequests.length > 0
+			? { pendingClientToolRequests }
+			: {}),
+		...(pendingToolRetryRequests.length > 0
+			? { pendingToolRetryRequests }
+			: {}),
+		...(pendingRequests.length > 0 ? { pendingRequests } : {}),
+	};
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -83,6 +83,7 @@ import {
 	handleSessionAttachment,
 	handleSessionAttachmentExtract,
 } from "./handlers/session-attachments.js";
+import { handleSessionTimeline } from "./handlers/session-timeline.js";
 import {
 	handleSessionExport,
 	handleSessionShare,
@@ -860,6 +861,12 @@ export function createRoutes(context: WebServerContext): Route[] {
 					params as { id: string; attachmentId: string },
 					corsHeaders,
 				),
+		},
+		{
+			method: "GET",
+			path: "/api/sessions/:id/timeline",
+			handler: (req, res, params) =>
+				handleSessionTimeline(req, res, params as { id: string }, corsHeaders),
 		},
 		{
 			method: "GET",

--- a/src/server/session-timeline.ts
+++ b/src/server/session-timeline.ts
@@ -1,0 +1,462 @@
+import type {
+	ComposerPendingRequest,
+	ComposerPendingRequestPlatformOperation,
+	ComposerRunTimelineItem,
+	ComposerRunTimelineResponse,
+	ComposerRunTimelineStatus,
+} from "@evalops/contracts";
+import type {
+	AppMessage,
+	AssistantMessage,
+	ToolResultMessage,
+	UserMessage,
+} from "../agent/types.js";
+import type { SessionEntry } from "../session/types.js";
+
+const SUMMARY_LIMIT = 180;
+
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+	[/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{16,}/gi, "$1[redacted]"],
+	[/\b(sk-[A-Za-z0-9_-]{16,})\b/g, "[redacted-secret]"],
+	[/\b(gh[pousr]_[A-Za-z0-9_]{16,})\b/g, "[redacted-token]"],
+	[/\b(xox[a-zA-Z]?-[A-Za-z0-9-]{16,})\b/g, "[redacted-token]"],
+	[/\b(AKIA[0-9A-Z]{16})\b/g, "[redacted-access-key]"],
+];
+
+interface BuildComposerRunTimelineOptions {
+	sessionId: string;
+	entries?: SessionEntry[];
+	messages?: AppMessage[];
+	pendingRequests?: ComposerPendingRequest[];
+	generatedAt?: string;
+}
+
+function normalizeTimestamp(value: unknown, fallback: string): string {
+	if (typeof value === "string" || typeof value === "number") {
+		const date = new Date(value);
+		if (!Number.isNaN(date.getTime())) {
+			return date.toISOString();
+		}
+	}
+	return fallback;
+}
+
+function redactSecrets(value: string): string {
+	let redacted = value;
+	for (const [pattern, replacement] of SECRET_PATTERNS) {
+		redacted = redacted.replace(pattern, replacement);
+	}
+	return redacted;
+}
+
+function compactSummary(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	const singleLine = redactSecrets(value.replace(/\s+/g, " ").trim());
+	if (!singleLine) return undefined;
+	if (singleLine.length <= SUMMARY_LIMIT) return singleLine;
+	return `${singleLine.slice(0, SUMMARY_LIMIT - 3)}...`;
+}
+
+function textFromContent(content: unknown): string | undefined {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return undefined;
+	const text = content
+		.map((block) => {
+			if (!block || typeof block !== "object") return "";
+			const typed = block as { type?: unknown; text?: unknown };
+			if (typed.type === "text" && typeof typed.text === "string") {
+				return typed.text;
+			}
+			return "";
+		})
+		.filter(Boolean)
+		.join(" ");
+	return text || undefined;
+}
+
+function appendItem(
+	items: ComposerRunTimelineItem[],
+	item: ComposerRunTimelineItem,
+): void {
+	items.push(item);
+}
+
+function addMessageItems(
+	items: ComposerRunTimelineItem[],
+	sessionId: string,
+	message: AppMessage,
+	options: {
+		baseId: string;
+		timestamp: string;
+		source: "local" | "platform";
+	},
+): void {
+	if (message.role === "user") {
+		const userMessage = message as UserMessage;
+		const summary = compactSummary(textFromContent(userMessage.content));
+		appendItem(items, {
+			id: `message:${options.baseId}`,
+			sessionId,
+			timestamp: options.timestamp,
+			type: "message.user",
+			title: "User message",
+			visibility: "user",
+			source: options.source,
+			role: "user",
+			status: "completed",
+			...(summary ? { summary } : {}),
+		});
+		return;
+	}
+
+	if (message.role === "assistant") {
+		const assistantMessage = message as AssistantMessage;
+		const summary = compactSummary(textFromContent(assistantMessage.content));
+		appendItem(items, {
+			id: `message:${options.baseId}`,
+			sessionId,
+			timestamp: options.timestamp,
+			type: "message.assistant",
+			title: "Assistant response",
+			visibility: "user",
+			source: options.source,
+			role: "assistant",
+			status: assistantMessage.stopReason === "error" ? "failed" : "completed",
+			...(summary ? { summary } : {}),
+			...(assistantMessage.model
+				? { metadata: { model: assistantMessage.model } }
+				: {}),
+		});
+
+		for (const block of assistantMessage.content) {
+			if (block.type !== "toolCall") continue;
+			appendItem(items, {
+				id: `tool-requested:${options.baseId}:${block.id}`,
+				sessionId,
+				timestamp: options.timestamp,
+				type: "tool.requested",
+				title: `Requested ${block.name}`,
+				visibility: "user",
+				source: options.source,
+				status: "running",
+				toolCallId: block.id,
+				toolName: block.name,
+			});
+		}
+		return;
+	}
+
+	if (message.role === "toolResult") {
+		const toolResult = message as ToolResultMessage;
+		appendItem(items, {
+			id: `tool-result:${options.baseId}:${toolResult.toolCallId}`,
+			sessionId,
+			timestamp: options.timestamp,
+			type: toolResult.isError ? "tool.failed" : "tool.completed",
+			title: `${toolResult.toolName} ${
+				toolResult.isError ? "failed" : "completed"
+			}`,
+			visibility: "user",
+			source: options.source,
+			role: "tool",
+			status: toolResult.isError ? "failed" : "completed",
+			toolCallId: toolResult.toolCallId,
+			toolName: toolResult.toolName,
+		});
+	}
+}
+
+function statusForPendingRequest(
+	request: ComposerPendingRequest,
+): ComposerRunTimelineStatus {
+	return request.status === "pending" ? "pending" : "info";
+}
+
+function platformOperationForPending(
+	request: ComposerPendingRequest,
+): ComposerPendingRequestPlatformOperation | undefined {
+	if (!request.platform) return undefined;
+	if (request.kind === "approval") {
+		return request.platform.source === "tool_execution"
+			? "ResumeToolExecution"
+			: "ResolveApproval";
+	}
+	if (
+		request.kind === "client_tool" ||
+		request.kind === "mcp_elicitation" ||
+		request.kind === "user_input"
+	) {
+		return "ResumeRun";
+	}
+	return undefined;
+}
+
+function pendingRequestTitle(request: ComposerPendingRequest): string {
+	const label =
+		request.displayName ||
+		request.summaryLabel ||
+		request.toolName ||
+		"request";
+	switch (request.kind) {
+		case "approval":
+			return `Waiting for approval: ${label}`;
+		case "tool_retry":
+			return `Waiting for retry decision: ${label}`;
+		case "client_tool":
+			return `Waiting for client tool: ${label}`;
+		case "mcp_elicitation":
+			return "Waiting for MCP input";
+		case "user_input":
+			return "Waiting for user input";
+	}
+}
+
+function addPendingRequestItems(
+	items: ComposerRunTimelineItem[],
+	sessionId: string,
+	pendingRequests: ComposerPendingRequest[],
+	generatedAt: string,
+): void {
+	for (const request of pendingRequests) {
+		const summary = compactSummary(
+			request.actionDescription || request.summaryLabel || request.reason,
+		);
+		const platformOperation = platformOperationForPending(request);
+		appendItem(items, {
+			id: `pending:${request.id}`,
+			sessionId,
+			timestamp: normalizeTimestamp(request.createdAt, generatedAt),
+			type: "wait.pending",
+			title: pendingRequestTitle(request),
+			visibility: "user",
+			source: request.source,
+			status: statusForPendingRequest(request),
+			toolCallId: request.toolCallId,
+			toolName: request.toolName,
+			pendingRequestId: request.id,
+			pendingRequestKind: request.kind,
+			...(summary ? { summary } : {}),
+			...(request.platform?.approvalRequestId
+				? { approvalRequestId: request.platform.approvalRequestId }
+				: {}),
+			...(request.platform?.toolExecutionId
+				? { toolExecutionId: request.platform.toolExecutionId }
+				: {}),
+			...(request.platform ? { platform: request.platform } : {}),
+			...(platformOperation ? { platformOperation } : {}),
+		});
+	}
+}
+
+function addEntryItems(
+	items: ComposerRunTimelineItem[],
+	sessionId: string,
+	entries: SessionEntry[],
+	generatedAt: string,
+): number {
+	let messageEntryCount = 0;
+
+	for (const [index, entry] of entries.entries()) {
+		const timestamp = normalizeTimestamp(
+			(entry as { timestamp?: unknown }).timestamp,
+			generatedAt,
+		);
+
+		switch (entry.type) {
+			case "session": {
+				appendItem(items, {
+					id: `session-started:${entry.id}`,
+					sessionId,
+					timestamp,
+					type: "session.started",
+					title: "Session started",
+					visibility: "user",
+					source: "local",
+					status: "info",
+					...(entry.cwd ? { metadata: { cwd: entry.cwd } } : {}),
+				});
+				break;
+			}
+			case "session_meta": {
+				const summary = compactSummary(
+					entry.title || entry.resumeSummary || entry.summary,
+				);
+				appendItem(items, {
+					id: `session-updated:${index}`,
+					sessionId,
+					timestamp,
+					type: "session.updated",
+					title: "Session metadata updated",
+					visibility: "admin",
+					source: "local",
+					status: "info",
+					...(summary ? { summary } : {}),
+				});
+				break;
+			}
+			case "message": {
+				messageEntryCount += 1;
+				addMessageItems(items, sessionId, entry.message, {
+					baseId: entry.id,
+					timestamp,
+					source: "local",
+				});
+				break;
+			}
+			case "compaction": {
+				const summary = compactSummary(entry.summary);
+				appendItem(items, {
+					id: `compaction:${entry.id}`,
+					sessionId,
+					timestamp,
+					type: "compaction.created",
+					title: "Context compacted",
+					visibility: "admin",
+					source: "local",
+					status: "info",
+					...(summary ? { summary } : {}),
+					metadata: {
+						tokensBefore: entry.tokensBefore,
+						auto: entry.auto === true,
+						fromHook: entry.fromHook === true,
+					},
+				});
+				break;
+			}
+			case "branch_summary": {
+				const summary = compactSummary(entry.summary);
+				appendItem(items, {
+					id: `branch:${entry.id}`,
+					sessionId,
+					timestamp,
+					type: "branch.created",
+					title: "Branch summary created",
+					visibility: "admin",
+					source: "local",
+					status: "info",
+					...(summary ? { summary } : {}),
+					metadata: { fromId: entry.fromId },
+				});
+				break;
+			}
+			case "model_change": {
+				const summary = compactSummary(entry.model);
+				appendItem(items, {
+					id: `model-change:${entry.id}`,
+					sessionId,
+					timestamp,
+					type: "model.changed",
+					title: "Model changed",
+					visibility: "admin",
+					source: "local",
+					status: "info",
+					...(summary ? { summary } : {}),
+				});
+				break;
+			}
+			case "thinking_level_change": {
+				const summary = compactSummary(entry.thinkingLevel);
+				appendItem(items, {
+					id: `thinking-change:${entry.id}`,
+					sessionId,
+					timestamp,
+					type: "thinking.changed",
+					title: "Thinking level changed",
+					visibility: "admin",
+					source: "local",
+					status: "info",
+					...(summary ? { summary } : {}),
+				});
+				break;
+			}
+			case "custom_message": {
+				if (!entry.display) break;
+				const summary = compactSummary(textFromContent(entry.content));
+				appendItem(items, {
+					id: `custom-message:${entry.id}`,
+					sessionId,
+					timestamp,
+					type: "custom.event",
+					title: entry.customType,
+					visibility: "admin",
+					source: "local",
+					status: "info",
+					...(summary ? { summary } : {}),
+				});
+				break;
+			}
+			case "custom": {
+				appendItem(items, {
+					id: `custom:${entry.id}`,
+					sessionId,
+					timestamp,
+					type: "custom.event",
+					title: entry.customType,
+					visibility: "audit",
+					source: "local",
+					status: "info",
+				});
+				break;
+			}
+		}
+	}
+
+	return messageEntryCount;
+}
+
+function sortItems(
+	items: ComposerRunTimelineItem[],
+): ComposerRunTimelineItem[] {
+	return [...items].sort((a, b) => {
+		const timestampDelta =
+			new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+		if (timestampDelta !== 0) return timestampDelta;
+		return a.id.localeCompare(b.id);
+	});
+}
+
+export function buildComposerRunTimeline(
+	options: BuildComposerRunTimelineOptions,
+): ComposerRunTimelineResponse {
+	const generatedAt = options.generatedAt ?? new Date().toISOString();
+	const items: ComposerRunTimelineItem[] = [];
+	const entries = options.entries ?? [];
+	const messages = options.messages ?? [];
+	const pendingRequests = options.pendingRequests ?? [];
+
+	const messageEntryCount = addEntryItems(
+		items,
+		options.sessionId,
+		entries,
+		generatedAt,
+	);
+
+	if (messageEntryCount === 0) {
+		for (const [index, message] of messages.entries()) {
+			addMessageItems(items, options.sessionId, message, {
+				baseId: `fallback-${index}`,
+				timestamp: normalizeTimestamp(
+					(message as { timestamp?: unknown }).timestamp,
+					generatedAt,
+				),
+				source: "local",
+			});
+		}
+	}
+
+	addPendingRequestItems(
+		items,
+		options.sessionId,
+		pendingRequests,
+		generatedAt,
+	);
+
+	return {
+		sessionId: options.sessionId,
+		source: "local",
+		generatedAt,
+		platformBacked: false,
+		pendingRequestCount: pendingRequests.length,
+		items: sortItems(items),
+	};
+}

--- a/test/session-endpoints.test.ts
+++ b/test/session-endpoints.test.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleSessionTimeline } from "../src/server/handlers/session-timeline.js";
 import {
 	handleSessionExport,
 	handleSessionShare,
@@ -353,6 +354,194 @@ describe("Session Endpoints", () => {
 
 			expect(getStatus()).toBe(400);
 			expect(getBody()).toEqual({ error: "Invalid session id" });
+		});
+	});
+
+	describe("handleSessionTimeline - GET", () => {
+		it("returns a redacted run timeline with Platform wait references", async () => {
+			const secret = makeTestAnthropicToken();
+			const longPrompt = `Deploy with token ${secret} ${"x".repeat(300)}`;
+			const entries = [
+				{
+					type: "session",
+					id: "test-session-1",
+					version: 2,
+					timestamp: "2024-01-01T00:00:00.000Z",
+					cwd: "/workspace",
+				},
+				{
+					type: "message",
+					id: "user-1",
+					parentId: null,
+					timestamp: "2024-01-01T00:00:01.000Z",
+					message: {
+						role: "user",
+						content: longPrompt,
+						timestamp: 1704067201000,
+					},
+				},
+				{
+					type: "message",
+					id: "assistant-1",
+					parentId: "user-1",
+					timestamp: "2024-01-01T00:00:02.000Z",
+					message: {
+						role: "assistant",
+						content: [
+							{ type: "text", text: "I will inspect the workspace." },
+							{
+								type: "toolCall",
+								id: "tool-call-1",
+								name: "bash",
+								arguments: { command: "rm -rf /tmp/demo" },
+							},
+						],
+						api: "openai-responses",
+						provider: "openai",
+						model: "gpt-5.2",
+						usage: {
+							input: 1,
+							output: 1,
+							cacheRead: 0,
+							cacheWrite: 0,
+							cost: {
+								input: 0,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								total: 0,
+							},
+						},
+						stopReason: "toolUse",
+						timestamp: 1704067202000,
+					},
+				},
+				{
+					type: "message",
+					id: "tool-result-1",
+					parentId: "assistant-1",
+					timestamp: "2024-01-01T00:00:03.000Z",
+					message: {
+						role: "toolResult",
+						toolCallId: "tool-call-1",
+						toolName: "bash",
+						content: [{ type: "text", text: "done" }],
+						isError: false,
+						timestamp: 1704067203000,
+					},
+				},
+				{
+					type: "compaction",
+					id: "compaction-1",
+					parentId: "tool-result-1",
+					timestamp: "2024-01-01T00:00:04.000Z",
+					summary: "Kept the deploy context",
+					firstKeptEntryId: "assistant-1",
+					tokensBefore: 4096,
+				},
+			];
+			writeFileSync(
+				jsonlExportPath,
+				`${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+				"utf8",
+			);
+			vi.spyOn(serverRequestManager, "listPending").mockReturnValue([
+				{
+					id: "approval-1",
+					kind: "approval",
+					sessionId: "test-session-1",
+					callId: "approval-1",
+					toolName: "bash",
+					displayName: "Shell Command",
+					summaryLabel: "run bash",
+					actionDescription: "Run a shell command",
+					args: { command: "rm -rf /tmp/demo" },
+					reason: "Needs approval",
+					timestamp: 1704067205000,
+					timeoutMs: 60_000,
+					platform: {
+						source: "tool_execution",
+						toolExecutionId: "te_1",
+						approvalRequestId: "apr_1",
+					},
+				},
+			]);
+
+			const req = createMockRequest("GET");
+			const { res, getStatus, getBody } = createMockResponse();
+
+			await handleSessionTimeline(
+				req,
+				res,
+				{ id: "test-session-1" },
+				corsHeaders,
+			);
+
+			expect(getStatus()).toBe(200);
+			const body = getBody() as {
+				sessionId: string;
+				source: string;
+				platformBacked: boolean;
+				pendingRequestCount: number;
+				items: Array<{
+					type: string;
+					summary?: string;
+					toolCallId?: string;
+					pendingRequestId?: string;
+					toolExecutionId?: string;
+					approvalRequestId?: string;
+					platformOperation?: string;
+					source?: string;
+				}>;
+			};
+			expect(body.sessionId).toBe("test-session-1");
+			expect(body.source).toBe("local");
+			expect(body.platformBacked).toBe(false);
+			expect(body.pendingRequestCount).toBe(1);
+			expect(body.items.map((item) => item.type)).toEqual(
+				expect.arrayContaining([
+					"session.started",
+					"message.user",
+					"message.assistant",
+					"tool.requested",
+					"tool.completed",
+					"compaction.created",
+					"wait.pending",
+				]),
+			);
+			const userItem = body.items.find((item) => item.type === "message.user");
+			expect(userItem?.summary).toContain("[redacted-secret]");
+			expect(userItem?.summary?.length).toBeLessThanOrEqual(180);
+			const waitItem = body.items.find((item) => item.type === "wait.pending");
+			expect(waitItem).toEqual(
+				expect.objectContaining({
+					pendingRequestId: "approval-1",
+					toolExecutionId: "te_1",
+					approvalRequestId: "apr_1",
+					platformOperation: "ResumeToolExecution",
+					source: "platform",
+				}),
+			);
+			const serialized = JSON.stringify(body);
+			expect(serialized).not.toContain(secret);
+			expect(serialized).not.toContain("rm -rf /tmp/demo");
+		});
+
+		it("returns 400 for invalid timeline session ids", async () => {
+			const req = createMockRequest("GET");
+			const { res, getStatus, getBody } = createMockResponse();
+
+			await handleSessionTimeline(
+				req,
+				res,
+				{ id: "../malicious/path" },
+				corsHeaders,
+			);
+
+			expect(getStatus()).toBe(400);
+			expect(getBody()).toEqual(
+				expect.objectContaining({ error: "Invalid session id" }),
+			);
 		});
 	});
 

--- a/test/web/api-client-approvals.test.ts
+++ b/test/web/api-client-approvals.test.ts
@@ -175,4 +175,55 @@ describe("ApiClient approvals", () => {
 			}),
 		);
 	});
+
+	it("loads the session timeline from the session-scoped endpoint", async () => {
+		global.fetch = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					sessionId: "session 1",
+					source: "local",
+					generatedAt: "2024-01-01T00:00:00.000Z",
+					platformBacked: false,
+					pendingRequestCount: 1,
+					items: [
+						{
+							id: "pending:approval-1",
+							sessionId: "session 1",
+							timestamp: "2024-01-01T00:00:01.000Z",
+							type: "wait.pending",
+							title: "Waiting for approval: Shell Command",
+							visibility: "user",
+							source: "platform",
+							status: "pending",
+							toolCallId: "approval-1",
+							toolName: "bash",
+							pendingRequestId: "approval-1",
+							pendingRequestKind: "approval",
+							approvalRequestId: "apr_1",
+							toolExecutionId: "te_1",
+							platform: {
+								source: "tool_execution",
+								toolExecutionId: "te_1",
+								approvalRequestId: "apr_1",
+							},
+							platformOperation: "ResumeToolExecution",
+						},
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			),
+		);
+
+		const api = new ApiClient("http://localhost:8080");
+		const timeline = await api.getSessionTimeline("session 1");
+
+		expect(global.fetch).toHaveBeenCalled();
+		const [url] = vi.mocked(global.fetch).mock.calls[0] ?? [];
+		expect(String(url)).toContain("/api/sessions/session%201/timeline");
+		expect(timeline.pendingRequestCount).toBe(1);
+		expect(timeline.items[0]?.toolExecutionId).toBe("te_1");
+	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- previewed public-tree drift: `12` file(s) to copy/update and `0` stale file(s) to delete

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode