### PR TITLE
Share governed tool outcome type

### DIFF
--- a/src/agent/transport.ts
+++ b/src/agent/transport.ts
@@ -106,18 +106,12 @@ import type {
 	AgentTransport,
 	AppMessage,
 	AssistantMessage,
+	GovernedToolOutcome,
 	Message,
 	QueuedMessage,
 	ToolCall,
 	ToolResultMessage,
 } from "./types.js";
-
-type GovernedToolOutcome =
-	| "approval_required"
-	| "approval_pending"
-	| "authentication_required"
-	| "denied"
-	| "rate_limited";
 
 function getGovernedToolResultEventMetadata(details: unknown): {
 	errorCode?: string;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1034,6 +1034,13 @@ export interface AgentState {
  * - `error` - Error occurred
  * - `compaction` - Context was compacted
  */
+export type GovernedToolOutcome =
+	| "approval_required"
+	| "approval_pending"
+	| "authentication_required"
+	| "denied"
+	| "rate_limited";
+
 export type AgentEvent =
 	| {
 			/** Agent execution started */
@@ -1127,12 +1134,7 @@ export type AgentEvent =
 			/** Optional stable error or outcome code for telemetry and clients */
 			errorCode?: string;
 			/** Optional governed outcome classification surfaced by the tool result */
-			governedOutcome?:
-				| "approval_required"
-				| "approval_pending"
-				| "authentication_required"
-				| "denied"
-				| "rate_limited";
+			governedOutcome?: GovernedToolOutcome;
 			/** Optional selected skill artifact metadata surfaced by the tool result */
 			skillMetadata?: SkillArtifactMetadata;
 			/** Name of the tool */


### PR DESCRIPTION
## Summary
- export a shared `GovernedToolOutcome` type from agent event types
- reuse that shared type in transport governed-tool metadata extraction
- remove the duplicate inline governed-outcome union so future value changes are compiler-checked in one place

## Test plan
- `bunx biome check src/agent/types.ts src/agent/transport.ts`
- `npm test -- test/agent/mcp-governed-results.test.ts`
- `bunx tsc -p tsconfig.build.json --noEmit`
- pre-commit hook: guardian, `bun:lint`, build, binary compile
- `git diff --check`

Fixes lingering Bugbot feedback from #122.