### PR TITLE
Harden Maestro public runtime packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN apk add --no-cache tini git && \
     adduser --system --uid 1001 appuser
 
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src/db/migrations ./dist/db/migrations
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/skills ./skills

--- a/deploy/helm/maestro/templates/deployment.yaml
+++ b/deploy/helm/maestro/templates/deployment.yaml
@@ -68,13 +68,13 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
             initialDelaySeconds: 10
             periodSeconds: 15
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/deploy/helm/maestro/values.yaml
+++ b/deploy/helm/maestro/values.yaml
@@ -51,7 +51,7 @@ terminationGracePeriodSeconds: 45
 
 startupProbe:
   httpGet:
-    path: /health
+    path: /healthz
     port: http
   failureThreshold: 18
   periodSeconds: 5

--- a/scripts/prepare-public-release-mirror.mjs
+++ b/scripts/prepare-public-release-mirror.mjs
@@ -111,18 +111,24 @@ function patternToRegExp(pattern) {
 	return new RegExp(`^${source}$`);
 }
 
-function readExcludePatterns(sourceRoot, excludeFile) {
-	const patterns = [...DEFAULT_EXCLUDES];
-	const path = resolve(sourceRoot, excludeFile);
+function readPatternFile(path) {
 	if (!existsSync(path)) {
-		return patterns;
+		return [];
 	}
-
-	const configured = readFileSync(path, "utf8")
+	return readFileSync(path, "utf8")
 		.split(/\r?\n/u)
 		.map((line) => line.trim())
 		.filter((line) => line && !line.startsWith("#"));
+}
+
+function readExcludePatterns(sourceRoot, excludeFile) {
+	const patterns = [...DEFAULT_EXCLUDES];
+	const configured = readPatternFile(resolve(sourceRoot, excludeFile));
 	return [...patterns, ...configured];
+}
+
+function readSourceOnlyExcludePatterns(sourceRoot) {
+	return readPatternFile(resolve(sourceRoot, ".publish-exclude"));
 }
 
 function getNestedTargetExclude(sourceRoot, targetRoot) {
@@ -247,9 +253,15 @@ function resolvePublicPackageJson(
 	};
 }
 
-function buildMirrorPlan(sourceRoot, targetRoot, shouldExclude, packageName) {
-	const sourceFiles = new Set(walkFiles(sourceRoot, shouldExclude));
-	const targetFiles = new Set(walkFiles(targetRoot, shouldExclude));
+function buildMirrorPlan(
+	sourceRoot,
+	targetRoot,
+	sourceShouldExclude,
+	targetShouldExclude,
+	packageName,
+) {
+	const sourceFiles = new Set(walkFiles(sourceRoot, sourceShouldExclude));
+	const targetFiles = new Set(walkFiles(targetRoot, targetShouldExclude));
 	const { content: packageJsonContent, publicPackageName } =
 		resolvePublicPackageJson(sourceRoot, packageName);
 	const copiedPaths = [];
@@ -325,16 +337,22 @@ if (!existsSync(targetRoot)) {
 }
 
 const excludePatterns = readExcludePatterns(sourceRoot, options.excludeFile);
+const sourceOnlyExcludePatterns = readSourceOnlyExcludePatterns(sourceRoot);
 const nestedTargetExclude = getNestedTargetExclude(sourceRoot, targetRoot);
 if (nestedTargetExclude) {
 	excludePatterns.push(nestedTargetExclude);
 }
 
-const shouldExclude = createMatcher(excludePatterns);
+const sourceShouldExclude = createMatcher([
+	...excludePatterns,
+	...sourceOnlyExcludePatterns,
+]);
+const targetShouldExclude = createMatcher(excludePatterns);
 const plan = buildMirrorPlan(
 	sourceRoot,
 	targetRoot,
-	shouldExclude,
+	sourceShouldExclude,
+	targetShouldExclude,
 	options.packageName,
 );
 const report = {

--- a/test/deploy/dockerfile.test.ts
+++ b/test/deploy/dockerfile.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+describe("Maestro Dockerfile", () => {
+	it("copies database migration SQL files into the runtime image", () => {
+		const dockerfile = readFileSync(resolve(repoRoot, "Dockerfile"), "utf8");
+
+		expect(dockerfile).toContain(
+			"COPY --from=builder /app/src/db/migrations ./dist/db/migrations",
+		);
+	});
+});

--- a/test/deploy/helm-maestro.test.ts
+++ b/test/deploy/helm-maestro.test.ts
@@ -41,7 +41,10 @@ describe("maestro Helm chart", () => {
 		expect(result.stdout).toMatch(/mountPath:\s+\/tmp/);
 		expect(result.stdout).toContain("name: HOME");
 		expect(result.stdout).toContain("name: XDG_CACHE_HOME");
-		expect(result.stdout).toContain("startupProbe:");
+		expect(result.stdout).toMatch(/startupProbe:[\s\S]*path:\s+\/healthz/);
+		expect(result.stdout).toMatch(/livenessProbe:[\s\S]*path:\s+\/healthz/);
+		expect(result.stdout).toMatch(/readinessProbe:[\s\S]*path:\s+\/readyz/);
+		expect(result.stdout).not.toMatch(/path:\s+\/health\n/);
 		expect(result.stdout).toContain("preStop:");
 	});
 

--- a/test/scripts/prepare-public-release-mirror.test.ts
+++ b/test/scripts/prepare-public-release-mirror.test.ts
@@ -222,6 +222,73 @@ describe("prepare-public-release-mirror", () => {
 		expect(existsSync(join(target, "docs/release-ops.md"))).toBe(false);
 	});
 
+	it("honors .publish-exclude when the public mirror exclude file is absent", () => {
+		const { source, target } = makeFixture();
+		write(
+			join(source, "package.json"),
+			JSON.stringify(
+				{
+					name: internalPackageName,
+					version: "1.2.3",
+					maestro: {
+						canonicalPackageName: publicPackageName,
+					},
+				},
+				null,
+				2,
+			),
+		);
+		write(join(source, "README.md"), "public readme\n");
+		write(
+			join(source, ".publish-exclude"),
+			[
+				"# internal-only public-release filters",
+				"todo.md",
+				"docs/research/",
+				"docs/upstreams/",
+				"docs/opencode-parity.md",
+				"docs/design/SESSION_HUB_DO.md",
+				".publish-exclude",
+				"",
+			].join("\n"),
+		);
+		write(join(source, "todo.md"), "internal backlog\n");
+		write(join(source, "docs/research/competitor.md"), "internal research\n");
+		write(join(source, "docs/upstreams/codex.md"), "upstream notes\n");
+		write(join(source, "docs/opencode-parity.md"), "competitive notes\n");
+		write(join(source, "docs/design/SESSION_HUB_DO.md"), "internal design\n");
+		write(join(target, ".publish-exclude"), "previous leak\n");
+		write(join(target, "todo.md"), "previous leak\n");
+		write(join(target, "docs/research/competitor.md"), "previous leak\n");
+		write(join(target, "docs/upstreams/codex.md"), "previous leak\n");
+		write(join(target, "docs/opencode-parity.md"), "previous leak\n");
+		write(join(target, "docs/design/SESSION_HUB_DO.md"), "previous leak\n");
+
+		execFileSync(
+			process.execPath,
+			[
+				"scripts/prepare-public-release-mirror.mjs",
+				"--source",
+				source,
+				"--target",
+				target,
+			],
+			{ cwd: process.cwd(), stdio: "pipe" },
+		);
+
+		expect(readFileSync(join(target, "README.md"), "utf8")).toBe(
+			"public readme\n",
+		);
+		expect(existsSync(join(target, ".publish-exclude"))).toBe(false);
+		expect(existsSync(join(target, "todo.md"))).toBe(false);
+		expect(existsSync(join(target, "docs/research/competitor.md"))).toBe(false);
+		expect(existsSync(join(target, "docs/upstreams/codex.md"))).toBe(false);
+		expect(existsSync(join(target, "docs/opencode-parity.md"))).toBe(false);
+		expect(existsSync(join(target, "docs/design/SESSION_HUB_DO.md"))).toBe(
+			false,
+		);
+	});
+
 	it("reports planned changes in check mode without mutating the target", () => {
 		const { source, target } = makeFixture();
 		const reportPath = join(source, "public-tree-report.json");


### PR DESCRIPTION
## Summary
- point Helm startup/liveness/readiness probes at the server routes Maestro actually serves (`/healthz` and `/readyz`)
- copy database SQL migrations into `dist/db/migrations` in the runtime image
- honor `.publish-exclude` as source-only public mirror filters so internal files are omitted and stale leaked copies are deleted

## Test Plan
- npm test -- test/deploy/helm-maestro.test.ts test/deploy/dockerfile.test.ts test/scripts/prepare-public-release-mirror.test.ts
- bunx biome check Dockerfile deploy/helm/maestro/values.yaml deploy/helm/maestro/templates/deployment.yaml scripts/prepare-public-release-mirror.mjs test/deploy/helm-maestro.test.ts test/deploy/dockerfile.test.ts test/scripts/prepare-public-release-mirror.test.ts
- git diff --check
- pre-commit guardian, lint/evals, build, and binary compile hooks