### PR TITLE
Fix Platform ToolExecution bridge feedback

### DIFF
--- a/src/agent/transport/tool-execution-bridge.ts
+++ b/src/agent/transport/tool-execution-bridge.ts
@@ -34,13 +34,6 @@ import type {
 const logger = createLogger("transport:tool-execution-bridge");
 
 const OBSERVE_OUTPUT_SUMMARY_MAX_LENGTH = 280;
-const OBSERVE_RESULT_FIELDS = [
-	"maestro_bridge_mode",
-	"maestro_local_outcome",
-	"maestro_local_output_summary",
-	"maestro_local_output_redactions",
-] as const;
-
 const READ_ONLY_BASH_PREFIXES = [
 	"cat",
 	"cd",
@@ -49,7 +42,6 @@ const READ_ONLY_BASH_PREFIXES = [
 	"echo",
 	"env",
 	"find",
-	"git branch",
 	"git diff",
 	"git log",
 	"git remote -v",
@@ -88,6 +80,19 @@ const BASH_MUTATION_MARKERS = [
 	/\bterraform\s+(apply|destroy|import)\b/u,
 	/(^|[^<])>{1,2}/u,
 ] as const;
+
+const READ_ONLY_GIT_BRANCH_ARGS = new Set([
+	"--all",
+	"--list",
+	"--merged",
+	"--no-contains",
+	"--no-merged",
+	"--points-at",
+	"--remotes",
+	"-a",
+	"-l",
+	"-r",
+]);
 
 export type PlatformBridgeMode = "observe" | "governed";
 
@@ -203,11 +208,31 @@ function isReadOnlyBashCommand(command: string): boolean {
 	if (!normalized) {
 		return false;
 	}
+	if (isReadOnlyGitBranchCommand(normalized)) {
+		return true;
+	}
 	if (BASH_MUTATION_MARKERS.some((pattern) => pattern.test(normalized))) {
 		return false;
 	}
 	return READ_ONLY_BASH_PREFIXES.some(
 		(prefix) => normalized === prefix || normalized.startsWith(`${prefix} `),
+	);
+}
+
+function isReadOnlyGitBranchCommand(normalized: string): boolean {
+	const parts = normalized.split(" ");
+	if (parts[0] !== "git" || parts[1] !== "branch") {
+		return false;
+	}
+	const args = parts.slice(2);
+	if (args.length === 0) {
+		return true;
+	}
+	return args.every(
+		(arg) =>
+			READ_ONLY_GIT_BRANCH_ARGS.has(arg) ||
+			arg.startsWith("--format=") ||
+			arg.startsWith("--sort="),
 	);
 }
 
@@ -291,12 +316,7 @@ function classifyToolExecution(
 	}
 	const mode: PlatformBridgeMode = rollout.governedEnabled
 		? "governed"
-		: rollout.observeEnabled
-			? "observe"
-			: "observe";
-	if (mode === "observe" && !rollout.observeEnabled) {
-		return null;
-	}
+		: "observe";
 	const toolName = mcpTool.tool ?? toolCall.name;
 	const readOnly = isReadOnlyTool(toolCall.name, toolDef?.annotations);
 	return {
@@ -613,6 +633,9 @@ export class DefaultPlatformToolExecutionBridge
 					return { status: "allow", plan };
 			}
 		} catch (error) {
+			if (isAbortError(error)) {
+				throw error;
+			}
 			const message = error instanceof Error ? error.message : String(error);
 			return {
 				status: "deny",
@@ -679,6 +702,9 @@ export class DefaultPlatformToolExecutionBridge
 					return { status: "allow", plan: nextPlan };
 			}
 		} catch (error) {
+			if (isAbortError(error)) {
+				throw error;
+			}
 			const message = error instanceof Error ? error.message : String(error);
 			return decision.approved
 				? {
@@ -744,10 +770,6 @@ export function getDefaultPlatformToolExecutionBridge(): PlatformToolExecutionBr
 	return defaultBridge;
 }
 
-export function resetPlatformToolExecutionBridgeForTests(): void {
-	defaultBridge = null;
-}
-
 export function buildObservedResultMetadata(
 	plan: ToolExecutionBridgePlan | undefined,
 	observation: ObserveToolExecutionResult | undefined,
@@ -764,15 +786,6 @@ export function buildObservedResultMetadata(
 	};
 }
 
-export function stripObserveResultMetadata(
-	metadata: Record<string, string>,
-): Record<string, string> {
-	return Object.fromEntries(
-		Object.entries(metadata).filter(
-			([key]) =>
-				!OBSERVE_RESULT_FIELDS.includes(
-					key as (typeof OBSERVE_RESULT_FIELDS)[number],
-				),
-		),
-	);
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
 }

--- a/src/platform/tool-execution-client.ts
+++ b/src/platform/tool-execution-client.ts
@@ -443,10 +443,3 @@ export async function resumeToolExecutionWithPlatform(
 		execution: normalizeExecutionRecord(objectValue(payload, "execution")),
 	};
 }
-
-export function hasToolExecutionDestination(): boolean {
-	return Boolean(
-		getEnvValue(TOOL_EXECUTION_TOKEN_ENV_VARS) &&
-			getEnvValue(TOOL_EXECUTION_ORGANIZATION_ENV_VARS),
-	);
-}

--- a/test/agent/tool-execution-bridge.test.ts
+++ b/test/agent/tool-execution-bridge.test.ts
@@ -196,6 +196,40 @@ describe("tool execution bridge", () => {
 		expect(fetch).not.toHaveBeenCalled();
 	});
 
+	it("keeps git branch listing in observe mode", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+		]);
+		vi.stubGlobal("fetch", vi.fn());
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		await expect(
+			bridge.prepare({
+				cfg: baseConfig(),
+				toolCall: {
+					type: "toolCall",
+					id: "tc_branch_1",
+					name: "bash",
+					arguments: { command: "git branch" },
+				},
+				sanitizedArgs: { command: "git branch" },
+			}),
+		).resolves.toMatchObject({
+			status: "observe",
+			plan: {
+				classification: {
+					mode: "observe",
+					tool: {
+						idempotent: true,
+						mutatesResource: false,
+					},
+				},
+			},
+		});
+
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
 	it("keeps local observe-only execution when Platform recording fails", async () => {
 		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
 			MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG,
@@ -483,5 +517,95 @@ describe("tool execution bridge", () => {
 			status: "deny",
 			reason: expect.stringContaining("Platform ToolExecution unavailable"),
 		});
+	});
+
+	it("propagates AbortError while preparing governed executions", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+		]);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new DOMException("Aborted", "AbortError");
+			}),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		const abortController = new AbortController();
+		abortController.abort();
+		await expect(
+			bridge.prepare(
+				{
+					cfg: baseConfig(),
+					toolCall: {
+						type: "toolCall",
+						id: "tc_abort_1",
+						name: "bash",
+						arguments: { command: "git push" },
+					},
+					sanitizedArgs: { command: "git push" },
+				},
+				abortController.signal,
+			),
+		).rejects.toMatchObject({ name: "AbortError" });
+	});
+
+	it("propagates AbortError while resuming governed approvals", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+		]);
+		let requestsSeen = 0;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				requestsSeen++;
+				if (requestsSeen === 1) {
+					return new Response(
+						JSON.stringify({
+							execution: {
+								id: "texec_abort_resume_1",
+								state: "TOOL_EXECUTION_STATE_WAITING_APPROVAL",
+								approvalWait: {
+									approvalRequestId: "approval_abort_1",
+									resumeToken: "resume_abort_1",
+								},
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				throw new DOMException("Aborted", "AbortError");
+			}),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		const input = {
+			cfg: baseConfig(),
+			toolCall: {
+				type: "toolCall",
+				id: "tc_abort_resume_1",
+				name: "bash",
+				arguments: { command: "git push" },
+			} satisfies ToolCall,
+			sanitizedArgs: { command: "git push" },
+		};
+		const prepared = await bridge.prepare(input);
+		if (prepared.status !== "wait_approval") {
+			throw new Error("expected approval wait");
+		}
+
+		const abortController = new AbortController();
+		abortController.abort();
+		await expect(
+			bridge.resolveApproval(
+				input,
+				prepared.plan,
+				{
+					approved: true,
+					resolvedBy: "user",
+				},
+				abortController.signal,
+			),
+		).rejects.toMatchObject({ name: "AbortError" });
 	});
 });


### PR DESCRIPTION
## Summary
- keep read-only `git branch` listing in observe mode instead of matching the mutation marker first
- propagate governed ToolExecution `AbortError`s during prepare/resume instead of turning cancellation into denials
- simplify MCP bridge mode selection and remove unused bridge/client helper exports

## Test plan
- `npm test -- test/agent/tool-execution-bridge.test.ts`
- `bunx biome check src/agent/transport/tool-execution-bridge.ts src/platform/tool-execution-client.ts test/agent/tool-execution-bridge.test.ts`
- pre-commit hook with pinned Bun (`PATH=/private/tmp/bun-1.3.6/bin:$PATH`) including lint, build, and binary compile
- `git diff --check`