### PR TITLE
Fix Rust hosted-runner feedback

### DIFF
--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -932,11 +932,6 @@ impl AgentSupervisorHostedRunnerMessageExecutor {
     pub fn new(supervisor: Arc<Mutex<AgentSupervisor>>) -> Self {
         Self { supervisor }
     }
-
-    #[must_use]
-    pub fn supervisor(&self) -> Arc<Mutex<AgentSupervisor>> {
-        Arc::clone(&self.supervisor)
-    }
 }
 
 impl std::fmt::Debug for AgentSupervisorHostedRunnerMessageExecutor {
@@ -1471,10 +1466,27 @@ impl SharedRunner {
 
     fn reset_envelope(&self, reason: impl Into<String>) -> StreamEnvelope {
         let state = self.state.lock().expect("hosted runner state poisoned");
+        self.reset_envelope_from_state(&state, reason)
+    }
+
+    fn reset_envelope_from_state(
+        &self,
+        state: &RunnerState,
+        reason: impl Into<String>,
+    ) -> StreamEnvelope {
         StreamEnvelope::Reset {
             reason: reason.into(),
-            snapshot: self.snapshot(&state),
+            snapshot: self.snapshot(state),
         }
+    }
+
+    fn reset_and_subscribe(
+        &self,
+        reason: impl Into<String>,
+    ) -> (Vec<StreamEnvelope>, broadcast::Receiver<StreamEnvelope>) {
+        let state = self.state.lock().expect("hosted runner state poisoned");
+        let rx = self.events.subscribe();
+        (vec![self.reset_envelope_from_state(&state, reason)], rx)
     }
 
     fn subscribe_from(
@@ -1958,8 +1970,7 @@ fn handle_events(
         .map(|value| value.trim_start().starts_with('-'))
         .unwrap_or(false)
     {
-        let replay = vec![shared.reset_envelope("replay_gap")];
-        let rx = shared.events.subscribe();
+        let (replay, rx) = shared.reset_and_subscribe("replay_gap");
         return Ok(ResponseBody::Sse { replay, rx, shared });
     }
     let cursor = query
@@ -2944,10 +2955,15 @@ fn connection_from_headers(headers: &HashMap<String, String>) -> (Option<String>
         headers
             .get("x-maestro-headless-connection-id")
             .or_else(|| headers.get("x-composer-headless-connection-id"))
+            .or_else(|| headers.get("x-evalops-headless-connection-id"))
             .cloned(),
         headers
             .get("x-maestro-headless-subscriber-id")
+            .or_else(|| headers.get("x-maestro-headless-subscription-id"))
             .or_else(|| headers.get("x-composer-headless-subscriber-id"))
+            .or_else(|| headers.get("x-composer-headless-subscription-id"))
+            .or_else(|| headers.get("x-evalops-headless-subscriber-id"))
+            .or_else(|| headers.get("x-evalops-headless-subscription-id"))
             .cloned(),
     )
 }
@@ -3441,6 +3457,25 @@ mod tests {
         assert!(event_text.contains(r#""reason":"replay_gap""#));
 
         handle.shutdown().await;
+    }
+
+    #[test]
+    fn connection_headers_accept_evalops_subscription_aliases() {
+        let headers = HashMap::from([
+            (
+                "x-evalops-headless-connection-id".to_string(),
+                "conn_evalops".to_string(),
+            ),
+            (
+                "x-evalops-headless-subscription-id".to_string(),
+                "sub_evalops".to_string(),
+            ),
+        ]);
+
+        let (connection_id, subscription_id) = connection_from_headers(&headers);
+
+        assert_eq!(connection_id.as_deref(), Some("conn_evalops"));
+        assert_eq!(subscription_id.as_deref(), Some("sub_evalops"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- make negative-cursor replay-gap reset and SSE subscription atomic under the hosted-runner state lock
- accept `x-evalops-headless-*` and `*-subscription-id` header aliases for hosted-runner connection references
- remove the unused public supervisor accessor from the hosted runner executor

## Test plan
- `cargo fmt --manifest-path packages/tui-rs/Cargo.toml -- packages/tui-rs/src/hosted_runner.rs`
- `cargo test --manifest-path packages/tui-rs/Cargo.toml hosted_runner::tests::connection_headers_accept_evalops_subscription_aliases`
- `cargo test --manifest-path packages/tui-rs/Cargo.toml hosted_runner::tests::events_negative_cursor_returns_replay_gap_reset`
- `git diff --check`