### PR TITLE
Allow dot-dot-prefixed workspace paths

### DIFF
--- a/src/headless/workspace-root.ts
+++ b/src/headless/workspace-root.ts
@@ -3,7 +3,10 @@ import { isAbsolute, relative, resolve, sep } from "node:path";
 
 function isInsidePath(parent: string, candidate: string): boolean {
 	const rel = relative(parent, candidate);
-	return rel === "" || (!rel.startsWith("..") && !rel.includes(`..${sep}`));
+	return (
+		rel === "" ||
+		(rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+	);
 }
 
 export function getHostedWorkspaceRoot(env = process.env): string | undefined {

--- a/test/headless/workspace-root.test.ts
+++ b/test/headless/workspace-root.test.ts
@@ -42,6 +42,18 @@ describe("hosted workspace root guard", () => {
 		).toBe(realpathSync(join(workspaceRoot, "src")));
 	});
 
+	it("allows inside paths whose segment names start with dot-dot", async () => {
+		const workspaceRoot = await createTempDir("maestro-workspace-root-");
+		await mkdir(join(workspaceRoot, "..cache"));
+
+		expect(
+			resolveHostedWorkspacePath("..cache", {
+				MAESTRO_HOSTED_RUNNER_MODE: "1",
+				MAESTRO_WORKSPACE_ROOT: workspaceRoot,
+			}),
+		).toBe(realpathSync(join(workspaceRoot, "..cache")));
+	});
+
 	it("rejects paths outside the hosted workspace root", async () => {
 		const workspaceRoot = await createTempDir("maestro-workspace-root-");
 		const outsideRoot = await createTempDir("maestro-workspace-outside-");


### PR DESCRIPTION
## Summary
- distinguish real parent traversal from valid workspace child names that start with `..`
- keep absolute relative-path escapes rejected
- add a hosted workspace-root regression for a `..cache` child directory

Fix-forward for old review thread: https://github.com/evalops/maestro/pull/94#discussion_r3127541790

## Test Plan
- bunx biome check src/headless/workspace-root.ts test/headless/workspace-root.test.ts
- npm test -- test/headless/workspace-root.test.ts
- git diff --check
- pre-commit guardian/lint/build hooks