### PR TITLE
Reject hosted headless traffic while draining

### DIFF
--- a/packages/tui-rs/src/headless/async_transport.rs
+++ b/packages/tui-rs/src/headless/async_transport.rs
@@ -59,6 +59,7 @@ pub enum RemoteErrorKind {
     RoleConflict,
     AccessDenied,
     OwnershipConflict,
+    RuntimeNotReady,
 }
 
 /// Error type for async transport operations

--- a/packages/tui-rs/src/headless/remote_transport.rs
+++ b/packages/tui-rs/src/headless/remote_transport.rs
@@ -1480,6 +1480,9 @@ fn classify_remote_status(
     if body_has_remote_error_code(trimmed_body, "runtime_owned_elsewhere") {
         return (false, RemoteErrorKind::OwnershipConflict);
     }
+    if body_has_remote_error_code(trimmed_body, "runtime_not_ready") {
+        return (true, RemoteErrorKind::RuntimeNotReady);
+    }
 
     if trimmed_body.contains("Headless connection not found") {
         return (
@@ -2954,6 +2957,26 @@ mod tests {
                 r#"{"error":"Hosted runner is bound to Maestro session sess_owner","code":"ALREADY_EXISTS","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"runtime_owned_elsewhere","domain":"maestro.hosted_runner","metadata":{"owner_instance_id":"pod-a","maestro_session_id":"sess_owner"}}]}"#,
             ),
             (false, RemoteErrorKind::OwnershipConflict)
+        );
+    }
+
+    #[test]
+    fn retryability_classifies_structured_runtime_not_ready_as_retryable() {
+        assert_eq!(
+            classify_remote_status(
+                StatusCode::SERVICE_UNAVAILABLE,
+                RemoteRequestKind::Subscribe,
+                r#"{"error":"Hosted runner is draining and not accepting headless session traffic","code":"UNAVAILABLE","error_type":"runtime_not_ready"}"#,
+            ),
+            (true, RemoteErrorKind::RuntimeNotReady)
+        );
+        assert_eq!(
+            classify_remote_status(
+                StatusCode::SERVICE_UNAVAILABLE,
+                RemoteRequestKind::Message,
+                r#"{"error":"Hosted runner is draining and not accepting headless session traffic","code":"UNAVAILABLE","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"runtime_not_ready","domain":"maestro.hosted_runner","metadata":{"draining":"true","maestro_session_id":"sess_owner"}}]}"#,
+            ),
+            (true, RemoteErrorKind::RuntimeNotReady)
         );
     }
 

--- a/src/server/handlers/headless-sessions.ts
+++ b/src/server/handlers/headless-sessions.ts
@@ -35,6 +35,13 @@ import {
 import { createSessionManagerForRequest } from "../session-scope.js";
 import { parseAndValidateJson, validatePayload } from "../validation.js";
 
+export enum HostedRunnerErrorType {
+	RuntimeNotReady = "runtime_not_ready",
+	RuntimeOwnedElsewhere = "runtime_owned_elsewhere",
+}
+
+const HOSTED_RUNNER_ERROR_DOMAIN = "maestro.hosted_runner";
+
 function stringLiteralUnion<const T extends readonly string[]>(values: T) {
 	return Type.Unsafe<T[number]>(
 		Type.Union(
@@ -279,11 +286,10 @@ function getScopeKey(req: IncomingMessage): string {
 	return getAuthScopeKey(req);
 }
 
-function hostedRunnerOwnershipError(
+function hostedRunnerErrorMetadata(
 	context: WebServerContext,
-	message: string,
 	metadata: Record<string, string | undefined>,
-): ApiError {
+): Record<string, string> {
 	const hostedRunner = context.hostedRunner;
 	const detailMetadata: Record<string, string> = {};
 	for (const [key, value] of Object.entries({
@@ -297,17 +303,44 @@ function hostedRunnerOwnershipError(
 			detailMetadata[key] = value;
 		}
 	}
+	return detailMetadata;
+}
+
+function hostedRunnerOwnershipError(
+	context: WebServerContext,
+	message: string,
+	metadata: Record<string, string | undefined>,
+): ApiError {
 	return new ApiError(
 		409,
 		message,
 		[
 			{
-				reason: "runtime_owned_elsewhere",
-				domain: "maestro.hosted_runner",
-				metadata: detailMetadata,
+				reason: HostedRunnerErrorType.RuntimeOwnedElsewhere,
+				domain: HOSTED_RUNNER_ERROR_DOMAIN,
+				metadata: hostedRunnerErrorMetadata(context, metadata),
 			},
 		],
-		"runtime_owned_elsewhere",
+		HostedRunnerErrorType.RuntimeOwnedElsewhere,
+	);
+}
+
+function hostedRunnerNotReadyError(
+	context: WebServerContext,
+	message: string,
+	metadata: Record<string, string | undefined>,
+): ApiError {
+	return new ApiError(
+		503,
+		message,
+		[
+			{
+				reason: HostedRunnerErrorType.RuntimeNotReady,
+				domain: HOSTED_RUNNER_ERROR_DOMAIN,
+				metadata: hostedRunnerErrorMetadata(context, metadata),
+			},
+		],
+		HostedRunnerErrorType.RuntimeNotReady,
 	);
 }
 
@@ -322,6 +355,17 @@ function ensureHostedRunnerCanUseSession(
 	const activeSessionId =
 		hostedRunner.activeMaestroSessionId ??
 		hostedRunner.configuredMaestroSessionId;
+	if (hostedRunner.draining) {
+		throw hostedRunnerNotReadyError(
+			context,
+			"Hosted runner is draining and not accepting headless session traffic",
+			{
+				draining: "true",
+				maestro_session_id: activeSessionId,
+				requested_maestro_session_id: requestedSessionId,
+			},
+		);
+	}
 	if (!activeSessionId) {
 		return;
 	}

--- a/test/web/headless-sessions.test.ts
+++ b/test/web/headless-sessions.test.ts
@@ -28,6 +28,7 @@ import type { RegisteredModel } from "../../src/models/registry.js";
 import type { WebServerContext } from "../../src/server/app-context.js";
 import { clientToolService } from "../../src/server/client-tools-service.js";
 import {
+	HostedRunnerErrorType,
 	handleHeadlessConnectionCreate,
 	handleHeadlessSessionCreate,
 	handleHeadlessSessionDisconnect,
@@ -2842,6 +2843,150 @@ describe("headless session handlers", () => {
 		} finally {
 			await rm(hostedWorkspaceRoot, { recursive: true, force: true });
 			await rm(requestedWorkspaceRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("returns structured runtime-not-ready errors while hosted runners drain", async () => {
+		const workspaceRoot = await mkdtemp(
+			join(tmpdir(), "maestro-headless-hosted-draining-"),
+		);
+		try {
+			const context = createContext({
+				hostedRunner: {
+					enabled: true,
+					runnerSessionId: "mrs_test",
+					ownerInstanceId: "pod-a",
+					workspaceRoot,
+					workspaceId: "ws_1",
+					agentRunId: "run_1",
+					activeMaestroSessionId: "session_owner",
+					draining: true,
+				},
+			});
+			const req = createJsonRequest("POST", "/api/headless/sessions", {
+				model: TEST_MODEL.id,
+			});
+			const res = new MockResponse();
+			res.req = req;
+
+			let caught: unknown;
+			try {
+				await handleHeadlessSessionCreate(
+					req,
+					res as unknown as ServerResponse,
+					context,
+				);
+			} catch (error) {
+				caught = error;
+			}
+
+			expect(caught).toBeInstanceOf(ApiError);
+			expect((caught as ApiError).errorType).toBe(
+				HostedRunnerErrorType.RuntimeNotReady,
+			);
+
+			const errorRes = new MockResponse();
+			errorRes.req = req;
+			respondWithApiError(
+				errorRes as unknown as ServerResponse,
+				caught,
+				500,
+				{},
+				req,
+			);
+
+			expect(errorRes.statusCode).toBe(503);
+			expect(JSON.parse(errorRes.body)).toMatchObject({
+				error:
+					"Hosted runner is draining and not accepting headless session traffic",
+				code: "UNAVAILABLE",
+				error_type: HostedRunnerErrorType.RuntimeNotReady,
+				details: [
+					{
+						reason: HostedRunnerErrorType.RuntimeNotReady,
+						domain: "maestro.hosted_runner",
+						metadata: {
+							runner_session_id: "mrs_test",
+							owner_instance_id: "pod-a",
+							workspace_id: "ws_1",
+							agent_run_id: "run_1",
+							maestro_session_id: "session_owner",
+							draining: "true",
+						},
+					},
+				],
+			});
+		} finally {
+			await rm(workspaceRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("reports hosted runner draining before accepting new session mutations", async () => {
+		const workspaceRoot = await mkdtemp(
+			join(tmpdir(), "maestro-headless-hosted-draining-"),
+		);
+		try {
+			const context = createContext({
+				hostedRunner: {
+					enabled: true,
+					runnerSessionId: "mrs_test",
+					ownerInstanceId: "pod-a",
+					workspaceRoot,
+					activeMaestroSessionId: "session_owner",
+					draining: true,
+				},
+			});
+			const req = createJsonRequest(
+				"POST",
+				"/api/headless/sessions/session_owner/messages",
+				{ type: "prompt", content: "after drain" },
+			);
+			const res = new MockResponse();
+			res.req = req;
+
+			let caught: unknown;
+			try {
+				await handleHeadlessSessionMessage(
+					req,
+					res as unknown as ServerResponse,
+					context,
+					{
+						id: "session_owner",
+					},
+				);
+			} catch (error) {
+				caught = error;
+			}
+
+			expect(caught).toBeInstanceOf(ApiError);
+
+			const errorRes = new MockResponse();
+			errorRes.req = req;
+			respondWithApiError(
+				errorRes as unknown as ServerResponse,
+				caught,
+				500,
+				{},
+				req,
+			);
+
+			expect(errorRes.statusCode).toBe(503);
+			expect(JSON.parse(errorRes.body)).toMatchObject({
+				error_type: HostedRunnerErrorType.RuntimeNotReady,
+				details: [
+					{
+						reason: HostedRunnerErrorType.RuntimeNotReady,
+						metadata: {
+							owner_instance_id: "pod-a",
+							maestro_session_id: "session_owner",
+							requested_maestro_session_id: "session_owner",
+							draining: "true",
+						},
+					},
+				],
+			});
+		} finally {
+			await rm(workspaceRoot, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
## Summary
- add enum-backed hosted runner error types for `runtime_not_ready` and `runtime_owned_elsewhere`
- reject new hosted headless session traffic with structured 503 `runtime_not_ready` while the runner is draining
- teach the Rust remote transport classifier to treat structured `runtime_not_ready` as retryable `RuntimeNotReady`

## Test Plan
- `npm test -- test/web/headless-sessions.test.ts`
- `npm test -- test/headless/runtime-conformance.test.ts -t "drains hosted runners into a manifest and rejects new mutations"`
- `cargo test --manifest-path packages/tui-rs/Cargo.toml retryability_classifies_structured_runtime`
- `npm run tui-rs:check`
- `bunx biome check src/server/handlers/headless-sessions.ts test/web/headless-sessions.test.ts`
- `cargo fmt --manifest-path packages/tui-rs/Cargo.toml --check`
- `git diff --check`

Note: `bun run bun:check` passes Biome/lint helpers but the repo-wide `tsc --noEmit` still fails on existing examples/desktop/web-test type debt unrelated to this branch.

Refs #78, #76