### PR TITLE
Enum-back hosted runner drain statuses

### DIFF
--- a/src/server/handlers/hosted-runner-drain.ts
+++ b/src/server/handlers/hosted-runner-drain.ts
@@ -25,7 +25,34 @@ export const HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION =
 export const HOSTED_RUNNER_RETENTION_POLICY_VERSION =
 	"evalops.remote-runner.retention.v1";
 
-type SnapshotManifestStatus = "drained" | "interrupted";
+export enum HostedRunnerDrainStatusValue {
+	Drained = "drained",
+	Interrupted = "interrupted",
+}
+
+export enum HostedRunnerRuntimeFlushStatusValue {
+	Completed = "completed",
+	Failed = "failed",
+	Skipped = "skipped",
+}
+
+export enum HostedRunnerWorkspaceExportPathTypeValue {
+	File = "file",
+	Directory = "directory",
+	Other = "other",
+}
+
+export enum HostedRunnerWorkspaceExportModeValue {
+	LocalPathContract = "local_path_contract",
+}
+
+export type HostedRunnerDrainStatus = HostedRunnerDrainStatusValue;
+export type HostedRunnerRuntimeFlushStatus =
+	HostedRunnerRuntimeFlushStatusValue;
+export type HostedRunnerWorkspaceExportPathType =
+	HostedRunnerWorkspaceExportPathTypeValue;
+export type HostedRunnerWorkspaceExportMode =
+	HostedRunnerWorkspaceExportModeValue;
 
 export interface HostedRunnerRetentionPolicy {
 	policy_version: typeof HOSTED_RUNNER_RETENTION_POLICY_VERSION;
@@ -68,7 +95,7 @@ export interface HostedRunnerWorkspaceExportPath {
 	input: string;
 	path: string;
 	relative_path: string;
-	type: "file" | "directory" | "other";
+	type: HostedRunnerWorkspaceExportPathType;
 }
 
 export interface HostedRunnerSnapshotManifest {
@@ -82,7 +109,7 @@ export interface HostedRunnerSnapshotManifest {
 	created_at: string;
 	workspace_root: string;
 	runtime: {
-		flush_status: "completed" | "failed" | "skipped";
+		flush_status: HostedRunnerRuntimeFlushStatus;
 		error?: string;
 		session_id: string;
 		session_file?: string;
@@ -90,7 +117,7 @@ export interface HostedRunnerSnapshotManifest {
 		cursor?: number;
 	};
 	workspace_export: {
-		mode: "local_path_contract";
+		mode: HostedRunnerWorkspaceExportMode;
 		paths: HostedRunnerWorkspaceExportPath[];
 	};
 	snapshot: HeadlessRuntimeSnapshot;
@@ -103,7 +130,7 @@ export interface HostedRunnerSnapshotManifest {
 }
 
 export interface HostedRunnerDrainResult {
-	status: SnapshotManifestStatus;
+	status: HostedRunnerDrainStatus;
 	runner_session_id: string;
 	reason?: string;
 	requested_by?: string;
@@ -245,10 +272,10 @@ async function resolveWorkspaceExportPaths(
 			path: realPath,
 			relative_path: relative(workspaceRoot, realPath) || ".",
 			type: pathStat.isDirectory()
-				? "directory"
+				? HostedRunnerWorkspaceExportPathTypeValue.Directory
 				: pathStat.isFile()
-					? "file"
-					: "other",
+					? HostedRunnerWorkspaceExportPathTypeValue.File
+					: HostedRunnerWorkspaceExportPathTypeValue.Other,
 		});
 	}
 	return paths;
@@ -304,11 +331,12 @@ function buildHostedRunnerSnapshot(
 	state.cwd = workspaceRoot;
 	state.provider = "typescript";
 	state.model = "typescript-hosted-runner";
-	state.is_ready = runtime.flush_status === "completed";
+	state.is_ready =
+		runtime.flush_status === HostedRunnerRuntimeFlushStatusValue.Completed;
 	state.last_status =
-		runtime.flush_status === "completed"
+		runtime.flush_status === HostedRunnerRuntimeFlushStatusValue.Completed
 			? "Drained"
-			: runtime.flush_status === "failed"
+			: runtime.flush_status === HostedRunnerRuntimeFlushStatusValue.Failed
 				? "Drain interrupted before runtime flush completed"
 				: "Drain skipped: no runtime activity was available";
 	if (runtime.error) {
@@ -375,9 +403,9 @@ export async function drainHostedRunner(
 		hostedRunner.configuredMaestroSessionId;
 	const maestroSessionId = activeSessionId ?? hostedRunner.runnerSessionId;
 
-	let status: SnapshotManifestStatus = "drained";
+	let status: HostedRunnerDrainStatus = HostedRunnerDrainStatusValue.Drained;
 	let runtime: HostedRunnerSnapshotManifest["runtime"] = {
-		flush_status: "skipped",
+		flush_status: HostedRunnerRuntimeFlushStatusValue.Skipped,
 		session_id: maestroSessionId,
 	};
 	let runtimeSnapshot: HeadlessRuntimeSnapshot | undefined;
@@ -392,7 +420,7 @@ export async function drainHostedRunner(
 				runtimeResult?.cursor ?? runtimeResult?.snapshot?.cursor;
 			runtime = runtimeResult
 				? {
-						flush_status: "completed",
+						flush_status: HostedRunnerRuntimeFlushStatusValue.Completed,
 						session_id: runtimeResult.sessionId,
 						...(runtimeResult.sessionFile
 							? { session_file: runtimeResult.sessionFile }
@@ -403,14 +431,14 @@ export async function drainHostedRunner(
 						...(runtimeCursor !== undefined ? { cursor: runtimeCursor } : {}),
 					}
 				: {
-						flush_status: "skipped",
+						flush_status: HostedRunnerRuntimeFlushStatusValue.Skipped,
 						session_id: activeSessionId,
 					};
 			runtimeSnapshot = runtimeResult?.snapshot;
 		} catch (error) {
-			status = "interrupted";
+			status = HostedRunnerDrainStatusValue.Interrupted;
 			runtime = {
-				flush_status: "failed",
+				flush_status: HostedRunnerRuntimeFlushStatusValue.Failed,
 				session_id: activeSessionId,
 				error: error instanceof Error ? error.message : String(error),
 			};
@@ -442,7 +470,7 @@ export async function drainHostedRunner(
 		workspace_root: workspaceRoot,
 		runtime,
 		workspace_export: {
-			mode: "local_path_contract",
+			mode: HostedRunnerWorkspaceExportModeValue.LocalPathContract,
 			paths: exportPaths,
 		},
 		snapshot,
@@ -515,7 +543,7 @@ export async function handleHostedRunnerDrain(
 
 	sendJson(
 		res,
-		result.status === "interrupted" ? 503 : 200,
+		result.status === HostedRunnerDrainStatusValue.Interrupted ? 503 : 200,
 		{
 			protocol_version: HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION,
 			status: result.status,

--- a/test/server/hosted-runner-drain.test.ts
+++ b/test/server/hosted-runner-drain.test.ts
@@ -17,6 +17,9 @@ import type { HostedRunnerContext } from "../../src/server/app-context.js";
 import {
 	HOSTED_RUNNER_RETENTION_POLICY_VERSION,
 	HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
+	HostedRunnerDrainStatusValue,
+	HostedRunnerRuntimeFlushStatusValue,
+	HostedRunnerWorkspaceExportPathTypeValue,
 	drainHostedRunner,
 } from "../../src/server/handlers/hosted-runner-drain.js";
 import type { HeadlessRuntimeSnapshot } from "../../src/server/headless-runtime-service.js";
@@ -101,7 +104,7 @@ describe("hosted runner drain", () => {
 			},
 		);
 
-		expect(result?.status).toBe("drained");
+		expect(result?.status).toBe(HostedRunnerDrainStatusValue.Drained);
 		expect(result?.runner_session_id).toBe("mrs_123");
 		expect(result?.reason).toBe("ttl_expired");
 		expect(result?.requested_by).toBe("platform");
@@ -118,7 +121,7 @@ describe("hosted runner drain", () => {
 			created_at: "2026-04-23T00:00:00.000Z",
 			workspace_root: workspaceRoot,
 			runtime: {
-				flush_status: "completed",
+				flush_status: HostedRunnerRuntimeFlushStatusValue.Completed,
 				session_id: "session_123",
 				protocol_version: HEADLESS_PROTOCOL_VERSION,
 				cursor: 7,
@@ -158,13 +161,13 @@ describe("hosted runner drain", () => {
 				input: ".",
 				path: workspaceRoot,
 				relative_path: ".",
-				type: "directory",
+				type: HostedRunnerWorkspaceExportPathTypeValue.Directory,
 			},
 			{
 				input: "README.md",
 				path: join(workspaceRoot, "README.md"),
 				relative_path: "README.md",
-				type: "file",
+				type: HostedRunnerWorkspaceExportPathTypeValue.File,
 			},
 		]);
 
@@ -190,14 +193,14 @@ describe("hosted runner drain", () => {
 			},
 		);
 
-		expect(result?.status).toBe("interrupted");
+		expect(result?.status).toBe(HostedRunnerDrainStatusValue.Interrupted);
 		expect(context.draining).toBe(true);
 		expect(result?.manifest.protocol_version).toBe(
 			HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
 		);
 		expect(result?.manifest.maestro_session_id).toBe("session_123");
 		expect(result?.manifest.runtime).toMatchObject({
-			flush_status: "failed",
+			flush_status: HostedRunnerRuntimeFlushStatusValue.Failed,
 			session_id: "session_123",
 			error: "flush timed out",
 		});
@@ -233,13 +236,13 @@ describe("hosted runner drain", () => {
 			},
 		);
 
-		expect(result?.status).toBe("drained");
+		expect(result?.status).toBe(HostedRunnerDrainStatusValue.Drained);
 		expect(result?.manifest).toMatchObject({
 			protocol_version: HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
 			maestro_session_id: "session_123",
 			reason: "empty-runtime",
 			runtime: {
-				flush_status: "skipped",
+				flush_status: HostedRunnerRuntimeFlushStatusValue.Skipped,
 				session_id: "session_123",
 			},
 			snapshot: {


### PR DESCRIPTION
## Summary
- replace hosted-runner drain string unions with exported enum-backed statuses
- enum-back runtime flush status and workspace export mode/path type while preserving the JSON wire values
- update drain tests to assert through those enums

Refs #78.

## Test plan
- `npm test -- test/server/hosted-runner-drain.test.ts`
- `bunx biome check src/server/handlers/hosted-runner-drain.ts test/server/hosted-runner-drain.test.ts`
- `git diff --check`