### PR TITLE
Preserve skill metadata across compaction restores

### DIFF
--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -1096,6 +1096,7 @@ async function collectRecentSkillRestoreMessages(
 					? details.name
 					: extractSkillRestoreName(message.content);
 			content = message.content;
+			skillMetadata = getSkillArtifactMetadataFromDetails(details);
 		}
 
 		if (!skillName || !content || seenSkillNames.has(skillName)) {

--- a/test/agent/perform-compaction.test.ts
+++ b/test/agent/perform-compaction.test.ts
@@ -267,13 +267,18 @@ function createActiveSkillHookMessage(name = "debug"): AppMessage {
 function createRestoredSkillHookMessage(
 	name = "reviewer",
 	content = "# Skill: reviewer\n\n> Review specialist\n\n## Instructions\n\nInspect the diff for regressions.",
+	skillMetadata?: Record<string, string>,
 ): AppMessage {
 	return {
 		role: "hookMessage",
 		customType: "skill",
 		content: [{ type: "text", text: content.replaceAll("reviewer", name) }],
 		display: false,
-		details: { name, source: "tool" },
+		details: {
+			name,
+			source: "tool",
+			...(skillMetadata ? { skillMetadata } : {}),
+		},
 		timestamp: Date.now(),
 	};
 }
@@ -2268,7 +2273,18 @@ Current plan contents:
 
 	it("re-restores prior hidden tool skill context across repeated compactions", async () => {
 		const messages = buildConversation(10);
-		messages.splice(2, 0, createRestoredSkillHookMessage("reviewer"));
+		const skillMetadata = {
+			name: "reviewer",
+			hash: "hash_review_skill",
+			source: "service",
+			artifactId: "skill_review_1",
+			version: "7",
+		};
+		messages.splice(
+			2,
+			0,
+			createRestoredSkillHookMessage("reviewer", undefined, skillMetadata),
+		);
 		const agent = createMockAgentWithoutAppendMessage(messages);
 		const sessionManager = createMockSessionManager();
 
@@ -2284,7 +2300,7 @@ Current plan contents:
 			role: "hookMessage",
 			customType: "skill",
 			display: false,
-			details: { name: "reviewer", source: "tool" },
+			details: { name: "reviewer", source: "tool", skillMetadata },
 		});
 		expect(JSON.stringify(restoredSkillMessages[0]?.content)).toContain(
 			"Inspect the diff for regressions.",


### PR DESCRIPTION
## Summary
- preserve `skillMetadata` when re-restoring hidden skill hook messages during repeated compactions
- extend the compaction regression to assert restored skill metadata survives the hook-message path
- fix-forward for Cursor Bugbot feedback on #129

## Test Plan
- npm test -- test/agent/perform-compaction.test.ts -t "re-restores prior hidden tool skill context across repeated compactions"
- npm test -- test/agent/perform-compaction.test.ts
- bunx biome check src/agent/compaction.ts test/agent/perform-compaction.test.ts
- npm run check (after building `@evalops/contracts`, `@evalops/tui`, and `@evalops/governance` workspace artifacts in the fresh worktree)

Source-of-truth internal PR: evalops/maestro-internal#1477