### PR TITLE
Drain hosted runners during shutdown

### DIFF
--- a/deploy/helm/maestro/values.yaml
+++ b/deploy/helm/maestro/values.yaml
@@ -63,7 +63,31 @@ gracefulShutdown:
       command:
         - /bin/sh
         - -c
-        - sleep 5
+        - |
+          node <<'EOF' || true
+          const port = process.env.PORT || "8080";
+          const controller = new AbortController();
+          setTimeout(() => controller.abort(), 4000).unref();
+          fetch(`http://127.0.0.1:${port}/.well-known/evalops/remote-runner/drain`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              reason: "kubernetes_prestop",
+              requested_by: "kubernetes_prestop",
+            }),
+            signal: controller.signal,
+          }).then(async (res) => {
+            if (res.status === 404) return;
+            if (!res.ok) {
+              console.error(await res.text());
+              process.exitCode = 1;
+            }
+          }).catch((error) => {
+            console.error(error?.message ?? String(error));
+            process.exitCode = 1;
+          });
+          EOF
+          sleep 5
 
 podDisruptionBudget:
   enabled: true

--- a/docs/protocols/hosted-runner-contract.md
+++ b/docs/protocols/hosted-runner-contract.md
@@ -176,6 +176,13 @@ Drain uses:
 POST /.well-known/evalops/remote-runner/drain
 ```
 
+The Helm chart's default preStop hook calls this endpoint with the enum-backed
+`kubernetes_prestop` reason/requester before sleeping briefly for Kubernetes
+termination propagation. If a process receives SIGINT or SIGTERM without that
+preStop call, the web server runs the same drain path with the
+`process_shutdown` reason and writes the same manifest envelope before closing
+connections.
+
 The manifest protocol is
 `evalops.remote-runner.snapshot-manifest.v1`. Both Rust-hosted and
 TypeScript-hosted drain paths write this same local manifest envelope, including

--- a/src/server/handlers/hosted-runner-drain.ts
+++ b/src/server/handlers/hosted-runner-drain.ts
@@ -46,6 +46,16 @@ export enum HostedRunnerWorkspaceExportModeValue {
 	LocalPathContract = "local_path_contract",
 }
 
+export enum HostedRunnerDrainReasonValue {
+	KubernetesPreStop = "kubernetes_prestop",
+	ProcessShutdown = "process_shutdown",
+}
+
+export enum HostedRunnerDrainRequestedByValue {
+	KubernetesPreStop = "kubernetes_prestop",
+	MaestroWebServer = "maestro_web_server",
+}
+
 export type HostedRunnerDrainStatus = HostedRunnerDrainStatusValue;
 export type HostedRunnerRuntimeFlushStatus =
 	HostedRunnerRuntimeFlushStatusValue;
@@ -53,6 +63,10 @@ export type HostedRunnerWorkspaceExportPathType =
 	HostedRunnerWorkspaceExportPathTypeValue;
 export type HostedRunnerWorkspaceExportMode =
 	HostedRunnerWorkspaceExportModeValue;
+export type HostedRunnerDrainReason = HostedRunnerDrainReasonValue | string;
+export type HostedRunnerDrainRequestedBy =
+	| HostedRunnerDrainRequestedByValue
+	| string;
 
 export interface HostedRunnerRetentionPolicy {
 	policy_version: typeof HOSTED_RUNNER_RETENTION_POLICY_VERSION;
@@ -78,8 +92,8 @@ export interface HostedRunnerRetentionPolicy {
 }
 
 export interface HostedRunnerDrainInput {
-	reason?: string;
-	requestedBy?: string;
+	reason?: HostedRunnerDrainReason;
+	requestedBy?: HostedRunnerDrainRequestedBy;
 	exportPaths?: string[];
 }
 
@@ -144,6 +158,20 @@ export interface DrainHostedRunnerOptions {
 		sessionId: string,
 	) => Promise<HostedRunnerRuntimeDrainResult | null>;
 	now?: () => Date;
+}
+
+interface HostedRunnerDrainRuntimeContext {
+	hostedRunner?: HostedRunnerContext;
+	headlessRuntimeService: Pick<
+		WebServerContext["headlessRuntimeService"],
+		"getRuntimeBySessionId"
+	>;
+}
+
+export interface DrainHostedRunnerForShutdownOptions {
+	now?: () => Date;
+	reason?: HostedRunnerDrainReason;
+	requestedBy?: HostedRunnerDrainRequestedBy;
 }
 
 function getString(value: unknown, field: string): string | undefined {
@@ -495,7 +523,7 @@ export async function drainHostedRunner(
 }
 
 async function drainActiveRuntime(
-	context: WebServerContext,
+	context: HostedRunnerDrainRuntimeContext,
 	sessionId: string,
 ): Promise<HostedRunnerRuntimeDrainResult | null> {
 	const runtime =
@@ -513,6 +541,25 @@ async function drainActiveRuntime(
 		cursor: snapshot.cursor,
 		snapshot,
 	};
+}
+
+export async function drainHostedRunnerForShutdown(
+	context: HostedRunnerDrainRuntimeContext,
+	options: DrainHostedRunnerForShutdownOptions = {},
+): Promise<HostedRunnerDrainResult | null> {
+	return drainHostedRunner(
+		{
+			reason: options.reason ?? HostedRunnerDrainReasonValue.ProcessShutdown,
+			requestedBy:
+				options.requestedBy ??
+				HostedRunnerDrainRequestedByValue.MaestroWebServer,
+		},
+		{
+			hostedRunner: context.hostedRunner,
+			drainRuntime: (sessionId) => drainActiveRuntime(context, sessionId),
+			now: options.now,
+		},
+	);
 }
 
 export async function handleHostedRunnerDrain(

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -63,6 +63,11 @@ import type {
 	HostedRunnerContext,
 	WebServerContext,
 } from "./server/app-context.js";
+import {
+	HostedRunnerDrainReasonValue,
+	HostedRunnerDrainStatusValue,
+	drainHostedRunnerForShutdown,
+} from "./server/handlers/hosted-runner-drain.js";
 import { createWorkspaceConfigMiddleware } from "./services/workspace-config/middleware.js";
 import { recordApiRequest } from "./telemetry.js";
 import { artifactsClientTool } from "./tools/artifacts-client.js";
@@ -912,7 +917,34 @@ export async function startWebServer(
 			if (shuttingDown) return;
 			shuttingDown = true;
 			if (context.hostedRunner) {
-				context.hostedRunner.draining = true;
+				if (context.hostedRunner.draining) {
+					logger.info("Hosted runner already draining before shutdown", {
+						runnerSessionId: context.hostedRunner.runnerSessionId,
+					});
+				} else {
+					try {
+						const drainResult = await drainHostedRunnerForShutdown(context, {
+							reason: HostedRunnerDrainReasonValue.ProcessShutdown,
+						});
+						if (drainResult) {
+							const log =
+								drainResult.status === HostedRunnerDrainStatusValue.Interrupted
+									? logger.warn.bind(logger)
+									: logger.info.bind(logger);
+							log("Hosted runner drained during graceful shutdown", {
+								runnerSessionId: drainResult.runner_session_id,
+								status: drainResult.status,
+								manifestPath: drainResult.manifest_path,
+							});
+						}
+					} catch (error) {
+						context.hostedRunner.draining = true;
+						logger.warn("Hosted runner shutdown drain failed", {
+							runnerSessionId: context.hostedRunner.runnerSessionId,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					}
+				}
 			}
 			logger.info(`${signal} received. Starting graceful shutdown...`);
 			stopStatsCollection();

--- a/test/deploy/helm-maestro.test.ts
+++ b/test/deploy/helm-maestro.test.ts
@@ -43,6 +43,8 @@ describe("maestro Helm chart", () => {
 		expect(result.stdout).toContain("name: XDG_CACHE_HOME");
 		expect(result.stdout).toContain("startupProbe:");
 		expect(result.stdout).toContain("preStop:");
+		expect(result.stdout).toContain("/.well-known/evalops/remote-runner/drain");
+		expect(result.stdout).toContain("kubernetes_prestop");
 	});
 
 	helmIt("can render an HPA without a fixed deployment replica count", () => {

--- a/test/server/hosted-runner-drain.test.ts
+++ b/test/server/hosted-runner-drain.test.ts
@@ -17,10 +17,13 @@ import type { HostedRunnerContext } from "../../src/server/app-context.js";
 import {
 	HOSTED_RUNNER_RETENTION_POLICY_VERSION,
 	HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
+	HostedRunnerDrainReasonValue,
+	HostedRunnerDrainRequestedByValue,
 	HostedRunnerDrainStatusValue,
 	HostedRunnerRuntimeFlushStatusValue,
 	HostedRunnerWorkspaceExportPathTypeValue,
 	drainHostedRunner,
+	drainHostedRunnerForShutdown,
 } from "../../src/server/handlers/hosted-runner-drain.js";
 import type { HeadlessRuntimeSnapshot } from "../../src/server/headless-runtime-service.js";
 
@@ -258,6 +261,54 @@ describe("hosted runner drain", () => {
 				policy_version: HOSTED_RUNNER_RETENTION_POLICY_VERSION,
 				managed_by: "platform",
 			},
+		});
+	});
+
+	it("drains active runtime state for process shutdown", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const context = hostedRunnerContext(workspaceRoot);
+		const snapshot = runtimeSnapshot(workspaceRoot, 11);
+		const runtime = {
+			getSnapshot: vi.fn(() => snapshot),
+			getSessionFile: vi.fn(() =>
+				join(workspaceRoot, ".maestro", "sessions", "session.jsonl"),
+			),
+			dispose: vi.fn().mockResolvedValue(undefined),
+		};
+		const headlessRuntimeService = {
+			getRuntimeBySessionId: vi.fn(() => runtime),
+		};
+
+		const result = await drainHostedRunnerForShutdown(
+			{
+				hostedRunner: context,
+				headlessRuntimeService,
+			},
+			{
+				now: () => new Date("2026-04-23T00:02:30.000Z"),
+			},
+		);
+
+		expect(result?.status).toBe(HostedRunnerDrainStatusValue.Drained);
+		expect(result?.reason).toBe(HostedRunnerDrainReasonValue.ProcessShutdown);
+		expect(result?.requested_by).toBe(
+			HostedRunnerDrainRequestedByValue.MaestroWebServer,
+		);
+		expect(context.draining).toBe(true);
+		expect(headlessRuntimeService.getRuntimeBySessionId).toHaveBeenCalledWith(
+			"session_123",
+		);
+		expect(runtime.dispose).toHaveBeenCalled();
+		expect(result?.manifest).toMatchObject({
+			maestro_session_id: "session_123",
+			reason: HostedRunnerDrainReasonValue.ProcessShutdown,
+			requested_by: HostedRunnerDrainRequestedByValue.MaestroWebServer,
+			runtime: {
+				flush_status: HostedRunnerRuntimeFlushStatusValue.Completed,
+				session_id: "session_123",
+				cursor: 11,
+			},
+			snapshot,
 		});
 	});
 


### PR DESCRIPTION
## Summary
- add enum-backed internal drain reason/requester values for Kubernetes preStop and process shutdown
- run hosted-runner manifest drain during SIGINT/SIGTERM before closing server connections
- make the Helm default preStop call the hosted-runner drain endpoint before sleeping

## Test Plan
- `npm test -- test/deploy/helm-maestro.test.ts test/server/hosted-runner-drain.test.ts`
- `npm test -- test/headless/runtime-conformance.test.ts -t "drains hosted runners into a manifest and rejects new mutations"`
- `bunx tsc -p tsconfig.build.json --noEmit`
- `bunx biome check deploy/helm/maestro/values.yaml docs/protocols/hosted-runner-contract.md src/server/handlers/hosted-runner-drain.ts src/web-server.ts test/deploy/helm-maestro.test.ts test/server/hosted-runner-drain.test.ts`
- `helm template maestro deploy/helm/maestro`
- `git diff --check`

Part of #78.


## Internal Source
- evalops/maestro-internal#1478
