### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/.github/PUBLIC_TREE_MIRROR_BOUNDARY.md
+++ b/.github/PUBLIC_TREE_MIRROR_BOUNDARY.md
@@ -8,7 +8,9 @@ public-tree mirror runs on every push to internal `main`.
 Related:
 
 - `scripts/prepare-public-release-mirror.mjs`
+- `scripts/check-public-mirror-drift.mjs`
 - `.github/public-release-mirror.exclude`
+- `.github/workflows/public-mirror-drift-audit.yml`
 - `.github/workflows/sync-public-release-mirror.yml`
 - `evalops/maestro-internal#1425`
 
@@ -88,7 +90,17 @@ and opens or updates the stable public mirror PR. The report lists:
 - the resolved public package name
 
 The workflow writes those counts and a sample file list to the GitHub step
-summary so each sync PR shows the size and shape of the public-tree update.
+summary so each sync PR shows the size and shape of the public-tree update. It
+also uploads a machine-readable status bundle:
+
+- `public-tree-mirror-report.json`: raw copy/delete plan
+- `public-tree-mirror-status.json`: source SHA, public SHA, invariant, drift
+  counts, and sampled changed paths
+- `public-tree-mirror-status.md`: at-a-glance dashboard for humans
+
+The scheduled `public-mirror-drift-audit` workflow writes the same status bundle
+against current internal `main` and public `main`. Treat its check as the
+current answer to "is public a verified projection of private right now?"
 
 ## Operating Rules
 
@@ -98,3 +110,5 @@ summary so each sync PR shows the size and shape of the public-tree update.
    generated tree unless ownership deliberately moves back into internal.
 4. Treat a failed mirror sync as a release-blocking bridge failure; do not
    backfill public directly except for emergency recovery.
+5. Treat a missing or malformed public sync status as a bridge failure. The
+   generated public PR must carry source-of-truth metadata, not just a diff.

--- a/scripts/check-public-mirror-drift.mjs
+++ b/scripts/check-public-mirror-drift.mjs
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 
-import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 
 function parseArgs(argv) {
 	const args = {
+		markdownOutput: "",
 		report: "",
 		source: process.cwd(),
+		statusOutput: "",
 		summaryLimit: 25,
 		target: "",
 	};
@@ -16,11 +18,17 @@ function parseArgs(argv) {
 	for (let index = 0; index < argv.length; index += 1) {
 		const arg = argv[index];
 		switch (arg) {
+			case "--markdown-output":
+				args.markdownOutput = argv[++index] ?? args.markdownOutput;
+				break;
 			case "--report":
 				args.report = argv[++index] ?? args.report;
 				break;
 			case "--source":
 				args.source = argv[++index] ?? args.source;
+				break;
+			case "--status-output":
+				args.statusOutput = argv[++index] ?? args.statusOutput;
 				break;
 			case "--summary-limit":
 				args.summaryLimit = Number.parseInt(argv[++index] ?? "", 10);
@@ -59,18 +67,91 @@ function samplePaths(report, limit) {
 	].slice(0, limit);
 }
 
-function buildMarkdown(report, limit) {
+function runGit(root, args) {
+	const result = spawnSync("git", ["-C", root, ...args], {
+		encoding: "utf8",
+	});
+	if (result.status !== 0) {
+		return "";
+	}
+	return result.stdout.trim();
+}
+
+function normalizeRemote(value) {
+	if (!value) {
+		return "";
+	}
+	const sshMatch = value.match(/^git@github[.]com:(.+?)(?:[.]git)?$/u);
+	if (sshMatch) {
+		return `https://github.com/${sshMatch[1]}`;
+	}
+	return value.replace(/[.]git$/u, "");
+}
+
+function gitContext(root) {
+	const sha = runGit(root, ["rev-parse", "HEAD"]);
+	const branch = runGit(root, ["rev-parse", "--abbrev-ref", "HEAD"]);
+	return {
+		branch: branch && branch !== "HEAD" ? branch : "",
+		remote: normalizeRemote(runGit(root, ["config", "--get", "remote.origin.url"])),
+		sha,
+	};
+}
+
+function buildStatus(report, limit, sourceRoot, targetRoot) {
 	const copiedCount = Number(report.copiedCount ?? 0);
 	const deletedCount = Number(report.deletedCount ?? 0);
 	const total = copiedCount + deletedCount;
-	const samples = samplePaths(report, limit);
+	return {
+		schemaVersion: 1,
+		generatedAt: new Date().toISOString(),
+		result: total === 0 ? "in_sync" : "drift_detected",
+		invariant:
+			total === 0
+				? "public_is_verified_projection"
+				: "public_projection_has_drift",
+		source: {
+			kind: "private-source-of-truth",
+			...gitContext(sourceRoot),
+		},
+		target: {
+			kind: "public-projection",
+			...gitContext(targetRoot),
+		},
+		mirror: {
+			publicPackageName: report.publicPackageName ?? "unknown",
+			filesToCopyOrUpdate: copiedCount,
+			staleFilesToDelete: deletedCount,
+			sourceFileCount: Number(report.sourceFileCount ?? 0),
+			targetFileCount: Number(report.targetFileCount ?? 0),
+			sampleLimit: limit,
+			sampledChangedPaths: samplePaths(report, limit),
+		},
+		guidance:
+			total === 0
+				? "Public main matches the sanitized private source tree for mirrored paths."
+				: "Let internal main generate and merge the public sync PR before relying on public main.",
+	};
+}
+
+function formatRef(context) {
+	const ref = context.branch || "detached";
+	const sha = context.sha ? context.sha.slice(0, 12) : "unknown";
+	return context.remote ? `${context.remote}@${ref} (${sha})` : `${ref} (${sha})`;
+}
+
+function buildMarkdown(status) {
+	const samples = status.mirror.sampledChangedPaths;
 	const lines = [
 		"## Public Mirror Drift Audit",
 		"",
-		`- package: \`${report.publicPackageName ?? "unknown"}\``,
-		`- files to copy or update: \`${copiedCount}\``,
-		`- stale files to delete: \`${deletedCount}\``,
-		`- result: ${total === 0 ? "in sync" : "drift detected"}`,
+		`- package: \`${status.mirror.publicPackageName}\``,
+		`- private source: \`${formatRef(status.source)}\``,
+		`- public projection: \`${formatRef(status.target)}\``,
+		`- files to copy or update: \`${status.mirror.filesToCopyOrUpdate}\``,
+		`- stale files to delete: \`${status.mirror.staleFilesToDelete}\``,
+		`- result: ${status.result === "in_sync" ? "in sync" : "drift detected"}`,
+		`- invariant: \`${status.invariant}\``,
 	];
 
 	if (samples.length > 0) {
@@ -78,10 +159,14 @@ function buildMarkdown(report, limit) {
 		for (const sample of samples) {
 			lines.push(`- ${sample}`);
 		}
+		const total =
+			status.mirror.filesToCopyOrUpdate + status.mirror.staleFilesToDelete;
 		if (total > samples.length) {
 			lines.push(`- ... ${total - samples.length} more`);
 		}
 	}
+
+	lines.push("", "### Guidance", "", status.guidance);
 
 	return `${lines.join("\n")}\n`;
 }
@@ -119,9 +204,16 @@ if (result.error) {
 }
 
 const report = readReport(reportPath);
-const markdown = buildMarkdown(report, options.summaryLimit);
+const status = buildStatus(report, options.summaryLimit, sourceRoot, targetRoot);
+const markdown = buildMarkdown(status);
 process.stdout.write(markdown);
 
+if (options.statusOutput) {
+	writeFileSync(resolve(options.statusOutput), `${JSON.stringify(status, null, 2)}\n`);
+}
+if (options.markdownOutput) {
+	writeFileSync(resolve(options.markdownOutput), markdown);
+}
 if (process.env.GITHUB_STEP_SUMMARY) {
 	appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${markdown}`);
 }

--- a/test/scripts/check-public-mirror-drift.test.ts
+++ b/test/scripts/check-public-mirror-drift.test.ts
@@ -1,0 +1,148 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const fixtures: string[] = [];
+const scriptPath = join(process.cwd(), "scripts/check-public-mirror-drift.mjs");
+const packageName = ["@evalops", "maestro"].join("/");
+
+function makeFixture() {
+	const root = join(
+		tmpdir(),
+		`maestro-public-mirror-drift-${process.pid}-${Date.now()}-${fixtures.length}`,
+	);
+	fixtures.push(root);
+	const source = join(root, "source");
+	const target = join(root, "target");
+	mkdirSync(source, { recursive: true });
+	mkdirSync(target, { recursive: true });
+	writePackage(source);
+	writePackage(target);
+	return { root, source, target };
+}
+
+function write(path: string, content: string) {
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, content);
+}
+
+function writePackage(root: string) {
+	write(
+		join(root, "package.json"),
+		`${JSON.stringify(
+			{
+				name: packageName,
+				version: "1.0.0",
+				maestro: {
+					canonicalPackageName: packageName,
+					packageAliases: [packageName],
+				},
+			},
+			null,
+			2,
+		)}\n`,
+	);
+}
+
+function readJson(path: string) {
+	return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+}
+
+function runCheck(
+	source: string,
+	target: string,
+	reportPath: string,
+	statusPath: string,
+	markdownPath: string,
+) {
+	return spawnSync(
+		process.execPath,
+		[
+			scriptPath,
+			"--source",
+			source,
+			"--target",
+			target,
+			"--report",
+			reportPath,
+			"--status-output",
+			statusPath,
+			"--markdown-output",
+			markdownPath,
+			"--summary-limit",
+			"3",
+		],
+		{ encoding: "utf8" },
+	);
+}
+
+describe("check-public-mirror-drift", () => {
+	afterEach(() => {
+		for (const fixture of fixtures.splice(0)) {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	it("writes source-of-truth status when public is in sync", () => {
+		const { root, source, target } = makeFixture();
+		write(join(source, "README.md"), "hello\n");
+		write(join(target, "README.md"), "hello\n");
+		const reportPath = join(root, "drift.json");
+		const statusPath = join(root, "status.json");
+		const markdownPath = join(root, "status.md");
+
+		const result = runCheck(
+			source,
+			target,
+			reportPath,
+			statusPath,
+			markdownPath,
+		);
+
+		expect(result.status).toBe(0);
+		const status = readJson(statusPath);
+		expect(status).toMatchObject({
+			invariant: "public_is_verified_projection",
+			mirror: {
+				filesToCopyOrUpdate: 0,
+				staleFilesToDelete: 0,
+				publicPackageName: packageName,
+			},
+			result: "in_sync",
+		});
+		expect(readFileSync(markdownPath, "utf8")).toContain(
+			"public_is_verified_projection",
+		);
+	});
+
+	it("reports sampled changed paths when public has drift", () => {
+		const { root, source, target } = makeFixture();
+		write(join(source, "README.md"), "new\n");
+		write(join(target, "README.md"), "old\n");
+		const reportPath = join(root, "drift.json");
+		const statusPath = join(root, "status.json");
+		const markdownPath = join(root, "status.md");
+
+		const result = runCheck(
+			source,
+			target,
+			reportPath,
+			statusPath,
+			markdownPath,
+		);
+
+		expect(result.status).toBe(1);
+		const status = readJson(statusPath);
+		expect(status).toMatchObject({
+			invariant: "public_projection_has_drift",
+			mirror: {
+				filesToCopyOrUpdate: 1,
+				sampledChangedPaths: ["copy/update README.md"],
+			},
+			result: "drift_detected",
+		});
+		expect(readFileSync(markdownPath, "utf8")).toContain("drift detected");
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `965471344c687e531d3487b77712aad73b744f60`
- last generated public sync base: `2525ad7ffee823e1526b60a4413b9f2d7beb996d`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `4`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (965471344c68)`
- public projection: `https://github.com/evalops/maestro@main (5b7686d09928)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update .github/PUBLIC_TREE_MIRROR_BOUNDARY.md
- copy/update scripts/check-public-mirror-drift.mjs
- copy/update test/scripts/check-public-mirror-drift.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update .github/PUBLIC_TREE_MIRROR_BOUNDARY.md
- copy/update scripts/check-public-mirror-drift.mjs
- copy/update test/scripts/check-public-mirror-drift.test.ts

## Public-only commits since last generated sync

- 5b7686d0 Merge pull request #166 from evalops/jh/public-source-status-20260424
- b68f3485 Add Maestro agent-runtime ledger client (#164)
- 9688f5df Drain hosted runners during shutdown (#163)
- 8e3ddb52 Preserve skill metadata across compaction restores (#162)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode