### PR TITLE
Record hosted headless sessions in AgentRuntime

### DIFF
--- a/src/cli-tui/run/run-shell-command.ts
+++ b/src/cli-tui/run/run-shell-command.ts
@@ -13,14 +13,23 @@ export interface ShellCommandOptions {
 	env?: NodeJS.ProcessEnv;
 }
 
+function shellEscape(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 export async function runShellCommand(
 	command: string,
 	options: ShellCommandOptions = {},
 ): Promise<ShellCommandResult> {
 	return await new Promise((resolve) => {
-		const child = spawn("bash", ["-lc", command], {
-			cwd: options.cwd ?? process.cwd(),
-			env: options.env ?? process.env,
+		const cwd = options.cwd ?? process.cwd();
+		const shellCommand = `cd -- ${shellEscape(cwd)} && ${command}`;
+		const child = spawn("bash", ["-lc", shellCommand], {
+			cwd,
+			env: {
+				...(options.env ?? process.env),
+				PWD: cwd,
+			},
 		});
 		let stdout = "";
 		let stderr = "";

--- a/src/cli-tui/run/streaming-shell-command.ts
+++ b/src/cli-tui/run/streaming-shell-command.ts
@@ -15,6 +15,10 @@ export interface StreamingShellCommandResult {
 	stderr: string;
 }
 
+function shellEscape(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 /**
  * Run a shell command with streaming output callbacks.
  * Calls onStdout/onStderr for each chunk received, enabling real-time display.
@@ -25,7 +29,8 @@ export async function runStreamingShellCommand(
 ): Promise<StreamingShellCommandResult> {
 	return await new Promise((resolve) => {
 		const cwd = options.cwd ?? process.cwd();
-		const child: ChildProcess = spawn("bash", ["-lc", command], {
+		const shellCommand = `cd -- ${shellEscape(cwd)} && ${command}`;
+		const child: ChildProcess = spawn("bash", ["-lc", shellCommand], {
 			cwd,
 			env: {
 				...(options.env ?? process.env),

--- a/src/cli-tui/run/streaming-shell-command.ts
+++ b/src/cli-tui/run/streaming-shell-command.ts
@@ -24,9 +24,13 @@ export async function runStreamingShellCommand(
 	options: StreamingShellCommandOptions = {},
 ): Promise<StreamingShellCommandResult> {
 	return await new Promise((resolve) => {
+		const cwd = options.cwd ?? process.cwd();
 		const child: ChildProcess = spawn("bash", ["-lc", command], {
-			cwd: options.cwd ?? process.cwd(),
-			env: options.env ?? process.env,
+			cwd,
+			env: {
+				...(options.env ?? process.env),
+				PWD: cwd,
+			},
 		});
 
 		let stdout = "";

--- a/src/server/handlers/headless-sessions.ts
+++ b/src/server/handlers/headless-sessions.ts
@@ -11,9 +11,12 @@ import {
 	headlessUtilityOperations,
 } from "@evalops/contracts";
 import { type Static, type TSchema, Type } from "@sinclair/typebox";
+import type { ApprovalMode } from "../../agent/action-approval.js";
 import type { ThinkingLevel } from "../../agent/types.js";
 import type { HeadlessToAgentMessage } from "../../cli/headless-protocol.js";
 import { resolveExistingWorkspaceRoot } from "../../headless/workspace-root.js";
+import type { RegisteredModel } from "../../models/registry.js";
+import { recordMaestroSessionRuntimeTrigger } from "../../platform/agent-runtime-client.js";
 import type { WebServerContext } from "../app-context.js";
 import {
 	normalizeApprovalMode,
@@ -499,7 +502,10 @@ function rethrowHeadlessConnectionLifecycleError(error: unknown): never {
 async function ensureRuntime(
 	req: IncomingMessage,
 	context: WebServerContext,
-	input: HeadlessSessionCreateInput & { registerConnection?: boolean },
+	input: HeadlessSessionCreateInput & {
+		registerConnection?: boolean;
+		recordAgentRuntimeTrigger?: boolean;
+	},
 ) {
 	const sessionManager = createSessionManagerForRequest(req, false);
 	const role = getHeadlessRole(req, input.role);
@@ -585,7 +591,56 @@ async function ensureRuntime(
 	if (context.hostedRunner) {
 		claimHostedRunnerSession(context, runtime.getSnapshot().session_id);
 	}
+	if (input.recordAgentRuntimeTrigger !== false) {
+		await recordPlatformAgentRuntimeSessionStart({
+			context,
+			runtime,
+			subject,
+			registeredModel,
+			role,
+			thinkingLevel: (input.thinkingLevel ?? "off") as ThinkingLevel,
+			approvalMode: effectiveApproval,
+			workspaceRoot,
+			input,
+		});
+	}
 	return runtime;
+}
+
+async function recordPlatformAgentRuntimeSessionStart(options: {
+	context: WebServerContext;
+	runtime: HeadlessSessionRuntime;
+	subject?: string;
+	registeredModel: RegisteredModel;
+	role: HeadlessConnectionRole;
+	thinkingLevel: ThinkingLevel;
+	approvalMode: ApprovalMode;
+	workspaceRoot: string | undefined;
+	input: HeadlessSessionCreateInput;
+}): Promise<void> {
+	const snapshot = options.runtime.getSnapshot();
+	const hostedRunner = options.context.hostedRunner;
+	const result = await recordMaestroSessionRuntimeTrigger({
+		workspaceId: hostedRunner?.workspaceId,
+		sessionId: snapshot.session_id,
+		actorId: options.subject,
+		correlationId: `maestro-session:${snapshot.session_id}`,
+		metadata: {
+			model: options.registeredModel.id,
+			provider: options.registeredModel.provider,
+			role: options.role,
+			thinking_level: options.thinkingLevel,
+			approval_mode: options.approvalMode,
+			client: options.input.client ?? "generic",
+			protocol_version: options.input.protocolVersion,
+			workspace_root: options.workspaceRoot,
+			runner_session_id: hostedRunner?.runnerSessionId,
+			owner_instance_id: hostedRunner?.ownerInstanceId,
+		},
+	});
+	if (result?.run.id && hostedRunner && !hostedRunner.agentRunId) {
+		hostedRunner.agentRunId = result.run.id;
+	}
 }
 
 async function ensureConnection(
@@ -596,6 +651,7 @@ async function ensureConnection(
 	const runtime = await ensureRuntime(req, context, {
 		...input,
 		registerConnection: false,
+		recordAgentRuntimeTrigger: false,
 	});
 	const role = getHeadlessRole(req, input.role);
 	const heartbeat = runtime.registerConnection({

--- a/test/tui/bash-mode.test.ts
+++ b/test/tui/bash-mode.test.ts
@@ -23,6 +23,7 @@ import {
 	saveBashHistory,
 } from "../../src/cli-tui/bash/bash-history.js";
 import { highlightBashCommand } from "../../src/cli-tui/bash/bash-syntax.js";
+import { runShellCommand } from "../../src/cli-tui/run/run-shell-command.js";
 import { runStreamingShellCommand } from "../../src/cli-tui/run/streaming-shell-command.js";
 import { backgroundTaskManager } from "../../src/tools/background-tasks.js";
 
@@ -741,6 +742,16 @@ describe("runStreamingShellCommand", () => {
 		);
 
 		expect(result.stdout).toBe("line1\nline2\nline3");
+	});
+});
+
+describe("runShellCommand", () => {
+	it("respects cwd option", async () => {
+		const result = await runShellCommand("pwd", {
+			cwd: "/tmp",
+		});
+
+		expect(result.stdout).toMatch(/^\/tmp|^\/private\/tmp/);
 	});
 });
 

--- a/test/web/headless-sessions.test.ts
+++ b/test/web/headless-sessions.test.ts
@@ -25,6 +25,13 @@ import {
 	createHeadlessRuntimeState,
 } from "../../src/cli/headless-protocol.js";
 import type { RegisteredModel } from "../../src/models/registry.js";
+import {
+	MaestroAgentRuntimeSourceEventType,
+	PlatformAgentRunStateValue,
+	PlatformRuntimeChannelKindValue,
+	PlatformRuntimeTriggerKindValue,
+	PlatformSurfaceValue,
+} from "../../src/platform/agent-runtime-client.js";
 import type { WebServerContext } from "../../src/server/app-context.js";
 import { clientToolService } from "../../src/server/client-tools-service.js";
 import {
@@ -285,6 +292,8 @@ function createMockAttachedStream(
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+	vi.unstubAllGlobals();
 	for (const request of serverRequestManager.listPending()) {
 		serverRequestManager.cancel(request.id, "Test cleanup");
 	}
@@ -2801,6 +2810,110 @@ describe("headless session handlers", () => {
 					cwd: resolvedWorkspaceRoot,
 				},
 			});
+		} finally {
+			await rm(workspaceRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("records hosted session starts in Platform agent-runtime when configured", async () => {
+		const workspaceRoot = await mkdtemp(
+			join(tmpdir(), "maestro-headless-runtime-ledger-"),
+		);
+		try {
+			vi.stubEnv("MAESTRO_AGENT_RUNTIME_SERVICE_URL", "https://runtime.test/");
+			vi.stubEnv("MAESTRO_AGENT_RUNTIME_SERVICE_TOKEN", "runtime-token");
+			vi.stubEnv("MAESTRO_AGENT_RUNTIME_ORG_ID", "org_1");
+			vi.stubEnv("MAESTRO_AGENT_RUNTIME_WORKSPACE_ID", "ws_env");
+
+			const requests: Record<string, unknown>[] = [];
+			const fetchMock = vi.fn(
+				async (input: RequestInfo | URL, init?: RequestInit) => {
+					expect(String(input)).toBe(
+						"https://runtime.test/agentruntime.v1.AgentRuntimeService/HandleTrigger",
+					);
+					requests.push(
+						JSON.parse(String(init?.body)) as Record<string, unknown>,
+					);
+					return new Response(
+						JSON.stringify({
+							run: {
+								id: "agent_run_123",
+								state: PlatformAgentRunStateValue.Accepted,
+								linkage: {
+									runId: "agent_run_123",
+									workspaceId: "ws_hosted",
+									agentId: "maestro",
+								},
+							},
+							events: [],
+							idempotentReplay: false,
+						}),
+						{ status: 200 },
+					);
+				},
+			);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const createAgent = vi.fn().mockResolvedValue(new FakeAgent());
+			const context = createContext({
+				createAgent,
+				hostedRunner: {
+					enabled: true,
+					runnerSessionId: "mrs_test",
+					ownerInstanceId: "pod-a",
+					workspaceRoot,
+					workspaceId: "ws_hosted",
+				},
+			});
+			const req = createJsonRequest("POST", "/api/headless/sessions", {
+				model: TEST_MODEL.id,
+				workspaceRoot,
+				client: "vscode",
+				protocolVersion: "headless.v1",
+			});
+			const res = new MockResponse();
+			res.req = req;
+
+			await handleHeadlessSessionCreate(
+				req,
+				res as unknown as ServerResponse,
+				context,
+			);
+
+			const snapshot = JSON.parse(res.body) as { session_id: string };
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(requests[0]).toMatchObject({
+				trigger: {
+					workspaceId: "ws_hosted",
+					agentId: "maestro",
+					channelId: `maestro-session:${snapshot.session_id}`,
+					idempotencyKey: `maestro-session:ws_hosted:${snapshot.session_id}`,
+					sourceEventType: MaestroAgentRuntimeSourceEventType.SessionStarted,
+					surfaceType: PlatformSurfaceValue.Maestro,
+					triggerKind: PlatformRuntimeTriggerKindValue.Api,
+					channelContext: {
+						channelKind: PlatformRuntimeChannelKindValue.Api,
+						providerWorkspaceId: "ws_hosted",
+						threadId: snapshot.session_id,
+					},
+					payload: {
+						maestroSessionId: snapshot.session_id,
+						metadata: {
+							model: TEST_MODEL.id,
+							provider: TEST_MODEL.provider,
+							role: "controller",
+							thinking_level: "off",
+							approval_mode: "prompt",
+							client: "vscode",
+							protocol_version: "headless.v1",
+							workspace_root: realpathSync(workspaceRoot),
+							runner_session_id: "mrs_test",
+							owner_instance_id: "pod-a",
+						},
+					},
+				},
+			});
+			expect(context.hostedRunner?.agentRunId).toBe("agent_run_123");
 		} finally {
 			await rm(workspaceRoot, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary
- record headless session creation through Maestro's Platform AgentRuntime client when configured
- include hosted runner/workspace/model/session metadata and persist the returned AgentRun id on the hosted runner context
- avoid duplicate AgentRuntime triggers when clients only create an additional connection

## Test Plan
- npm test -- test/web/headless-sessions.test.ts test/platform/agent-runtime-client.test.ts
- bunx biome check src/server/handlers/headless-sessions.ts test/web/headless-sessions.test.ts
- npm run build
- git diff --check HEAD~1..HEAD

Advances #72.

Source-of-truth PR: evalops/maestro-internal#1481
