### PR TITLE
Expose hosted runner drain signal

### DIFF
--- a/src/server/app-context.ts
+++ b/src/server/app-context.ts
@@ -34,6 +34,13 @@ export interface HostedRunnerContext {
 	configuredMaestroSessionId?: string;
 	activeMaestroSessionId?: string;
 	draining?: boolean;
+	lastDrain?: {
+		status: string;
+		manifestPath: string;
+		drainedAt: string;
+		reason?: string;
+		requestedBy?: string;
+	};
 }
 
 export interface WebServerServices {

--- a/src/server/handlers/health.ts
+++ b/src/server/handlers/health.ts
@@ -30,6 +30,13 @@ export interface HealthCheckResult {
 			workspaceId?: string;
 			agentRunId?: string;
 			maestroSessionId?: string;
+			lastDrain?: {
+				status: string;
+				manifestPath: string;
+				drainedAt: string;
+				reason?: string;
+				requestedBy?: string;
+			};
 			error?: string;
 		};
 	};
@@ -67,6 +74,9 @@ export async function checkHostedRunnerReadiness(
 		maestroSessionId:
 			hostedRunner.activeMaestroSessionId ??
 			hostedRunner.configuredMaestroSessionId,
+		...(hostedRunner.lastDrain
+			? { lastDrain: { ...hostedRunner.lastDrain } }
+			: {}),
 	};
 	if (hostedRunner.draining) {
 		return {

--- a/src/server/handlers/hosted-runner-drain.ts
+++ b/src/server/handlers/hosted-runner-drain.ts
@@ -511,6 +511,13 @@ export async function drainHostedRunner(
 		`${JSON.stringify(manifest, null, 2)}\n`,
 		"utf8",
 	);
+	hostedRunner.lastDrain = {
+		status,
+		manifestPath: snapshotPath,
+		drainedAt: requestedAt,
+		...(input.reason ? { reason: input.reason } : {}),
+		...(input.requestedBy ? { requestedBy: input.requestedBy } : {}),
+	};
 
 	return {
 		status,

--- a/src/server/handlers/hosted-runner-identity.ts
+++ b/src/server/handlers/hosted-runner-identity.ts
@@ -15,6 +15,9 @@ export interface HostedRunnerIdentity {
 	owner_instance_id: string;
 	ready: boolean;
 	draining: boolean;
+	drain_status?: string;
+	drain_manifest_path?: string;
+	drained_at?: string;
 }
 
 export async function buildHostedRunnerIdentity(
@@ -33,6 +36,15 @@ export async function buildHostedRunnerIdentity(
 		owner_instance_id: hostedRunner.ownerInstanceId,
 		ready: readiness.status === "ready",
 		draining,
+		...(hostedRunner.lastDrain?.status
+			? { drain_status: hostedRunner.lastDrain.status }
+			: {}),
+		...(hostedRunner.lastDrain?.manifestPath
+			? { drain_manifest_path: hostedRunner.lastDrain.manifestPath }
+			: {}),
+		...(hostedRunner.lastDrain?.drainedAt
+			? { drained_at: hostedRunner.lastDrain.drainedAt }
+			: {}),
 	};
 }
 

--- a/test/server/health.test.ts
+++ b/test/server/health.test.ts
@@ -50,10 +50,24 @@ describe("runHealthChecks", () => {
 				runnerSessionId: "mrs_123",
 				workspaceRoot,
 				draining: true,
+				lastDrain: {
+					status: "drained",
+					manifestPath: "/workspace/.maestro/runner-snapshots/mrs_123.json",
+					drainedAt: "2026-04-23T00:00:00.000Z",
+					reason: "kubernetes_prestop",
+					requestedBy: "kubernetes_prestop",
+				},
 			},
 		});
 
 		expect(result.status).toBe("unhealthy");
 		expect(result.checks.hostedRunner?.status).toBe("draining");
+		expect(result.checks.hostedRunner?.lastDrain).toMatchObject({
+			status: "drained",
+			manifestPath: "/workspace/.maestro/runner-snapshots/mrs_123.json",
+			drainedAt: "2026-04-23T00:00:00.000Z",
+			reason: "kubernetes_prestop",
+			requestedBy: "kubernetes_prestop",
+		});
 	});
 });

--- a/test/server/hosted-runner-drain.test.ts
+++ b/test/server/hosted-runner-drain.test.ts
@@ -112,6 +112,13 @@ describe("hosted runner drain", () => {
 		expect(result?.reason).toBe("ttl_expired");
 		expect(result?.requested_by).toBe("platform");
 		expect(context.draining).toBe(true);
+		expect(context.lastDrain).toMatchObject({
+			status: HostedRunnerDrainStatusValue.Drained,
+			manifestPath: result?.manifest_path,
+			drainedAt: "2026-04-23T00:00:00.000Z",
+			reason: "ttl_expired",
+			requestedBy: "platform",
+		});
 		expect(drainRuntime).toHaveBeenCalledWith("session_123");
 		expect(result?.manifest).toMatchObject({
 			protocol_version: HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,

--- a/test/server/hosted-runner-identity.test.ts
+++ b/test/server/hosted-runner-identity.test.ts
@@ -51,12 +51,20 @@ describe("hosted runner identity", () => {
 				ownerInstanceId: "pod_123",
 				workspaceRoot,
 				draining: true,
+				lastDrain: {
+					status: "drained",
+					manifestPath: "/workspace/.maestro/runner-snapshots/mrs_123.json",
+					drainedAt: "2026-04-23T00:00:00.000Z",
+				},
 			}),
 		).resolves.toMatchObject({
 			runner_session_id: "mrs_123",
 			owner_instance_id: "pod_123",
 			ready: false,
 			draining: true,
+			drain_status: "drained",
+			drain_manifest_path: "/workspace/.maestro/runner-snapshots/mrs_123.json",
+			drained_at: "2026-04-23T00:00:00.000Z",
 		});
 	});
 


### PR DESCRIPTION
## Summary
- persist the latest hosted-runner drain status, manifest path, timestamp, reason, and requester on the runner context
- expose that drain signal through hosted runner readiness and identity responses while a pod is draining
- cover drain, health, and identity responses so future durable routing/drain controllers can discover the final snapshot manifest

## Test plan
- `bunx biome check src/server/app-context.ts src/server/handlers/hosted-runner-drain.ts src/server/handlers/health.ts src/server/handlers/hosted-runner-identity.ts test/server/hosted-runner-drain.test.ts test/server/health.test.ts test/server/hosted-runner-identity.test.ts`
- `npm test -- test/server/hosted-runner-drain.test.ts test/server/health.test.ts test/server/hosted-runner-identity.test.ts test/web/headless-sessions.test.ts -t "drain|draining|identity|readiness"`
- `git diff --check`

Related to #78 and #76


Internal source PR: evalops/maestro-internal#1482