### PR TITLE
Add runtime context to Platform tool executions

### DIFF
--- a/docs/design/PLATFORM_TOOL_EXECUTION_BRIDGE.md
+++ b/docs/design/PLATFORM_TOOL_EXECUTION_BRIDGE.md
@@ -112,7 +112,9 @@ Each governed or observed call builds a Platform `ExecuteTool` request with:
 - sanitized arguments only
 - risk level and retry policy
 - metadata carrying Maestro correlation fields such as session ID, remote-runner
-  session ID, display labels, and redaction state
+  session ID, AgentRun ID, AgentRun step ID, actor ID, correlation ID, cwd,
+  workspace root, repository root/name, git branch, git commit, display labels,
+  and redaction state
 
 Observe-only result recording adds:
 
@@ -122,6 +124,12 @@ Observe-only result recording adds:
 
 Only a short scrubbed output summary leaves Maestro. Secret-like tokens are
 redacted before the summary is sent.
+
+The runtime context metadata is built from explicit Maestro/CI environment
+variables such as `MAESTRO_CWD`, `MAESTRO_WORKSPACE_ROOT`,
+`MAESTRO_REPOSITORY_ROOT`, `MAESTRO_GIT_REPOSITORY`, `MAESTRO_GIT_BRANCH`, and
+`MAESTRO_GIT_COMMIT`, with `process.cwd()` as the cwd fallback. Maestro does not
+shell out while preparing the Platform request.
 
 ## Flow
 

--- a/src/agent/transport/tool-execution-bridge.ts
+++ b/src/agent/transport/tool-execution-bridge.ts
@@ -34,6 +34,7 @@ import type {
 const logger = createLogger("transport:tool-execution-bridge");
 
 const OBSERVE_OUTPUT_SUMMARY_MAX_LENGTH = 280;
+const METADATA_VALUE_MAX_LENGTH = 512;
 const READ_ONLY_BASH_PREFIXES = [
 	"cat",
 	"cd",
@@ -193,6 +194,38 @@ function getEnvValue(names: readonly string[]): string | undefined {
 		}
 	}
 	return undefined;
+}
+
+function metadataValue(value: string | undefined): string | undefined {
+	const normalized = value
+		?.split("")
+		.map((char) => {
+			const codePoint = char.codePointAt(0);
+			return codePoint !== undefined && (codePoint < 32 || codePoint === 127)
+				? " "
+				: char;
+		})
+		.join("");
+	const trimmed = trimString(normalized);
+	if (!trimmed) {
+		return undefined;
+	}
+	if (trimmed.length <= METADATA_VALUE_MAX_LENGTH) {
+		return trimmed;
+	}
+	return `${trimmed.slice(0, METADATA_VALUE_MAX_LENGTH - 3).trimEnd()}...`;
+}
+
+function getMetadataEnvValue(names: readonly string[]): string | undefined {
+	return metadataValue(getEnvValue(names));
+}
+
+function getCurrentWorkingDirectory(): string | undefined {
+	try {
+		return metadataValue(process.cwd());
+	} catch {
+		return undefined;
+	}
 }
 
 function buildShellCommandSummary(command: string): string {
@@ -430,9 +463,60 @@ function buildLinkage(
 	};
 }
 
+function buildRuntimeContextMetadata(
+	linkage: ToolExecutionLinkage,
+): Record<string, string> {
+	const cwd =
+		getMetadataEnvValue(["MAESTRO_CWD"]) ?? getCurrentWorkingDirectory();
+	const workspaceRoot = getMetadataEnvValue([
+		"MAESTRO_WORKSPACE_ROOT",
+		"WORKSPACE_ROOT",
+	]);
+	const repositoryRoot =
+		getMetadataEnvValue([
+			"MAESTRO_REPOSITORY_ROOT",
+			"MAESTRO_REPO_ROOT",
+			"GITHUB_WORKSPACE",
+		]) ?? workspaceRoot;
+	const repository = getMetadataEnvValue([
+		"MAESTRO_GIT_REPOSITORY",
+		"GITHUB_REPOSITORY",
+		"CI_PROJECT_PATH",
+	]);
+	const gitBranch = getMetadataEnvValue([
+		"MAESTRO_GIT_BRANCH",
+		"GITHUB_HEAD_REF",
+		"GITHUB_REF_NAME",
+		"CI_COMMIT_REF_NAME",
+		"VERCEL_GIT_COMMIT_REF",
+	]);
+	const gitCommit = getMetadataEnvValue([
+		"MAESTRO_GIT_COMMIT",
+		"GITHUB_SHA",
+		"CI_COMMIT_SHA",
+		"VERCEL_GIT_COMMIT_SHA",
+	]);
+
+	return {
+		...(linkage.runId ? { maestro_agent_run_id: linkage.runId } : {}),
+		maestro_agent_run_step_id: linkage.stepId,
+		...(linkage.actorId ? { maestro_actor_id: linkage.actorId } : {}),
+		...(linkage.correlationId
+			? { maestro_correlation_id: linkage.correlationId }
+			: {}),
+		...(cwd ? { maestro_cwd: cwd } : {}),
+		...(workspaceRoot ? { maestro_workspace_root: workspaceRoot } : {}),
+		...(repositoryRoot ? { maestro_repository_root: repositoryRoot } : {}),
+		...(repository ? { maestro_repository: repository } : {}),
+		...(gitBranch ? { maestro_git_branch: gitBranch } : {}),
+		...(gitCommit ? { maestro_git_commit: gitCommit } : {}),
+	};
+}
+
 function buildMetadata(
 	input: ToolExecutionBridgeInput,
 	classification: ToolExecutionClassification,
+	linkage: ToolExecutionLinkage,
 ): Record<string, string> {
 	const originalArgs = input.toolCall.arguments as Record<string, unknown>;
 	const redactedArguments =
@@ -446,6 +530,7 @@ function buildMetadata(
 	return {
 		maestro_bridge_mode: classification.mode,
 		maestro_tool_call_id: input.toolCall.id,
+		...buildRuntimeContextMetadata(linkage),
 		...(sessionId ? { maestro_session_id: sessionId } : {}),
 		...(remoteRunnerSessionId
 			? { maestro_remote_runner_session_id: remoteRunnerSessionId }
@@ -470,13 +555,14 @@ function buildExecuteRequest(
 	config: ToolExecutionServiceConfig,
 	classification: ToolExecutionClassification,
 ): ExecutePlatformToolRequest {
+	const linkage = buildLinkage(
+		input.cfg,
+		input.toolCall,
+		config.organizationId,
+		config.workspaceId ?? process.cwd(),
+	);
 	return {
-		linkage: buildLinkage(
-			input.cfg,
-			input.toolCall,
-			config.organizationId,
-			config.workspaceId ?? process.cwd(),
-		),
+		linkage,
 		tool: classification.tool,
 		...(classification.connector
 			? { connector: classification.connector }
@@ -490,7 +576,7 @@ function buildExecuteRequest(
 			allowNonIdempotentRetry: false,
 		},
 		idempotencyKey: `maestro:${input.toolCall.id}`,
-		metadata: buildMetadata(input, classification),
+		metadata: buildMetadata(input, classification, linkage),
 	};
 }
 

--- a/test/agent/tool-execution-bridge.test.ts
+++ b/test/agent/tool-execution-bridge.test.ts
@@ -90,8 +90,18 @@ describe("tool execution bridge", () => {
 		vi.stubEnv("MAESTRO_AGENT_RUN_ID", "run_1");
 		vi.stubEnv("MAESTRO_AGENT_ID", "maestro");
 		vi.stubEnv("MAESTRO_SURFACE", "cli");
+		vi.stubEnv("MAESTRO_CHANNEL_ID", "cli:local");
 		vi.stubEnv("MAESTRO_SESSION_ID", "sess_1");
 		vi.stubEnv("MAESTRO_REMOTE_RUNNER_SESSION_ID", "rrs_1");
+		vi.stubEnv("MAESTRO_CWD", "/workspace/evalops/maestro");
+		vi.stubEnv("MAESTRO_WORKSPACE_ROOT", "/workspace/evalops/maestro");
+		vi.stubEnv("MAESTRO_REPOSITORY_ROOT", "/workspace/evalops/maestro");
+		vi.stubEnv("MAESTRO_GIT_REPOSITORY", "evalops/maestro");
+		vi.stubEnv("MAESTRO_GIT_BRANCH", "jh/platform-runtime-lifecycle");
+		vi.stubEnv(
+			"MAESTRO_GIT_COMMIT",
+			"0123456789abcdef0123456789abcdef01234567",
+		);
 	});
 
 	afterEach(() => {
@@ -161,6 +171,16 @@ describe("tool execution bridge", () => {
 			body: expect.objectContaining({
 				metadata: expect.objectContaining({
 					maestro_bridge_mode: "observe",
+					maestro_agent_run_id: "run_1",
+					maestro_agent_run_step_id: "tc_1",
+					maestro_actor_id: "user_1",
+					maestro_correlation_id: "sess_1:tc_1",
+					maestro_cwd: "/workspace/evalops/maestro",
+					maestro_workspace_root: "/workspace/evalops/maestro",
+					maestro_repository_root: "/workspace/evalops/maestro",
+					maestro_repository: "evalops/maestro",
+					maestro_git_branch: "jh/platform-runtime-lifecycle",
+					maestro_git_commit: "0123456789abcdef0123456789abcdef01234567",
 					maestro_local_outcome: "succeeded",
 					maestro_local_output_summary: "git status clean",
 				}),


### PR DESCRIPTION
## Summary
- include AgentRun, AgentRun step, actor, correlation, cwd, workspace root, repo, branch, and commit metadata on Maestro Platform ToolExecution requests
- normalize metadata values without shelling out while preparing the Platform request
- document the runtime-context env contract and pin it with focused bridge tests

## Verification
- `export PATH="/private/tmp/bun-1.3.6/bin:$PATH" && npm test -- test/agent/tool-execution-bridge.test.ts test/platform/tool-execution-client.test.ts`
- `export PATH="/private/tmp/bun-1.3.6/bin:$PATH" && bunx biome check src/agent/transport/tool-execution-bridge.ts test/agent/tool-execution-bridge.test.ts docs/design/PLATFORM_TOOL_EXECUTION_BRIDGE.md`
- `git diff --check`

Notes: the local pre-commit hook reached `prebuild` through system Bun 1.1.31 and failed on the repo lockfile version. The same focused checks above ran successfully with the repo-compatible Bun 1.3.6.

Source-of-truth internal PR: evalops/maestro-internal#1483.

Closes part of #171.