### PR TITLE
Simplify metadata control character scrubber

### DIFF
--- a/src/agent/transport/tool-execution-bridge.ts
+++ b/src/agent/transport/tool-execution-bridge.ts
@@ -197,15 +197,18 @@ function getEnvValue(names: readonly string[]): string | undefined {
 }
 
 function metadataValue(value: string | undefined): string | undefined {
-	const normalized = value
-		?.split("")
-		.map((char) => {
+	let normalized: string | undefined;
+	if (value !== undefined) {
+		let next = "";
+		for (const char of value) {
 			const codePoint = char.codePointAt(0);
-			return codePoint !== undefined && (codePoint < 32 || codePoint === 127)
-				? " "
-				: char;
-		})
-		.join("");
+			next +=
+				codePoint !== undefined && (codePoint < 32 || codePoint === 127)
+					? " "
+					: char;
+		}
+		normalized = next;
+	}
 	const trimmed = trimString(normalized);
 	if (!trimmed) {
 		return undefined;


### PR DESCRIPTION
## Summary
- address Cursor Bugbot feedback from #173 by replacing the split/map/join metadata scrubber with a direct `for...of` loop
- keep the control-character and DEL replacement behavior unchanged without using a regex that violates Biome rules

## Verification
- `export PATH="/private/tmp/bun-1.3.6/bin:$PATH" && npm test -- test/agent/tool-execution-bridge.test.ts test/platform/tool-execution-client.test.ts`
- `export PATH="/private/tmp/bun-1.3.6/bin:$PATH" && bunx biome check src/agent/transport/tool-execution-bridge.ts test/agent/tool-execution-bridge.test.ts docs/design/PLATFORM_TOOL_EXECUTION_BRIDGE.md`
- `git diff --check`

Source-of-truth internal PR: evalops/maestro-internal#1484.

Follow-up to #173 / #171.