### PR TITLE
Record governed tool outputs in Platform

### DIFF
--- a/src/agent/transport/tool-execution-bridge.ts
+++ b/src/agent/transport/tool-execution-bridge.ts
@@ -10,11 +10,13 @@ import {
 	type PlatformConnectorRef,
 	type PlatformToolExecutionRecord,
 	type PlatformToolRef,
+	type RecordPlatformToolExecutionOutputRequest,
 	type ResumePlatformToolExecutionRequest,
 	type ToolExecutionLinkage,
 	type ToolExecutionRiskLevel,
 	type ToolExecutionServiceConfig,
 	executeToolWithPlatform,
+	recordToolExecutionOutputWithPlatform,
 	resolveToolExecutionServiceConfig,
 	resumeToolExecutionWithPlatform,
 } from "../../platform/tool-execution-client.js";
@@ -440,6 +442,27 @@ function summarizeToolResult(result: ToolResultMessage): {
 	};
 }
 
+function buildOutputPayload(
+	result: ToolResultMessage,
+	durationMs: number | undefined,
+): RecordPlatformToolExecutionOutputRequest["output"] {
+	const summary = summarizeToolResult(result);
+	const safeOutput = {
+		status: result.isError ? "failed" : "succeeded",
+		tool_name: result.toolName,
+		tool_call_id: result.toolCallId,
+		summary: summary.summary,
+	};
+	return {
+		safeOutput,
+		redactions: summary.redactions,
+		contentType: "application/json",
+		...(durationMs !== undefined
+			? { durationMs: Math.max(0, Math.round(durationMs)) }
+			: {}),
+	};
+}
+
 function buildLinkage(
 	cfg: AgentRunConfig,
 	toolCall: ToolCall,
@@ -652,6 +675,12 @@ export interface PlatformToolExecutionBridge {
 		result: ToolResultMessage,
 		signal?: AbortSignal,
 	): Promise<ObserveToolExecutionResult>;
+	recordGovernedOutput(
+		plan: GovernedToolExecutionPlan,
+		result: ToolResultMessage,
+		durationMs?: number,
+		signal?: AbortSignal,
+	): Promise<ObserveToolExecutionResult>;
 }
 
 export class DefaultPlatformToolExecutionBridge
@@ -844,6 +873,56 @@ export class DefaultPlatformToolExecutionBridge
 				error: message,
 				toolName: plan.request.tool.name,
 				toolCallId: plan.request.metadata?.maestro_tool_call_id,
+			});
+			return { metadata: plan.metadata };
+		}
+	}
+
+	async recordGovernedOutput(
+		plan: GovernedToolExecutionPlan,
+		result: ToolResultMessage,
+		durationMs?: number,
+		signal?: AbortSignal,
+	): Promise<ObserveToolExecutionResult> {
+		const executionId = plan.metadata.toolExecutionId;
+		if (!executionId) {
+			return { metadata: plan.metadata };
+		}
+
+		const request: RecordPlatformToolExecutionOutputRequest = {
+			executionId,
+			output: buildOutputPayload(result, durationMs),
+			metadata: {
+				...plan.request.metadata,
+				maestro_bridge_mode: "governed",
+				maestro_local_outcome: result.isError ? "failed" : "succeeded",
+				maestro_tool_call_id: result.toolCallId,
+			},
+		};
+		try {
+			const response = await recordToolExecutionOutputWithPlatform(
+				plan.config,
+				request,
+				signal,
+			);
+			return {
+				metadata: {
+					toolExecutionId: response.execution.id ?? executionId,
+					approvalRequestId:
+						response.execution.approvalWait?.approvalRequestId ??
+						plan.metadata.approvalRequestId,
+				},
+			};
+		} catch (error) {
+			if (isAbortError(error)) {
+				throw error;
+			}
+			const message = error instanceof Error ? error.message : String(error);
+			logger.warn("Failed to record governed tool execution output", {
+				error: message,
+				toolName: plan.request.tool.name,
+				toolCallId: result.toolCallId,
+				toolExecutionId: executionId,
 			});
 			return { metadata: plan.metadata };
 		}

--- a/src/agent/transport/tool-execution.ts
+++ b/src/agent/transport/tool-execution.ts
@@ -556,11 +556,23 @@ export function createToolExecutionPromise(
 							signal,
 						)
 					: undefined;
+			const governedOutput =
+				toolExecutionBridge && toolExecutionBridgePlan?.kind === "governed"
+					? await toolExecutionBridge.recordGovernedOutput(
+							toolExecutionBridgePlan,
+							toolResultMsg,
+							clock.now() - startTime,
+							signal,
+						)
+					: undefined;
 
 			return {
 				message: toolResultMsg,
 				isError: toolResultMsg.isError,
-				...buildObservedResultMetadata(toolExecutionBridgePlan, observed),
+				...buildObservedResultMetadata(
+					toolExecutionBridgePlan,
+					observed ?? governedOutput,
+				),
 			};
 		} catch (error: unknown) {
 			if (error instanceof Error && error.name === "AbortError") {
@@ -621,11 +633,23 @@ export function createToolExecutionPromise(
 							signal,
 						)
 					: undefined;
+			const governedOutput =
+				toolExecutionBridge && toolExecutionBridgePlan?.kind === "governed"
+					? await toolExecutionBridge.recordGovernedOutput(
+							toolExecutionBridgePlan,
+							toolResultMsg,
+							clock.now() - startTime,
+							signal,
+						)
+					: undefined;
 
 			return {
 				message: toolResultMsg,
 				isError: true,
-				...buildObservedResultMetadata(toolExecutionBridgePlan, observed),
+				...buildObservedResultMetadata(
+					toolExecutionBridgePlan,
+					observed ?? governedOutput,
+				),
 			};
 		}
 	})();

--- a/src/platform/tool-execution-client.ts
+++ b/src/platform/tool-execution-client.ts
@@ -62,6 +62,9 @@ const EXECUTE_TOOL_PATH = platformConnectMethodPath(
 const RESUME_TOOL_EXECUTION_PATH = platformConnectMethodPath(
 	PLATFORM_CONNECT_METHODS.toolexecution.resumeToolExecution,
 );
+const RECORD_TOOL_EXECUTION_OUTPUT_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.toolexecution.recordToolExecutionOutput,
+);
 
 export type ToolExecutionRiskLevel =
 	| "RISK_LEVEL_UNSPECIFIED"
@@ -140,6 +143,29 @@ export interface ResumePlatformToolExecutionRequest {
 	reason?: string;
 }
 
+export interface PlatformToolOutputProposal {
+	kind: string;
+	targetRef?: string;
+	payload?: Record<string, unknown>;
+	metadata?: Record<string, string>;
+}
+
+export interface PlatformToolExecutionOutput {
+	rawOutput?: Record<string, unknown>;
+	safeOutput?: Record<string, unknown>;
+	proposals?: PlatformToolOutputProposal[];
+	redactions?: string[];
+	contentType?: string;
+	outputDigest?: string;
+	durationMs?: number;
+}
+
+export interface RecordPlatformToolExecutionOutputRequest {
+	executionId: string;
+	output: PlatformToolExecutionOutput;
+	metadata?: Record<string, string>;
+}
+
 export interface PlatformApprovalWait {
 	approvalRequestId?: string;
 	resumeToken?: string;
@@ -162,6 +188,10 @@ export interface ResumePlatformToolExecutionResponse {
 	execution: PlatformToolExecutionRecord;
 }
 
+export interface RecordPlatformToolExecutionOutputResponse {
+	execution: PlatformToolExecutionRecord;
+}
+
 export interface ToolExecutionServiceConfig extends PlatformServiceConfig {}
 
 function stripTrailingSlashes(value: string): string {
@@ -173,6 +203,7 @@ function normalizeBaseUrl(baseUrl: string): string {
 	for (const suffix of [
 		EXECUTE_TOOL_PATH,
 		RESUME_TOOL_EXECUTION_PATH,
+		RECORD_TOOL_EXECUTION_OUTPUT_PATH,
 		platformConnectServicePath(
 			PLATFORM_CONNECT_METHODS.toolexecution.executeTool.service,
 		),
@@ -197,6 +228,7 @@ export async function resolveToolExecutionServiceConfig(
 		baseUrlSuffixes: [
 			EXECUTE_TOOL_PATH,
 			RESUME_TOOL_EXECUTION_PATH,
+			RECORD_TOOL_EXECUTION_OUTPUT_PATH,
 			platformConnectServicePath(
 				PLATFORM_CONNECT_METHODS.toolexecution.executeTool.service,
 			),
@@ -373,6 +405,27 @@ function normalizeExecuteToolRequest(
 	});
 }
 
+function normalizeToolExecutionOutput(
+	output: PlatformToolExecutionOutput,
+): Record<string, unknown> {
+	return stripUndefinedValues({
+		rawOutput: output.rawOutput,
+		safeOutput: output.safeOutput,
+		proposals: output.proposals?.map((proposal) =>
+			stripUndefinedValues({
+				kind: proposal.kind,
+				targetRef: proposal.targetRef,
+				payload: proposal.payload,
+				metadata: proposal.metadata,
+			}),
+		),
+		redactions: output.redactions,
+		contentType: output.contentType,
+		outputDigest: output.outputDigest,
+		durationMs: output.durationMs,
+	});
+}
+
 async function parseJsonResponse(
 	response: Response,
 	serviceName: string,
@@ -429,6 +482,33 @@ export async function resumeToolExecutionWithPlatform(
 			approved: request.approved,
 			decidedBy: request.decidedBy,
 			reason: request.reason,
+		}),
+		{
+			serviceName: "tool execution service",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+			signal,
+		},
+	);
+	const payload = await parseJsonResponse(response, "tool execution service");
+	return {
+		execution: normalizeExecutionRecord(objectValue(payload, "execution")),
+	};
+}
+
+export async function recordToolExecutionOutputWithPlatform(
+	config: ToolExecutionServiceConfig,
+	request: RecordPlatformToolExecutionOutputRequest,
+	signal?: AbortSignal,
+): Promise<RecordPlatformToolExecutionOutputResponse> {
+	const response = await postPlatformConnect(
+		config,
+		RECORD_TOOL_EXECUTION_OUTPUT_PATH,
+		stripUndefinedValues({
+			executionId: request.executionId,
+			output: normalizeToolExecutionOutput(request.output),
+			metadata: request.metadata,
 		}),
 		{
 			serviceName: "tool execution service",

--- a/test/agent/tool-execution-bridge.test.ts
+++ b/test/agent/tool-execution-bridge.test.ts
@@ -471,6 +471,94 @@ describe("tool execution bridge", () => {
 		});
 	});
 
+	it("records governed local output against the Platform execution", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
+		]);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+				return new Response(
+					JSON.stringify({
+						execution: {
+							id: "texec_output_1",
+							state: "TOOL_EXECUTION_STATE_SUCCEEDED",
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		const prepared = await bridge.prepare({
+			cfg: baseConfig(),
+			toolCall: {
+				type: "toolCall",
+				id: "tc_output_1",
+				name: "bash",
+				arguments: { command: "git push" },
+			},
+			sanitizedArgs: { command: "git push" },
+		});
+		if (prepared.status !== "allow") {
+			throw new Error("expected allowed governed plan");
+		}
+
+		await expect(
+			bridge.recordGovernedOutput(
+				prepared.plan,
+				{
+					role: "toolResult",
+					toolCallId: "tc_output_1",
+					toolName: "bash",
+					content: [{ type: "text", text: "pushed main" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+				42,
+			),
+		).resolves.toEqual({
+			metadata: {
+				toolExecutionId: "texec_output_1",
+				approvalRequestId: undefined,
+			},
+		});
+
+		expect(requests[1]).toMatchObject({
+			pathname:
+				"/toolexecution.v1.ToolExecutionService/RecordToolExecutionOutput",
+			body: {
+				executionId: "texec_output_1",
+				output: {
+					safeOutput: {
+						status: "succeeded",
+						tool_name: "bash",
+						tool_call_id: "tc_output_1",
+						summary: "pushed main",
+					},
+					redactions: [],
+					contentType: "application/json",
+					durationMs: 42,
+				},
+				metadata: expect.objectContaining({
+					maestro_bridge_mode: "governed",
+					maestro_local_outcome: "succeeded",
+					maestro_tool_call_id: "tc_output_1",
+				}),
+			},
+		});
+	});
+
 	it("denies governed executions when Platform rejects them", async () => {
 		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
 			MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,

--- a/test/platform/tool-execution-client.test.ts
+++ b/test/platform/tool-execution-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	executeToolWithPlatform,
+	recordToolExecutionOutputWithPlatform,
 	resolveToolExecutionServiceConfig,
 	resumeToolExecutionWithPlatform,
 } from "../../src/platform/tool-execution-client.js";
@@ -97,6 +98,21 @@ describe("tool execution client", () => {
 				if (
 					parsed.pathname ===
 					"/toolexecution.v1.ToolExecutionService/ResumeToolExecution"
+				) {
+					return new Response(
+						JSON.stringify({
+							execution: {
+								id: "texec_1",
+								state: "TOOL_EXECUTION_STATE_SUCCEEDED",
+							},
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				if (
+					parsed.pathname ===
+					"/toolexecution.v1.ToolExecutionService/RecordToolExecutionOutput"
 				) {
 					return new Response(
 						JSON.stringify({
@@ -224,6 +240,54 @@ describe("tool execution client", () => {
 			approved: true,
 			decidedBy: "user_1",
 			reason: "approved in ui",
+		});
+	});
+
+	it("records local execution output through the shared connect catalog", async () => {
+		const config = await resolveToolExecutionServiceConfig();
+		if (!config) {
+			throw new Error("expected tool execution config");
+		}
+
+		await expect(
+			recordToolExecutionOutputWithPlatform(config, {
+				executionId: "texec_1",
+				output: {
+					safeOutput: {
+						status: "succeeded",
+						summary: "git status clean",
+					},
+					redactions: [],
+					contentType: "application/json",
+					durationMs: 42,
+				},
+				metadata: {
+					maestro_local_outcome: "succeeded",
+				},
+			}),
+		).resolves.toMatchObject({
+			execution: {
+				id: "texec_1",
+				state: "TOOL_EXECUTION_STATE_SUCCEEDED",
+			},
+		});
+
+		expect(requests[0]?.pathname).toBe(
+			"/toolexecution.v1.ToolExecutionService/RecordToolExecutionOutput",
+		);
+		expect(requests[0]?.body).toMatchObject({
+			executionId: "texec_1",
+			output: {
+				safeOutput: {
+					status: "succeeded",
+					summary: "git status clean",
+				},
+				contentType: "application/json",
+				durationMs: 42,
+			},
+			metadata: {
+				maestro_local_outcome: "succeeded",
+			},
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- add a typed `RecordToolExecutionOutput` client for Platform ToolExecution
- record governed Maestro local tool results back to Platform after execution completes
- cover the output-recording client and governed-output bridge behavior with focused tests

Source of truth: evalops/maestro-internal#1485

## Test plan
- `npm test -- test/platform/tool-execution-client.test.ts test/agent/tool-execution-bridge.test.ts test/agent/tool-execution-retry.test.ts`
- `bunx biome check src/platform/tool-execution-client.ts src/agent/transport/tool-execution-bridge.ts src/agent/transport/tool-execution.ts test/platform/tool-execution-client.test.ts test/agent/tool-execution-bridge.test.ts`
- `git diff --check`

Note: local repo-wide `bunx tsc -p tsconfig.build.json --noEmit` is currently blocked by workspace package resolution for `@evalops/tui` / `@evalops/contracts` in this scratch worktree; the touched files are covered by the focused test/Biome pass above.
