### PR TITLE
Simplify tool metadata control cleanup

### DIFF
--- a/src/agent/transport/tool-execution-bridge.ts
+++ b/src/agent/transport/tool-execution-bridge.ts
@@ -199,18 +199,8 @@ function getEnvValue(names: readonly string[]): string | undefined {
 }
 
 function metadataValue(value: string | undefined): string | undefined {
-	let normalized: string | undefined;
-	if (value !== undefined) {
-		let next = "";
-		for (const char of value) {
-			const codePoint = char.codePointAt(0);
-			next +=
-				codePoint !== undefined && (codePoint < 32 || codePoint === 127)
-					? " "
-					: char;
-		}
-		normalized = next;
-	}
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: metadata must neutralize C0 control characters and DEL.
+	const normalized = value?.replace(/[\x00-\x1f\x7f]/gu, " ");
 	const trimmed = trimString(normalized);
 	if (!trimmed) {
 		return undefined;


### PR DESCRIPTION
## Summary
- replace manual metadata control-character normalization with a direct C0/DEL regex replacement
- keep the existing trimming and metadata length cap behavior unchanged

## Test plan
- ~/.bun/bin/bun install --frozen-lockfile
- ~/.bun/bin/bun run --filter @evalops/contracts build
- ~/.bun/bin/bun run --filter @evalops/tui build
- ./node_modules/.bin/tsc -p tsconfig.build.json --noEmit --pretty false
- ./node_modules/.bin/biome check src/agent/transport/tool-execution-bridge.ts
- git diff --check

## Source provenance
- evalops/maestro-internal#1488