### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/scripts/generate-maestro-platform-replay-fixture.ts
+++ b/scripts/generate-maestro-platform-replay-fixture.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env tsx
+import { canonicalMaestroPlatformReplayFixtureJson } from "../src/telemetry/maestro-platform-replay-fixture.js";
+
+process.stdout.write(canonicalMaestroPlatformReplayFixtureJson());

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -85,6 +85,14 @@ export {
 	type ToolCallResultEventData,
 } from "./maestro-event-bus.js";
 
+export {
+	CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+	buildCanonicalMaestroPlatformReplayFixture,
+	canonicalMaestroPlatformReplayFixtureJson,
+	type MaestroPlatformReplayFixture,
+	type MaestroPlatformReplayFixtureEvent,
+} from "./maestro-platform-replay-fixture.js";
+
 // Wide events (canonical turn events)
 export {
 	TurnCollector,

--- a/src/telemetry/maestro-platform-replay-fixture.ts
+++ b/src/telemetry/maestro-platform-replay-fixture.ts
@@ -1,0 +1,477 @@
+import {
+	MaestroBusEventType,
+	type MaestroCloudEvent,
+	type MaestroCorrelation,
+	type MaestroPrincipal,
+	buildMaestroCloudEvent,
+} from "./maestro-event-bus.js";
+
+export const CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME =
+	"canonical-maestro-session-platform-replay";
+
+const ORGANIZATION_ID = "org_evalops_fixture";
+const WORKSPACE_ID = "workspace_platform_replay";
+const SESSION_ID = "session_platform_replay_001";
+const AGENT_RUN_ID = "agent_run_platform_replay_001";
+const BASH_TOOL_CALL_ID = "tool_call_platform_replay_bash_001";
+const BASH_TOOL_EXECUTION_ID = "tool_exec_platform_replay_bash_001";
+const SKILL_TOOL_CALL_ID = "tool_call_platform_replay_skill_001";
+const SKILL_TOOL_EXECUTION_ID = "tool_exec_platform_replay_skill_001";
+const APPROVAL_REQUEST_ID = "approval_platform_replay_001";
+const SKILL_ID = "skill_incident_review";
+
+const promptMetadata = {
+	name: "maestro-system",
+	label: "production",
+	surface: "web",
+	version: 9,
+	versionId: "prompt_version_9",
+	hash: "sha256:prompt-platform-replay",
+	source: "service",
+};
+
+const skillMetadata = {
+	name: "incident-review",
+	hash: "sha256:skill-incident-review",
+	source: "service",
+	artifactId: SKILL_ID,
+	version: "3",
+};
+
+const baseCorrelation: MaestroCorrelation = {
+	organization_id: ORGANIZATION_ID,
+	workspace_id: WORKSPACE_ID,
+	session_id: SESSION_ID,
+	agent_run_id: AGENT_RUN_ID,
+	agent_run_step_id: "agent_run_step_platform_replay_001",
+	agent_id: "agent_maestro_platform_replay",
+	actor_id: "user_platform_replay",
+	principal_id: "principal_platform_replay",
+	trace_id: "trace_platform_replay_001",
+	request_id: "request_platform_replay_001",
+	remote_runner_session_id: "remote_runner_platform_replay_001",
+	objective_id: "objective_platform_replay_001",
+	conversation_id: "conversation_platform_replay_001",
+	attributes: {
+		fixture: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+	},
+};
+
+const principal: MaestroPrincipal = {
+	subject: "user:platform-replay@example.com",
+	user_id: "user_platform_replay",
+	organization_id: ORGANIZATION_ID,
+	workspace_id: WORKSPACE_ID,
+	roles: ["developer"],
+	scopes: ["maestro:run", "tool:execute"],
+	claims: {
+		auth_provider: "fixture",
+	},
+};
+
+const fixtureEnv: NodeJS.ProcessEnv = {
+	MAESTRO_EVENT_BUS_URL: "nats://maestro-fixture.invalid:4222",
+	MAESTRO_EVENT_BUS_SOURCE: "maestro-fixture",
+	MAESTRO_EVALOPS_ORG_ID: ORGANIZATION_ID,
+	MAESTRO_EVALOPS_WORKSPACE_ID: WORKSPACE_ID,
+	MAESTRO_SESSION_ID: SESSION_ID,
+	MAESTRO_AGENT_RUN_ID: AGENT_RUN_ID,
+	MAESTRO_AGENT_ID: baseCorrelation.agent_id,
+	MAESTRO_ACTOR_ID: baseCorrelation.actor_id,
+	MAESTRO_PRINCIPAL_ID: baseCorrelation.principal_id,
+	MAESTRO_REQUEST_ID: baseCorrelation.request_id,
+	MAESTRO_REMOTE_RUNNER_SESSION_ID: baseCorrelation.remote_runner_session_id,
+	MAESTRO_OBJECTIVE_ID: baseCorrelation.objective_id,
+	MAESTRO_CONVERSATION_ID: baseCorrelation.conversation_id,
+	MAESTRO_SURFACE: "web",
+	MAESTRO_RUNTIME_MODE: "hosted",
+};
+
+const eventPlan = [
+	{
+		type: MaestroBusEventType.SessionStarted,
+		id: "evt_maestro_replay_001_session_started",
+		time: "2026-04-23T18:00:00.000Z",
+	},
+	{
+		type: MaestroBusEventType.PromptVariantSelected,
+		id: "evt_maestro_replay_002_prompt_variant_selected",
+		time: "2026-04-23T18:01:00.000Z",
+	},
+	{
+		type: MaestroBusEventType.ToolCallAttempted,
+		id: "evt_maestro_replay_003_skill_tool_call_attempted",
+		time: "2026-04-23T18:02:00.000Z",
+	},
+	{
+		type: MaestroBusEventType.ToolCallCompleted,
+		id: "evt_maestro_replay_004_skill_tool_call_completed",
+		time: "2026-04-23T18:03:00.000Z",
+	},
+	{
+		type: MaestroBusEventType.SkillInvoked,
+		id: "evt_maestro_replay_005_skill_invoked",
+		time: "2026-04-23T18:04:00.000Z",
+	},
+	{
+		type: MaestroBusEventType.ApprovalHit,
+		id: "evt_maestro_replay_006_approval_hit",
+		time: "2026-04-23T18:05:00.000Z",
+	},
+	{
+		type: MaestroBusEventType.ToolCallAttempted,
+		id: "evt_maestro_replay_007_eval_tool_call_attempted",
+		time: "2026-04-23T18:06:00.000Z",
+	},
+	{
+		type: MaestroBusEventType.ToolCallCompleted,
+		id: "evt_maestro_replay_008_eval_tool_call_completed",
+		time: "2026-04-23T18:07:00.000Z",
+	},
+	{
+		type: MaestroBusEventType.EvalScored,
+		id: "evt_maestro_replay_009_eval_scored",
+		time: "2026-04-23T18:08:00.000Z",
+	},
+	{
+		type: MaestroBusEventType.SkillFailed,
+		id: "evt_maestro_replay_010_skill_failed",
+		time: "2026-04-23T18:09:00.000Z",
+	},
+	{
+		type: MaestroBusEventType.SessionClosed,
+		id: "evt_maestro_replay_011_session_closed",
+		time: "2026-04-23T18:10:00.000Z",
+	},
+] as const;
+
+export type MaestroPlatformReplayFixtureEvent = MaestroCloudEvent<
+	Record<string, unknown>
+>;
+
+export interface MaestroPlatformReplayFixture {
+	fixture_version: "maestro-platform-replay/v1";
+	name: typeof CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME;
+	event_count: number;
+	correlation: Record<string, string>;
+	subjects: MaestroBusEventType[];
+	events: MaestroPlatformReplayFixtureEvent[];
+	expected_assertions: {
+		required_event_types: MaestroBusEventType[];
+		required_subjects: MaestroBusEventType[];
+		platform_join_keys: Record<string, string>;
+		timeline: Array<{
+			type: MaestroBusEventType;
+			title: string;
+			visible: boolean;
+		}>;
+	};
+}
+
+function eventFor(
+	type: MaestroBusEventType,
+	data: Record<string, unknown>,
+	index: number,
+	agentRunStepId?: string,
+): MaestroPlatformReplayFixtureEvent {
+	const plan = eventPlan[index];
+	if (!plan) {
+		throw new Error(
+			`missing Maestro platform replay event plan at index ${index}`,
+		);
+	}
+	const stepId =
+		agentRunStepId ??
+		(typeof data.tool_call_id === "string" ? data.tool_call_id : undefined) ??
+		baseCorrelation.agent_run_step_id;
+	return buildMaestroCloudEvent(
+		type,
+		{
+			correlation: {
+				...baseCorrelation,
+				agent_run_step_id: stepId,
+			},
+			...data,
+		},
+		{
+			env: fixtureEnv,
+			eventId: plan.id,
+			time: plan.time,
+		},
+	);
+}
+
+function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
+	return [
+		eventFor(
+			MaestroBusEventType.SessionStarted,
+			{
+				state: "MAESTRO_SESSION_STATE_STARTED",
+				surface: "MAESTRO_SURFACE_WEB",
+				runtime_mode: "MAESTRO_RUNTIME_MODE_HOSTED",
+				principal,
+				workspace_root: "/workspace/evalops/platform-replay",
+				repository: "evalops/maestro-internal",
+				git_ref: "refs/heads/codex/maestro-platform-replay-fixture",
+				runtime_version: "0.0.0-fixture",
+				runner_profile: "hosted-standard",
+				started_at: eventPlan[0].time,
+				metadata: {
+					fixture: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+				},
+			},
+			0,
+		),
+		eventFor(
+			MaestroBusEventType.PromptVariantSelected,
+			{
+				prompt_metadata: promptMetadata,
+				selected_at: eventPlan[1].time,
+			},
+			1,
+		),
+		eventFor(
+			MaestroBusEventType.ToolCallAttempted,
+			{
+				tool_call_id: SKILL_TOOL_CALL_ID,
+				tool_execution_id: SKILL_TOOL_EXECUTION_ID,
+				prompt_metadata: promptMetadata,
+				tool_namespace: "builtin",
+				tool_name: "Skill",
+				tool_version: "1",
+				capability: "skill:invoke",
+				mutates_resource: false,
+				risk_level: "RISK_LEVEL_LOW",
+				safe_arguments: {
+					skill_id: SKILL_ID,
+				},
+				idempotency_key: "idempotency_platform_replay_skill_001",
+				attempted_at: eventPlan[2].time,
+			},
+			2,
+		),
+		eventFor(
+			MaestroBusEventType.ToolCallCompleted,
+			{
+				tool_call_id: SKILL_TOOL_CALL_ID,
+				tool_execution_id: SKILL_TOOL_EXECUTION_ID,
+				prompt_metadata: promptMetadata,
+				skill_metadata: skillMetadata,
+				status: "MAESTRO_TOOL_CALL_STATUS_SUCCEEDED",
+				duration: "1.111s",
+				safe_output: {
+					summary: "Skill selected incident review workflow",
+				},
+				completed_at: eventPlan[3].time,
+			},
+			3,
+		),
+		eventFor(
+			MaestroBusEventType.SkillInvoked,
+			{
+				prompt_metadata: promptMetadata,
+				skill_metadata: skillMetadata,
+				tool_call_id: SKILL_TOOL_CALL_ID,
+				tool_execution_id: SKILL_TOOL_EXECUTION_ID,
+				invoked_at: eventPlan[4].time,
+			},
+			4,
+		),
+		eventFor(
+			MaestroBusEventType.ApprovalHit,
+			{
+				approval_request_id: APPROVAL_REQUEST_ID,
+				governance_decision_id: "governance_decision_platform_replay_001",
+				action: "Run workspace test command",
+				command: "bunx vitest --run test/telemetry",
+				risk_level: "RISK_LEVEL_MEDIUM",
+				decision_mode: "MAESTRO_DECISION_MODE_REQUIRE_APPROVAL",
+				policy_id: "policy_workspace_test_approval",
+				reason: "fixture approval path",
+				context: {
+					tool_name: "Bash",
+					display_name: "Bash",
+					summary_label: "Bash",
+					args: {
+						command: "bunx vitest --run test/telemetry",
+					},
+				},
+				occurred_at: eventPlan[5].time,
+			},
+			5,
+			BASH_TOOL_CALL_ID,
+		),
+		eventFor(
+			MaestroBusEventType.ToolCallAttempted,
+			{
+				tool_call_id: BASH_TOOL_CALL_ID,
+				tool_execution_id: BASH_TOOL_EXECUTION_ID,
+				prompt_metadata: promptMetadata,
+				tool_namespace: "builtin",
+				tool_name: "Bash",
+				tool_version: "1",
+				capability: "workspace:test",
+				mutates_resource: false,
+				risk_level: "RISK_LEVEL_MEDIUM",
+				safe_arguments: {
+					command_summary: "bunx vitest --run test/telemetry",
+				},
+				redactions: ["raw_command"],
+				idempotency_key: "idempotency_platform_replay_bash_001",
+				attempted_at: eventPlan[6].time,
+			},
+			6,
+		),
+		eventFor(
+			MaestroBusEventType.ToolCallCompleted,
+			{
+				tool_call_id: BASH_TOOL_CALL_ID,
+				tool_execution_id: BASH_TOOL_EXECUTION_ID,
+				prompt_metadata: promptMetadata,
+				skill_metadata: skillMetadata,
+				approval_request_id: APPROVAL_REQUEST_ID,
+				status: "MAESTRO_TOOL_CALL_STATUS_SUCCEEDED",
+				duration: "2.345s",
+				safe_output: {
+					exit_code: 0,
+					summary: "8 telemetry tests passed",
+				},
+				redactions: ["stdout"],
+				estimated_cost: {
+					currency_code: "USD",
+					amount: 0.001,
+				},
+				completed_at: eventPlan[7].time,
+			},
+			7,
+		),
+		eventFor(
+			MaestroBusEventType.EvalScored,
+			{
+				prompt_metadata: promptMetadata,
+				skill_metadata: skillMetadata,
+				tool_call_id: BASH_TOOL_CALL_ID,
+				tool_execution_id: BASH_TOOL_EXECUTION_ID,
+				tool_name: "Bash",
+				score: 0.82,
+				passed: false,
+				threshold: 0.9,
+				rationale: "formatting checks failed",
+				assertion_count: 1,
+				scored_at: eventPlan[8].time,
+			},
+			8,
+		),
+		eventFor(
+			MaestroBusEventType.SkillFailed,
+			{
+				prompt_metadata: promptMetadata,
+				skill_metadata: skillMetadata,
+				tool_call_id: SKILL_TOOL_CALL_ID,
+				tool_execution_id: SKILL_TOOL_EXECUTION_ID,
+				turn_status: "evaluation_failed",
+				error_category: "evaluation",
+				error_message: "formatting checks failed",
+				evaluation_tool_name: "Bash",
+				evaluation_tool_call_id: BASH_TOOL_CALL_ID,
+				evaluation_tool_execution_id: BASH_TOOL_EXECUTION_ID,
+				evaluation_score: 0.82,
+				evaluation_threshold: 0.9,
+				evaluation_assertion_count: 1,
+				evaluation_rationale: "formatting checks failed",
+				outcome_at: eventPlan[9].time,
+			},
+			9,
+		),
+		eventFor(
+			MaestroBusEventType.SessionClosed,
+			{
+				state: "MAESTRO_SESSION_STATE_CLOSED",
+				surface: "MAESTRO_SURFACE_WEB",
+				runtime_mode: "MAESTRO_RUNTIME_MODE_HOSTED",
+				principal,
+				workspace_root: "/workspace/evalops/platform-replay",
+				repository: "evalops/maestro-internal",
+				git_ref: "refs/heads/codex/maestro-platform-replay-fixture",
+				runtime_version: "0.0.0-fixture",
+				runner_profile: "hosted-standard",
+				closed_at: eventPlan[10].time,
+				close_reason: "MAESTRO_CLOSE_REASON_COMPLETED",
+				close_message: "fixture run complete",
+			},
+			10,
+		),
+	];
+}
+
+export function buildCanonicalMaestroPlatformReplayFixture(): MaestroPlatformReplayFixture {
+	const events = buildEvents();
+	const subjects = eventPlan.map((event) => event.type);
+	return {
+		fixture_version: "maestro-platform-replay/v1",
+		name: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+		event_count: events.length,
+		correlation: {
+			organization_id: ORGANIZATION_ID,
+			workspace_id: WORKSPACE_ID,
+			session_id: SESSION_ID,
+			agent_run_id: AGENT_RUN_ID,
+			tool_call_id: BASH_TOOL_CALL_ID,
+			tool_execution_id: BASH_TOOL_EXECUTION_ID,
+			skill_tool_call_id: SKILL_TOOL_CALL_ID,
+			skill_tool_execution_id: SKILL_TOOL_EXECUTION_ID,
+			approval_request_id: APPROVAL_REQUEST_ID,
+		},
+		subjects,
+		events,
+		expected_assertions: {
+			required_event_types: subjects,
+			required_subjects: subjects,
+			platform_join_keys: {
+				agent_run_id: AGENT_RUN_ID,
+				prompt_id: promptMetadata.name,
+				prompt_version_id: promptMetadata.versionId,
+				prompt_artifact_hash: promptMetadata.hash,
+				tool_call_id: BASH_TOOL_CALL_ID,
+				tool_execution_id: BASH_TOOL_EXECUTION_ID,
+				evaluation_tool_call_id: BASH_TOOL_CALL_ID,
+				evaluation_tool_execution_id: BASH_TOOL_EXECUTION_ID,
+				skill_tool_call_id: SKILL_TOOL_CALL_ID,
+				skill_tool_execution_id: SKILL_TOOL_EXECUTION_ID,
+				approval_request_id: APPROVAL_REQUEST_ID,
+				skill_id: SKILL_ID,
+			},
+			timeline: [
+				{
+					type: MaestroBusEventType.SessionStarted,
+					title: "Session started",
+					visible: true,
+				},
+				{
+					type: MaestroBusEventType.ApprovalHit,
+					title: "Approval required",
+					visible: true,
+				},
+				{
+					type: MaestroBusEventType.ToolCallCompleted,
+					title: "Tool completed",
+					visible: true,
+				},
+				{
+					type: MaestroBusEventType.EvalScored,
+					title: "Evaluation scored",
+					visible: true,
+				},
+				{
+					type: MaestroBusEventType.SessionClosed,
+					title: "Session closed",
+					visible: true,
+				},
+			],
+		},
+	};
+}
+
+export function canonicalMaestroPlatformReplayFixtureJson(): string {
+	return `${JSON.stringify(buildCanonicalMaestroPlatformReplayFixture(), null, 2)}\n`;
+}

--- a/test/telemetry/maestro-platform-replay-fixture.test.ts
+++ b/test/telemetry/maestro-platform-replay-fixture.test.ts
@@ -1,0 +1,310 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { MaestroBusEventType } from "../../src/telemetry/maestro-event-bus.js";
+import {
+	CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+	buildCanonicalMaestroPlatformReplayFixture,
+	canonicalMaestroPlatformReplayFixtureJson,
+} from "../../src/telemetry/maestro-platform-replay-fixture.js";
+
+describe("canonical Maestro Platform replay fixture", () => {
+	const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+	it("emits deterministic Platform replay events with stable join keys", () => {
+		const fixture = buildCanonicalMaestroPlatformReplayFixture();
+
+		expect(fixture).toMatchObject({
+			fixture_version: "maestro-platform-replay/v1",
+			name: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+			event_count: 11,
+			correlation: {
+				organization_id: "org_evalops_fixture",
+				workspace_id: "workspace_platform_replay",
+				session_id: "session_platform_replay_001",
+				agent_run_id: "agent_run_platform_replay_001",
+				tool_call_id: "tool_call_platform_replay_bash_001",
+				tool_execution_id: "tool_exec_platform_replay_bash_001",
+				skill_tool_call_id: "tool_call_platform_replay_skill_001",
+				skill_tool_execution_id: "tool_exec_platform_replay_skill_001",
+				approval_request_id: "approval_platform_replay_001",
+			},
+		});
+
+		expect(fixture.subjects).toEqual([
+			MaestroBusEventType.SessionStarted,
+			MaestroBusEventType.PromptVariantSelected,
+			MaestroBusEventType.ToolCallAttempted,
+			MaestroBusEventType.ToolCallCompleted,
+			MaestroBusEventType.SkillInvoked,
+			MaestroBusEventType.ApprovalHit,
+			MaestroBusEventType.ToolCallAttempted,
+			MaestroBusEventType.ToolCallCompleted,
+			MaestroBusEventType.EvalScored,
+			MaestroBusEventType.SkillFailed,
+			MaestroBusEventType.SessionClosed,
+		]);
+
+		expect(fixture.events.map((event) => event.id)).toEqual([
+			"evt_maestro_replay_001_session_started",
+			"evt_maestro_replay_002_prompt_variant_selected",
+			"evt_maestro_replay_003_skill_tool_call_attempted",
+			"evt_maestro_replay_004_skill_tool_call_completed",
+			"evt_maestro_replay_005_skill_invoked",
+			"evt_maestro_replay_006_approval_hit",
+			"evt_maestro_replay_007_eval_tool_call_attempted",
+			"evt_maestro_replay_008_eval_tool_call_completed",
+			"evt_maestro_replay_009_eval_scored",
+			"evt_maestro_replay_010_skill_failed",
+			"evt_maestro_replay_011_session_closed",
+		]);
+
+		for (const event of fixture.events) {
+			expect(event).toMatchObject({
+				spec_version: "1.0",
+				source: "maestro-fixture",
+				tenant_id: "org_evalops_fixture",
+				data_content_type: "application/protobuf",
+				data: {
+					correlation: {
+						organization_id: "org_evalops_fixture",
+						workspace_id: "workspace_platform_replay",
+						session_id: "session_platform_replay_001",
+						agent_run_id: "agent_run_platform_replay_001",
+						trace_id: "trace_platform_replay_001",
+						request_id: "request_platform_replay_001",
+					},
+				},
+			});
+			expect(event.subject).toBe(event.type);
+			expect(event.extensions.dataschema).toMatch(
+				/^buf\.build\/evalops\/proto\/maestro\.v1\./,
+			);
+			expect(event.time).toMatch(/^2026-04-23T18:/);
+		}
+	});
+
+	it("uses production Maestro metadata shapes for prompt, skill, and eval assertions", () => {
+		const fixture = buildCanonicalMaestroPlatformReplayFixture();
+		const byType = new Map(fixture.events.map((event) => [event.type, event]));
+
+		const promptVariantSelected = byType.get(
+			MaestroBusEventType.PromptVariantSelected,
+		)?.data;
+		expect(promptVariantSelected).toMatchObject({
+			"@type": "type.googleapis.com/maestro.v1.PromptVariantSelected",
+			prompt_metadata: {
+				name: "maestro-system",
+				label: "production",
+				surface: "web",
+				version: 9,
+				versionId: "prompt_version_9",
+				hash: "sha256:prompt-platform-replay",
+				source: "service",
+			},
+			selected_at: "2026-04-23T18:01:00.000Z",
+		});
+		expect(promptVariantSelected).not.toHaveProperty("prompt_id");
+		expect(promptVariantSelected).not.toHaveProperty("version_id");
+		const toolAttempts = fixture.events
+			.filter((event) => event.type === MaestroBusEventType.ToolCallAttempted)
+			.map((event) => event.data);
+		expect(toolAttempts).toHaveLength(2);
+		expect(toolAttempts[0]).toMatchObject({
+			tool_call_id: "tool_call_platform_replay_skill_001",
+			tool_execution_id: "tool_exec_platform_replay_skill_001",
+			tool_name: "Skill",
+			prompt_metadata: {
+				name: "maestro-system",
+				label: "production",
+			},
+		});
+		expect(toolAttempts[0]).not.toHaveProperty("skill_metadata");
+		expect(toolAttempts[1]).toMatchObject({
+			tool_call_id: "tool_call_platform_replay_bash_001",
+			tool_execution_id: "tool_exec_platform_replay_bash_001",
+			tool_name: "Bash",
+			prompt_metadata: {
+				name: "maestro-system",
+				label: "production",
+			},
+		});
+		expect(toolAttempts[1]).not.toHaveProperty("skill_metadata");
+		expect(byType.get(MaestroBusEventType.SkillInvoked)?.data).toMatchObject({
+			"@type": "type.googleapis.com/maestro.v1.SkillInvocation",
+			prompt_metadata: {
+				name: "maestro-system",
+				label: "production",
+			},
+			skill_metadata: {
+				name: "incident-review",
+				hash: "sha256:skill-incident-review",
+				source: "service",
+				artifactId: "skill_incident_review",
+				version: "3",
+			},
+			tool_call_id: "tool_call_platform_replay_skill_001",
+			tool_execution_id: "tool_exec_platform_replay_skill_001",
+			invoked_at: "2026-04-23T18:04:00.000Z",
+		});
+		expect(
+			byType.get(MaestroBusEventType.SkillInvoked)?.data,
+		).not.toHaveProperty("invocation_id");
+		expect(
+			byType.get(MaestroBusEventType.SkillInvoked)?.data,
+		).not.toHaveProperty("skill_id");
+		expect(byType.get(MaestroBusEventType.SkillFailed)?.data).toMatchObject({
+			"@type": "type.googleapis.com/maestro.v1.SkillOutcome",
+			prompt_metadata: {
+				name: "maestro-system",
+				label: "production",
+			},
+			skill_metadata: {
+				name: "incident-review",
+				hash: "sha256:skill-incident-review",
+				source: "service",
+				artifactId: "skill_incident_review",
+				version: "3",
+			},
+			tool_call_id: "tool_call_platform_replay_skill_001",
+			tool_execution_id: "tool_exec_platform_replay_skill_001",
+			turn_status: "evaluation_failed",
+			error_category: "evaluation",
+			error_message: "formatting checks failed",
+			evaluation_tool_name: "Bash",
+			evaluation_tool_call_id: "tool_call_platform_replay_bash_001",
+			evaluation_tool_execution_id: "tool_exec_platform_replay_bash_001",
+			evaluation_score: 0.82,
+			evaluation_threshold: 0.9,
+			evaluation_assertion_count: 1,
+			evaluation_rationale: "formatting checks failed",
+			outcome_at: "2026-04-23T18:09:00.000Z",
+		});
+		expect(
+			byType.get(MaestroBusEventType.SkillFailed)?.data,
+		).not.toHaveProperty("invocation_id");
+		expect(
+			byType.get(MaestroBusEventType.SkillFailed)?.data,
+		).not.toHaveProperty("status");
+		expect(byType.get(MaestroBusEventType.ApprovalHit)?.data).toMatchObject({
+			context: {
+				tool_name: "Bash",
+				display_name: "Bash",
+				summary_label: "Bash",
+				args: {
+					command: "bunx vitest --run test/telemetry",
+				},
+			},
+		});
+		expect(
+			byType.get(MaestroBusEventType.ApprovalHit)?.data.context,
+		).not.toHaveProperty("tool_call_id");
+		expect(byType.get(MaestroBusEventType.EvalScored)?.data).toMatchObject({
+			"@type": "type.googleapis.com/maestro.v1.MaestroEvalScore",
+			tool_call_id: "tool_call_platform_replay_bash_001",
+			tool_execution_id: "tool_exec_platform_replay_bash_001",
+			tool_name: "Bash",
+			score: 0.82,
+			passed: false,
+			threshold: 0.9,
+			rationale: "formatting checks failed",
+			assertion_count: 1,
+			scored_at: "2026-04-23T18:08:00.000Z",
+		});
+		expect(byType.get(MaestroBusEventType.EvalScored)?.data).not.toHaveProperty(
+			"eval_run_id",
+		);
+		expect(byType.get(MaestroBusEventType.EvalScored)?.data).not.toHaveProperty(
+			"scenario_id",
+		);
+		expect(byType.get(MaestroBusEventType.EvalScored)?.data).not.toHaveProperty(
+			"suite_id",
+		);
+
+		expect(fixture.expected_assertions).toMatchObject({
+			required_event_types: fixture.subjects,
+			required_subjects: fixture.subjects,
+			platform_join_keys: {
+				agent_run_id: "agent_run_platform_replay_001",
+				prompt_id: "maestro-system",
+				prompt_version_id: "prompt_version_9",
+				prompt_artifact_hash: "sha256:prompt-platform-replay",
+				tool_call_id: "tool_call_platform_replay_bash_001",
+				tool_execution_id: "tool_exec_platform_replay_bash_001",
+				evaluation_tool_call_id: "tool_call_platform_replay_bash_001",
+				evaluation_tool_execution_id: "tool_exec_platform_replay_bash_001",
+				skill_tool_call_id: "tool_call_platform_replay_skill_001",
+				skill_tool_execution_id: "tool_exec_platform_replay_skill_001",
+				approval_request_id: "approval_platform_replay_001",
+				skill_id: "skill_incident_review",
+			},
+		});
+	});
+
+	it("uses event-specific Maestro correlation step ids", () => {
+		const fixture = buildCanonicalMaestroPlatformReplayFixture();
+
+		expect(
+			fixture.events.map((event) => event.data.correlation.agent_run_step_id),
+		).toEqual([
+			"agent_run_step_platform_replay_001",
+			"agent_run_step_platform_replay_001",
+			"tool_call_platform_replay_skill_001",
+			"tool_call_platform_replay_skill_001",
+			"tool_call_platform_replay_skill_001",
+			"tool_call_platform_replay_bash_001",
+			"tool_call_platform_replay_bash_001",
+			"tool_call_platform_replay_bash_001",
+			"tool_call_platform_replay_bash_001",
+			"tool_call_platform_replay_skill_001",
+			"agent_run_step_platform_replay_001",
+		]);
+	});
+
+	it("serializes the fixture as stable JSON for Platform replay tests", () => {
+		const serialized = canonicalMaestroPlatformReplayFixtureJson();
+		const parsed = JSON.parse(serialized);
+
+		expect(serialized.endsWith("\n")).toBe(true);
+		expect(serialized).toBe(canonicalMaestroPlatformReplayFixtureJson());
+		expect(parsed).toMatchObject({
+			fixture_version: "maestro-platform-replay/v1",
+			name: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+			event_count: 11,
+		});
+		expect(parsed.events).toHaveLength(11);
+	});
+
+	it("provides a one-command JSON fixture generator for Platform tests", () => {
+		const output = execFileSync(
+			resolve(repoRoot, "node_modules/.bin/tsx"),
+			["scripts/generate-maestro-platform-replay-fixture.ts"],
+			{
+				cwd: repoRoot,
+				encoding: "utf8",
+			},
+		);
+		const parsed = JSON.parse(output);
+
+		expect(parsed).toMatchObject({
+			fixture_version: "maestro-platform-replay/v1",
+			name: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+			event_count: 11,
+		});
+		expect(parsed.events.map((event: { type: string }) => event.type)).toEqual(
+			parsed.subjects,
+		);
+	});
+
+	it("exports the fixture builder from the telemetry boundary", async () => {
+		const telemetry = await import("../../src/telemetry/index.js");
+
+		expect(
+			telemetry.buildCanonicalMaestroPlatformReplayFixture(),
+		).toMatchObject({
+			name: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+			event_count: 11,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `c125cd077e22c132aa60ea6c6f3ebf585edb6423`
- last generated public sync base: `34c99f3adb27b3417511d1e3457e3bc082d9c92f`
- previewed public-tree drift: `4` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (c125cd077e22)`
- public projection: `https://github.com/evalops/maestro@main (34c99f3adb27)`
- files to copy or update: `4`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update scripts/generate-maestro-platform-replay-fixture.ts
- copy/update src/telemetry/index.ts
- copy/update src/telemetry/maestro-platform-replay-fixture.ts
- copy/update test/telemetry/maestro-platform-replay-fixture.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update scripts/generate-maestro-platform-replay-fixture.ts
- copy/update src/telemetry/index.ts
- copy/update src/telemetry/maestro-platform-replay-fixture.ts
- copy/update test/telemetry/maestro-platform-replay-fixture.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode