### PR TITLE
[maestro] Harden Semgrep install in evals workflow with uv + retries

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -45,8 +45,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install Semgrep CLI
-        run: python3 -m pip install --user "semgrep==1.144.0" && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        env:
+          UV_HTTP_TIMEOUT: "120"
+        run: |
+          set -e
+          for attempt in 1 2 3; do
+            if uv tool install "semgrep==1.144.0"; then
+              break
+            fi
+            if [ "$attempt" = "3" ]; then
+              echo "uv tool install failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "uv tool install attempt $attempt failed; retrying..." >&2
+            sleep $((attempt * 5))
+          done
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Composer Guardian
         run: bash scripts/guardian.sh --all --trigger ci
       - run: npx nx run maestro:build:all

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -36,15 +36,6 @@ jobs:
         with:
           ensure-ripgrep: "true"
 
-      - name: Cache pip (GitHub)
-        if: ${{ !(startsWith(runner.name, 'blacksmith-') || env.BLACKSMITH_ACTIONS_RESULTS_URL != '') }}
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/evals.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install Semgrep CLI


### PR DESCRIPTION
## Summary
- Replaces `python3 -m pip install --user semgrep==1.144.0` in `.github/workflows/evals.yml` with `uv tool install` after `astral-sh/setup-uv@v8.1.0`.
- Adds a 3-attempt retry loop with exponential-ish backoff (5s, 10s) and `UV_HTTP_TIMEOUT=120` to absorb transient PyPI/CDN failures that have been flaking the evals job.
- Drops `--user` and the `pip install -U pip` pattern; `$HOME/.local/bin` is still appended to `$GITHUB_PATH` so downstream steps find `semgrep`.

Mirrors evalops/maestro-internal#1492 — semantically identical change against the public mirror's `evals.yml` (only `.github/workflows/evals.yml` contained `pip install` in this repo).

## Test plan
- [ ] `evals` workflow runs green on this PR with the `run-evals` label
- [ ] Semgrep version reported in CI is `1.144.0`
- [ ] Retry log lines are absent on a clean run (no spurious failures)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>