### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/web/src/components/composer-chat-client-requests.test.ts
+++ b/packages/web/src/components/composer-chat-client-requests.test.ts
@@ -125,7 +125,7 @@ describe("ComposerChatClientRequests", () => {
 		]);
 	});
 
-	it("restores normalized pending requests when split queues are absent", () => {
+	it("restores legacy wrapped pending requests when split queues are absent", () => {
 		const { clientRequests, state } = createClientRequestHarness();
 
 		const replayable = clientRequests.restorePendingRequests({
@@ -296,6 +296,65 @@ describe("ComposerChatClientRequests", () => {
 				pendingRequest: {
 					source: "platform",
 					createdAt: "2026-04-23T23:00:00.000Z",
+				},
+			},
+		]);
+	});
+
+	it("attaches normalized pending request metadata without downgrading split tool retry details", () => {
+		const { clientRequests, state } = createClientRequestHarness();
+
+		clientRequests.restorePendingRequests({
+			pendingToolRetryRequests: [
+				{
+					id: "retry-1",
+					toolCallId: "tool-call-1",
+					toolName: "bash",
+					args: { command: "npm test" },
+					errorMessage: "exit 1",
+					attempt: 2,
+					maxAttempts: 3,
+					summary: "Tests failed",
+				},
+			],
+			pendingRequests: [
+				{
+					id: "retry-1",
+					kind: "tool_retry",
+					status: "pending",
+					visibility: "user",
+					sessionId: "session-1",
+					toolCallId: "tool-call-1",
+					toolName: "bash",
+					args: { command: "npm test" },
+					reason: "Latest Platform wait projection",
+					createdAt: "2026-04-23T23:00:00.000Z",
+					source: "platform",
+					platform: {
+						source: "tool_execution",
+						toolExecutionId: "texec-1",
+					},
+				},
+			],
+		});
+
+		expect(state.pendingToolRetryQueue).toMatchObject([
+			{
+				id: "retry-1",
+				toolCallId: "tool-call-1",
+				toolName: "bash",
+				args: { command: "npm test" },
+				errorMessage: "exit 1",
+				attempt: 2,
+				maxAttempts: 3,
+				summary: "Tests failed",
+				pendingRequest: {
+					source: "platform",
+					createdAt: "2026-04-23T23:00:00.000Z",
+					platform: {
+						source: "tool_execution",
+						toolExecutionId: "texec-1",
+					},
 				},
 			},
 		]);

--- a/packages/web/src/components/composer-chat-client-requests.ts
+++ b/packages/web/src/components/composer-chat-client-requests.ts
@@ -132,6 +132,11 @@ function mergeToolRetryRequests(
 	}
 	if (Array.isArray(session.pendingRequests)) {
 		for (const request of session.pendingRequests) {
+			const existing = merged.get(request.id);
+			if (request.kind === "tool_retry" && existing) {
+				merged.set(request.id, attachPendingRequestMetadata(existing, request));
+				continue;
+			}
 			const toolRetryRequest = toolRetryRequestFromPendingRequest(request);
 			if (toolRetryRequest) {
 				merged.set(toolRetryRequest.id, toolRetryRequest);

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -221,6 +221,9 @@ function isFailedToolEvaluation(summary: ToolEvaluationSummary): boolean {
 	if (summary.passed === false) {
 		return true;
 	}
+	if (summary.passed === true) {
+		return false;
+	}
 	return (
 		typeof summary.score === "number" &&
 		typeof summary.threshold === "number" &&

--- a/src/agent/transport/tool-execution-bridge.ts
+++ b/src/agent/transport/tool-execution-bridge.ts
@@ -209,7 +209,16 @@ function metadataValue(value: string | undefined): string | undefined {
 	if (trimmed.length <= METADATA_VALUE_MAX_LENGTH) {
 		return trimmed;
 	}
-	return `${trimmed.slice(0, METADATA_VALUE_MAX_LENGTH - 3).trimEnd()}...`;
+	const suffix = "...";
+	const maxPrefixLength = METADATA_VALUE_MAX_LENGTH - suffix.length;
+	let prefix = "";
+	for (const char of trimmed) {
+		if (prefix.length + char.length > maxPrefixLength) {
+			break;
+		}
+		prefix += char;
+	}
+	return `${prefix.trimEnd()}${suffix}`;
 }
 
 function getMetadataEnvValue(names: readonly string[]): string | undefined {

--- a/src/platform/cerebro-facts-client.ts
+++ b/src/platform/cerebro-facts-client.ts
@@ -117,6 +117,7 @@ const CEREBRO_CHANGE_LIMIT_ENV_VARS = [
 ] as const;
 
 const CEREBRO_SERVICE_PATH = "/cerebro.v1.CerebroService/";
+const CEREBRO_SERVICE_SUFFIX = "/cerebro.v1.CerebroService";
 
 function jsonRecordArray(value: unknown): JsonRecord[] {
 	return Array.isArray(value)
@@ -187,6 +188,13 @@ function truncatePromptAddition(value: string): string {
 	return `${value.slice(0, MAX_PROMPT_CHARS).trimEnd()}\n[truncated]`;
 }
 
+function normalizeCerebroBaseUrl(baseUrl: string): string {
+	const normalized = normalizeBaseUrl(baseUrl);
+	return normalized.endsWith(CEREBRO_SERVICE_SUFFIX)
+		? normalized.slice(0, -CEREBRO_SERVICE_SUFFIX.length)
+		: normalized;
+}
+
 export function buildMaestroSessionFactsQuery(
 	input: MaestroSessionFactsInput,
 ): string | undefined {
@@ -209,7 +217,7 @@ export function resolveCerebroFactsServiceConfig(): CerebroFactsServiceConfig | 
 		return null;
 	}
 	return {
-		baseUrl: normalizeBaseUrl(baseUrl),
+		baseUrl: normalizeCerebroBaseUrl(baseUrl),
 		token: resolveConfiguredToken(CEREBRO_TOKEN_ENV_VARS),
 		workspaceId: resolveWorkspaceId(CEREBRO_WORKSPACE_ENV_VARS),
 		timeoutMs: parsePositiveInt(

--- a/src/server/pending-request-payload.ts
+++ b/src/server/pending-request-payload.ts
@@ -8,6 +8,24 @@ import {
 	serverRequestManager,
 } from "./server-request-manager.js";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function getToolRetryPayload(args: unknown): Record<string, unknown> {
+	return isRecord(args) ? args : {};
+}
+
+function pendingRequestArgs(entry: PendingServerRequestSnapshot): unknown {
+	if (entry.kind !== "tool_retry") {
+		return entry.args;
+	}
+	const args = getToolRetryPayload(entry.args);
+	return Object.prototype.hasOwnProperty.call(args, "args")
+		? args.args
+		: entry.args;
+}
+
 function mapPendingComposerRequests(
 	pending: PendingServerRequestSnapshot[],
 ): ComposerPendingRequest[] {
@@ -28,7 +46,7 @@ function mapPendingComposerRequests(
 			displayName: entry.displayName,
 			summaryLabel: entry.summaryLabel,
 			actionDescription: entry.actionDescription,
-			args: entry.args,
+			args: pendingRequestArgs(entry),
 			reason: entry.reason,
 			createdAt,
 			expiresAt,
@@ -92,12 +110,7 @@ export function getPendingServerRequestPayload(
 	const pendingToolRetryRequests = pending
 		.filter((entry) => entry.kind === "tool_retry")
 		.map((entry) => {
-			const args =
-				entry.args &&
-				typeof entry.args === "object" &&
-				!Array.isArray(entry.args)
-					? (entry.args as Record<string, unknown>)
-					: {};
+			const args = getToolRetryPayload(entry.args);
 			return {
 				id: entry.id,
 				toolCallId:

--- a/src/telemetry/maestro-platform-replay-fixture.ts
+++ b/src/telemetry/maestro-platform-replay-fixture.ts
@@ -145,6 +145,13 @@ const eventPlan = [
 	},
 ] as const;
 
+const TOOL_CALL_CORRELATED_EVENT_TYPES = new Set<MaestroBusEventType>([
+	MaestroBusEventType.ToolCallAttempted,
+	MaestroBusEventType.ToolCallCompleted,
+	MaestroBusEventType.SkillInvoked,
+	MaestroBusEventType.EvalScored,
+]);
+
 export type MaestroPlatformReplayFixtureEvent = MaestroCloudEvent<
 	Record<string, unknown>
 >;
@@ -182,7 +189,10 @@ function eventFor(
 	}
 	const stepId =
 		agentRunStepId ??
-		(typeof data.tool_call_id === "string" ? data.tool_call_id : undefined) ??
+		(TOOL_CALL_CORRELATED_EVENT_TYPES.has(type) &&
+		typeof data.tool_call_id === "string"
+			? data.tool_call_id
+			: undefined) ??
 		baseCorrelation.agent_run_step_id;
 	return buildMaestroCloudEvent(
 		type,
@@ -337,10 +347,6 @@ function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
 					summary: "8 telemetry tests passed",
 				},
 				redactions: ["stdout"],
-				estimated_cost: {
-					currency_code: "USD",
-					amount: 0.001,
-				},
 				completed_at: eventPlan[7].time,
 			},
 			7,

--- a/test/agent/skill-outcome-telemetry.test.ts
+++ b/test/agent/skill-outcome-telemetry.test.ts
@@ -145,6 +145,34 @@ function createEvaluatedToolResult(toolCallId: string): ToolResultMessage {
 	};
 }
 
+function createExplicitPassedEvaluationToolResult(
+	toolCallId: string,
+): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "Bash",
+		content: [{ type: "text", text: "bash completed" }],
+		details: {
+			evaluation: {
+				score: 0.1,
+				threshold: 0.9,
+				passed: true,
+				rationale: "reviewer accepted the output",
+			},
+			assertions: [
+				{
+					name: "manual-review",
+					passed: true,
+					score: 0.1,
+				},
+			],
+		},
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
 class SkillSelectionTransport implements AgentTransport {
 	constructor(
 		private readonly shouldFailAfterSelection = false,
@@ -155,6 +183,7 @@ class SkillSelectionTransport implements AgentTransport {
 			skillMetadata: SkillArtifactMetadata;
 		}> = [],
 		private readonly failureMessage = "turn blew up",
+		private readonly evaluationResultFactory = createEvaluatedToolResult,
 	) {}
 
 	async *continue(): AsyncGenerator<AgentEvent, void, unknown> {}
@@ -240,7 +269,7 @@ class SkillSelectionTransport implements AgentTransport {
 				args: { command: "npm test" },
 			};
 
-			const evalResult = createEvaluatedToolResult(evalToolCallId);
+			const evalResult = this.evaluationResultFactory(evalToolCallId);
 			yield { type: "message_start", message: evalResult };
 			yield { type: "message_end", message: evalResult };
 			yield {
@@ -428,6 +457,63 @@ describe("skill outcome telemetry", () => {
 					version: "3",
 					source: "service",
 				},
+			},
+		});
+	});
+
+	it("treats explicit passed evaluation as authoritative over score threshold", async () => {
+		const published: Array<{ subject: string; payload: string }> = [];
+		process.env.MAESTRO_EVENT_BUS_URL = "nats://bus.example:4222";
+		setMaestroEventBusTransportForTests({
+			async publish(subject, payload) {
+				published.push({ subject, payload });
+			},
+		});
+
+		const agent = new Agent({
+			transport: new SkillSelectionTransport(
+				false,
+				true,
+				[],
+				"turn blew up",
+				createExplicitPassedEvaluationToolResult,
+			),
+			initialState: {
+				model: mockModel,
+				tools: [],
+				session: {
+					id: "session_123",
+					startedAt: new Date("2026-04-23T18:00:00.000Z"),
+				},
+			},
+		});
+
+		await agent.prompt("load the incident review skill and evaluate the run");
+
+		const payloads = published.map(({ payload }) => JSON.parse(payload));
+		expect(
+			payloads.find((payload) => payload.type === "maestro.events.eval.scored"),
+		).toMatchObject({
+			data: {
+				score: 0.1,
+				threshold: 0.9,
+				passed: true,
+				rationale: "reviewer accepted the output",
+			},
+		});
+		expect(
+			payloads.some(
+				(payload) => payload.type === "maestro.events.skill.failed",
+			),
+		).toBe(false);
+		expect(
+			payloads.find(
+				(payload) => payload.type === "maestro.events.skill.succeeded",
+			),
+		).toMatchObject({
+			data: {
+				tool_call_id: "tool-skill-1",
+				turn_status: "success",
 			},
 		});
 	});

--- a/test/agent/tool-execution-bridge.test.ts
+++ b/test/agent/tool-execution-bridge.test.ts
@@ -78,6 +78,15 @@ const okResult: ToolResultMessage = {
 	timestamp: Date.now(),
 };
 
+function expectNoLoneSurrogates(value: string): void {
+	for (const char of Array.from(value)) {
+		const codePoint = char.codePointAt(0);
+		expect(
+			codePoint === undefined || codePoint < 0xd800 || codePoint > 0xdfff,
+		).toBe(true);
+	}
+}
+
 describe("tool execution bridge", () => {
 	let requests: CapturedRequest[];
 
@@ -190,6 +199,65 @@ describe("tool execution bridge", () => {
 				}),
 			}),
 		});
+	});
+
+	it("truncates metadata without splitting surrogate pairs", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG,
+		]);
+		const branch = `${"a".repeat(508)}😀feature`;
+		vi.stubEnv("MAESTRO_GIT_BRANCH", branch);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+				return new Response(
+					JSON.stringify({
+						execution: {
+							id: "texec_unicode_1",
+							state: "TOOL_EXECUTION_STATE_SUCCEEDED",
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge();
+		const prepared = await bridge.prepare({
+			cfg: baseConfig(),
+			toolCall: {
+				type: "toolCall",
+				id: "tc_unicode_1",
+				name: "bash",
+				arguments: { command: "git status" },
+			},
+			sanitizedArgs: { command: "git status" },
+		});
+		if (prepared.status !== "observe") {
+			throw new Error("expected observe plan");
+		}
+		await bridge.recordObservation(prepared.plan, {
+			...okResult,
+			toolCallId: "tc_unicode_1",
+		});
+
+		const metadata = requests[0]?.body?.metadata as
+			| Record<string, string>
+			| undefined;
+		const gitBranch = metadata?.maestro_git_branch;
+		expect(gitBranch).toBeDefined();
+		expect(gitBranch?.length).toBeLessThanOrEqual(512);
+		expect(gitBranch).toMatch(/\.\.\.$/u);
+		expectNoLoneSurrogates(gitBranch ?? "");
 	});
 
 	it("skips the bridge when no Platform destination is configured", async () => {

--- a/test/platform/agent-runtime-client.test.ts
+++ b/test/platform/agent-runtime-client.test.ts
@@ -9,6 +9,7 @@ import {
 	buildMaestroSessionRuntimeTrigger,
 	recordMaestroSessionRuntimeTrigger,
 } from "../../src/platform/agent-runtime-client.js";
+import { resolveCerebroFactsServiceConfig } from "../../src/platform/cerebro-facts-client.js";
 
 function headersToRecord(
 	headers: HeadersInit | undefined,
@@ -54,6 +55,8 @@ describe("agent runtime service client", () => {
 			"CEREBRO_WORKSPACE_ID",
 			"MAESTRO_CEREBRO_TIMEOUT_MS",
 			"CEREBRO_TIMEOUT_MS",
+			"MAESTRO_CEREBRO_MAX_ATTEMPTS",
+			"CEREBRO_MAX_ATTEMPTS",
 			"MAESTRO_CEREBRO_SEARCH_LIMIT",
 			"CEREBRO_SEARCH_LIMIT",
 			"MAESTRO_CEREBRO_CHANGE_LIMIT",
@@ -101,6 +104,17 @@ describe("agent runtime service client", () => {
 				maestroSessionId: "session_1",
 				metadata: { model: "gpt-5" },
 			},
+		});
+	});
+
+	it("accepts full Cerebro service URLs without duplicating the service path", () => {
+		vi.stubEnv(
+			"CEREBRO_SERVICE_URL",
+			"https://cerebro.test/cerebro.v1.CerebroService/",
+		);
+
+		expect(resolveCerebroFactsServiceConfig()).toMatchObject({
+			baseUrl: "https://cerebro.test",
 		});
 	});
 
@@ -229,7 +243,12 @@ describe("agent runtime service client", () => {
 								kind: "THING_KIND_SERVICE",
 							},
 						],
-						evidence: [{ id: "evidence_search", uri: "https://repo.test" }],
+						evidence: [
+							{
+								id: "evidence_search",
+								uri: "https://github.com/evalops/platform",
+							},
+						],
 					});
 				}
 
@@ -240,7 +259,7 @@ describe("agent runtime service client", () => {
 					});
 					return Response.json({
 						thing: {
-							id: "thing_pipeline",
+							id: "thing_pipeline_canonical",
 							name: "Pipeline",
 							kind: "THING_KIND_SERVICE",
 						},
@@ -249,6 +268,7 @@ describe("agent runtime service client", () => {
 								id: "fact_pipeline_owner",
 								subjectThingId: "thing_pipeline",
 								statement: "Pipeline is owned by Platform",
+								confidence: 0.9,
 							},
 						],
 						recentEvents: [
@@ -257,22 +277,24 @@ describe("agent runtime service client", () => {
 								summary: "Pipeline deployed",
 							},
 						],
-						evidence: [{ id: "evidence_owner", uri: "https://owner.test" }],
+						evidence: [
+							{
+								id: "evidence_owner",
+								uri: "https://github.com/evalops/platform",
+							},
+						],
 					});
 				}
 
 				if (url.endsWith("/cerebro.v1.CerebroService/ListChanges")) {
 					expect(body).toMatchObject({
 						workspaceId: "ws_env",
-						thingIds: ["thing_pipeline"],
+						thingIds: ["thing_pipeline", "thing_pipeline_canonical"],
 						limit: 10,
 					});
 					return Response.json({
 						changes: [
-							{
-								id: "change_pipeline_recent",
-								thingId: "thing_pipeline",
-							},
+							{ id: "change_pipeline_recent", thingId: "thing_pipeline" },
 						],
 					});
 				}
@@ -295,10 +317,10 @@ describe("agent runtime service client", () => {
 									provider: "cerebro",
 									workspaceId: "ws_env",
 									query: "triage pipeline regressions",
-									thingIds: ["thing_pipeline"],
+									thingIds: ["thing_pipeline", "thing_pipeline_canonical"],
 									factIds: ["fact_pipeline_owner"],
 									summary: {
-										thingCount: 1,
+										thingCount: 2,
 										factCount: 1,
 										eventCount: 1,
 										changeCount: 1,
@@ -312,6 +334,11 @@ describe("agent runtime service client", () => {
 						run: {
 							id: "run_with_facts",
 							state: PlatformAgentRunStateValue.Accepted,
+							linkage: {
+								runId: "run_with_facts",
+								workspaceId: "ws_env",
+								agentId: "maestro",
+							},
 						},
 						events: [],
 						idempotentReplay: false,

--- a/test/session-endpoints.test.ts
+++ b/test/session-endpoints.test.ts
@@ -301,6 +301,11 @@ describe("Session Endpoints", () => {
 					toolCallId: string;
 					toolName: string;
 				}>;
+				pendingRequests: Array<{
+					id: string;
+					kind: string;
+					args: unknown;
+				}>;
 			};
 			expect(body.pendingApprovalRequests).toEqual([
 				{
@@ -334,6 +339,13 @@ describe("Session Endpoints", () => {
 					reason: "Client execution required",
 				},
 			]);
+			expect(
+				body.pendingRequests.find((request) => request.id === "retry-1"),
+			).toMatchObject({
+				id: "retry-1",
+				kind: "tool_retry",
+				args: { file: "README.md" },
+			});
 		});
 
 		it("should return 404 for non-existent session", async () => {

--- a/test/telemetry/maestro-platform-replay-fixture.test.ts
+++ b/test/telemetry/maestro-platform-replay-fixture.test.ts
@@ -187,6 +187,9 @@ describe("canonical Maestro Platform replay fixture", () => {
 		expect(
 			byType.get(MaestroBusEventType.SkillFailed)?.data,
 		).not.toHaveProperty("status");
+		expect(
+			byType.get(MaestroBusEventType.ToolCallCompleted)?.data,
+		).not.toHaveProperty("estimated_cost");
 		expect(byType.get(MaestroBusEventType.ApprovalHit)?.data).toMatchObject({
 			context: {
 				tool_name: "Bash",
@@ -257,7 +260,7 @@ describe("canonical Maestro Platform replay fixture", () => {
 			"tool_call_platform_replay_bash_001",
 			"tool_call_platform_replay_bash_001",
 			"tool_call_platform_replay_bash_001",
-			"tool_call_platform_replay_skill_001",
+			"agent_run_step_platform_replay_001",
 			"agent_run_step_platform_replay_001",
 		]);
 	});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `3a7c3c08bf5ae825fea2198d7922eb55bfe6bf37`
- last generated public sync base: `077f53b24c34ea37974fdbceca510a1ac0f3dbdc`
- previewed public-tree drift: `13` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (3a7c3c08bf5a)`
- public projection: `https://github.com/evalops/maestro@main (d5a603c7e4bc)`
- files to copy or update: `13`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/web/src/components/composer-chat-client-requests.test.ts
- copy/update packages/web/src/components/composer-chat-client-requests.ts
- copy/update src/agent/agent.ts
- copy/update src/agent/transport/tool-execution-bridge.ts
- copy/update src/platform/agent-runtime-client.ts
- copy/update src/platform/cerebro-facts-client.ts
- copy/update src/server/pending-request-payload.ts
- copy/update src/telemetry/maestro-platform-replay-fixture.ts
- copy/update test/agent/skill-outcome-telemetry.test.ts
- copy/update test/agent/tool-execution-bridge.test.ts
- copy/update test/platform/agent-runtime-client.test.ts
- copy/update test/session-endpoints.test.ts
- copy/update test/telemetry/maestro-platform-replay-fixture.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/web/src/components/composer-chat-client-requests.test.ts
- copy/update packages/web/src/components/composer-chat-client-requests.ts
- copy/update src/agent/agent.ts
- copy/update src/agent/transport/tool-execution-bridge.ts
- copy/update src/platform/agent-runtime-client.ts
- copy/update src/platform/cerebro-facts-client.ts
- copy/update src/server/pending-request-payload.ts
- copy/update src/telemetry/maestro-platform-replay-fixture.ts
- copy/update test/agent/skill-outcome-telemetry.test.ts
- copy/update test/agent/tool-execution-bridge.test.ts
- copy/update test/platform/agent-runtime-client.test.ts
- copy/update test/session-endpoints.test.ts
- copy/update test/telemetry/maestro-platform-replay-fixture.test.ts

## Public-only commits since last generated sync

- d5a603c7 [maestro] Harden Semgrep install in evals workflow with uv + retries (#182)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #183 to internal source `3a7c3c08bf5ae825fea2198d7922eb55bfe6bf37`