### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/platform/cerebro-facts-client.ts
+++ b/src/platform/cerebro-facts-client.ts
@@ -151,6 +151,11 @@ function recordId(record: JsonRecord): string | undefined {
 	return typeof id === "string" && id.trim().length > 0 ? id : undefined;
 }
 
+function recordString(record: JsonRecord, name: string): string {
+	const value = record[name];
+	return typeof value === "string" ? value.trim() : "";
+}
+
 function pushUniqueRecord(
 	records: JsonRecord[],
 	seen: Set<string>,
@@ -208,6 +213,42 @@ function pushUniquePath(
 	}
 	seen.add(key);
 	paths.push(path);
+}
+
+function changeKey(change: JsonRecord): string | undefined {
+	const id = recordId(change);
+	if (id) {
+		return `id:${id}`;
+	}
+	const event = change.event;
+	if (typeof event === "object" && event !== null && !Array.isArray(event)) {
+		const eventId = recordString(event as JsonRecord, "id");
+		if (eventId) {
+			return `event:${eventId}`;
+		}
+	}
+	const affectedThingIds = recordStringArray(change, "affectedThingIds");
+	const whyItMatters = recordString(change, "whyItMatters");
+	if (affectedThingIds.length === 0 && !whyItMatters) {
+		return undefined;
+	}
+	return `${affectedThingIds.join("\u0000")}\u0001${whyItMatters}`;
+}
+
+function pushUniqueChange(
+	changes: JsonRecord[],
+	seen: Set<string>,
+	change: JsonRecord | undefined,
+): void {
+	if (!change) {
+		return;
+	}
+	const key = changeKey(change);
+	if (!key || seen.has(key)) {
+		return;
+	}
+	seen.add(key);
+	changes.push(change);
 }
 
 function isAbortError(error: unknown): boolean {
@@ -395,7 +436,7 @@ export async function gatherMaestroSessionFactsContext(
 			{ signal: options?.signal, failureMode: options?.failureMode },
 		);
 		for (const change of jsonRecordArray(response.changes)) {
-			pushUniqueRecord(changes, changeIds, change);
+			pushUniqueChange(changes, changeIds, change);
 		}
 	}
 

--- a/test/platform/agent-runtime-client.test.ts
+++ b/test/platform/agent-runtime-client.test.ts
@@ -354,6 +354,17 @@ describe("agent runtime service client", () => {
 					return Response.json({
 						changes: [
 							{ id: "change_pipeline_recent", thingId: "thing_pipeline" },
+							{
+								event: { id: "" },
+								affectedThingIds: ["thing_pipeline"],
+								whyItMatters: "Pipeline ownership changed",
+							},
+							{
+								event: { id: "" },
+								affectedThingIds: ["thing_pipeline"],
+								whyItMatters: "Pipeline ownership changed",
+							},
+							{ affectedThingIds: [], whyItMatters: "" },
 						],
 					});
 				}
@@ -404,6 +415,17 @@ describe("agent runtime service client", () => {
 											linkIds: ["link_pipeline_owner"],
 										},
 									],
+									changes: [
+										{
+											id: "change_pipeline_recent",
+											thingId: "thing_pipeline",
+										},
+										{
+											event: { id: "" },
+											affectedThingIds: ["thing_pipeline"],
+											whyItMatters: "Pipeline ownership changed",
+										},
+									],
 									watermarks: [],
 									summary: {
 										thingCount: 3,
@@ -411,7 +433,7 @@ describe("agent runtime service client", () => {
 										pathCount: 1,
 										factCount: 1,
 										eventCount: 1,
-										changeCount: 1,
+										changeCount: 2,
 										evidenceCount: 3,
 										watermarkCount: 0,
 									},


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `5f5b19c054cc2cb036a1ea1e8df633e641ed25f5`
- last generated public sync base: `45c8a7f2a2b1a1551bbc70358f72adb13fdcac33`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (5f5b19c054cc)`
- public projection: `https://github.com/evalops/maestro@main (45c8a7f2a2b1)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/platform/cerebro-facts-client.ts
- copy/update test/platform/agent-runtime-client.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/platform/cerebro-facts-client.ts
- copy/update test/platform/agent-runtime-client.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode