### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/ambient-agent-rs/src/daemon.rs
+++ b/packages/ambient-agent-rs/src/daemon.rs
@@ -939,4 +939,54 @@ mod tests {
         );
         assert_eq!(closed["data"]["close_message"], "shutdown requested");
     }
+
+    #[tokio::test]
+    async fn test_daemon_publishes_closed_event_when_save_state_fails() {
+        let temp = TempDir::new().unwrap();
+        let transport = Arc::new(RecordingTransport::default());
+        let publisher =
+            PlatformEventBus::with_transport(PlatformEventBusConfig::for_test(), transport.clone());
+        let mut daemon = DaemonBuilder::new()
+            .config(test_config())
+            .data_dir(temp.path().to_path_buf())
+            .ipc_socket_path(temp.path().join("daemon-save-failure.sock"))
+            .platform_event_bus(publisher)
+            .build()
+            .unwrap();
+        let cmd_tx = daemon.get_command_sender();
+
+        let daemon_handle = tokio::spawn(async move { daemon.run().await });
+
+        wait_for_published(&transport, 1).await;
+
+        std::fs::create_dir(temp.path().join("learner.json")).unwrap();
+
+        cmd_tx.send(DaemonCommand::Shutdown).await.unwrap();
+
+        let result = daemon_handle.await.unwrap();
+
+        assert!(result.is_err());
+        wait_for_published(&transport, 2).await;
+
+        let published = transport.published.lock().unwrap();
+        let subjects: Vec<_> = published
+            .iter()
+            .map(|(subject, _)| subject.as_str())
+            .collect();
+        assert_eq!(
+            subjects,
+            vec![
+                "maestro.sessions.session.started",
+                "maestro.sessions.session.closed",
+            ]
+        );
+
+        let closed: Value = serde_json::from_str(&published[1].1).unwrap();
+        assert_eq!(closed["data"]["state"], "MAESTRO_SESSION_STATE_CLOSED");
+        assert_eq!(
+            closed["data"]["close_reason"],
+            "MAESTRO_CLOSE_REASON_USER_STOPPED"
+        );
+        assert_eq!(closed["data"]["close_message"], "shutdown requested");
+    }
 }


### PR DESCRIPTION
## Summary

- sync-public-release-mirror rescue after #191 landed on public main
- keep the remaining Ambient daemon closed-event regression from the internal public-mirror sync
- rebase the sync PR onto current public main, reducing the diff to the one still-missing daemon test
- internal source SHA: `4960f682073fec830d7ffa1c245285c5007be254`
- matching private source-of-truth PR: evalops/maestro-internal#1507
- last generated public sync base: `1c2fde463273bb62fab17d51d2c7aa19f6cb04a2`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (4960f682073f)`
- public projection: `https://github.com/evalops/maestro@main (1c2fde463273)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: residual drift detected after public #191
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/ambient-agent-rs/src/daemon.rs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- `CARGO_TARGET_DIR=/tmp/cargo-target-ambient-public-192 mise x rust@1.88 -- cargo fmt --manifest-path packages/ambient-agent-rs/Cargo.toml --check`
- `CARGO_TARGET_DIR=/tmp/cargo-target-ambient-public-192 mise x rust@1.88 -- cargo test --manifest-path packages/ambient-agent-rs/Cargo.toml`
- `CARGO_TARGET_DIR=/tmp/cargo-target-ambient-public-192 mise x rust@1.88 -- cargo check --manifest-path packages/ambient-agent-rs/Cargo.toml`
- `git diff --check`