### PR TITLE
Add ambient save-failure lifecycle regression

### DIFF
--- a/packages/ambient-agent-rs/src/daemon.rs
+++ b/packages/ambient-agent-rs/src/daemon.rs
@@ -794,6 +794,7 @@ mod tests {
     use crate::platform_event_bus::{PlatformEventBusConfig, PlatformEventBusTransport};
     use async_trait::async_trait;
     use serde_json::Value;
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
 
@@ -932,6 +933,61 @@ mod tests {
         );
 
         let closed: Value = serde_json::from_str(&published[3].1).unwrap();
+        assert_eq!(closed["data"]["state"], "MAESTRO_SESSION_STATE_CLOSED");
+        assert_eq!(
+            closed["data"]["close_reason"],
+            "MAESTRO_CLOSE_REASON_USER_STOPPED"
+        );
+        assert_eq!(closed["data"]["close_message"], "shutdown requested");
+    }
+
+    #[tokio::test]
+    async fn test_daemon_publishes_closed_event_when_save_state_fails() {
+        let temp = TempDir::new().unwrap();
+        let transport = Arc::new(RecordingTransport::default());
+        let publisher =
+            PlatformEventBus::with_transport(PlatformEventBusConfig::for_test(), transport.clone());
+        let mut daemon = DaemonBuilder::new()
+            .config(test_config())
+            .data_dir(temp.path().to_path_buf())
+            .ipc_socket_path(temp.path().join("daemon-save-failure.sock"))
+            .platform_event_bus(publisher)
+            .build()
+            .unwrap();
+        let cmd_tx = daemon.get_command_sender();
+
+        let daemon_handle = tokio::spawn(async move { daemon.run().await });
+
+        wait_for_published(&transport, 1).await;
+
+        let original_permissions = std::fs::metadata(temp.path()).unwrap().permissions();
+        let mut read_only_permissions = original_permissions.clone();
+        read_only_permissions.set_mode(0o500);
+        std::fs::set_permissions(temp.path(), read_only_permissions).unwrap();
+
+        cmd_tx.send(DaemonCommand::Shutdown).await.unwrap();
+
+        let result = daemon_handle.await.unwrap();
+
+        std::fs::set_permissions(temp.path(), original_permissions).unwrap();
+
+        assert!(result.is_err());
+        wait_for_published(&transport, 2).await;
+
+        let published = transport.published.lock().unwrap();
+        let subjects: Vec<_> = published
+            .iter()
+            .map(|(subject, _)| subject.as_str())
+            .collect();
+        assert_eq!(
+            subjects,
+            vec![
+                "maestro.sessions.session.started",
+                "maestro.sessions.session.closed",
+            ]
+        );
+
+        let closed: Value = serde_json::from_str(&published[1].1).unwrap();
         assert_eq!(closed["data"]["state"], "MAESTRO_SESSION_STATE_CLOSED");
         assert_eq!(
             closed["data"]["close_reason"],


### PR DESCRIPTION
## Summary

- add the Ambient daemon regression test from the internal Bugbot autofix
- assert closed lifecycle events still publish when state persistence fails during shutdown

## Source PR

- evalops/maestro-internal#1507

## Validation

- `cargo fmt --manifest-path packages/ambient-agent-rs/Cargo.toml`
- `cargo test --manifest-path packages/ambient-agent-rs/Cargo.toml`
- `cargo check --manifest-path packages/ambient-agent-rs/Cargo.toml`

Follow-up to #191 and part of #49.