### PR TITLE
Record TUI session close events

### DIFF
--- a/src/cli-tui/commands/types.ts
+++ b/src/cli-tui/commands/types.ts
@@ -67,7 +67,7 @@ export interface CommandHandlers {
 	queue(context: CommandExecutionContext): Promise<void> | void;
 	branch(context: CommandExecutionContext): void;
 	tree(context: CommandExecutionContext): void;
-	quit(context: CommandExecutionContext): void;
+	quit(context: CommandExecutionContext): Promise<void> | void;
 	approvals(context: CommandExecutionContext): void;
 	planMode(context: CommandExecutionContext): void;
 	commands(context: CommandExecutionContext): void | Promise<void>;

--- a/src/cli-tui/editor-view.ts
+++ b/src/cli-tui/editor-view.ts
@@ -26,7 +26,7 @@ interface EditorViewOptions {
 	 * Called when Ctrl+D is pressed with an empty editor.
 	 * Standard Unix behavior: exit/end of input.
 	 */
-	onCtrlD?: () => void;
+	onCtrlD?: () => Promise<void> | void;
 	showCommandPalette: () => void;
 	showFileSearch: () => void;
 	onEditLastQueuedFollowUp?: () => boolean;
@@ -73,7 +73,7 @@ export class EditorView {
 			this.options.onCtrlC?.();
 		};
 		editor.onCtrlD = () => {
-			this.options.onCtrlD?.();
+			void this.options.onCtrlD?.();
 		};
 		editor.onShortcut = (shortcut) => {
 			if (shortcut === "command-palette") {

--- a/src/cli-tui/run/run-controller.ts
+++ b/src/cli-tui/run/run-controller.ts
@@ -7,7 +7,7 @@ interface RunControllerOptions {
 	setEditorDisabled: (disabled: boolean) => void;
 	focusEditor: () => void;
 	clearEditor: () => void;
-	stopRenderer: () => void;
+	stopRenderer: () => Promise<void> | void;
 	refreshFooterHint: () => void;
 	notifyFileChanges: () => void;
 	inMinimalMode: () => boolean;
@@ -37,11 +37,12 @@ export class RunController {
 		this.options.focusEditor();
 	}
 
-	handleCtrlC(): void {
+	async handleCtrlC(): Promise<void> {
 		const now = Date.now();
 		if (now - this.lastCtrlCTime < 500) {
-			this.options.stopRenderer();
+			await this.options.stopRenderer();
 			process.exit(0);
+			return;
 		}
 		this.options.clearEditor();
 		this.options.focusEditor();

--- a/src/cli-tui/tui-renderer.ts
+++ b/src/cli-tui/tui-renderer.ts
@@ -2572,6 +2572,10 @@ export class TuiRenderer {
 	}
 
 	stop(): void {
+		this.agentEventBridge?.recordSessionClosed({
+			closeReason: "MAESTRO_CLOSE_REASON_USER_STOPPED",
+			closeMessage: "TUI stopped",
+		});
 		this.slashHintController?.dispose();
 		this.loaderView.stop();
 		this.backgroundTasksController.stop();

--- a/src/cli-tui/tui-renderer.ts
+++ b/src/cli-tui/tui-renderer.ts
@@ -900,7 +900,9 @@ export class TuiRenderer {
 			notifyFileChanges: () => this.gitView.notifyFileChanges(),
 			inMinimalMode: () => this.isMinimalMode(),
 		});
-		this.ui.setInterruptHandler(() => this.handleCtrlC());
+		this.ui.setInterruptHandler(() => {
+			void this.handleCtrlC();
+		});
 		const sessionSubsystem = createSessionSubsystem({
 			agent: this.agent,
 			sessionManager: this.sessionManager,
@@ -1201,8 +1203,8 @@ export class TuiRenderer {
 						),
 				},
 				refreshFooterHint: () => this.refreshFooterHint(),
-				onQuit: () => {
-					this.stop();
+				onQuit: async () => {
+					await this.stop();
 					process.exit(0);
 				},
 			}),
@@ -1294,8 +1296,12 @@ export class TuiRenderer {
 				this.isAgentRunning || this.interruptController.isArmed(),
 			onInterrupt: () => this.inputController.handleInterruptRequest(),
 			onKeepPartial: () => this.inputController.handleKeepPartialRequest(),
-			onCtrlC: () => this.handleCtrlC(),
-			onCtrlD: () => this.inputController.handleCtrlDExit(),
+			onCtrlC: () => {
+				void this.handleCtrlC();
+			},
+			onCtrlD: () => {
+				void this.inputController.handleCtrlDExit();
+			},
 			showCommandPalette: () =>
 				this.getCommandPaletteView().showCommandPalette(),
 			showFileSearch: () => this.getFileSearchView().showFileSearch(),
@@ -1875,7 +1881,7 @@ export class TuiRenderer {
 		this.inputController.setInterruptCallback(callback);
 	}
 
-	private handleCtrlC(): void {
+	private async handleCtrlC(): Promise<void> {
 		const bashModeView = this.bashModeView;
 		if (bashModeView?.isCommandRunning()) {
 			if (bashModeView.abortCurrentCommand()) {
@@ -1883,7 +1889,7 @@ export class TuiRenderer {
 				return;
 			}
 		}
-		this.runController.handleCtrlC();
+		await this.runController.handleCtrlC();
 	}
 
 	private renderHeader(): void {
@@ -2571,8 +2577,8 @@ export class TuiRenderer {
 		this.notificationView.showInfo(formatPerfReport(snap));
 	}
 
-	stop(): void {
-		this.agentEventBridge?.recordSessionClosed({
+	async stop(): Promise<void> {
+		await this.agentEventBridge?.recordSessionClosed({
 			closeReason: "MAESTRO_CLOSE_REASON_USER_STOPPED",
 			closeMessage: "TUI stopped",
 		});

--- a/src/cli-tui/tui-renderer/agent-event-bridge.ts
+++ b/src/cli-tui/tui-renderer/agent-event-bridge.ts
@@ -73,6 +73,7 @@ export class AgentEventBridge {
 	private readonly deps: AgentEventBridgeDeps;
 	private readonly callbacks: AgentEventBridgeCallbacks;
 	private sessionStartTime: number | null = null;
+	private sessionTelemetrySessionId: string | null = null;
 	private sessionTelemetryRecorded = false;
 	private sessionCloseTelemetryRecorded = false;
 	private sessionTelemetryMetadata: Record<string, unknown> | undefined;
@@ -115,7 +116,9 @@ export class AgentEventBridge {
 				});
 			}
 			if (!this.sessionTelemetryRecorded) {
+				const sessionId = this.deps.sessionManager.getSessionId();
 				this.sessionStartTime = Date.now();
+				this.sessionTelemetrySessionId = sessionId;
 				this.sessionTelemetryRecorded = true;
 				this.sessionTelemetryMetadata = {
 					model: state.model
@@ -124,7 +127,7 @@ export class AgentEventBridge {
 					provider: state.model?.provider,
 					...this.getPromptTelemetryMetadata(state),
 				};
-				recordSessionStart(this.deps.sessionManager.getSessionId(), {
+				recordSessionStart(sessionId, {
 					...this.sessionTelemetryMetadata,
 				});
 			}
@@ -155,17 +158,18 @@ export class AgentEventBridge {
 			closeReason?: MaestroCloseReason;
 			closeMessage?: string;
 		} = {},
-	): void {
+	): Promise<void> {
 		if (
 			!this.sessionTelemetryRecorded ||
 			this.sessionCloseTelemetryRecorded ||
-			this.sessionStartTime === null
+			this.sessionStartTime === null ||
+			this.sessionTelemetrySessionId === null
 		) {
-			return;
+			return Promise.resolve();
 		}
 		this.sessionCloseTelemetryRecorded = true;
-		recordSessionDuration(
-			this.deps.sessionManager.getSessionId(),
+		return recordSessionDuration(
+			this.sessionTelemetrySessionId,
 			Math.max(0, Date.now() - this.sessionStartTime),
 			{
 				...this.sessionTelemetryMetadata,

--- a/src/cli-tui/tui-renderer/agent-event-bridge.ts
+++ b/src/cli-tui/tui-renderer/agent-event-bridge.ts
@@ -23,7 +23,12 @@ import {
 	type SessionModelMetadata,
 	toSessionModelMetadata,
 } from "../../session/manager.js";
-import { recordSessionStart, recordTokenUsage } from "../../telemetry.js";
+import {
+	recordSessionDuration,
+	recordSessionStart,
+	recordTokenUsage,
+} from "../../telemetry.js";
+import type { MaestroCloseReason } from "../../telemetry/maestro-event-bus.js";
 import type { AgentEventRouter } from "../agent-event-router.js";
 import type { FooterComponent } from "../footer.js";
 import type { InterruptController } from "../interrupt-controller.js";
@@ -69,6 +74,8 @@ export class AgentEventBridge {
 	private readonly callbacks: AgentEventBridgeCallbacks;
 	private sessionStartTime: number | null = null;
 	private sessionTelemetryRecorded = false;
+	private sessionCloseTelemetryRecorded = false;
+	private sessionTelemetryMetadata: Record<string, unknown> | undefined;
 
 	constructor(options: AgentEventBridgeOptions) {
 		this.deps = options.deps;
@@ -110,12 +117,15 @@ export class AgentEventBridge {
 			if (!this.sessionTelemetryRecorded) {
 				this.sessionStartTime = Date.now();
 				this.sessionTelemetryRecorded = true;
-				recordSessionStart(this.deps.sessionManager.getSessionId(), {
+				this.sessionTelemetryMetadata = {
 					model: state.model
 						? `${state.model.provider}/${state.model.id}`
 						: undefined,
 					provider: state.model?.provider,
 					...this.getPromptTelemetryMetadata(state),
+				};
+				recordSessionStart(this.deps.sessionManager.getSessionId(), {
+					...this.sessionTelemetryMetadata,
 				});
 			}
 		} else if (event.type === "agent_end") {
@@ -138,6 +148,31 @@ export class AgentEventBridge {
 			: undefined;
 		this.callbacks.setCurrentModelMetadata(metadata);
 		this.deps.agentEventRouter.handle(event);
+	}
+
+	recordSessionClosed(
+		options: {
+			closeReason?: MaestroCloseReason;
+			closeMessage?: string;
+		} = {},
+	): void {
+		if (
+			!this.sessionTelemetryRecorded ||
+			this.sessionCloseTelemetryRecorded ||
+			this.sessionStartTime === null
+		) {
+			return;
+		}
+		this.sessionCloseTelemetryRecorded = true;
+		recordSessionDuration(
+			this.deps.sessionManager.getSessionId(),
+			Math.max(0, Date.now() - this.sessionStartTime),
+			{
+				...this.sessionTelemetryMetadata,
+				closeReason: options.closeReason ?? "MAESTRO_CLOSE_REASON_USER_STOPPED",
+				closeMessage: options.closeMessage ?? "TUI stopped",
+			},
+		);
 	}
 
 	private recordTokenUsageFromMessages(state: AgentState): void {

--- a/src/cli-tui/tui-renderer/command-registry-options.ts
+++ b/src/cli-tui/tui-renderer/command-registry-options.ts
@@ -137,7 +137,7 @@ export interface TuiCommandRegistryDeps {
 	handleModeCommand: (context: CommandExecutionContext) => void;
 	commandSuite: CommandSuiteRuntimeDeps;
 	refreshFooterHint: () => void;
-	onQuit: () => void;
+	onQuit: () => Promise<void> | void;
 }
 
 export function buildTuiCommandRegistryOptions(
@@ -256,7 +256,9 @@ export function buildTuiCommandRegistryOptions(
 		branch: (context) =>
 			deps.getBranchController().handleBranchCommand(context),
 		tree: (context) => deps.handleTreeCommand(context),
-		quit: (_context) => deps.onQuit(),
+		quit: async (_context) => {
+			await deps.onQuit();
+		},
 		approvals: (context) =>
 			handleApprovalsCommand(context, deps.approvalService, {
 				showToast: (msg, type) => deps.notificationView.showToast(msg, type),

--- a/src/cli-tui/tui-renderer/input-controller.ts
+++ b/src/cli-tui/tui-renderer/input-controller.ts
@@ -23,7 +23,7 @@ export interface InputControllerDeps {
 
 export interface InputControllerCallbacks {
 	showInfo: (message: string) => void;
-	stopRenderer: () => void;
+	stopRenderer: () => Promise<void> | void;
 	exitProcess: (code?: number) => void;
 }
 
@@ -97,8 +97,8 @@ export class InputController {
 		this.onInterruptCallback?.(options);
 	}
 
-	handleCtrlDExit(): void {
-		this.callbacks.stopRenderer();
+	async handleCtrlDExit(): Promise<void> {
+		await this.callbacks.stopRenderer();
 		this.callbacks.exitProcess(0);
 	}
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -682,10 +682,16 @@ export function recordSessionDuration(
 	sessionId: string,
 	durationMs: number,
 	metadata?: Omit<BusinessMetricTelemetry["metadata"], "sessionId">,
-): void {
-	recordBusinessMetric("session.duration", durationMs, {
-		...metadata,
-		sessionId,
+): Promise<void> {
+	return recordTelemetry({
+		type: "business-metric",
+		timestamp: new Date().toISOString(),
+		metric: "session.duration",
+		value: durationMs,
+		metadata: {
+			...metadata,
+			sessionId,
+		},
 	});
 }
 

--- a/src/telemetry/maestro-event-bus.ts
+++ b/src/telemetry/maestro-event-bus.ts
@@ -877,6 +877,25 @@ function stringMetadata(metadata: unknown, name: string): string | undefined {
 		: undefined;
 }
 
+function closeReasonFromMetadata(
+	metadata: unknown,
+): MaestroCloseReason | undefined {
+	const value =
+		stringMetadata(metadata, "closeReason") ??
+		stringMetadata(metadata, "close_reason");
+	switch (value) {
+		case "MAESTRO_CLOSE_REASON_COMPLETED":
+		case "MAESTRO_CLOSE_REASON_USER_STOPPED":
+		case "MAESTRO_CLOSE_REASON_IDLE_TIMEOUT":
+		case "MAESTRO_CLOSE_REASON_TTL_EXPIRED":
+		case "MAESTRO_CLOSE_REASON_ERROR":
+		case "MAESTRO_CLOSE_REASON_POLICY_DENIED":
+			return value;
+		default:
+			return undefined;
+	}
+}
+
 function durationFromMs(value: unknown): string | undefined {
 	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
 		return undefined;
@@ -1239,7 +1258,13 @@ export async function mirrorTelemetryToMaestroEventBus(
 						: undefined,
 				close_reason:
 					eventType === MaestroBusEventType.SessionClosed
-						? "MAESTRO_CLOSE_REASON_COMPLETED"
+						? (closeReasonFromMetadata(fields.metadata) ??
+							"MAESTRO_CLOSE_REASON_COMPLETED")
+						: undefined,
+				close_message:
+					eventType === MaestroBusEventType.SessionClosed
+						? (stringMetadata(fields.metadata, "closeMessage") ??
+							stringMetadata(fields.metadata, "close_message"))
 						: undefined,
 				metadata: contextFromMetadata(fields.metadata, {
 					value: fields.value,

--- a/test/agent/telemetry-metrics.test.ts
+++ b/test/agent/telemetry-metrics.test.ts
@@ -59,12 +59,12 @@ describe("Business Metrics Telemetry", () => {
 	});
 
 	describe("recordSessionDuration", () => {
-		it("records session duration in ms", () => {
-			expect(() => {
+		it("records session duration in ms", async () => {
+			await expect(
 				recordSessionDuration("session-123", 60000, {
 					model: "claude-3-opus",
-				});
-			}).not.toThrow();
+				}),
+			).resolves.toBeUndefined();
 		});
 	});
 

--- a/test/cli-tui/agent-event-bridge.test.ts
+++ b/test/cli-tui/agent-event-bridge.test.ts
@@ -81,12 +81,14 @@ function createState(): AgentState {
 	};
 }
 
-function createBridge(options: { backup?: unknown } = {}) {
+function createBridge(
+	options: { backup?: unknown; getSessionId?: () => string } = {},
+) {
 	return new AgentEventBridge({
 		deps: {
 			agent: {} as never,
 			sessionManager: {
-				getSessionId: () => "session-123",
+				getSessionId: options.getSessionId ?? (() => "session-123"),
 			} as never,
 			sessionRecoveryManager: {
 				getCurrentBackup: () => options.backup ?? null,
@@ -169,8 +171,8 @@ describe("AgentEventBridge prompt telemetry", () => {
 			{ type: "agent_start" } as AgentEvent,
 			createState(),
 		);
-		bridge.recordSessionClosed();
-		bridge.recordSessionClosed();
+		await bridge.recordSessionClosed();
+		await bridge.recordSessionClosed();
 
 		expect(telemetryMocks.recordSessionDuration).toHaveBeenCalledTimes(1);
 		expect(telemetryMocks.recordSessionDuration).toHaveBeenCalledWith(
@@ -183,6 +185,30 @@ describe("AgentEventBridge prompt telemetry", () => {
 				prompt_hash: "hash_123",
 				closeReason: "MAESTRO_CLOSE_REASON_USER_STOPPED",
 				closeMessage: "TUI stopped",
+			}),
+		);
+	});
+
+	it("uses the session id captured at start when recording close telemetry", async () => {
+		let sessionId = "session-start";
+		const bridge = createBridge({ getSessionId: () => sessionId });
+
+		await bridge.handleEvent(
+			{ type: "agent_start" } as AgentEvent,
+			createState(),
+		);
+		sessionId = "session-after-clear";
+		await bridge.recordSessionClosed();
+
+		expect(telemetryMocks.recordSessionStart).toHaveBeenCalledWith(
+			"session-start",
+			expect.any(Object),
+		);
+		expect(telemetryMocks.recordSessionDuration).toHaveBeenCalledWith(
+			"session-start",
+			expect.any(Number),
+			expect.objectContaining({
+				closeReason: "MAESTRO_CLOSE_REASON_USER_STOPPED",
 			}),
 		);
 	});

--- a/test/cli-tui/agent-event-bridge.test.ts
+++ b/test/cli-tui/agent-event-bridge.test.ts
@@ -1,13 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const telemetryMocks = vi.hoisted(() => ({
+	recordSessionDuration: vi.fn(),
 	recordSessionStart: vi.fn(),
 	recordTokenUsage: vi.fn(),
 }));
 
-vi.mock("../../src/telemetry.js", () => ({
-	recordSessionStart: telemetryMocks.recordSessionStart,
-	recordTokenUsage: telemetryMocks.recordTokenUsage,
+vi.mock("../../src/telemetry.js", () => telemetryMocks);
+vi.mock("../../src/cli-tui/utils/footer-utils.js", () => ({
+	calculateFooterStats: vi.fn(() => ({
+		totalInput: 0,
+		totalOutput: 0,
+		totalCacheRead: 0,
+		totalCacheWrite: 0,
+		totalCost: 0,
+		contextTokens: 0,
+		contextWindow: 0,
+		contextPercent: 0,
+	})),
 }));
 
 import type { AgentEvent, AgentState } from "../../src/agent/types.js";
@@ -71,40 +81,45 @@ function createState(): AgentState {
 	};
 }
 
+function createBridge(options: { backup?: unknown } = {}) {
+	return new AgentEventBridge({
+		deps: {
+			agent: {} as never,
+			sessionManager: {
+				getSessionId: () => "session-123",
+			} as never,
+			sessionRecoveryManager: {
+				getCurrentBackup: () => options.backup ?? null,
+				startSession: vi.fn(),
+				updateMessages: vi.fn(),
+			} as never,
+			autoRetryController: { checkAndRetry: vi.fn() } as never,
+			interruptController: { clear: vi.fn() } as never,
+			footer: { updateState: vi.fn() } as never,
+			agentEventRouter: { handle: vi.fn() } as never,
+		},
+		callbacks: {
+			ensureInitialized: async () => {},
+			handleApprovalRequired: vi.fn(),
+			handleApprovalResolved: vi.fn(),
+			handleToolRetryRequired: vi.fn(),
+			handleToolRetryResolved: vi.fn(),
+			setAgentRunning: vi.fn(),
+			maybeShowContextWarning: vi.fn(),
+			setCurrentModelMetadata: vi.fn(),
+		},
+	});
+}
+
 describe("AgentEventBridge prompt telemetry", () => {
 	beforeEach(() => {
+		telemetryMocks.recordSessionDuration.mockReset();
 		telemetryMocks.recordSessionStart.mockReset();
 		telemetryMocks.recordTokenUsage.mockReset();
 	});
 
 	it("includes prompt metadata in session start telemetry", async () => {
-		const bridge = new AgentEventBridge({
-			deps: {
-				agent: {} as never,
-				sessionManager: {
-					getSessionId: () => "session-123",
-				} as never,
-				sessionRecoveryManager: {
-					getCurrentBackup: () => null,
-					startSession: vi.fn(),
-					updateMessages: vi.fn(),
-				} as never,
-				autoRetryController: { checkAndRetry: vi.fn() } as never,
-				interruptController: { clear: vi.fn() } as never,
-				footer: { updateState: vi.fn() } as never,
-				agentEventRouter: { handle: vi.fn() } as never,
-			},
-			callbacks: {
-				ensureInitialized: async () => {},
-				handleApprovalRequired: vi.fn(),
-				handleApprovalResolved: vi.fn(),
-				handleToolRetryRequired: vi.fn(),
-				handleToolRetryResolved: vi.fn(),
-				setAgentRunning: vi.fn(),
-				maybeShowContextWarning: vi.fn(),
-				setCurrentModelMetadata: vi.fn(),
-			},
-		});
+		const bridge = createBridge();
 
 		await bridge.handleEvent(
 			{ type: "agent_start" } as AgentEvent,
@@ -123,33 +138,7 @@ describe("AgentEventBridge prompt telemetry", () => {
 	});
 
 	it("includes prompt metadata in token usage telemetry", async () => {
-		const bridge = new AgentEventBridge({
-			deps: {
-				agent: {} as never,
-				sessionManager: {
-					getSessionId: () => "session-123",
-				} as never,
-				sessionRecoveryManager: {
-					getCurrentBackup: () => ({}),
-					startSession: vi.fn(),
-					updateMessages: vi.fn(),
-				} as never,
-				autoRetryController: { checkAndRetry: vi.fn() } as never,
-				interruptController: { clear: vi.fn() } as never,
-				footer: { updateState: vi.fn() } as never,
-				agentEventRouter: { handle: vi.fn() } as never,
-			},
-			callbacks: {
-				ensureInitialized: async () => {},
-				handleApprovalRequired: vi.fn(),
-				handleApprovalResolved: vi.fn(),
-				handleToolRetryRequired: vi.fn(),
-				handleToolRetryResolved: vi.fn(),
-				setAgentRunning: vi.fn(),
-				maybeShowContextWarning: vi.fn(),
-				setCurrentModelMetadata: vi.fn(),
-			},
-		});
+		const bridge = createBridge({ backup: {} });
 
 		await bridge.handleEvent(
 			{ type: "agent_end" } as AgentEvent,
@@ -170,6 +159,31 @@ describe("AgentEventBridge prompt telemetry", () => {
 				prompt_version: 9,
 				prompt_hash: "hash_123",
 			},
+		);
+	});
+
+	it("records one closed session duration when the TUI stops", async () => {
+		const bridge = createBridge();
+
+		await bridge.handleEvent(
+			{ type: "agent_start" } as AgentEvent,
+			createState(),
+		);
+		bridge.recordSessionClosed();
+		bridge.recordSessionClosed();
+
+		expect(telemetryMocks.recordSessionDuration).toHaveBeenCalledTimes(1);
+		expect(telemetryMocks.recordSessionDuration).toHaveBeenCalledWith(
+			"session-123",
+			expect.any(Number),
+			expect.objectContaining({
+				model: "anthropic/claude-sonnet-4",
+				provider: "anthropic",
+				prompt_version: 9,
+				prompt_hash: "hash_123",
+				closeReason: "MAESTRO_CLOSE_REASON_USER_STOPPED",
+				closeMessage: "TUI stopped",
+			}),
 		);
 	});
 });

--- a/test/telemetry/maestro-event-bus.test.ts
+++ b/test/telemetry/maestro-event-bus.test.ts
@@ -91,7 +91,7 @@ describe("maestro event bus", () => {
 		process.env.MAESTRO_EVENT_BUS_URL = "nats://bus.example:4222";
 		process.env.MAESTRO_EVENT_BUS_SOURCE = "maestro-tui-test";
 		try {
-			recordSessionDuration("session_tui", 1234, {
+			await recordSessionDuration("session_tui", 1234, {
 				closeReason: "MAESTRO_CLOSE_REASON_USER_STOPPED",
 				closeMessage: "TUI stopped",
 			});

--- a/test/telemetry/maestro-event-bus.test.ts
+++ b/test/telemetry/maestro-event-bus.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { recordSessionDuration } from "../../src/telemetry.js";
 import {
 	MaestroBusEventType,
 	buildMaestroCloudEvent,
@@ -76,6 +77,58 @@ describe("maestro event bus", () => {
 			"type.googleapis.com/maestro.v1.ToolCallAttempt",
 		);
 		expect(event.data.tool_call_id).toBe("tool_1");
+	});
+
+	it("maps session duration metadata to a close lifecycle CloudEvent", async () => {
+		const published: Array<{ subject: string; payload: string }> = [];
+		setMaestroEventBusTransportForTests({
+			async publish(subject, payload) {
+				published.push({ subject, payload });
+			},
+		});
+		const previousUrl = process.env.MAESTRO_EVENT_BUS_URL;
+		const previousSource = process.env.MAESTRO_EVENT_BUS_SOURCE;
+		process.env.MAESTRO_EVENT_BUS_URL = "nats://bus.example:4222";
+		process.env.MAESTRO_EVENT_BUS_SOURCE = "maestro-tui-test";
+		try {
+			recordSessionDuration("session_tui", 1234, {
+				closeReason: "MAESTRO_CLOSE_REASON_USER_STOPPED",
+				closeMessage: "TUI stopped",
+			});
+			for (let i = 0; i < 10 && published.length === 0; i++) {
+				await new Promise((resolve) => setTimeout(resolve, 0));
+			}
+		} finally {
+			if (previousUrl === undefined) {
+				delete process.env.MAESTRO_EVENT_BUS_URL;
+			} else {
+				process.env.MAESTRO_EVENT_BUS_URL = previousUrl;
+			}
+			if (previousSource === undefined) {
+				delete process.env.MAESTRO_EVENT_BUS_SOURCE;
+			} else {
+				process.env.MAESTRO_EVENT_BUS_SOURCE = previousSource;
+			}
+		}
+
+		expect(published).toHaveLength(1);
+		expect(published[0]?.subject).toBe("maestro.sessions.session.closed");
+		expect(JSON.parse(published[0]?.payload ?? "{}")).toMatchObject({
+			type: "maestro.sessions.session.closed",
+			source: "maestro-tui-test",
+			data: {
+				correlation: {
+					session_id: "session_tui",
+				},
+				state: "MAESTRO_SESSION_STATE_CLOSED",
+				close_reason: "MAESTRO_CLOSE_REASON_USER_STOPPED",
+				close_message: "TUI stopped",
+				metadata: {
+					metric: "session.duration",
+					value: 1234,
+				},
+			},
+		});
 	});
 
 	it("publishes prompt variant selected CloudEvents with prompt identity", async () => {

--- a/test/tui/command-registry-options.test.ts
+++ b/test/tui/command-registry-options.test.ts
@@ -313,4 +313,19 @@ describe("buildTuiCommandRegistryOptions", () => {
 		expect(commandSuiteHandlers).toBeDefined();
 		expect(options.getCommandSuiteHandlers()).toBe(commandSuiteHandlers);
 	});
+
+	it("waits for the quit shutdown hook", async () => {
+		const { deps } = createDeps();
+		const calls: string[] = [];
+		deps.onQuit = vi.fn(async () => {
+			calls.push("stop-start");
+			await Promise.resolve();
+			calls.push("stop-finished");
+		});
+		const options = buildTuiCommandRegistryOptions(deps);
+
+		await options.handlers.quit(createCommandContext("/quit"));
+
+		expect(calls).toEqual(["stop-start", "stop-finished"]);
+	});
 });

--- a/test/tui/input-controller.test.ts
+++ b/test/tui/input-controller.test.ts
@@ -10,6 +10,8 @@ function createController(options?: {
 	isBashModeActive?: boolean;
 	tryHandleOneOffInput?: boolean;
 	tryHandleInput?: boolean;
+	stopRenderer?: () => Promise<void> | void;
+	exitProcess?: (code?: number) => void;
 }) {
 	const editor = {
 		addToHistory: vi.fn(),
@@ -46,8 +48,8 @@ function createController(options?: {
 		},
 		callbacks: {
 			showInfo: vi.fn(),
-			stopRenderer: vi.fn(),
-			exitProcess: vi.fn(),
+			stopRenderer: options?.stopRenderer ?? vi.fn(),
+			exitProcess: options?.exitProcess ?? vi.fn(),
 		},
 	});
 
@@ -95,5 +97,23 @@ describe("InputController", () => {
 		expect(getBashModeView).toHaveBeenCalledTimes(1);
 		expect(bashModeView.tryHandleOneOffInput).toHaveBeenCalledWith("pwd");
 		expect(bashModeView.tryHandleInput).toHaveBeenCalledWith("pwd");
+	});
+
+	it("waits for renderer shutdown before exiting on Ctrl-D", async () => {
+		const calls: string[] = [];
+		const { controller } = createController({
+			stopRenderer: async () => {
+				calls.push("stop-start");
+				await Promise.resolve();
+				calls.push("stop-finished");
+			},
+			exitProcess: (code) => {
+				calls.push(`exit-${code}`);
+			},
+		});
+
+		await controller.handleCtrlDExit();
+
+		expect(calls).toEqual(["stop-start", "stop-finished", "exit-0"]);
 	});
 });

--- a/test/tui/run-controller.test.ts
+++ b/test/tui/run-controller.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RunController } from "../../src/cli-tui/run/run-controller.js";
+
+describe("RunController", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("waits for renderer shutdown before exiting on double Ctrl-C", async () => {
+		const calls: string[] = [];
+		vi.spyOn(process, "exit").mockImplementation(((
+			code?: number | string | null,
+		) => {
+			calls.push(`exit-${code}`);
+			return undefined as never;
+		}) as typeof process.exit);
+		const controller = new RunController({
+			loaderView: {} as never,
+			ui: { requestRender: vi.fn() } as never,
+			setEditorDisabled: vi.fn(),
+			focusEditor: () => {
+				calls.push("focus");
+			},
+			clearEditor: () => {
+				calls.push("clear");
+			},
+			stopRenderer: async () => {
+				calls.push("stop-start");
+				await Promise.resolve();
+				calls.push("stop-finished");
+			},
+			refreshFooterHint: vi.fn(),
+			notifyFileChanges: vi.fn(),
+			inMinimalMode: () => false,
+		});
+
+		await controller.handleCtrlC();
+		await controller.handleCtrlC();
+
+		expect(calls).toEqual([
+			"clear",
+			"focus",
+			"stop-start",
+			"stop-finished",
+			"exit-0",
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- record a TUI session-duration close event exactly once when the TUI renderer stops
- preserve explicit close reason/message when session-duration telemetry mirrors to the Maestro event bus
- cover the TUI bridge and shared event-bus mirror with focused tests

## Source PR

- evalops/maestro-internal#1508

## Validation

- `./node_modules/.bin/biome check src/cli-tui/tui-renderer/agent-event-bridge.ts src/cli-tui/tui-renderer.ts src/telemetry/maestro-event-bus.ts test/cli-tui/agent-event-bridge.test.ts test/telemetry/maestro-event-bus.test.ts`
- `node ./scripts/run-vitest.js --run test/cli-tui/agent-event-bridge.test.ts test/telemetry/maestro-event-bus.test.ts`
- `~/.bun/bin/bun run --cwd packages/tui build`
- `~/.bun/bin/bun run --cwd packages/contracts build`
- `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit --pretty false`
- pre-commit hook: Guardian, Biome/lint, build, bundle

Part of #49.