### PR TITLE
Publish web session start events

### DIFF
--- a/src/server/session-initialization.ts
+++ b/src/server/session-initialization.ts
@@ -1,5 +1,6 @@
 import type { EnterpriseSession } from "../enterprise/context.js";
 import { checkSessionLimits } from "../safety/policy.js";
+import { recordMaestroSessionEvent } from "../telemetry/maestro-event-bus.js";
 
 type SessionState = Parameters<SessionInitializationManager["startSession"]>[0];
 
@@ -36,6 +37,16 @@ export interface SessionInitializationEnterpriseContext {
 
 export interface SessionInitializationLogger {
 	warn(message: string, context: Record<string, unknown>): void;
+}
+
+function webSessionEventEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+	return {
+		...env,
+		MAESTRO_EVENT_BUS_SOURCE: env.MAESTRO_EVENT_BUS_SOURCE ?? "maestro.web",
+		MAESTRO_SURFACE: env.MAESTRO_SURFACE ?? "web",
+	};
 }
 
 export async function startSessionWithPolicy(params: {
@@ -85,8 +96,17 @@ export async function startSessionWithPolicy(params: {
 	}
 
 	sessionManager.startSession(agent.state, { subject });
+	const sessionId = sessionManager.getSessionId();
+	recordMaestroSessionEvent("MAESTRO_SESSION_STATE_STARTED", {
+		sessionId,
+		env: webSessionEventEnv(),
+		metadata: {
+			model: modelId,
+			...(subject ? { subject } : {}),
+		},
+	});
 	if (enterpriseContext.isEnterprise()) {
-		enterpriseContext.startSession(sessionManager.getSessionId(), modelId);
+		enterpriseContext.startSession(sessionId, modelId);
 		const session = enterpriseContext.getSession();
 		if (session) {
 			agent.setSession({
@@ -96,6 +116,6 @@ export async function startSessionWithPolicy(params: {
 		}
 	}
 
-	onSessionReady(sessionManager.getSessionId());
+	onSessionReady(sessionId);
 	return null;
 }

--- a/test/server/session-initialization.test.ts
+++ b/test/server/session-initialization.test.ts
@@ -8,6 +8,13 @@ import {
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const telemetryMocks = vi.hoisted(() => ({
+	recordMaestroSessionEvent: vi.fn(),
+}));
+
+vi.mock("../../src/telemetry/maestro-event-bus.js", () => telemetryMocks);
+
 import { loadPolicy } from "../../src/safety/policy.js";
 import { startSessionWithPolicy } from "../../src/server/session-initialization.js";
 
@@ -84,6 +91,7 @@ describe("startSessionWithPolicy", () => {
 		expect(countActiveSessions).toHaveBeenCalledWith(expect.any(Date));
 		expect(manager.loadAllSessions).not.toHaveBeenCalled();
 		expect(startSession).not.toHaveBeenCalled();
+		expect(telemetryMocks.recordMaestroSessionEvent).not.toHaveBeenCalled();
 	});
 
 	it("starts a session when async active-session count is within policy", async () => {
@@ -113,5 +121,70 @@ describe("startSessionWithPolicy", () => {
 		expect(result).toBeNull();
 		expect(startSession).toHaveBeenCalledTimes(1);
 		expect(onSessionReady).toHaveBeenCalledWith("session-id");
+		expect(telemetryMocks.recordMaestroSessionEvent).toHaveBeenCalledWith(
+			"MAESTRO_SESSION_STATE_STARTED",
+			expect.objectContaining({
+				sessionId: "session-id",
+				metadata: {
+					model: "test-model",
+				},
+				env: expect.objectContaining({
+					MAESTRO_EVENT_BUS_SOURCE: "maestro.web",
+					MAESTRO_SURFACE: "web",
+				}),
+			}),
+		);
+	});
+
+	it("adds web subject metadata without overriding configured event source", async () => {
+		const previousSource = process.env.MAESTRO_EVENT_BUS_SOURCE;
+		const previousSurface = process.env.MAESTRO_SURFACE;
+		process.env.MAESTRO_EVENT_BUS_SOURCE = "maestro.custom-web";
+		delete process.env.MAESTRO_SURFACE;
+		try {
+			const manager = {
+				loadAllSessions: vi.fn(() => []),
+				countActiveSessions: vi.fn(async () => 0),
+				startSession: vi.fn(),
+				getSessionId: vi.fn(() => "session-web"),
+			};
+
+			const result = await startSessionWithPolicy({
+				agent: createAgent(),
+				enterpriseContext: createEnterpriseContext(),
+				logger: { warn: vi.fn() },
+				modelId: "anthropic/claude-sonnet-4",
+				onSessionReady: vi.fn(),
+				sessionManager: manager,
+				subject: "web-chat",
+			});
+
+			expect(result).toBeNull();
+			expect(telemetryMocks.recordMaestroSessionEvent).toHaveBeenCalledWith(
+				"MAESTRO_SESSION_STATE_STARTED",
+				expect.objectContaining({
+					sessionId: "session-web",
+					metadata: {
+						model: "anthropic/claude-sonnet-4",
+						subject: "web-chat",
+					},
+					env: expect.objectContaining({
+						MAESTRO_EVENT_BUS_SOURCE: "maestro.custom-web",
+						MAESTRO_SURFACE: "web",
+					}),
+				}),
+			);
+		} finally {
+			if (previousSource === undefined) {
+				delete process.env.MAESTRO_EVENT_BUS_SOURCE;
+			} else {
+				process.env.MAESTRO_EVENT_BUS_SOURCE = previousSource;
+			}
+			if (previousSurface === undefined) {
+				delete process.env.MAESTRO_SURFACE;
+			} else {
+				process.env.MAESTRO_SURFACE = previousSurface;
+			}
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- emit web chat session-start lifecycle CloudEvents from `startSessionWithPolicy`
- stamp web surface/source defaults without overriding a configured event source
- cover policy-denied, allowed, and subject metadata behavior in server initialization tests

Internal source PR: evalops/maestro-internal#1509
Part of evalops/maestro#49.

## Test plan
- `./node_modules/.bin/biome check --write src/server/session-initialization.ts test/server/session-initialization.test.ts`
- `node ./scripts/run-vitest.js --run test/server/session-initialization.test.ts`
- `~/.bun/bin/bun run --cwd packages/tui build`
- `~/.bun/bin/bun run --cwd packages/contracts build`
- `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit --pretty false`
- pre-commit hook
