### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/headless.md
+++ b/docs/protocols/headless.md
@@ -487,5 +487,11 @@ telemetry. Audit-bus publishing is controlled separately with
 `MAESTRO_EVENT_BUS`; set it to `0` or `false` to suppress bus writes even when
 managed EvalOps routing is active.
 
+To verify a live JetStream route without relying on best-effort runtime
+publishing, run `bun run smoke:event-bus` with `MAESTRO_EVENT_BUS_URL` or
+`EVALOPS_NATS_URL` configured. The smoke publishes a single
+`maestro.sessions.session.started` CloudEvent and fails on connection or
+publish errors.
+
 For the larger remote-attach and control-plane architecture, see the companion
 design document: [docs/design/HEADLESS_CONTROL_PLANE.md](../design/HEADLESS_CONTROL_PLANE.md).

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "tui": "npm run cli",
     "verify": "npm run format && npm run lint && npm run test && npm run build && npm run smoke && npm run telemetry:report",
     "smoke": "node scripts/smoke-cli.js",
+    "smoke:event-bus": "tsx scripts/smoke-maestro-event-bus.ts",
     "smoke:headless": "node scripts/smoke-headless.js",
     "headless:responsiveness": "node scripts/headless-responsiveness-harness.js",
     "smoke:pack": "node scripts/smoke-packed-cli.js",

--- a/packages/ambient-agent-rs/src/daemon.rs
+++ b/packages/ambient-agent-rs/src/daemon.rs
@@ -794,6 +794,7 @@ mod tests {
     use crate::platform_event_bus::{PlatformEventBusConfig, PlatformEventBusTransport};
     use async_trait::async_trait;
     use serde_json::Value;
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
 
@@ -959,11 +960,16 @@ mod tests {
 
         wait_for_published(&transport, 1).await;
 
-        std::fs::create_dir(temp.path().join("learner.json")).unwrap();
+        let original_permissions = std::fs::metadata(temp.path()).unwrap().permissions();
+        let mut read_only_permissions = original_permissions.clone();
+        read_only_permissions.set_mode(0o500);
+        std::fs::set_permissions(temp.path(), read_only_permissions).unwrap();
 
         cmd_tx.send(DaemonCommand::Shutdown).await.unwrap();
 
         let result = daemon_handle.await.unwrap();
+
+        std::fs::set_permissions(temp.path(), original_permissions).unwrap();
 
         assert!(result.is_err());
         wait_for_published(&transport, 2).await;

--- a/scripts/smoke-maestro-event-bus.ts
+++ b/scripts/smoke-maestro-event-bus.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env tsx
+import { randomUUID } from "node:crypto";
+import {
+	MaestroBusEventType,
+	closeMaestroEventBusTransport,
+	publishMaestroCloudEventStrict,
+	resolveMaestroEventBusConfig,
+} from "../src/telemetry/maestro-event-bus.js";
+
+const config = resolveMaestroEventBusConfig();
+if (!config.natsUrl) {
+	throw new Error(
+		"Set MAESTRO_EVENT_BUS_URL or EVALOPS_NATS_URL before running the Maestro event bus smoke.",
+	);
+}
+
+const now = new Date().toISOString();
+const sessionId =
+	process.env.MAESTRO_EVENT_BUS_SMOKE_SESSION_ID ??
+	`maestro-event-bus-smoke-${Date.now()}`;
+const eventId =
+	process.env.MAESTRO_EVENT_BUS_SMOKE_EVENT_ID ??
+	`maestro-event-bus-smoke-${randomUUID()}`;
+
+try {
+	await publishMaestroCloudEventStrict(
+		MaestroBusEventType.SessionStarted,
+		{
+			correlation: {
+				...config.defaultCorrelation,
+				session_id: sessionId,
+			},
+			state: "MAESTRO_SESSION_STATE_STARTED",
+			surface: config.defaultSurface,
+			runtime_mode: config.defaultRuntimeMode,
+			principal: config.defaultPrincipal,
+			workspace_root: process.cwd(),
+			started_at: now,
+			metadata: {
+				smoke: "event-bus",
+				source: "scripts/smoke-maestro-event-bus.ts",
+			},
+		},
+		{
+			eventId,
+			env: process.env,
+			source: process.env.MAESTRO_EVENT_BUS_SOURCE ?? "maestro.smoke",
+			time: now,
+		},
+	);
+	console.log(
+		`Published Maestro event bus smoke event ${eventId} to ${MaestroBusEventType.SessionStarted}`,
+	);
+} finally {
+	await closeMaestroEventBusTransport();
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -53,6 +53,7 @@ export {
 	closeMaestroEventBusTransport,
 	getMaestroEventBusStatus,
 	publishMaestroCloudEvent,
+	publishMaestroCloudEventStrict,
 	recordMaestroApprovalHit,
 	recordMaestroEvalScored,
 	recordMaestroFirewallBlock,

--- a/src/telemetry/maestro-event-bus.ts
+++ b/src/telemetry/maestro-event-bus.ts
@@ -821,6 +821,25 @@ export async function publishMaestroCloudEvent<
 	}
 }
 
+export async function publishMaestroCloudEventStrict<
+	TData extends Record<string, unknown>,
+>(
+	type: MaestroBusEventType,
+	data: TData,
+	options: PublishMaestroEventOptions = {},
+): Promise<void> {
+	const config = resolveMaestroEventBusConfig(options.env);
+	if (!config.enabled) {
+		throw new Error(`Maestro event bus is not enabled: ${config.reason}`);
+	}
+	const transport = await getTransport(config);
+	if (!transport) {
+		throw new Error("Maestro event bus transport is unavailable");
+	}
+	const event = buildMaestroCloudEvent(type, data, options);
+	await transport.publish(type, JSON.stringify(event));
+}
+
 function contextFromMetadata(
 	metadata: unknown,
 	extra?: Record<string, unknown>,

--- a/test/telemetry/maestro-event-bus.test.ts
+++ b/test/telemetry/maestro-event-bus.test.ts
@@ -6,6 +6,7 @@ import {
 	closeMaestroEventBusTransport,
 	getMaestroEventBusStatus,
 	publishMaestroCloudEvent,
+	publishMaestroCloudEventStrict,
 	recordMaestroEvalScored,
 	recordMaestroPromptVariantSelected,
 	recordMaestroSkillInvoked,
@@ -492,6 +493,57 @@ describe("maestro event bus", () => {
 				decision_mode: "MAESTRO_DECISION_MODE_REQUIRE_APPROVAL",
 			},
 		});
+	});
+
+	it("keeps runtime publish best-effort but exposes a strict smoke path", async () => {
+		setMaestroEventBusTransportForTests({
+			async publish() {
+				throw new Error("nats unavailable");
+			},
+		});
+		const data = {
+			correlation: {
+				workspace_id: "workspace_123",
+				session_id: "session_123",
+			},
+			action: "Smoke approval",
+			decision_mode: "MAESTRO_DECISION_MODE_REQUIRE_APPROVAL" as const,
+			occurred_at: "2026-04-22T16:00:00.000Z",
+		};
+		const options = {
+			env: { MAESTRO_EVENT_BUS_URL: "nats://bus.example:4222" },
+			eventId: "event_strict",
+			time: "2026-04-22T16:00:00.000Z",
+		};
+
+		await expect(
+			publishMaestroCloudEvent(MaestroBusEventType.ApprovalHit, data, options),
+		).resolves.toBeUndefined();
+		await expect(
+			publishMaestroCloudEventStrict(
+				MaestroBusEventType.ApprovalHit,
+				data,
+				options,
+			),
+		).rejects.toThrow("nats unavailable");
+	});
+
+	it("fails strict smoke publishing when bus routing is not configured", async () => {
+		await expect(
+			publishMaestroCloudEventStrict(
+				MaestroBusEventType.ApprovalHit,
+				{
+					correlation: {
+						workspace_id: "workspace_123",
+						session_id: "session_123",
+					},
+					action: "Smoke approval",
+					decision_mode: "MAESTRO_DECISION_MODE_REQUIRE_APPROVAL",
+					occurred_at: "2026-04-22T16:00:00.000Z",
+				},
+				{ env: {} },
+			),
+		).rejects.toThrow("Maestro event bus is not enabled: disabled");
 	});
 
 	it("reports missing NATS URL separately from disabled bus state", () => {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `bf676b5f7b01d15bb8803bbde34767350b89633c`
- last generated public sync base: `e0c79e1c98b8b6795f83c39fb5bfb5d559be9215`
- previewed public-tree drift: `7` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `5`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (bf676b5f7b01)`
- public projection: `https://github.com/evalops/maestro@main (c89c0cec4b5c)`
- files to copy or update: `7`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/headless.md
- copy/update package.json
- copy/update packages/ambient-agent-rs/src/daemon.rs
- copy/update scripts/smoke-maestro-event-bus.ts
- copy/update src/telemetry/index.ts
- copy/update src/telemetry/maestro-event-bus.ts
- copy/update test/telemetry/maestro-event-bus.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/headless.md
- copy/update package.json
- copy/update packages/ambient-agent-rs/src/daemon.rs
- copy/update scripts/smoke-maestro-event-bus.ts
- copy/update src/telemetry/index.ts
- copy/update src/telemetry/maestro-event-bus.ts
- copy/update test/telemetry/maestro-event-bus.test.ts

## Public-only commits since last generated sync

- c89c0cec Publish web session delete close events (#197)
- 2bb8a1d8 Record TUI session close events (#194)
- 2ac32dd4 Publish web session start events (#195)
- 3768ac4c Keep Ambient closed event regression in mirror (#192)
- 1c2fde46 Wire ambient daemon session events to event bus (#191)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #196 to internal source `bf676b5f7b01d15bb8803bbde34767350b89633c`