### PR TITLE
Publish web session delete close events

### DIFF
--- a/src/server/handlers/sessions.ts
+++ b/src/server/handlers/sessions.ts
@@ -47,6 +47,7 @@ import {
 } from "../../safety/outbound-secret-preflight.js";
 import { safeReadSessionEntries } from "../../session/session-context.js";
 import type { SessionEntry } from "../../session/types.js";
+import { recordMaestroSessionEvent } from "../../telemetry/maestro-event-bus.js";
 import { createLogger } from "../../utils/logger.js";
 import { getAuthSubject } from "../authz.js";
 import { isHostedSessionManager } from "../hosted-session-manager.js";
@@ -57,6 +58,7 @@ import {
 	respondWithApiError,
 	sendJson,
 } from "../server-utils.js";
+import { webSessionEventEnv } from "../session-event-env.js";
 import {
 	createWebSessionManagerForRequest,
 	createWebSessionManagerForScope,
@@ -450,6 +452,14 @@ export async function handleSessions(
 			}
 
 			await sessionManager.deleteSession(sessionId);
+			recordMaestroSessionEvent("MAESTRO_SESSION_STATE_CLOSED", {
+				sessionId,
+				closeReason: "MAESTRO_CLOSE_REASON_USER_STOPPED",
+				closeMessage: "Web session deleted",
+				correlation: { principal_id: subject },
+				env: webSessionEventEnv(),
+				metadata: { operation: "session.delete" },
+			});
 
 			res.writeHead(204, cors);
 			res.end();

--- a/src/server/session-event-env.ts
+++ b/src/server/session-event-env.ts
@@ -1,0 +1,9 @@
+export function webSessionEventEnv(
+	env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+	return {
+		...env,
+		MAESTRO_EVENT_BUS_SOURCE: env.MAESTRO_EVENT_BUS_SOURCE ?? "maestro.web",
+		MAESTRO_SURFACE: env.MAESTRO_SURFACE ?? "web",
+	};
+}

--- a/src/server/session-initialization.ts
+++ b/src/server/session-initialization.ts
@@ -1,6 +1,7 @@
 import type { EnterpriseSession } from "../enterprise/context.js";
 import { checkSessionLimits } from "../safety/policy.js";
 import { recordMaestroSessionEvent } from "../telemetry/maestro-event-bus.js";
+import { webSessionEventEnv } from "./session-event-env.js";
 
 type SessionState = Parameters<SessionInitializationManager["startSession"]>[0];
 
@@ -37,16 +38,6 @@ export interface SessionInitializationEnterpriseContext {
 
 export interface SessionInitializationLogger {
 	warn(message: string, context: Record<string, unknown>): void;
-}
-
-function webSessionEventEnv(
-	env: NodeJS.ProcessEnv = process.env,
-): NodeJS.ProcessEnv {
-	return {
-		...env,
-		MAESTRO_EVENT_BUS_SOURCE: env.MAESTRO_EVENT_BUS_SOURCE ?? "maestro.web",
-		MAESTRO_SURFACE: env.MAESTRO_SURFACE ?? "web",
-	};
 }
 
 export async function startSessionWithPolicy(params: {

--- a/test/session-endpoints.test.ts
+++ b/test/session-endpoints.test.ts
@@ -12,6 +12,13 @@ import {
 } from "../src/server/handlers/sessions.js";
 import { serverRequestManager } from "../src/server/server-request-manager.js";
 
+const telemetryMocks = vi.hoisted(() => ({
+	recordMaestroPromptVariantSelected: vi.fn(),
+	recordMaestroSessionEvent: vi.fn(),
+}));
+
+vi.mock("../src/telemetry/maestro-event-bus.js", () => telemetryMocks);
+
 function makeTestAnthropicToken(): string {
 	return [
 		"sk-ant-api03-",
@@ -808,12 +815,43 @@ describe("Session Endpoints", () => {
 
 	describe("handleSessions - DELETE", () => {
 		it("should delete a session", async () => {
+			const previousSource = process.env.MAESTRO_EVENT_BUS_SOURCE;
+			const previousSurface = process.env.MAESTRO_SURFACE;
+			delete process.env.MAESTRO_EVENT_BUS_SOURCE;
+			delete process.env.MAESTRO_SURFACE;
 			const req = createMockRequest("DELETE");
 			const { res, getStatus } = createMockResponse();
 
-			await handleSessions(req, res, { id: "test-session-1" }, corsHeaders);
+			try {
+				await handleSessions(req, res, { id: "test-session-1" }, corsHeaders);
 
-			expect(getStatus()).toBe(204);
+				expect(getStatus()).toBe(204);
+				expect(telemetryMocks.recordMaestroSessionEvent).toHaveBeenCalledWith(
+					"MAESTRO_SESSION_STATE_CLOSED",
+					expect.objectContaining({
+						sessionId: "test-session-1",
+						closeReason: "MAESTRO_CLOSE_REASON_USER_STOPPED",
+						closeMessage: "Web session deleted",
+						correlation: { principal_id: "anon" },
+						env: expect.objectContaining({
+							MAESTRO_EVENT_BUS_SOURCE: "maestro.web",
+							MAESTRO_SURFACE: "web",
+						}),
+						metadata: { operation: "session.delete" },
+					}),
+				);
+			} finally {
+				if (previousSource === undefined) {
+					delete process.env.MAESTRO_EVENT_BUS_SOURCE;
+				} else {
+					process.env.MAESTRO_EVENT_BUS_SOURCE = previousSource;
+				}
+				if (previousSurface === undefined) {
+					delete process.env.MAESTRO_SURFACE;
+				} else {
+					process.env.MAESTRO_SURFACE = previousSurface;
+				}
+			}
 		});
 
 		it("should return 400 for invalid session id", async () => {
@@ -823,6 +861,7 @@ describe("Session Endpoints", () => {
 			await handleSessions(req, res, { id: "invalid/id" }, corsHeaders);
 
 			expect(getStatus()).toBe(400);
+			expect(telemetryMocks.recordMaestroSessionEvent).not.toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- emit a web-surface session.closed CloudEvent after an authorized session delete succeeds
- share the web event source/surface defaults with session-start publication
- assert delete emits the closed event and invalid delete requests remain quiet

Internal source PR: evalops/maestro-internal#1510
Part of evalops/maestro#49.

## Test plan
- `./node_modules/.bin/biome check --write src/server/session-event-env.ts src/server/session-initialization.ts src/server/handlers/sessions.ts test/session-endpoints.test.ts`
- `node ./scripts/run-vitest.js --run test/session-endpoints.test.ts test/server/session-initialization.test.ts`
- `~/.bun/bin/bun run --cwd packages/tui build`
- `~/.bun/bin/bun run --cwd packages/contracts build`
- `./node_modules/.bin/tsc -p tsconfig.build.json --noEmit --pretty false`
- pre-commit hook
