### PR TITLE
Fix production migration packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN apk add --no-cache tini git && \
     adduser --system --uid 1001 appuser
 
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src/db/migrations ./dist/db/migrations
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/skills ./skills

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prepare": "husky",
     "install:local": "node ./scripts/install-client.js",
     "prebuild": "node ./scripts/ensure-deps.js && node ./scripts/headless-protocol-codegen.mjs && bun run generate:headless-proto:buf",
-    "build": "node ./scripts/ensure-dir.js ./tmp/tsbuildinfo && tsc -b tsconfig.build.json --force && bun build ./src/cli.ts --target node --packages external --external tree-sitter --external tree-sitter-bash --outfile dist/cli.js && node ./scripts/bundle-runtime-deps.mjs && node ./scripts/copy-themes.js",
+		"build": "node ./scripts/ensure-dir.js ./tmp/tsbuildinfo && tsc -b tsconfig.build.json --force && bun build ./src/cli.ts --target node --packages external --external tree-sitter --external tree-sitter-bash --outfile dist/cli.js && node ./scripts/bundle-runtime-deps.mjs && node ./scripts/copy-themes.js && node ./scripts/copy-db-migrations.js",
     "start": "node --enable-source-maps dist/cli.js",
     "start:native": "MAESTRO_AGENT_SCRIPT=\"$(pwd)/dist/cli.js\" ./packages/tui-rs/target/release/maestro-tui",
     "dev": "node ./scripts/headless-protocol-codegen.mjs && bun run generate:headless-proto:buf && node ./scripts/ensure-dir.js ./tmp/tsbuildinfo && tsc -b tsconfig.build.json --watch --preserveWatchOutput",

--- a/scripts/copy-db-migrations.js
+++ b/scripts/copy-db-migrations.js
@@ -1,0 +1,23 @@
+import { cpSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.dirname(path.dirname(__filename));
+
+export function copyDbMigrations(options = {}) {
+	const {
+		sourceDir = path.join(repoRoot, "src", "db", "migrations"),
+		targetDir = path.join(repoRoot, "dist", "db", "migrations"),
+	} = options;
+
+	if (!existsSync(sourceDir)) {
+		return;
+	}
+
+	cpSync(sourceDir, targetDir, { recursive: true });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+	copyDbMigrations();
+}

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -35,6 +35,145 @@ interface MigrationRecord {
 	applied_at: Date;
 }
 
+export interface InitialSchemaMarker {
+	kind: "constraint" | "index" | "table" | "type";
+	name: string;
+	exists: boolean;
+}
+
+export interface InitialSchemaState {
+	exists: boolean;
+	partial: boolean;
+	present: string[];
+	missing: string[];
+}
+
+type InitialSchemaMarkerDefinition = Pick<InitialSchemaMarker, "kind" | "name">;
+
+// Full 0000_initial baseline, except audit_hash_cache objects repaired by 0007.
+export const INITIAL_SCHEMA_BASELINE_MARKERS = [
+	{ kind: "type", name: "alert_severity" },
+	{ kind: "type", name: "audit_status" },
+	{ kind: "type", name: "model_approval_status" },
+	{ kind: "type", name: "user_role" },
+	{ kind: "type", name: "webhook_delivery_status" },
+	{ kind: "table", name: "alerts" },
+	{ kind: "table", name: "api_keys" },
+	{ kind: "table", name: "audit_logs" },
+	{ kind: "table", name: "directory_access_rules" },
+	{ kind: "table", name: "distributed_locks" },
+	{ kind: "table", name: "model_approvals" },
+	{ kind: "table", name: "org_memberships" },
+	{ kind: "table", name: "organizations" },
+	{ kind: "table", name: "permissions" },
+	{ kind: "table", name: "revoked_tokens" },
+	{ kind: "table", name: "role_permissions" },
+	{ kind: "table", name: "roles" },
+	{ kind: "table", name: "session_messages" },
+	{ kind: "table", name: "sessions" },
+	{ kind: "table", name: "totp_rate_limits" },
+	{ kind: "table", name: "totp_used_codes" },
+	{ kind: "table", name: "user_revocation_timestamps" },
+	{ kind: "table", name: "users" },
+	{ kind: "table", name: "webhook_deliveries" },
+	{ kind: "constraint", name: "organizations_slug_unique" },
+	{ kind: "constraint", name: "revoked_tokens_token_hash_unique" },
+	{ kind: "constraint", name: "totp_rate_limits_user_id_unique" },
+	{
+		kind: "constraint",
+		name: "user_revocation_timestamps_user_id_unique",
+	},
+	{ kind: "constraint", name: "users_email_unique" },
+	{ kind: "constraint", name: "alerts_org_id_organizations_id_fk" },
+	{ kind: "constraint", name: "alerts_user_id_users_id_fk" },
+	{ kind: "constraint", name: "api_keys_org_id_organizations_id_fk" },
+	{ kind: "constraint", name: "api_keys_user_id_users_id_fk" },
+	{ kind: "constraint", name: "audit_logs_org_id_organizations_id_fk" },
+	{ kind: "constraint", name: "audit_logs_user_id_users_id_fk" },
+	{ kind: "constraint", name: "audit_logs_session_id_sessions_id_fk" },
+	{
+		kind: "constraint",
+		name: "directory_access_rules_org_id_organizations_id_fk",
+	},
+	{ kind: "constraint", name: "model_approvals_org_id_organizations_id_fk" },
+	{ kind: "constraint", name: "model_approvals_approved_by_users_id_fk" },
+	{ kind: "constraint", name: "org_memberships_org_id_organizations_id_fk" },
+	{ kind: "constraint", name: "org_memberships_user_id_users_id_fk" },
+	{ kind: "constraint", name: "org_memberships_role_id_roles_id_fk" },
+	{ kind: "constraint", name: "revoked_tokens_user_id_users_id_fk" },
+	{ kind: "constraint", name: "revoked_tokens_org_id_organizations_id_fk" },
+	{ kind: "constraint", name: "revoked_tokens_revoked_by_users_id_fk" },
+	{ kind: "constraint", name: "role_permissions_role_id_roles_id_fk" },
+	{
+		kind: "constraint",
+		name: "role_permissions_permission_id_permissions_id_fk",
+	},
+	{ kind: "constraint", name: "roles_org_id_organizations_id_fk" },
+	{ kind: "constraint", name: "session_messages_session_id_sessions_id_fk" },
+	{ kind: "constraint", name: "sessions_org_id_organizations_id_fk" },
+	{ kind: "constraint", name: "sessions_user_id_users_id_fk" },
+	{ kind: "constraint", name: "totp_rate_limits_user_id_users_id_fk" },
+	{ kind: "constraint", name: "totp_used_codes_user_id_users_id_fk" },
+	{
+		kind: "constraint",
+		name: "user_revocation_timestamps_user_id_users_id_fk",
+	},
+	{
+		kind: "constraint",
+		name: "user_revocation_timestamps_revoked_by_users_id_fk",
+	},
+	{ kind: "constraint", name: "users_default_org_id_organizations_id_fk" },
+	{ kind: "constraint", name: "webhook_deliveries_org_id_organizations_id_fk" },
+	{ kind: "index", name: "alert_org_user_idx" },
+	{ kind: "index", name: "alert_type_idx" },
+	{ kind: "index", name: "alert_unread_idx" },
+	{ kind: "index", name: "api_key_org_user_idx" },
+	{ kind: "index", name: "api_key_prefix_idx" },
+	{ kind: "index", name: "audit_log_org_user_idx" },
+	{ kind: "index", name: "audit_log_action_idx" },
+	{ kind: "index", name: "audit_log_resource_idx" },
+	{ kind: "index", name: "audit_log_session_idx" },
+	{ kind: "index", name: "audit_log_trace_idx" },
+	{ kind: "index", name: "audit_log_org_created_idx" },
+	{ kind: "index", name: "dir_access_org_idx" },
+	{ kind: "index", name: "distributed_lock_expires_idx" },
+	{ kind: "index", name: "model_approval_org_model_idx" },
+	{ kind: "index", name: "model_approval_status_idx" },
+	{ kind: "index", name: "org_membership_org_user_idx" },
+	{ kind: "index", name: "org_membership_user_idx" },
+	{ kind: "index", name: "org_slug_idx" },
+	{ kind: "index", name: "org_active_idx" },
+	{ kind: "index", name: "permission_resource_action_idx" },
+	{ kind: "index", name: "revoked_token_hash_idx" },
+	{ kind: "index", name: "revoked_token_user_idx" },
+	{ kind: "index", name: "revoked_token_expires_idx" },
+	{ kind: "index", name: "role_permission_pk" },
+	{ kind: "index", name: "role_org_name_idx" },
+	{ kind: "index", name: "session_message_session_idx" },
+	{ kind: "index", name: "session_message_pii_idx" },
+	{ kind: "index", name: "session_org_user_idx" },
+	{ kind: "index", name: "session_user_idx" },
+	{ kind: "index", name: "session_created_idx" },
+	{ kind: "index", name: "totp_rate_limit_user_idx" },
+	{ kind: "index", name: "totp_rate_limit_locked_idx" },
+	{ kind: "index", name: "totp_used_code_user_idx" },
+	{ kind: "index", name: "totp_used_code_window_idx" },
+	{ kind: "index", name: "user_revocation_user_idx" },
+	{ kind: "index", name: "user_email_idx" },
+	{ kind: "index", name: "user_active_idx" },
+	{ kind: "index", name: "webhook_delivery_org_status_idx" },
+	{ kind: "index", name: "webhook_delivery_retry_idx" },
+] as const;
+
+function firstRow(results: unknown): Record<string, unknown> | null {
+	const rows = Array.from(results as Iterable<Record<string, unknown>>);
+	return rows[0] ?? null;
+}
+
+function sqlBoolean(value: unknown): boolean {
+	return value === true || value === "true" || value === 1 || value === "1";
+}
+
 /**
  * Get the list of migrations from the journal
  */
@@ -129,6 +268,115 @@ async function markMigrationApplied(tag: string): Promise<void> {
 	`);
 }
 
+async function relationExists(relationName: string): Promise<boolean> {
+	const db = getDb();
+
+	const result = await db.execute(sql`
+		SELECT to_regclass(${`public.${relationName}`}) IS NOT NULL AS exists
+	`);
+
+	return sqlBoolean(firstRow(result)?.exists);
+}
+
+async function constraintExists(constraintName: string): Promise<boolean> {
+	const db = getDb();
+
+	const result = await db.execute(sql`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_constraint c
+			JOIN pg_namespace n ON n.oid = c.connamespace
+			WHERE n.nspname = 'public' AND c.conname = ${constraintName}
+		) AS exists
+	`);
+
+	return sqlBoolean(firstRow(result)?.exists);
+}
+
+async function enumTypeExists(typeName: string): Promise<boolean> {
+	const db = getDb();
+
+	const result = await db.execute(sql`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_type t
+			JOIN pg_namespace n ON n.oid = t.typnamespace
+			WHERE n.nspname = 'public' AND t.typname = ${typeName}
+		) AS exists
+	`);
+
+	return sqlBoolean(firstRow(result)?.exists);
+}
+
+function markerLabel(marker: InitialSchemaMarkerDefinition): string {
+	return `${marker.kind}:${marker.name}`;
+}
+
+export function classifyInitialSchemaMarkers(
+	markers: InitialSchemaMarker[],
+): InitialSchemaState {
+	const present = markers.filter((marker) => marker.exists).map(markerLabel);
+	const missing = markers.filter((marker) => !marker.exists).map(markerLabel);
+
+	return {
+		exists: missing.length === 0,
+		partial: present.length > 0 && missing.length > 0,
+		present,
+		missing,
+	};
+}
+
+async function getInitialSchemaState(): Promise<InitialSchemaState> {
+	const markers: InitialSchemaMarker[] = [];
+
+	for (const marker of INITIAL_SCHEMA_BASELINE_MARKERS) {
+		if (marker.kind === "constraint") {
+			markers.push({
+				...marker,
+				exists: await constraintExists(marker.name),
+			});
+			continue;
+		}
+
+		if (marker.kind === "type") {
+			markers.push({ ...marker, exists: await enumTypeExists(marker.name) });
+			continue;
+		}
+
+		markers.push({ ...marker, exists: await relationExists(marker.name) });
+	}
+
+	return classifyInitialSchemaMarkers(markers);
+}
+
+async function reconcileLegacyMigrationRecords(
+	migrationEntries: MigrationJournal["entries"],
+	appliedMigrations: Set<string>,
+): Promise<void> {
+	for (const entry of migrationEntries) {
+		if (entry.tag !== "0000_initial" || appliedMigrations.has(entry.tag)) {
+			continue;
+		}
+
+		const initialSchemaState = await getInitialSchemaState();
+		if (initialSchemaState.partial) {
+			throw new Error(
+				`Detected a partial legacy initial schema before ${entry.tag}; refusing to mark it applied or replay it. Missing markers: ${initialSchemaState.missing.join(", ")}`,
+			);
+		}
+		if (!initialSchemaState.exists) {
+			continue;
+		}
+
+		logger.warn(
+			"Detected existing initial schema for untracked migration; marking as applied",
+			{ tag: entry.tag, presentMarkers: initialSchemaState.present },
+		);
+		await markMigrationApplied(entry.tag);
+		appliedMigrations.add(entry.tag);
+	}
+}
+
 /**
  * Remove a migration from the applied list (for rollback)
  */
@@ -175,6 +423,7 @@ export async function migrate(): Promise<number> {
 	await ensureMigrationsTable();
 	const appliedMigrations = await getAppliedMigrations();
 	const migrationEntries = getMigrationEntries();
+	await reconcileLegacyMigrationRecords(migrationEntries, appliedMigrations);
 
 	let applied = 0;
 

--- a/src/db/migrations/0007_reconcile_legacy_audit_hash_cache.sql
+++ b/src/db/migrations/0007_reconcile_legacy_audit_hash_cache.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS "audit_hash_cache" (
+	"org_id" uuid PRIMARY KEY NOT NULL,
+	"last_hash" varchar(64) NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF to_regclass('public.organizations') IS NOT NULL
+		AND NOT EXISTS (
+			SELECT 1
+			FROM pg_constraint
+			WHERE conname = 'audit_hash_cache_org_id_organizations_id_fk'
+				AND conrelid = 'public.audit_hash_cache'::regclass
+		)
+	THEN
+		ALTER TABLE "audit_hash_cache"
+			ADD CONSTRAINT "audit_hash_cache_org_id_organizations_id_fk"
+			FOREIGN KEY ("org_id")
+			REFERENCES "public"."organizations"("id")
+			ON DELETE cascade
+			ON UPDATE no action;
+	END IF;
+END $$;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
 			"when": 1776800461000,
 			"tag": "0006_hosted_session_storage",
 			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1776800462000,
+			"tag": "0007_reconcile_legacy_audit_hash_cache",
+			"breakpoints": true
 		}
 	]
 }

--- a/test/db/hosted-session-storage.integration.test.ts
+++ b/test/db/hosted-session-storage.integration.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../src/session/session-memory.js", () => ({
 const BASE_DB_URL =
 	process.env.MAESTRO_DATABASE_URL || process.env.DATABASE_URL;
 const describeDb = BASE_DB_URL ? describe : describe.skip;
+const EXPECTED_MIGRATION_COUNT = 8;
 
 const originalEnv = { ...process.env };
 
@@ -192,7 +193,7 @@ describeDb("hosted session database storage", () => {
 
 	it("persists scoped web sessions in Postgres instead of JSONL files", async () => {
 		const { migrate } = await import("../../src/db/migrate.js");
-		await expect(migrate()).resolves.toBe(7);
+		await expect(migrate()).resolves.toBe(EXPECTED_MIGRATION_COUNT);
 
 		const { createWebSessionManagerForRequest } = await import(
 			"../../src/server/session-scope.js"
@@ -281,7 +282,7 @@ describeDb("hosted session database storage", () => {
 		process.env.MAESTRO_JWT_SECRET = "test-jwt-secret-should-be-long-enough";
 
 		const { migrate } = await import("../../src/db/migrate.js");
-		await expect(migrate()).resolves.toBe(7);
+		await expect(migrate()).resolves.toBe(EXPECTED_MIGRATION_COUNT);
 
 		const { checkApiAuth } = await import("../../src/server/authz.js");
 		const { createWebSessionManagerForRequest } = await import(
@@ -359,7 +360,7 @@ describeDb("hosted session database storage", () => {
 		}));
 
 		const { migrate } = await import("../../src/db/migrate.js");
-		await expect(migrate()).resolves.toBe(7);
+		await expect(migrate()).resolves.toBe(EXPECTED_MIGRATION_COUNT);
 
 		const { createWebSessionManagerForRequest } = await import(
 			"../../src/server/session-scope.js"
@@ -399,7 +400,7 @@ describeDb("hosted session database storage", () => {
 
 	it("does not truncate unbounded hosted session listings", async () => {
 		const { migrate } = await import("../../src/db/migrate.js");
-		await expect(migrate()).resolves.toBe(7);
+		await expect(migrate()).resolves.toBe(EXPECTED_MIGRATION_COUNT);
 		const { getDb } = await import("../../src/db/client.js");
 		const { hostedSessions } = await import("../../src/db/schema.js");
 		const { HostedSessionManager } = await import(
@@ -437,7 +438,7 @@ describeDb("hosted session database storage", () => {
 
 	it("surfaces queued database write failures on flush", async () => {
 		const { migrate } = await import("../../src/db/migrate.js");
-		await expect(migrate()).resolves.toBe(7);
+		await expect(migrate()).resolves.toBe(EXPECTED_MIGRATION_COUNT);
 		const { createWebSessionManagerForRequest } = await import(
 			"../../src/server/session-scope.js"
 		);

--- a/test/db/migrate-legacy-reconciliation.test.ts
+++ b/test/db/migrate-legacy-reconciliation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+	INITIAL_SCHEMA_BASELINE_MARKERS,
+	type InitialSchemaMarker,
+	classifyInitialSchemaMarkers,
+} from "../../src/db/migrate.js";
+
+function markers(existing: string[]): InitialSchemaMarker[] {
+	const existingMarkers = new Set(existing);
+	return INITIAL_SCHEMA_BASELINE_MARKERS.map((marker) => ({
+		...marker,
+		exists: existingMarkers.has(`${marker.kind}:${marker.name}`),
+	}));
+}
+
+describe("legacy migration reconciliation", () => {
+	it("treats a database with no baseline markers as fresh", () => {
+		const state = classifyInitialSchemaMarkers(markers([]));
+
+		expect(state).toMatchObject({
+			exists: false,
+			partial: false,
+			present: [],
+		});
+	});
+
+	it("does not treat a generic users table as the Maestro baseline", () => {
+		const state = classifyInitialSchemaMarkers(markers(["table:users"]));
+
+		expect(state.exists).toBe(false);
+		expect(state.partial).toBe(true);
+		expect(state.present).toEqual(["table:users"]);
+		expect(state.missing).toContain("type:alert_severity");
+		expect(state.missing).toContain("table:sessions");
+		expect(state.missing).toContain("index:user_email_idx");
+	});
+
+	it("does not accept an initial schema with non-exempt baseline gaps", () => {
+		const existingMarkers = INITIAL_SCHEMA_BASELINE_MARKERS.map(
+			(marker) => `${marker.kind}:${marker.name}`,
+		).filter((marker) => marker !== "table:api_keys");
+		const state = classifyInitialSchemaMarkers(markers(existingMarkers));
+
+		expect(state.exists).toBe(false);
+		expect(state.partial).toBe(true);
+		expect(state.missing).toEqual(["table:api_keys"]);
+	});
+
+	it("accepts an existing baseline only when all distinctive markers are present", () => {
+		const state = classifyInitialSchemaMarkers(
+			markers(
+				INITIAL_SCHEMA_BASELINE_MARKERS.map(
+					(marker) => `${marker.kind}:${marker.name}`,
+				),
+			),
+		);
+
+		expect(state).toMatchObject({
+			exists: true,
+			partial: false,
+			missing: [],
+		});
+		expect(state.present).toHaveLength(INITIAL_SCHEMA_BASELINE_MARKERS.length);
+		expect(state.present).not.toContain("table:audit_hash_cache");
+		expect(state.present).not.toContain(
+			"constraint:audit_hash_cache_org_id_organizations_id_fk",
+		);
+	});
+});

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -1,0 +1,93 @@
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { copyDbMigrations } from "../../scripts/copy-db-migrations.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), "..", "..");
+const migrationsDir = path.join(repoRoot, "src", "db", "migrations");
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("database migration packaging", () => {
+	it("keeps every journal entry backed by a SQL file", () => {
+		const journalPath = path.join(migrationsDir, "meta", "_journal.json");
+		const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+			entries: Array<{ tag: string }>;
+		};
+
+		expect(journal.entries.map((entry) => entry.tag)).toContain(
+			"0007_reconcile_legacy_audit_hash_cache",
+		);
+
+		for (const entry of journal.entries) {
+			expect(
+				existsSync(path.join(migrationsDir, `${entry.tag}.sql`)),
+				`missing migration SQL for ${entry.tag}`,
+			).toBe(true);
+		}
+	});
+
+	it("copies migrations into dist for package and image runtime", () => {
+		const sourceDir = mkdtempSync(
+			path.join(tmpdir(), "maestro-migrations-src-"),
+		);
+		const targetDir = mkdtempSync(
+			path.join(tmpdir(), "maestro-migrations-dst-"),
+		);
+		tempDirs.push(sourceDir, targetDir);
+
+		const metaDir = path.join(sourceDir, "meta");
+		mkdirSync(metaDir, { recursive: true });
+		writeFileSync(path.join(sourceDir, "0000_initial.sql"), "SELECT 1;\n");
+		writeFileSync(path.join(metaDir, "_journal.json"), "{}\n", {
+			flag: "wx",
+		});
+
+		copyDbMigrations({ sourceDir, targetDir });
+
+		expect(existsSync(path.join(targetDir, "0000_initial.sql"))).toBe(true);
+		expect(existsSync(path.join(targetDir, "meta", "_journal.json"))).toBe(
+			true,
+		);
+	});
+
+	it("keeps Docker and build scripts wired to ship migrations", () => {
+		const dockerfile = readFileSync(path.join(repoRoot, "Dockerfile"), "utf8");
+		expect(dockerfile).toContain(
+			"COPY --from=builder /app/src/db/migrations ./dist/db/migrations",
+		);
+
+		const packageJson = JSON.parse(
+			readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+		) as { scripts: Record<string, string> };
+		expect(packageJson.scripts.build).toContain("copy-db-migrations.js");
+	});
+
+	it("preserves the legacy audit hash cache repair migration", () => {
+		const migration = readFileSync(
+			path.join(migrationsDir, "0007_reconcile_legacy_audit_hash_cache.sql"),
+			"utf8",
+		);
+
+		expect(migration).toContain(
+			'CREATE TABLE IF NOT EXISTS "audit_hash_cache"',
+		);
+		expect(migration).toContain("audit_hash_cache_org_id_organizations_id_fk");
+	});
+});


### PR DESCRIPTION
## Summary
- ship database migrations into dist and the runtime Docker image so startup can find the Drizzle journal
- reconcile legacy databases only when the full 0000_initial baseline exists, with audit_hash_cache as the explicit 0007 repair exception
- add a repair migration for missing audit_hash_cache and tests that guard migration packaging plus baseline detection

## Validation
- ./node_modules/.bin/biome check src/db/migrate.ts test/db/migrate-legacy-reconciliation.test.ts test/db/migration-files.test.ts test/db/hosted-session-storage.integration.test.ts
- node ./scripts/run-vitest.js --run test/db/migrate-legacy-reconciliation.test.ts test/db/migration-files.test.ts test/db/hosted-session-storage.integration.test.ts test/web-health.test.ts test/server/health.test.ts
- PATH=/Users/jonathanhaas/.bun/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/jonathanhaas/.dotfiles/bin:/Users/jonathanhaas/.dotfiles/scripts:/Users/jonathanhaas/.dotfiles/scripts/bin:/Users/jonathanhaas/.codex/tmp/arg0/codex-arg0c51p5M:/etc/profiles/per-user/jonathanhaas/bin:/opt/homebrew/opt/node@22/bin:/nix/var/nix/profiles/default/bin:/Users/jonathanhaas/.nix-profile/bin:/Users/jonathanhaas/.local/bin:/Users/jonathanhaas/bin:/run/current-system/sw/bin:/Users/jonathanhaas/.npm-global/bin:/Users/jonathanhaas/.config/zsh/plugins/fast-syntax-highlighting:/Users/jonathanhaas/.config/zsh/plugins/zsh-autosuggestions:/Users/jonathanhaas/.config/zsh/plugins/zsh-completions:/Users/jonathanhaas/.config/zsh/plugins/fzf-tab:/Users/jonathanhaas/.config/zsh/plugins/zsh-you-should-use:/Applications/Ghostty.app/Contents/MacOS bun run --cwd packages/contracts build
- PATH=/Users/jonathanhaas/.bun/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/opt/homebrew/bin:/Users/jonathanhaas/.dotfiles/bin:/Users/jonathanhaas/.dotfiles/scripts:/Users/jonathanhaas/.dotfiles/scripts/bin:/Users/jonathanhaas/.codex/tmp/arg0/codex-arg0c51p5M:/etc/profiles/per-user/jonathanhaas/bin:/opt/homebrew/opt/node@22/bin:/nix/var/nix/profiles/default/bin:/Users/jonathanhaas/.nix-profile/bin:/Users/jonathanhaas/.local/bin:/Users/jonathanhaas/bin:/run/current-system/sw/bin:/Users/jonathanhaas/.npm-global/bin:/Users/jonathanhaas/.config/zsh/plugins/fast-syntax-highlighting:/Users/jonathanhaas/.config/zsh/plugins/zsh-autosuggestions:/Users/jonathanhaas/.config/zsh/plugins/zsh-completions:/Users/jonathanhaas/.config/zsh/plugins/fzf-tab:/Users/jonathanhaas/.config/zsh/plugins/zsh-you-should-use:/Applications/Ghostty.app/Contents/MacOS bun run --cwd packages/tui build
- ./node_modules/.bin/tsc -p tsconfig.build.json --noEmit --pretty false

Internal source PRs: evalops/maestro-internal#1513, evalops/maestro-internal#1514