### PR TITLE
Reconcile legacy webhook delivery schema

### DIFF
--- a/src/db/health.ts
+++ b/src/db/health.ts
@@ -17,7 +17,28 @@ export const CRITICAL_DATABASE_TABLES = [
 export interface CriticalTableCheck {
 	name: (typeof CRITICAL_DATABASE_TABLES)[number];
 	exists: boolean;
+	missingColumns?: string[];
 }
+
+const CRITICAL_DATABASE_COLUMNS: Partial<
+	Record<(typeof CRITICAL_DATABASE_TABLES)[number], readonly string[]>
+> = {
+	webhook_deliveries: [
+		"org_id",
+		"url",
+		"payload",
+		"signature",
+		"status",
+		"attempts",
+		"max_attempts",
+		"next_retry_at",
+		"last_error",
+		"last_status_code",
+		"last_response_time_ms",
+		"delivered_at",
+		"created_at",
+	],
+};
 
 export async function checkCriticalTables(
 	tables: readonly (typeof CRITICAL_DATABASE_TABLES)[number][] = CRITICAL_DATABASE_TABLES,
@@ -31,9 +52,29 @@ export async function checkCriticalTables(
 			SELECT to_regclass(${qualifiedName}) IS NOT NULL AS exists
 		`);
 		const [row] = Array.from(result) as Array<Record<string, unknown>>;
+		const requiredColumns = CRITICAL_DATABASE_COLUMNS[tableName] ?? [];
+		let missingColumns: string[] = [];
+		if (row?.exists === true && requiredColumns.length > 0) {
+			const columnsResult = await db.execute(sql`
+				SELECT column_name
+				FROM information_schema.columns
+				WHERE table_schema = 'public'
+					AND table_name = ${tableName}
+			`);
+			const actualColumns = new Set(
+				(Array.from(columnsResult) as Array<Record<string, unknown>>)
+					.map((column) => column.column_name)
+					.filter((name): name is string => typeof name === "string"),
+			);
+			missingColumns = requiredColumns.filter(
+				(column) => !actualColumns.has(column),
+			);
+		}
+
 		checks.push({
 			name: tableName,
 			exists: row?.exists === true,
+			...(missingColumns.length > 0 ? { missingColumns } : {}),
 		});
 	}
 

--- a/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
+++ b/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
@@ -188,10 +188,14 @@ BEGIN
 	END IF;
 END $$;
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "webhook_delivery_org_status_idx"
-	ON "webhook_deliveries" USING btree ("org_id", "status");
---> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "webhook_delivery_retry_idx"
-	ON "webhook_deliveries" USING btree ("status", "next_retry_at");
+DO $$
+BEGIN
+	IF to_regclass('public.webhook_deliveries') IS NOT NULL THEN
+		CREATE INDEX IF NOT EXISTS "webhook_delivery_org_status_idx"
+			ON "webhook_deliveries" USING btree ("org_id", "status");
+		CREATE INDEX IF NOT EXISTS "webhook_delivery_retry_idx"
+			ON "webhook_deliveries" USING btree ("status", "next_retry_at");
+	END IF;
+END $$;
 --> statement-breakpoint
 DROP FUNCTION IF EXISTS maestro_reconcile_webhook_payload(text);

--- a/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
+++ b/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
@@ -1,0 +1,197 @@
+CREATE OR REPLACE FUNCTION maestro_reconcile_webhook_payload(value text)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	RETURN value::jsonb;
+EXCEPTION WHEN others THEN
+	RETURN jsonb_build_object('legacy_payload', value);
+END;
+$$;
+--> statement-breakpoint
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_type t
+		JOIN pg_namespace n ON n.oid = t.typnamespace
+		WHERE n.nspname = 'public' AND t.typname = 'webhook_delivery_status'
+	) THEN
+		CREATE TYPE "webhook_delivery_status" AS ENUM (
+			'pending',
+			'delivered',
+			'failed',
+			'retrying'
+		);
+	END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+DECLARE
+	payload_type text;
+	status_type text;
+BEGIN
+	IF to_regclass('public.webhook_deliveries') IS NULL THEN
+		RETURN;
+	END IF;
+
+	ALTER TABLE "webhook_deliveries" ADD COLUMN IF NOT EXISTS "org_id" uuid;
+	ALTER TABLE "webhook_deliveries" ADD COLUMN IF NOT EXISTS "url" text;
+	ALTER TABLE "webhook_deliveries" ADD COLUMN IF NOT EXISTS "signature" varchar(200);
+	ALTER TABLE "webhook_deliveries" ADD COLUMN IF NOT EXISTS "max_attempts" integer DEFAULT 5;
+	ALTER TABLE "webhook_deliveries" ADD COLUMN IF NOT EXISTS "next_retry_at" timestamp with time zone;
+	ALTER TABLE "webhook_deliveries" ADD COLUMN IF NOT EXISTS "last_error" text;
+	ALTER TABLE "webhook_deliveries" ADD COLUMN IF NOT EXISTS "last_status_code" integer;
+	ALTER TABLE "webhook_deliveries" ADD COLUMN IF NOT EXISTS "last_response_time_ms" integer;
+	ALTER TABLE "webhook_deliveries" ADD COLUMN IF NOT EXISTS "delivered_at" timestamp with time zone;
+
+	IF EXISTS (
+		SELECT 1
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND table_name = 'webhook_deliveries'
+			AND column_name = 'organization_id'
+	) THEN
+		UPDATE "webhook_deliveries"
+		SET "org_id" = "organization_id"
+		WHERE "org_id" IS NULL;
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND table_name = 'webhook_deliveries'
+			AND column_name = 'next_attempt_at'
+	) THEN
+		UPDATE "webhook_deliveries"
+		SET "next_retry_at" = "next_attempt_at"
+		WHERE "next_retry_at" IS NULL;
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND table_name = 'webhook_deliveries'
+			AND column_name = 'error'
+	) THEN
+		UPDATE "webhook_deliveries"
+		SET "last_error" = "error"
+		WHERE "last_error" IS NULL;
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND table_name = 'webhook_deliveries'
+			AND column_name = 'response_status'
+	) THEN
+		UPDATE "webhook_deliveries"
+		SET "last_status_code" = "response_status"
+		WHERE "last_status_code" IS NULL;
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND table_name = 'webhook_deliveries'
+			AND column_name = 'completed_at'
+	) THEN
+		UPDATE "webhook_deliveries"
+		SET "delivered_at" = "completed_at"
+		WHERE "delivered_at" IS NULL;
+	END IF;
+
+	SELECT data_type
+	INTO payload_type
+	FROM information_schema.columns
+	WHERE table_schema = 'public'
+		AND table_name = 'webhook_deliveries'
+		AND column_name = 'payload';
+
+	IF payload_type IS NOT NULL AND payload_type <> 'jsonb' THEN
+		ALTER TABLE "webhook_deliveries"
+			ALTER COLUMN "payload" TYPE jsonb
+			USING maestro_reconcile_webhook_payload("payload"::text);
+	END IF;
+
+	SELECT udt_name
+	INTO status_type
+	FROM information_schema.columns
+	WHERE table_schema = 'public'
+		AND table_name = 'webhook_deliveries'
+		AND column_name = 'status';
+
+	IF status_type IS NOT NULL AND status_type <> 'webhook_delivery_status' THEN
+		ALTER TABLE "webhook_deliveries"
+			ALTER COLUMN "status" TYPE "webhook_delivery_status"
+			USING (
+				CASE
+					WHEN "status"::text IN ('pending', 'delivered', 'failed', 'retrying')
+						THEN "status"::text::"webhook_delivery_status"
+					WHEN "status"::text IN ('completed', 'sent', 'success')
+						THEN 'delivered'::"webhook_delivery_status"
+					ELSE 'failed'::"webhook_delivery_status"
+				END
+			);
+	END IF;
+
+	UPDATE "webhook_deliveries" SET "payload" = '{}'::jsonb WHERE "payload" IS NULL;
+	UPDATE "webhook_deliveries" SET "status" = 'failed' WHERE "status" IS NULL;
+	UPDATE "webhook_deliveries" SET "attempts" = 0 WHERE "attempts" IS NULL;
+	UPDATE "webhook_deliveries" SET "max_attempts" = 5 WHERE "max_attempts" IS NULL;
+	UPDATE "webhook_deliveries" SET "created_at" = now() WHERE "created_at" IS NULL;
+	UPDATE "webhook_deliveries" SET "url" = '' WHERE "url" IS NULL;
+	UPDATE "webhook_deliveries"
+	SET
+		"status" = 'failed',
+		"last_error" = COALESCE(
+			"last_error",
+			'legacy webhook delivery row has no target url after schema reconciliation'
+		)
+	WHERE "url" = '' AND "status" IN ('pending', 'retrying');
+
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "payload" SET NOT NULL;
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "status" SET DEFAULT 'pending';
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "status" SET NOT NULL;
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "attempts" SET DEFAULT 0;
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "attempts" SET NOT NULL;
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "max_attempts" SET DEFAULT 5;
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "max_attempts" SET NOT NULL;
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "url" SET DEFAULT '';
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "url" SET NOT NULL;
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "created_at" SET DEFAULT now();
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "created_at" SET NOT NULL;
+
+	IF NOT EXISTS (SELECT 1 FROM "webhook_deliveries" WHERE "org_id" IS NULL) THEN
+		ALTER TABLE "webhook_deliveries" ALTER COLUMN "org_id" SET NOT NULL;
+	END IF;
+
+	IF to_regclass('public.organizations') IS NOT NULL
+		AND NOT EXISTS (
+			SELECT 1
+			FROM pg_constraint
+			WHERE conname = 'webhook_deliveries_org_id_organizations_id_fk'
+				AND conrelid = 'public.webhook_deliveries'::regclass
+		)
+	THEN
+		ALTER TABLE "webhook_deliveries"
+			ADD CONSTRAINT "webhook_deliveries_org_id_organizations_id_fk"
+			FOREIGN KEY ("org_id")
+			REFERENCES "public"."organizations"("id")
+			ON DELETE cascade
+			ON UPDATE no action
+			NOT VALID;
+	END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "webhook_delivery_org_status_idx"
+	ON "webhook_deliveries" USING btree ("org_id", "status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "webhook_delivery_retry_idx"
+	ON "webhook_deliveries" USING btree ("status", "next_retry_at");
+--> statement-breakpoint
+DROP FUNCTION IF EXISTS maestro_reconcile_webhook_payload(text);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
 			"when": 1776800462000,
 			"tag": "0007_reconcile_legacy_audit_hash_cache",
 			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1777303800000,
+			"tag": "0008_reconcile_legacy_webhook_deliveries",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/server/handlers/health.ts
+++ b/src/server/handlers/health.ts
@@ -130,9 +130,12 @@ export async function runHealthChecks(
 			checks.database.status = "up";
 			try {
 				const tableChecks = await checkCriticalTables();
-				const missing = tableChecks
-					.filter((table) => !table.exists)
-					.map((table) => table.name);
+				const missing = tableChecks.flatMap((table) => {
+					if (!table.exists) return [table.name];
+					return (table.missingColumns ?? []).map(
+						(column) => `${table.name}.${column}`,
+					);
+				});
 				checks.database.criticalTables = {
 					status: missing.length > 0 ? "missing" : "ok",
 					checked: tableChecks.map((table) => table.name),

--- a/test/db/hosted-session-storage.integration.test.ts
+++ b/test/db/hosted-session-storage.integration.test.ts
@@ -19,7 +19,7 @@ vi.mock("../../src/session/session-memory.js", () => ({
 const BASE_DB_URL =
 	process.env.MAESTRO_DATABASE_URL || process.env.DATABASE_URL;
 const describeDb = BASE_DB_URL ? describe : describe.skip;
-const EXPECTED_MIGRATION_COUNT = 8;
+const EXPECTED_MIGRATION_COUNT = 9;
 
 const originalEnv = { ...process.env };
 

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -34,6 +34,9 @@ describe("database migration packaging", () => {
 		expect(journal.entries.map((entry) => entry.tag)).toContain(
 			"0007_reconcile_legacy_audit_hash_cache",
 		);
+		expect(journal.entries.map((entry) => entry.tag)).toContain(
+			"0008_reconcile_legacy_webhook_deliveries",
+		);
 
 		for (const entry of journal.entries) {
 			expect(
@@ -89,5 +92,16 @@ describe("database migration packaging", () => {
 			'CREATE TABLE IF NOT EXISTS "audit_hash_cache"',
 		);
 		expect(migration).toContain("audit_hash_cache_org_id_organizations_id_fk");
+	});
+
+	it("preserves the legacy webhook delivery repair migration", () => {
+		const migration = readFileSync(
+			path.join(migrationsDir, "0008_reconcile_legacy_webhook_deliveries.sql"),
+			"utf8",
+		);
+
+		expect(migration).toContain("organization_id");
+		expect(migration).toContain("next_attempt_at");
+		expect(migration).toContain("webhook_delivery_retry_idx");
 	});
 });

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -102,6 +102,9 @@ describe("database migration packaging", () => {
 
 		expect(migration).toContain("organization_id");
 		expect(migration).toContain("next_attempt_at");
+		expect(migration).toContain(
+			"IF to_regclass('public.webhook_deliveries') IS NOT NULL THEN",
+		);
 		expect(migration).toContain("webhook_delivery_retry_idx");
 	});
 });

--- a/test/web-health.test.ts
+++ b/test/web-health.test.ts
@@ -116,6 +116,38 @@ describe("Health Checks", () => {
 			});
 		});
 
+		it("should return unhealthy when a critical table has missing columns", async () => {
+			vi.mocked(isDatabaseConfigured).mockReturnValue(true);
+			vi.mocked(testConnection).mockResolvedValue(true);
+			vi.mocked(checkCriticalTables).mockResolvedValue([
+				{ name: "_composer_migrations", exists: true },
+				{ name: "organizations", exists: true },
+				{ name: "users", exists: true },
+				{ name: "sessions", exists: true },
+				{
+					name: "webhook_deliveries",
+					exists: true,
+					missingColumns: ["org_id", "next_retry_at"],
+				},
+				{ name: "distributed_locks", exists: true },
+				{ name: "usage_metrics", exists: true },
+				{ name: "execution_traces", exists: true },
+				{ name: "workspace_config", exists: true },
+				{ name: "revenue_attribution", exists: true },
+			]);
+
+			const result = await runHealthChecks();
+
+			expect(result.status).toBe("unhealthy");
+			expect(result.checks.database.criticalTables).toMatchObject({
+				status: "missing",
+				missing: [
+					"webhook_deliveries.org_id",
+					"webhook_deliveries.next_retry_at",
+				],
+			});
+		});
+
 		it("should include timestamp in result", async () => {
 			vi.mocked(isDatabaseConfigured).mockReturnValue(false);
 


### PR DESCRIPTION
## Summary
- add a no-op-safe migration that reconciles legacy `webhook_deliveries` columns to the current queue schema
- make `/readyz` fail when critical `webhook_deliveries` columns are missing, not just when the table is missing
- cover migration packaging/readiness behavior with targeted tests

## Internal source
- evalops/maestro-internal#1515

## Live staging evidence
- current Maestro image is `ghcr.io/evalops/maestro:sha-be6be4e` running `node --enable-source-maps dist/web-server.js`
- live `/readyz` passed while webhook processing logged schema errors for missing current delivery columns
- live `webhook_deliveries` still had legacy columns like `organization_id`, `next_attempt_at`, and `response_status`

## Test plan
- `npm run test -- test/web-health.test.ts test/db/migration-files.test.ts test/db/migrate-legacy-reconciliation.test.ts`
- `bunx biome check src/db/health.ts src/server/handlers/health.ts test/web-health.test.ts test/db/migration-files.test.ts test/db/hosted-session-storage.integration.test.ts`
- `bun run build:all`
- commit hook full gate: guardian, biome, proto checks, build, compiled bun artifact
- `git diff --check`