### PR TITLE
Repair webhook status enum drift

### DIFF
--- a/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
+++ b/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
@@ -26,6 +26,14 @@ BEGIN
 	END IF;
 END $$;
 --> statement-breakpoint
+ALTER TYPE "webhook_delivery_status" ADD VALUE IF NOT EXISTS 'pending';
+--> statement-breakpoint
+ALTER TYPE "webhook_delivery_status" ADD VALUE IF NOT EXISTS 'delivered';
+--> statement-breakpoint
+ALTER TYPE "webhook_delivery_status" ADD VALUE IF NOT EXISTS 'failed';
+--> statement-breakpoint
+ALTER TYPE "webhook_delivery_status" ADD VALUE IF NOT EXISTS 'retrying';
+--> statement-breakpoint
 DO $$
 DECLARE
 	payload_type text;
@@ -144,6 +152,18 @@ BEGIN
 			);
 	END IF;
 
+	IF status_type = 'webhook_delivery_status' THEN
+		UPDATE "webhook_deliveries"
+		SET "status" = (
+			CASE
+				WHEN "status"::text IN ('completed', 'sent', 'success') THEN 'delivered'
+				ELSE 'failed'
+			END
+		)::"webhook_delivery_status"
+		WHERE "status" IS NOT NULL
+			AND "status"::text NOT IN ('pending', 'delivered', 'failed', 'retrying');
+	END IF;
+
 	UPDATE "webhook_deliveries" SET "id" = gen_random_uuid() WHERE "id" IS NULL;
 	UPDATE "webhook_deliveries" SET "payload" = '{}'::jsonb WHERE "payload" IS NULL;
 	UPDATE "webhook_deliveries" SET "status" = 'failed' WHERE "status" IS NULL;
@@ -158,7 +178,7 @@ BEGIN
 			"last_error",
 			'legacy webhook delivery row has no target url after schema reconciliation'
 		)
-	WHERE "url" = '' AND "status" IN ('pending', 'retrying');
+	WHERE "url" = '' AND "status"::text IN ('pending', 'retrying');
 
 	ALTER TABLE "webhook_deliveries" ALTER COLUMN "payload" SET NOT NULL;
 	ALTER TABLE "webhook_deliveries" ALTER COLUMN "status" SET DEFAULT 'pending';

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -103,6 +103,10 @@ describe("database migration packaging", () => {
 		expect(migration).toContain('ADD COLUMN IF NOT EXISTS "id"');
 		expect(migration).toContain('ADD COLUMN IF NOT EXISTS "payload"');
 		expect(migration).toContain('ADD COLUMN IF NOT EXISTS "status"');
+		expect(migration).toContain(
+			'ALTER TYPE "webhook_delivery_status" ADD VALUE IF NOT EXISTS',
+		);
+		expect(migration).toContain('"status"::text NOT IN');
 		expect(migration).toContain("webhook_deliveries_pkey");
 		expect(migration).toContain("organization_id");
 		expect(migration).toContain("next_attempt_at");


### PR DESCRIPTION
## Summary
- add missing `webhook_delivery_status` enum labels before webhook delivery reconciliation uses enum literals
- normalize same-name legacy enum values through `status::text`
- extend migration packaging tests so the enum drift guard is preserved

## Follow-up
- follows evalops/maestro#202, which merged before this internal review fix landed
- internal source: evalops/maestro-internal#1515

## Test plan
- `npm run test -- test/web-health.test.ts test/db/migration-files.test.ts test/db/migrate-legacy-reconciliation.test.ts`
- `bunx biome check src/db/health.ts src/server/handlers/health.ts test/web-health.test.ts test/db/migration-files.test.ts test/db/hosted-session-storage.integration.test.ts`
- `git diff --check`
- disposable Postgres: applied migration to legacy same-name enum missing expected labels plus text payload rows
- disposable Postgres: applied migration to fresh/no-table database
- disposable Postgres + app migration runner: `DATABASE_URL=... npm run test -- test/db/hosted-session-storage.integration.test.ts`