### PR TITLE
Keep webhook payload migration helper

### DIFF
--- a/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
+++ b/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
@@ -246,5 +246,3 @@ BEGIN
 			ON "webhook_deliveries" USING btree ("status", "next_retry_at");
 	END IF;
 END $$;
---> statement-breakpoint
-DROP FUNCTION IF EXISTS maestro_reconcile_webhook_payload(text);

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -107,6 +107,12 @@ describe("database migration packaging", () => {
 			'ALTER TYPE "webhook_delivery_status" ADD VALUE IF NOT EXISTS',
 		);
 		expect(migration).toContain('"status"::text NOT IN');
+		expect(migration).toContain(
+			"CREATE OR REPLACE FUNCTION maestro_reconcile_webhook_payload",
+		);
+		expect(migration).not.toContain(
+			"DROP FUNCTION IF EXISTS maestro_reconcile_webhook_payload",
+		);
 		expect(migration).toContain("webhook_deliveries_pkey");
 		expect(migration).toContain("organization_id");
 		expect(migration).toContain("next_attempt_at");


### PR DESCRIPTION
## Summary
- keep the webhook payload reconciliation helper function after migration instead of dropping it
- preserve a regression assertion so concurrent startup runners cannot lose the helper mid-migration

## Follow-up
- follows evalops/maestro#203 and internal review feedback on evalops/maestro-internal#1515

## Test plan
- `npm run test -- test/web-health.test.ts test/db/migration-files.test.ts test/db/migrate-legacy-reconciliation.test.ts`
- `bunx biome check src/db/health.ts src/server/handlers/health.ts test/web-health.test.ts test/db/migration-files.test.ts test/db/hosted-session-storage.integration.test.ts`
- `git diff --check`
- disposable Postgres: applied migration to a legacy enum/text-payload table and verified `maestro_reconcile_webhook_payload(text)` remains available after migration
- commit hook full gate: guardian, biome, proto checks, build, compiled bun artifact