### PR TITLE
Harden webhook migration concurrency

### DIFF
--- a/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
+++ b/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
@@ -211,8 +211,13 @@ BEGIN
 			HAVING count(*) > 1
 		)
 	THEN
-		ALTER TABLE "webhook_deliveries"
-			ADD CONSTRAINT "webhook_deliveries_pkey" PRIMARY KEY ("id");
+		BEGIN
+			ALTER TABLE "webhook_deliveries"
+				ADD CONSTRAINT "webhook_deliveries_pkey" PRIMARY KEY ("id");
+		EXCEPTION
+			WHEN duplicate_object OR invalid_table_definition THEN
+				NULL;
+		END;
 	END IF;
 
 	IF NOT EXISTS (SELECT 1 FROM "webhook_deliveries" WHERE "org_id" IS NULL) THEN
@@ -227,22 +232,38 @@ BEGIN
 				AND conrelid = 'public.webhook_deliveries'::regclass
 		)
 	THEN
-		ALTER TABLE "webhook_deliveries"
-			ADD CONSTRAINT "webhook_deliveries_org_id_organizations_id_fk"
-			FOREIGN KEY ("org_id")
-			REFERENCES "public"."organizations"("id")
-			ON DELETE cascade
-			ON UPDATE no action
-			NOT VALID;
+		BEGIN
+			ALTER TABLE "webhook_deliveries"
+				ADD CONSTRAINT "webhook_deliveries_org_id_organizations_id_fk"
+				FOREIGN KEY ("org_id")
+				REFERENCES "public"."organizations"("id")
+				ON DELETE cascade
+				ON UPDATE no action
+				NOT VALID;
+		EXCEPTION
+			WHEN duplicate_object THEN
+				NULL;
+		END;
 	END IF;
 END $$;
 --> statement-breakpoint
 DO $$
 BEGIN
 	IF to_regclass('public.webhook_deliveries') IS NOT NULL THEN
-		CREATE INDEX IF NOT EXISTS "webhook_delivery_org_status_idx"
-			ON "webhook_deliveries" USING btree ("org_id", "status");
-		CREATE INDEX IF NOT EXISTS "webhook_delivery_retry_idx"
-			ON "webhook_deliveries" USING btree ("status", "next_retry_at");
+		BEGIN
+			CREATE INDEX IF NOT EXISTS "webhook_delivery_org_status_idx"
+				ON "webhook_deliveries" USING btree ("org_id", "status");
+		EXCEPTION
+			WHEN duplicate_table OR unique_violation THEN
+				NULL;
+		END;
+
+		BEGIN
+			CREATE INDEX IF NOT EXISTS "webhook_delivery_retry_idx"
+				ON "webhook_deliveries" USING btree ("status", "next_retry_at");
+		EXCEPTION
+			WHEN duplicate_table OR unique_violation THEN
+				NULL;
+		END;
 	END IF;
 END $$;

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -114,6 +114,13 @@ describe("database migration packaging", () => {
 			"DROP FUNCTION IF EXISTS maestro_reconcile_webhook_payload",
 		);
 		expect(migration).toContain("webhook_deliveries_pkey");
+		expect(migration).toContain(
+			"WHEN duplicate_object OR invalid_table_definition THEN",
+		);
+		expect(migration).toContain("WHEN duplicate_object THEN");
+		expect(migration).toContain(
+			"WHEN duplicate_table OR unique_violation THEN",
+		);
 		expect(migration).toContain("organization_id");
 		expect(migration).toContain("next_attempt_at");
 		expect(migration).toContain('ALTER COLUMN "url" DROP DEFAULT');


### PR DESCRIPTION
Summary:
- Catch concurrent constraint creation races in the webhook delivery reconciliation migration.
- Guard concurrent index creation races observed in disposable Postgres.
- Extend migration packaging assertions for concurrency handlers.

Internal source PR: evalops/maestro-internal#1515

Test plan:
- npm run test -- test/web-health.test.ts test/db/migration-files.test.ts test/db/migrate-legacy-reconciliation.test.ts
- bunx biome check test/db/migration-files.test.ts
- git diff --check
- Disposable Postgres 16: ran 0008 migration twice concurrently against a drifted legacy webhook_deliveries schema and verified helper, PK, FK, indexes, status normalization, and invalid payload wrapping.