### PR TITLE
Keep npm available in Rust runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 FROM alpine:3.23 AS runner
 WORKDIR /app
 
-RUN apk add --no-cache tini git ca-certificates libstdc++ && \
+RUN apk add --no-cache tini git ca-certificates libstdc++ nodejs npm && \
     addgroup --system --gid 1001 appgroup && \
     adduser --system --uid 1001 appuser
 

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -70,7 +70,7 @@ describe("database migration packaging", () => {
 		);
 	});
 
-	it("keeps build scripts wired to ship migrations without the legacy Node image copy", () => {
+	it("keeps build scripts wired without the legacy Node image copy", () => {
 		const dockerfile = readFileSync(path.join(repoRoot, "Dockerfile"), "utf8");
 		const runnerStage =
 			dockerfile.split("# ---------- runner ----------")[1] ?? "";
@@ -85,7 +85,7 @@ describe("database migration packaging", () => {
 			"COPY --from=deps /app/node_modules ./node_modules",
 		);
 		expect(runnerStage).not.toContain("COPY package.json bun.lockb ./");
-		expect(runnerStage).not.toContain("nodejs npm");
+		expect(runnerStage).toContain("nodejs npm");
 		expect(runnerStage).not.toContain(
 			"COPY --from=builder /app/src/db/migrations",
 		);


### PR DESCRIPTION
## Summary
- install `nodejs npm` in the Rust control-plane runner image so `/api/run` has a supported package runner
- keep the lean runtime shape: no copied `node_modules`, package manifest, or legacy Node server payload
- update the Dockerfile packaging regression test for the runtime runner contract

Source-of-truth PR: evalops/maestro-internal#1518

## Test plan
- `node ./scripts/run-vitest.js --run test/db/migration-files.test.ts`
- dependency-free Dockerfile invariant check in both public and internal worktrees