### PR TITLE
ci: sync version bump runner

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   version-bump:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- align public version-bump workflow runner with maestro-internal
- clear public-release mirror drift for internal PR gates

## Test plan
- actionlint .github/workflows/version-bump.yml
- git diff --check