### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/telemetry/maestro-event-bus.ts
+++ b/src/telemetry/maestro-event-bus.ts
@@ -70,6 +70,7 @@ export interface MaestroCorrelation {
 	actor_id?: string;
 	principal_id?: string;
 	trace_id?: string;
+	traceparent?: string;
 	request_id?: string;
 	parent_event_id?: string;
 	remote_runner_session_id?: string;
@@ -100,6 +101,7 @@ export interface MaestroCloudEvent<TData extends Record<string, unknown>> {
 	data: TData & { "@type": string };
 	extensions: {
 		dataschema: string;
+		evalops_context_version: "evalops.context.v1";
 		[key: string]: string;
 	};
 }
@@ -226,6 +228,9 @@ export interface MaestroEventBusStatus {
 export interface PromptVariantSelectedEventData
 	extends Record<string, unknown> {
 	correlation: MaestroCorrelation;
+	prompt_id: string;
+	prompt_name: string;
+	version_id: string;
 	prompt_metadata: PromptMetadata;
 	selected_at: string;
 }
@@ -273,6 +278,8 @@ export interface SkillOutcomeEventData extends Record<string, unknown> {
 
 export interface EvalScoredEventData extends Record<string, unknown> {
 	correlation: MaestroCorrelation;
+	eval_run_id: string;
+	scenario_id: string;
 	prompt_metadata?: PromptMetadata;
 	skill_metadata?: SkillArtifactMetadata;
 	tool_call_id: string;
@@ -281,6 +288,7 @@ export interface EvalScoredEventData extends Record<string, unknown> {
 	score?: number;
 	threshold?: number;
 	passed?: boolean;
+	scorer?: string;
 	rationale?: string;
 	assertion_count?: number;
 	scored_at: string;
@@ -379,6 +387,9 @@ export interface RecordMaestroToolCallCompletedInput {
 
 export interface RecordMaestroPromptVariantSelectedInput {
 	event_id?: string;
+	prompt_id?: string;
+	prompt_name?: string;
+	version_id?: string;
 	prompt_metadata: PromptMetadata;
 	correlation?: Partial<MaestroCorrelation>;
 	selected_at?: string;
@@ -425,6 +436,8 @@ export interface RecordMaestroSkillOutcomeInput {
 
 export interface RecordMaestroEvalScoredInput {
 	event_id?: string;
+	eval_run_id?: string;
+	scenario_id?: string;
 	prompt_metadata?: PromptMetadata;
 	skill_metadata?: SkillArtifactMetadata;
 	tool_call_id: string;
@@ -433,6 +446,7 @@ export interface RecordMaestroEvalScoredInput {
 	score?: number;
 	threshold?: number;
 	passed?: boolean;
+	scorer?: string;
 	rationale?: string;
 	assertion_count?: number;
 	correlation?: Partial<MaestroCorrelation>;
@@ -555,6 +569,7 @@ function defaultCorrelation(env: Env): MaestroCorrelation {
 		actor_id: readEnv(env, ["MAESTRO_ACTOR_ID"]),
 		principal_id: readEnv(env, ["MAESTRO_PRINCIPAL_ID"]),
 		trace_id: readEnv(env, ["TRACE_ID", "OTEL_TRACE_ID"]),
+		traceparent: readEnv(env, ["TRACEPARENT", "TRACE_PARENT"]),
 		request_id: readEnv(env, ["MAESTRO_REQUEST_ID"]),
 		remote_runner_session_id: readEnv(env, [
 			"MAESTRO_REMOTE_RUNNER_SESSION_ID",
@@ -778,6 +793,7 @@ export function maestroCorrelationToChronicleMetadata(
 	putCanonicalMetadata("actor_id", correlation.actor_id);
 	putCanonicalMetadata("principal_id", correlation.principal_id);
 	putCanonicalMetadata("trace_id", correlation.trace_id);
+	putCanonicalMetadata("traceparent", correlation.traceparent);
 	putCanonicalMetadata("request_id", correlation.request_id);
 	putCanonicalMetadata(
 		"remote_runner_session_id",
@@ -826,13 +842,20 @@ export function buildMaestroCloudEvent<TData extends Record<string, unknown>>(
 		config.defaultCorrelation,
 		options.correlation,
 	);
-	const dataCorrelation =
+	const contextCorrelation =
 		"correlation" in data && data.correlation ? data.correlation : correlation;
+	const dataCorrelation = maestroDataCorrelation(
+		contextCorrelation as MaestroCorrelation,
+	);
 	const typedData = {
 		...data,
 		"@type": protoAnyTypeFor(type),
 		correlation: dataCorrelation,
 	} as TData & { "@type": string };
+	const contextExtensions = maestroContextExtensions(
+		contextCorrelation as MaestroCorrelation,
+		typedData,
+	);
 
 	return {
 		spec_version: "1.0",
@@ -844,8 +867,49 @@ export function buildMaestroCloudEvent<TData extends Record<string, unknown>>(
 		data_content_type: "application/protobuf",
 		tenant_id: options.tenantId ?? config.tenantId,
 		data: typedData,
-		extensions: { dataschema: dataSchemaFor(type) },
+		extensions: {
+			dataschema: dataSchemaFor(type),
+			evalops_context_version: "evalops.context.v1",
+			...contextExtensions,
+		},
 	};
+}
+
+function maestroDataCorrelation(
+	correlation: MaestroCorrelation,
+): MaestroCorrelation {
+	const { traceparent: _traceparent, ...dataCorrelation } = correlation;
+	return dataCorrelation;
+}
+
+function maestroContextExtensions(
+	correlation: MaestroCorrelation,
+	data: Record<string, unknown>,
+): Record<string, string> {
+	const extensions: Record<string, string> = {};
+	putMetadata(extensions, "workspace_id", correlation.workspace_id);
+	putMetadata(extensions, "maestro_session_id", correlation.session_id);
+	putMetadata(extensions, "agent_run_id", correlation.agent_run_id);
+	putMetadata(extensions, "agent_run_step_id", correlation.agent_run_step_id);
+	putMetadata(extensions, "trace_id", correlation.trace_id);
+	putMetadata(extensions, "traceparent", correlation.traceparent);
+	putMetadata(extensions, "request_id", correlation.request_id);
+	putMetadata(extensions, "source_issue", correlation.attributes?.source_issue);
+	putMetadata(extensions, "task_id", correlation.attributes?.task_id);
+	putMetadata(
+		extensions,
+		"tool_execution_id",
+		stringRecordValue(data, "tool_execution_id"),
+	);
+	return extensions;
+}
+
+function stringRecordValue(
+	record: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	const value = record[key];
+	return typeof value === "string" ? value : undefined;
 }
 
 export async function publishMaestroCloudEvent<
@@ -1159,6 +1223,12 @@ export function recordMaestroPromptVariantSelected(
 	event: RecordMaestroPromptVariantSelectedInput,
 ): void {
 	const selectedAt = event.selected_at ?? new Date().toISOString();
+	const promptID = event.prompt_id ?? event.prompt_metadata.name;
+	const promptName = event.prompt_name ?? event.prompt_metadata.name;
+	const versionID =
+		event.version_id ??
+		event.prompt_metadata.versionId ??
+		event.prompt_metadata.hash;
 	void publishMaestroCloudEvent<PromptVariantSelectedEventData>(
 		MaestroBusEventType.PromptVariantSelected,
 		{
@@ -1166,6 +1236,9 @@ export function recordMaestroPromptVariantSelected(
 				resolveMaestroEventBusConfig(event.env).defaultCorrelation,
 				event.correlation,
 			),
+			prompt_id: promptID,
+			prompt_name: promptName,
+			version_id: versionID,
 			prompt_metadata: event.prompt_metadata,
 			selected_at: selectedAt,
 		},
@@ -1241,6 +1314,14 @@ export function recordMaestroEvalScored(
 	event: RecordMaestroEvalScoredInput,
 ): void {
 	const scoredAt = event.scored_at ?? new Date().toISOString();
+	const evalRunID =
+		event.eval_run_id ?? event.tool_execution_id ?? event.tool_call_id;
+	const scenarioID =
+		event.scenario_id ??
+		event.skill_metadata?.artifactId ??
+		event.skill_metadata?.name ??
+		event.tool_name ??
+		event.tool_call_id;
 	void publishMaestroCloudEvent<EvalScoredEventData>(
 		MaestroBusEventType.EvalScored,
 		{
@@ -1248,6 +1329,8 @@ export function recordMaestroEvalScored(
 				resolveMaestroEventBusConfig(event.env).defaultCorrelation,
 				event.correlation,
 			),
+			eval_run_id: evalRunID,
+			scenario_id: scenarioID,
 			prompt_metadata: event.prompt_metadata,
 			skill_metadata: event.skill_metadata,
 			tool_call_id: event.tool_call_id,
@@ -1256,6 +1339,7 @@ export function recordMaestroEvalScored(
 			score: event.score,
 			threshold: event.threshold,
 			passed: event.passed,
+			scorer: event.scorer,
 			rationale: event.rationale,
 			assertion_count: event.assertion_count,
 			scored_at: scoredAt,

--- a/src/telemetry/maestro-platform-replay-fixture.ts
+++ b/src/telemetry/maestro-platform-replay-fixture.ts
@@ -235,6 +235,9 @@ function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
 		eventFor(
 			MaestroBusEventType.PromptVariantSelected,
 			{
+				prompt_id: "prompt_platform_replay_system",
+				prompt_name: "maestro-system",
+				version_id: "prompt_version_9",
 				prompt_metadata: promptMetadata,
 				selected_at: eventPlan[1].time,
 			},
@@ -279,6 +282,8 @@ function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
 		eventFor(
 			MaestroBusEventType.SkillInvoked,
 			{
+				invocation_id: "invocation_platform_replay_skill_001",
+				skill_id: SKILL_ID,
 				prompt_metadata: promptMetadata,
 				skill_metadata: skillMetadata,
 				tool_call_id: SKILL_TOOL_CALL_ID,
@@ -354,6 +359,8 @@ function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
 		eventFor(
 			MaestroBusEventType.EvalScored,
 			{
+				eval_run_id: "eval_run_platform_replay_001",
+				scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
 				prompt_metadata: promptMetadata,
 				skill_metadata: skillMetadata,
 				tool_call_id: BASH_TOOL_CALL_ID,
@@ -362,6 +369,7 @@ function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
 				score: 0.82,
 				passed: false,
 				threshold: 0.9,
+				scorer: "fermata.replay.score",
 				rationale: "formatting checks failed",
 				assertion_count: 1,
 				scored_at: eventPlan[8].time,
@@ -371,6 +379,8 @@ function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
 		eventFor(
 			MaestroBusEventType.SkillFailed,
 			{
+				invocation_id: "invocation_platform_replay_skill_001",
+				skill_id: SKILL_ID,
 				prompt_metadata: promptMetadata,
 				skill_metadata: skillMetadata,
 				tool_call_id: SKILL_TOOL_CALL_ID,
@@ -435,15 +445,17 @@ export function buildCanonicalMaestroPlatformReplayFixture(): MaestroPlatformRep
 			required_subjects: subjects,
 			platform_join_keys: {
 				agent_run_id: AGENT_RUN_ID,
-				prompt_id: promptMetadata.name,
+				prompt_id: "prompt_platform_replay_system",
 				prompt_version_id: promptMetadata.versionId,
 				prompt_artifact_hash: promptMetadata.hash,
 				tool_call_id: BASH_TOOL_CALL_ID,
 				tool_execution_id: BASH_TOOL_EXECUTION_ID,
 				evaluation_tool_call_id: BASH_TOOL_CALL_ID,
 				evaluation_tool_execution_id: BASH_TOOL_EXECUTION_ID,
+				eval_run_id: "eval_run_platform_replay_001",
 				skill_tool_call_id: SKILL_TOOL_CALL_ID,
 				skill_tool_execution_id: SKILL_TOOL_EXECUTION_ID,
+				skill_invocation_id: "invocation_platform_replay_skill_001",
 				approval_request_id: APPROVAL_REQUEST_ID,
 				skill_id: SKILL_ID,
 			},

--- a/test/telemetry/maestro-event-bus.test.ts
+++ b/test/telemetry/maestro-event-bus.test.ts
@@ -74,6 +74,9 @@ describe("maestro event bus", () => {
 			data_content_type: "application/protobuf",
 			extensions: {
 				dataschema: "buf.build/evalops/proto/maestro.v1.ToolCallAttempt",
+				evalops_context_version: "evalops.context.v1",
+				workspace_id: "workspace_123",
+				maestro_session_id: "session_123",
 			},
 		});
 		expect(event.data["@type"]).toBe(
@@ -93,6 +96,7 @@ describe("maestro event bus", () => {
 			actor_id: "user_123",
 			principal_id: "principal_123",
 			trace_id: "trace_123",
+			traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
 			request_id: "request_123",
 			parent_event_id: "event_parent",
 			attributes: {
@@ -115,6 +119,7 @@ describe("maestro event bus", () => {
 			actor_id: "user_123",
 			principal_id: "principal_123",
 			trace_id: "trace_123",
+			traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
 			request_id: "request_123",
 			parent_event_id: "event_parent",
 			task_id: "task_123",
@@ -213,6 +218,9 @@ describe("maestro event bus", () => {
 		expect(JSON.parse(published[0]?.payload ?? "{}")).toMatchObject({
 			type: "maestro.events.prompt_variant.selected",
 			data: {
+				prompt_id: "maestro-system",
+				prompt_name: "maestro-system",
+				version_id: "ver_9",
 				prompt_metadata: {
 					name: "maestro-system",
 					versionId: "ver_9",
@@ -424,6 +432,7 @@ describe("maestro event bus", () => {
 			score: 0.82,
 			threshold: 0.9,
 			passed: false,
+			scorer: "fermata.replay.score",
 			rationale: "formatting checks failed",
 			assertion_count: 1,
 			prompt_metadata: {
@@ -452,12 +461,15 @@ describe("maestro event bus", () => {
 		expect(JSON.parse(published[0]?.payload ?? "{}")).toMatchObject({
 			type: "maestro.events.eval.scored",
 			data: {
+				eval_run_id: "exec_eval_1",
+				scenario_id: "skill_remote_1",
 				tool_call_id: "tool_eval_1",
 				tool_execution_id: "exec_eval_1",
 				tool_name: "Bash",
 				score: 0.82,
 				threshold: 0.9,
 				passed: false,
+				scorer: "fermata.replay.score",
 				rationale: "formatting checks failed",
 				assertion_count: 1,
 				prompt_metadata: {

--- a/test/telemetry/maestro-platform-replay-fixture.test.ts
+++ b/test/telemetry/maestro-platform-replay-fixture.test.ts
@@ -105,8 +105,18 @@ describe("canonical Maestro Platform replay fixture", () => {
 			},
 			selected_at: "2026-04-23T18:01:00.000Z",
 		});
-		expect(promptVariantSelected).not.toHaveProperty("prompt_id");
-		expect(promptVariantSelected).not.toHaveProperty("version_id");
+		expect(promptVariantSelected).toHaveProperty(
+			"prompt_id",
+			"prompt_platform_replay_system",
+		);
+		expect(promptVariantSelected).toHaveProperty(
+			"prompt_name",
+			"maestro-system",
+		);
+		expect(promptVariantSelected).toHaveProperty(
+			"version_id",
+			"prompt_version_9",
+		);
 		const toolAttempts = fixture.events
 			.filter((event) => event.type === MaestroBusEventType.ToolCallAttempted)
 			.map((event) => event.data);
@@ -148,12 +158,14 @@ describe("canonical Maestro Platform replay fixture", () => {
 			tool_execution_id: "tool_exec_platform_replay_skill_001",
 			invoked_at: "2026-04-23T18:04:00.000Z",
 		});
-		expect(
-			byType.get(MaestroBusEventType.SkillInvoked)?.data,
-		).not.toHaveProperty("invocation_id");
-		expect(
-			byType.get(MaestroBusEventType.SkillInvoked)?.data,
-		).not.toHaveProperty("skill_id");
+		expect(byType.get(MaestroBusEventType.SkillInvoked)?.data).toHaveProperty(
+			"invocation_id",
+			"invocation_platform_replay_skill_001",
+		);
+		expect(byType.get(MaestroBusEventType.SkillInvoked)?.data).toHaveProperty(
+			"skill_id",
+			"skill_incident_review",
+		);
 		expect(byType.get(MaestroBusEventType.SkillFailed)?.data).toMatchObject({
 			"@type": "type.googleapis.com/maestro.v1.SkillOutcome",
 			prompt_metadata: {
@@ -181,9 +193,10 @@ describe("canonical Maestro Platform replay fixture", () => {
 			evaluation_rationale: "formatting checks failed",
 			outcome_at: "2026-04-23T18:09:00.000Z",
 		});
-		expect(
-			byType.get(MaestroBusEventType.SkillFailed)?.data,
-		).not.toHaveProperty("invocation_id");
+		expect(byType.get(MaestroBusEventType.SkillFailed)?.data).toHaveProperty(
+			"invocation_id",
+			"invocation_platform_replay_skill_001",
+		);
 		expect(
 			byType.get(MaestroBusEventType.SkillFailed)?.data,
 		).not.toHaveProperty("status");
@@ -211,15 +224,18 @@ describe("canonical Maestro Platform replay fixture", () => {
 			score: 0.82,
 			passed: false,
 			threshold: 0.9,
+			scorer: "fermata.replay.score",
 			rationale: "formatting checks failed",
 			assertion_count: 1,
 			scored_at: "2026-04-23T18:08:00.000Z",
 		});
-		expect(byType.get(MaestroBusEventType.EvalScored)?.data).not.toHaveProperty(
+		expect(byType.get(MaestroBusEventType.EvalScored)?.data).toHaveProperty(
 			"eval_run_id",
+			"eval_run_platform_replay_001",
 		);
-		expect(byType.get(MaestroBusEventType.EvalScored)?.data).not.toHaveProperty(
+		expect(byType.get(MaestroBusEventType.EvalScored)?.data).toHaveProperty(
 			"scenario_id",
+			"canonical-maestro-session-platform-replay",
 		);
 		expect(byType.get(MaestroBusEventType.EvalScored)?.data).not.toHaveProperty(
 			"suite_id",
@@ -230,15 +246,17 @@ describe("canonical Maestro Platform replay fixture", () => {
 			required_subjects: fixture.subjects,
 			platform_join_keys: {
 				agent_run_id: "agent_run_platform_replay_001",
-				prompt_id: "maestro-system",
+				prompt_id: "prompt_platform_replay_system",
 				prompt_version_id: "prompt_version_9",
 				prompt_artifact_hash: "sha256:prompt-platform-replay",
 				tool_call_id: "tool_call_platform_replay_bash_001",
 				tool_execution_id: "tool_exec_platform_replay_bash_001",
 				evaluation_tool_call_id: "tool_call_platform_replay_bash_001",
 				evaluation_tool_execution_id: "tool_exec_platform_replay_bash_001",
+				eval_run_id: "eval_run_platform_replay_001",
 				skill_tool_call_id: "tool_call_platform_replay_skill_001",
 				skill_tool_execution_id: "tool_exec_platform_replay_skill_001",
+				skill_invocation_id: "invocation_platform_replay_skill_001",
 				approval_request_id: "approval_platform_replay_001",
 				skill_id: "skill_incident_review",
 			},


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `d06c9f378549df50880696241ddbaadcfb55af0e`
- last generated public sync base: `4e64dd142636cd2ea0ab7c84daf73c8bffdbd6fd`
- previewed public-tree drift: `4` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (d06c9f378549)`
- public projection: `https://github.com/evalops/maestro@main (bdcf40b23806)`
- files to copy or update: `4`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/telemetry/maestro-event-bus.ts
- copy/update src/telemetry/maestro-platform-replay-fixture.ts
- copy/update test/telemetry/maestro-event-bus.test.ts
- copy/update test/telemetry/maestro-platform-replay-fixture.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/telemetry/maestro-event-bus.ts
- copy/update src/telemetry/maestro-platform-replay-fixture.ts
- copy/update test/telemetry/maestro-event-bus.test.ts
- copy/update test/telemetry/maestro-platform-replay-fixture.test.ts

## Public-only commits since last generated sync

- bdcf40b2 ci: sync version bump runner

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode