### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/telemetry/maestro-platform-replay-fixture.ts
+++ b/src/telemetry/maestro-platform-replay-fixture.ts
@@ -200,6 +200,7 @@ function eventFor(
 			correlation: {
 				...baseCorrelation,
 				agent_run_step_id: stepId,
+				traceparent: fixtureTraceparent(index),
 			},
 			...data,
 		},
@@ -209,6 +210,10 @@ function eventFor(
 			time: plan.time,
 		},
 	);
+}
+
+function fixtureTraceparent(index: number): string {
+	return `00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-${String(index + 1).padStart(16, "0")}-01`;
 }
 
 function buildEvents(): MaestroPlatformReplayFixtureEvent[] {

--- a/test/telemetry/maestro-platform-replay-fixture.test.ts
+++ b/test/telemetry/maestro-platform-replay-fixture.test.ts
@@ -60,7 +60,7 @@ describe("canonical Maestro Platform replay fixture", () => {
 			"evt_maestro_replay_011_session_closed",
 		]);
 
-		for (const event of fixture.events) {
+		for (const [index, event] of fixture.events.entries()) {
 			expect(event).toMatchObject({
 				spec_version: "1.0",
 				source: "maestro-fixture",
@@ -81,6 +81,10 @@ describe("canonical Maestro Platform replay fixture", () => {
 			expect(event.extensions.dataschema).toMatch(
 				/^buf\.build\/evalops\/proto\/maestro\.v1\./,
 			);
+			expect(event.extensions.traceparent).toBe(
+				`00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-${String(index + 1).padStart(16, "0")}-01`,
+			);
+			expect(event.data.correlation).not.toHaveProperty("traceparent");
 			expect(event.time).toMatch(/^2026-04-23T18:/);
 		}
 	});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `f94106507c3ee6c1883783a1af35f3d6e502c2a4`
- last generated public sync base: `43c60299fd2803b18a4eaff6df401916002eab96`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (f94106507c3e)`
- public projection: `https://github.com/evalops/maestro@main (43c60299fd28)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/telemetry/maestro-platform-replay-fixture.ts
- copy/update test/telemetry/maestro-platform-replay-fixture.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/telemetry/maestro-platform-replay-fixture.ts
- copy/update test/telemetry/maestro-platform-replay-fixture.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode