### PR TITLE
ci: reduce redundant workflow runs

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 concurrency:
   group: ghcr-publish-${{ github.workflow }}-${{ github.ref }}
@@ -20,13 +21,20 @@ jobs:
       packages: write
 
     steps:
+      - name: Publish is push-only
+        if: github.event_name == 'pull_request'
+        run: echo "GHCR publish runs only on main pushes; this PR check satisfies the required status without building an image."
+
       - name: Checkout repository
+        if: github.event_name == 'push'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
+        if: github.event_name == 'push'
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
+        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -34,6 +42,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract image metadata
+        if: github.event_name == 'push'
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -44,6 +53,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build image
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,9 +1,6 @@
 name: GHCR Publish
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -23,20 +20,13 @@ jobs:
       packages: write
 
     steps:
-      - name: Validate publish gate
-        if: github.event_name == 'pull_request'
-        run: echo "Image publishing runs only for pushes to main."
-
       - name: Checkout repository
-        if: github.event_name == 'push'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        if: github.event_name == 'push'
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -44,7 +34,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract image metadata
-        if: github.event_name == 'push'
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -55,7 +44,6 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build image
-        if: github.event_name == 'push'
         uses: docker/build-push-action@v7
         with:
           context: .


### PR DESCRIPTION
## Summary
- remove no-op PR runs from GHCR Publish
- wake evals on the opt-in run-evals label instead of every PR update that mostly skips

## Test plan
- git diff --check
- actionlint on changed workflow files