### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/ambient-agent-rs/src/daemon.rs
+++ b/packages/ambient-agent-rs/src/daemon.rs
@@ -298,16 +298,38 @@ impl AmbientDaemon {
                 Some(cmd) = command_rx.recv() => {
                     match cmd {
                         DaemonCommand::Pause => {
-                            info!("Pausing daemon");
-                            *self.status.write().await = DaemonStatus::Paused;
-                            self.record_session_event(AmbientSessionState::Suspended, None, None)
-                                .await;
+                            let should_publish = {
+                                let mut status = self.status.write().await;
+                                if *status == DaemonStatus::Running {
+                                    info!("Pausing daemon");
+                                    *status = DaemonStatus::Paused;
+                                    true
+                                } else {
+                                    debug!("Ignoring pause command while daemon is {:?}", *status);
+                                    false
+                                }
+                            };
+                            if should_publish {
+                                self.record_session_event(AmbientSessionState::Suspended, None, None)
+                                    .await;
+                            }
                         }
                         DaemonCommand::Resume => {
-                            info!("Resuming daemon");
-                            *self.status.write().await = DaemonStatus::Running;
-                            self.record_session_event(AmbientSessionState::Resumed, None, None)
-                                .await;
+                            let should_publish = {
+                                let mut status = self.status.write().await;
+                                if *status == DaemonStatus::Paused {
+                                    info!("Resuming daemon");
+                                    *status = DaemonStatus::Running;
+                                    true
+                                } else {
+                                    debug!("Ignoring resume command while daemon is {:?}", *status);
+                                    false
+                                }
+                            };
+                            if should_publish {
+                                self.record_session_event(AmbientSessionState::Resumed, None, None)
+                                    .await;
+                            }
                         }
                         DaemonCommand::Shutdown => {
                             info!("Shutting down daemon");
@@ -1152,10 +1174,19 @@ mod tests {
         let daemon_handle = tokio::spawn(async move { daemon.run().await });
 
         wait_for_published(&transport, 1).await;
+        cmd_tx.send(DaemonCommand::Resume).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        assert_eq!(transport.published.lock().unwrap().len(), 1);
         cmd_tx.send(DaemonCommand::Pause).await.unwrap();
         wait_for_published(&transport, 2).await;
+        cmd_tx.send(DaemonCommand::Pause).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        assert_eq!(transport.published.lock().unwrap().len(), 2);
         cmd_tx.send(DaemonCommand::Resume).await.unwrap();
         wait_for_published(&transport, 3).await;
+        cmd_tx.send(DaemonCommand::Resume).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        assert_eq!(transport.published.lock().unwrap().len(), 3);
         cmd_tx.send(DaemonCommand::Shutdown).await.unwrap();
 
         daemon_handle.await.unwrap().unwrap();

--- a/packages/github-agent/src/orchestrator.test.ts
+++ b/packages/github-agent/src/orchestrator.test.ts
@@ -19,6 +19,13 @@ import type { TaskExecutor } from "./worker/executor.js";
 
 // Mock all dependencies
 let mockMemory: MockMemoryStore;
+const { closeMaestroEventBusTransportMock } = vi.hoisted(() => ({
+	closeMaestroEventBusTransportMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@evalops/ai/telemetry", () => ({
+	closeMaestroEventBusTransport: closeMaestroEventBusTransportMock,
+}));
 
 vi.mock("./memory/store.js", () => ({
 	// biome-ignore lint/complexity/useArrowFunction: Vitest requires constructable mock for `new`.
@@ -742,9 +749,23 @@ describe("Orchestrator", () => {
 			await orchestrator.stop();
 
 			expect(mockWatcher.stop).toHaveBeenCalled();
+			expect(closeMaestroEventBusTransportMock).toHaveBeenCalled();
 			expect(mockMemory.save).toHaveBeenCalled();
 
 			await startPromise.catch(() => {});
+		});
+
+		it("should save memory when event bus shutdown fails", async () => {
+			closeMaestroEventBusTransportMock.mockRejectedValueOnce(
+				new Error("transport close failed"),
+			);
+
+			const orchestrator = new Orchestrator(config);
+
+			await expect(orchestrator.stop()).resolves.toBeUndefined();
+
+			expect(closeMaestroEventBusTransportMock).toHaveBeenCalled();
+			expect(mockMemory.save).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/github-agent/src/orchestrator.ts
+++ b/packages/github-agent/src/orchestrator.ts
@@ -8,6 +8,7 @@
  * - Learning from outcomes
  */
 
+import { closeMaestroEventBusTransport } from "@evalops/ai/telemetry";
 import { GitHubAuth } from "./github/auth.js";
 import { GitHubApiClient } from "./github/client.js";
 import { GitHubReporter, type TaskProgress } from "./github/reporter.js";
@@ -196,7 +197,16 @@ export class Orchestrator {
 		if (this.webhookServer) {
 			await this.webhookServer.stop();
 		}
-		this.memory.save();
+		try {
+			await closeMaestroEventBusTransport();
+		} catch (error) {
+			console.warn(
+				"[orchestrator] Failed to close event bus transport:",
+				error,
+			);
+		} finally {
+			this.memory.save();
+		}
 		console.log("[orchestrator] Stopped");
 	}
 

--- a/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
+++ b/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
@@ -212,6 +212,17 @@ BEGIN
 		ALTER TABLE "webhook_deliveries" ALTER COLUMN "id" SET NOT NULL;
 	END IF;
 
+	IF EXISTS (
+			SELECT 1
+			FROM "webhook_deliveries"
+			GROUP BY "id"
+			HAVING count(*) > 1
+		)
+	THEN
+		RAISE EXCEPTION 'webhook_deliveries contains duplicate id values after legacy schema reconciliation'
+			USING ERRCODE = 'unique_violation';
+	END IF;
+
 	IF NOT EXISTS (
 			SELECT 1
 			FROM pg_constraint
@@ -219,12 +230,6 @@ BEGIN
 				AND contype = 'p'
 		)
 		AND NOT EXISTS (SELECT 1 FROM "webhook_deliveries" WHERE "id" IS NULL)
-		AND NOT EXISTS (
-			SELECT 1
-			FROM "webhook_deliveries"
-			GROUP BY "id"
-			HAVING count(*) > 1
-		)
 	THEN
 		BEGIN
 			ALTER TABLE "webhook_deliveries"

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -132,6 +132,12 @@ describe("database migration packaging", () => {
 		);
 		expect(migration).toContain("webhook_deliveries_pkey");
 		expect(migration).toContain(
+			"webhook_deliveries contains duplicate id values after legacy schema reconciliation",
+		);
+		expect(migration).toMatch(
+			/RAISE EXCEPTION[\s\S]+USING ERRCODE = 'unique_violation'/,
+		);
+		expect(migration).toContain(
 			"WHEN duplicate_object OR invalid_table_definition THEN",
 		);
 		expect(migration).toContain("WHEN duplicate_object THEN");


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `b6024dcf86487736f69d5795ab54847e83453131`
- last generated public sync base: `efa0dd1592e0fe571b95ce52d9fbe830b8a5c7c6`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (b6024dcf8648)`
- public projection: `https://github.com/evalops/maestro@main (efa0dd1592e0)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/ambient-agent-rs/src/daemon.rs
- copy/update packages/github-agent/src/orchestrator.test.ts
- copy/update packages/github-agent/src/orchestrator.ts
- copy/update src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
- copy/update test/db/migration-files.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/ambient-agent-rs/src/daemon.rs
- copy/update packages/github-agent/src/orchestrator.test.ts
- copy/update packages/github-agent/src/orchestrator.ts
- copy/update src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
- copy/update test/db/migration-files.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode