### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/ambient-agent-rs/src/daemon.rs
+++ b/packages/ambient-agent-rs/src/daemon.rs
@@ -585,7 +585,7 @@ impl AmbientDaemon {
                 success: false,
                 confidence_predicted: 0.0,
                 tokens_used: 0,
-                cost_usd: routing.estimated_cost,
+                cost_usd: 0.0,
                 duration_secs: duration,
                 failure_reason: Some(failure_reason),
                 labels: event.labels.clone(),
@@ -1152,7 +1152,7 @@ mod tests {
         let learner_stats = daemon.learner.read().await.get_stats();
         assert_eq!(learner_stats.total_outcomes, 1);
         assert_eq!(learner_stats.overall_success_rate, 0.0);
-        assert!(learner_stats.total_cost > 0.0);
+        assert_eq!(learner_stats.total_cost, 0.0);
         assert!(daemon.checkpoint_mgr.read().await.list_active().is_empty());
     }
 


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `b0ee01b6f1696e8d46ad0cb687e89fcb8be51470`
- last generated public sync base: `b4a0f1b6eff879238f9316f81011d330f22403e4`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (b0ee01b6f169)`
- public projection: `https://github.com/evalops/maestro@main (b4a0f1b6eff8)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/ambient-agent-rs/src/daemon.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/ambient-agent-rs/src/daemon.rs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode