### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/ambient-agent-rs/src/daemon.rs
+++ b/packages/ambient-agent-rs/src/daemon.rs
@@ -14,7 +14,7 @@ use crate::{
         default_socket_path, verify_token_constant_time, IpcCommand, IpcResponse, IpcServer,
         StatusResponse,
     },
-    learner::{Learner, Outcome},
+    learner::{Learner, LearnerOutcome},
     platform_event_bus::{
         AmbientCloseReason, AmbientSessionEvent, AmbientSessionState, PlatformEventBus,
     },
@@ -576,7 +576,7 @@ impl AmbientDaemon {
                 error!("Failed to rollback cost-limited checkpoint: {}", e);
             }
             let duration = (Utc::now() - start_time).num_seconds() as u64;
-            let outcome = Outcome {
+            let outcome = LearnerOutcome {
                 task_id: plan.task_id.clone(),
                 event_type: event.event_type,
                 task_type: main_task_type,
@@ -619,7 +619,7 @@ impl AmbientDaemon {
 
         // Record outcome
         let duration = (Utc::now() - start_time).num_seconds() as u64;
-        let outcome = Outcome {
+        let outcome = LearnerOutcome {
             task_id: plan.task_id.clone(),
             event_type: event.event_type,
             task_type: main_task_type,

--- a/packages/ambient-agent-rs/src/learner.rs
+++ b/packages/ambient-agent-rs/src/learner.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::fs;
 
-/// Outcome record for learning
+/// Persisted task outcome used by the learner to derive patterns.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct Outcome {
+pub struct LearnerOutcome {
     pub task_id: String,
     pub event_type: EventType,
     pub task_type: TaskType,
@@ -30,7 +30,7 @@ pub struct Outcome {
     pub timestamp: DateTime<Utc>,
 }
 
-impl Outcome {
+impl LearnerOutcome {
     fn normalize_costs(&mut self) {
         // Older persisted outcomes only tracked a single cost field. Backfill the
         // explicit estimate so we can keep historical learner stats coherent.
@@ -68,7 +68,7 @@ pub enum PatternType {
 /// Learner tracks outcomes and derives patterns
 pub struct Learner {
     storage_path: PathBuf,
-    outcomes: Vec<Outcome>,
+    outcomes: Vec<LearnerOutcome>,
     patterns: HashMap<(PatternType, String), LearnedPattern>,
     max_outcomes: usize,
     min_samples_for_pattern: u64,
@@ -87,7 +87,7 @@ impl Learner {
     }
 
     /// Record an outcome
-    pub async fn record_outcome(&mut self, mut outcome: Outcome) -> anyhow::Result<()> {
+    pub async fn record_outcome(&mut self, mut outcome: LearnerOutcome) -> anyhow::Result<()> {
         outcome.normalize_costs();
         self.outcomes.push(outcome.clone());
 
@@ -108,7 +108,7 @@ impl Learner {
     }
 
     /// Update patterns based on new outcome
-    fn update_patterns(&mut self, outcome: &Outcome) {
+    fn update_patterns(&mut self, outcome: &LearnerOutcome) {
         // Update label patterns
         for label in &outcome.labels {
             self.update_pattern(PatternType::Label, label, outcome);
@@ -143,7 +143,7 @@ impl Learner {
     }
 
     /// Update a single pattern
-    fn update_pattern(&mut self, pattern_type: PatternType, key: &str, outcome: &Outcome) {
+    fn update_pattern(&mut self, pattern_type: PatternType, key: &str, outcome: &LearnerOutcome) {
         let pattern_key = (pattern_type.clone(), key.to_string());
 
         let pattern = self
@@ -372,7 +372,7 @@ pub struct LearnerStats {
 /// Serialization helper
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct LearnerData {
-    outcomes: Vec<Outcome>,
+    outcomes: Vec<LearnerOutcome>,
     patterns: Vec<LearnedPattern>,
 }
 
@@ -381,8 +381,8 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn make_outcome(success: bool, labels: Vec<&str>) -> Outcome {
-        Outcome {
+    fn make_outcome(success: bool, labels: Vec<&str>) -> LearnerOutcome {
+        LearnerOutcome {
             task_id: "test-task".to_string(),
             event_type: EventType::Issue,
             task_type: TaskType::Fix,


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `c1119ea232dffaadfff73c14a1c79f65a6073e46`
- last generated public sync base: `dc522640ed8c16dcbcc002f15c53d101b8b2d380`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (c1119ea232df)`
- public projection: `https://github.com/evalops/maestro@main (dc522640ed8c)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/ambient-agent-rs/src/daemon.rs
- copy/update packages/ambient-agent-rs/src/learner.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/ambient-agent-rs/src/daemon.rs
- copy/update packages/ambient-agent-rs/src/learner.rs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode