### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/ambient-agent-rs/src/daemon.rs
+++ b/packages/ambient-agent-rs/src/daemon.rs
@@ -4,7 +4,7 @@
 //! Watches for events, makes decisions, executes tasks, and learns.
 
 use crate::{
-    cascader::{Cascader, TaskContext},
+    cascader::Cascader,
     checkpoint::CheckpointManager,
     critic::{Critic, CriticConfig},
     decider::{Decider, DeciderConfig},
@@ -14,12 +14,13 @@ use crate::{
         default_socket_path, verify_token_constant_time, IpcCommand, IpcResponse, IpcServer,
         StatusResponse,
     },
-    learner::{Learner, LearnerOutcome},
+    learner::Learner,
     platform_event_bus::{
         AmbientCloseReason, AmbientSessionEvent, AmbientSessionState, PlatformEventBus,
     },
     pr_creator::{PrCreator, PrCreatorConfig},
     runtime_config::EffectiveRuntimeConfig,
+    task_run::{CostAccounting, PlanRunContext, PlanRunOutcome},
     types::*,
 };
 use chrono::Utc;
@@ -506,51 +507,14 @@ impl AmbientDaemon {
     /// Execute a task plan
     async fn execute_plan(&self, event: NormalizedEvent, plan: TaskPlan) {
         let start_time = Utc::now();
+        let run_context = PlanRunContext::from_plan(&event, &plan);
 
-        // Determine the main task type from the plan
-        let main_task_type = plan
-            .tasks
-            .first()
-            .map(|t| t.task_type)
-            .unwrap_or(TaskType::Fix);
-
-        // Create checkpoint
-        let checkpoint_id = match self
-            .checkpoint_mgr
-            .write()
-            .await
-            .create(&plan.task_id, &plan.summary)
-            .await
-        {
-            Ok(id) => id,
-            Err(e) => {
-                error!("Failed to create checkpoint: {}", e);
-                return;
-            }
+        let Some(checkpoint_id) = self.create_plan_checkpoint(&plan).await else {
+            return;
         };
 
-        // Route to appropriate model
-        let task = Task {
-            id: plan.task_id.clone(),
-            task_type: main_task_type,
-            prompt: format!(
-                "{}\n\n{}",
-                event.title,
-                event.body.as_deref().unwrap_or_default()
-            ),
-            files: plan.files.clone(),
-            depends_on: vec![],
-            priority: event.priority,
-            estimated_tokens: None,
-        };
-
-        let context = TaskContext {
-            complexity: plan.estimated_complexity,
-            task_type: main_task_type,
-            estimated_tokens: None,
-            previous_attempts: 0,
-        };
-
+        let task = run_context.route_task(&event, &plan);
+        let context = run_context.task_context();
         let routing = self.cascader.write().await.route(&task, &context);
 
         info!(
@@ -566,48 +530,18 @@ impl AmbientDaemon {
                 routing.estimated_cost, limits.max_cost_per_task_usd
             );
             warn!("Skipping event {} because {}", event.id, failure_reason);
-            if let Err(e) = self
-                .checkpoint_mgr
-                .write()
-                .await
-                .rollback(&checkpoint_id)
-                .await
-            {
-                error!("Failed to rollback cost-limited checkpoint: {}", e);
-            }
-            let duration = (Utc::now() - start_time).num_seconds() as u64;
-            let outcome = LearnerOutcome {
-                task_id: plan.task_id.clone(),
-                event_type: event.event_type,
-                task_type: main_task_type,
-                complexity: plan.estimated_complexity,
-                model_used: routing.model.clone(),
-                success: false,
-                confidence_predicted: 0.0,
-                tokens_used: 0,
-                estimated_cost_usd: routing.estimated_cost,
-                cost_usd: 0.0,
-                duration_secs: duration,
-                failure_reason: Some(failure_reason),
-                labels: event.labels.clone(),
-                repo: event.repository.clone(),
-                timestamp: Utc::now(),
-            };
-            if let Err(e) = self.learner.write().await.record_outcome(outcome).await {
-                error!("Failed to record cost-limited outcome: {}", e);
-            }
-            {
-                let mut stats = self.stats.write().await;
-                stats.tasks_executed += 1;
-                stats.tasks_failed += 1;
-            }
+            self.rollback_checkpoint(&checkpoint_id, "cost-limited")
+                .await;
+            let outcome = PlanRunOutcome::cost_limited(
+                failure_reason,
+                CostAccounting::estimated_only(routing.estimated_cost),
+            );
+            self.record_plan_outcome(&run_context, &routing.model, start_time, &outcome)
+                .await;
             return;
         }
 
-        // Execute the plan using the real LLM
         let result = self.executor.execute(&plan, &routing).await;
-
-        // Critique the result
         let critique = self.critic.critique(&plan, &result).await;
 
         info!(
@@ -617,70 +551,158 @@ impl AmbientDaemon {
             critique.issues.len()
         );
 
-        // Record outcome
-        let duration = (Utc::now() - start_time).num_seconds() as u64;
-        let outcome = LearnerOutcome {
-            task_id: plan.task_id.clone(),
-            event_type: event.event_type,
-            task_type: main_task_type,
-            complexity: plan.estimated_complexity,
-            model_used: routing.model.clone(),
-            success: critique.approved && result.status == ExecutionStatus::Success,
-            confidence_predicted: critique.confidence,
-            tokens_used: 0, // Would come from actual execution
-            estimated_cost_usd: routing.estimated_cost,
-            cost_usd: routing.estimated_cost,
-            duration_secs: duration,
-            failure_reason: result.error.clone(),
-            labels: event.labels.clone(),
-            repo: event.repository.clone(),
-            timestamp: Utc::now(),
-        };
+        let outcome = PlanRunOutcome::from_execution(
+            &result,
+            &critique,
+            CostAccounting::estimate_as_actual(routing.estimated_cost, 0),
+        );
+        self.record_plan_outcome(&run_context, &routing.model, start_time, &outcome)
+            .await;
+        self.finish_plan_execution(
+            &event,
+            &plan,
+            &checkpoint_id,
+            &routing.model,
+            &result,
+            &critique,
+            outcome.success,
+        )
+        .await;
+    }
 
-        if let Err(e) = self.learner.write().await.record_outcome(outcome).await {
+    async fn create_plan_checkpoint(&self, plan: &TaskPlan) -> Option<String> {
+        match self
+            .checkpoint_mgr
+            .write()
+            .await
+            .create(&plan.task_id, &plan.summary)
+            .await
+        {
+            Ok(id) => Some(id),
+            Err(e) => {
+                error!("Failed to create checkpoint: {}", e);
+                None
+            }
+        }
+    }
+
+    async fn rollback_checkpoint(&self, checkpoint_id: &str, reason: &str) {
+        if let Err(e) = self
+            .checkpoint_mgr
+            .write()
+            .await
+            .rollback(checkpoint_id)
+            .await
+        {
+            error!("Failed to rollback {reason} checkpoint: {}", e);
+        }
+    }
+
+    async fn commit_checkpoint(&self, checkpoint_id: &str) {
+        if let Err(e) = self
+            .checkpoint_mgr
+            .write()
+            .await
+            .commit(checkpoint_id)
+            .await
+        {
+            error!("Failed to commit checkpoint: {}", e);
+        }
+    }
+
+    async fn record_plan_outcome(
+        &self,
+        run_context: &PlanRunContext,
+        model_used: &str,
+        start_time: chrono::DateTime<Utc>,
+        outcome: &PlanRunOutcome,
+    ) {
+        let duration = (Utc::now() - start_time).num_seconds() as u64;
+        let learner_outcome = run_context.learner_outcome(model_used, duration, outcome);
+
+        if let Err(e) = self
+            .learner
+            .write()
+            .await
+            .record_outcome(learner_outcome)
+            .await
+        {
             error!("Failed to record outcome: {}", e);
         }
 
-        // Update stats
-        {
-            let mut stats = self.stats.write().await;
-            stats.tasks_executed += 1;
-            if critique.approved {
-                stats.tasks_succeeded += 1;
-            } else {
-                stats.tasks_failed += 1;
-            }
-            stats.total_cost += routing.estimated_cost;
+        let mut stats = self.stats.write().await;
+        stats.tasks_executed += 1;
+        if outcome.success {
+            stats.tasks_succeeded += 1;
+        } else {
+            stats.tasks_failed += 1;
         }
+        stats.total_cost += outcome.costs.actual_cost_usd;
+    }
 
-        // Handle result
-        if critique.approved {
-            // Commit checkpoint
-            if let Err(e) = self
-                .checkpoint_mgr
-                .write()
-                .await
-                .commit(&checkpoint_id)
+    async fn finish_plan_execution(
+        &self,
+        event: &NormalizedEvent,
+        plan: &TaskPlan,
+        checkpoint_id: &str,
+        model_used: &str,
+        result: &ExecutionResult,
+        critique: &CriticResult,
+        success: bool,
+    ) {
+        if success {
+            self.commit_checkpoint(checkpoint_id).await;
+
+            if let Some(pr_result) = self
+                .create_pr_for_execution(event, plan, model_used, result, critique)
                 .await
             {
-                error!("Failed to commit checkpoint: {}", e);
+                if pr_result.success {
+                    info!(
+                        "Created PR #{} at {}",
+                        pr_result.pr_number.unwrap_or(0),
+                        pr_result.pr_url.as_deref().unwrap_or("unknown")
+                    );
+                    self.stats.write().await.prs_created += 1;
+                } else {
+                    warn!(
+                        "Failed to create PR: {}",
+                        pr_result.error.as_deref().unwrap_or("unknown error")
+                    );
+                }
+            }
+        } else {
+            warn!("Execution did not pass final approval, rolling back");
+            for issue in &critique.issues {
+                warn!("  - {:?}: {}", issue.severity, issue.description);
             }
 
-            // Create PR for the changes
-            let pr_title = format!("[Ambient] {}", plan.summary);
-            let pr_body = self.generate_pr_body(&plan, &result, &critique);
-            let repo_path = std::path::Path::new(&event.repo.path);
-            let authorship =
-                match PrCreator::build_authorship_metadata(&event, routing.model.as_str()) {
-                    Ok(authorship) => authorship,
-                    Err(e) => {
-                        error!("Failed to build Maestro commit authorship trailers: {}", e);
-                        return;
-                    }
-                };
+            self.rollback_checkpoint(checkpoint_id, "failed execution")
+                .await;
+        }
+    }
 
-            let pr_result = self
-                .pr_creator
+    async fn create_pr_for_execution(
+        &self,
+        event: &NormalizedEvent,
+        plan: &TaskPlan,
+        model_used: &str,
+        result: &ExecutionResult,
+        critique: &CriticResult,
+    ) -> Option<crate::pr_creator::PrCreationResult> {
+        let pr_title = format!("[Ambient] {}", plan.summary);
+        let pr_body = self.generate_pr_body(plan, result, critique);
+        let repo_path = std::path::Path::new(&event.repo.path);
+        let authorship = match PrCreator::build_authorship_metadata(event, model_used) {
+            Ok(authorship) => authorship,
+            Err(e) => {
+                error!("Failed to build Maestro commit authorship trailers: {}", e);
+                return None;
+            }
+        };
+
+        Some(
+            self.pr_creator
                 .create_pr(
                     repo_path,
                     &event.repository,
@@ -688,41 +710,11 @@ impl AmbientDaemon {
                     &pr_title,
                     &pr_body,
                     &result.changes,
-                    &event,
+                    event,
                     &authorship,
                 )
-                .await;
-
-            if pr_result.success {
-                info!(
-                    "Created PR #{} at {}",
-                    pr_result.pr_number.unwrap_or(0),
-                    pr_result.pr_url.as_deref().unwrap_or("unknown")
-                );
-                self.stats.write().await.prs_created += 1;
-            } else {
-                warn!(
-                    "Failed to create PR: {}",
-                    pr_result.error.as_deref().unwrap_or("unknown error")
-                );
-            }
-        } else {
-            // Rollback
-            warn!("Critique failed, rolling back");
-            for issue in &critique.issues {
-                warn!("  - {:?}: {}", issue.severity, issue.description);
-            }
-
-            if let Err(e) = self
-                .checkpoint_mgr
-                .write()
-                .await
-                .rollback(&checkpoint_id)
-                .await
-            {
-                error!("Failed to rollback: {}", e);
-            }
-        }
+                .await,
+        )
     }
 
     /// Generate PR body from plan and results
@@ -887,7 +879,9 @@ impl Default for DaemonBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cascader::TaskContext;
     use crate::platform_event_bus::{PlatformEventBusConfig, PlatformEventBusTransport};
+    use crate::task_run::{CostAccounting, PlanRunOutcome};
     use async_trait::async_trait;
     use serde_json::Value;
     use std::sync::{Arc, Mutex};
@@ -1167,6 +1161,76 @@ mod tests {
         assert_eq!(learner_stats.overall_success_rate, 0.0);
         assert_eq!(learner_stats.total_estimated_cost, expected_estimated_cost);
         assert_eq!(learner_stats.total_cost, 0.0);
+        assert!(daemon.checkpoint_mgr.read().await.list_active().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_final_plan_success_requires_executor_success() {
+        let temp = TempDir::new().unwrap();
+        let daemon = DaemonBuilder::new()
+            .config(test_config())
+            .data_dir(temp.path().to_path_buf())
+            .ipc_socket_path(temp.path().join("daemon-final-success.sock"))
+            .build()
+            .unwrap();
+        let event = test_event(
+            "Fix failing route",
+            "The route should return a successful response.",
+            EventType::Issue,
+        );
+        let plan = TaskPlan {
+            task_id: "plan_final_success".to_string(),
+            summary: "Handle issue: Fix failing route".to_string(),
+            estimated_complexity: Complexity::Simple,
+            event: event.clone(),
+            strategy: ExecutionStrategy::Solo,
+            estimated_duration_ms: 60_000,
+            tasks: vec![Task {
+                id: "plan_final_success_main".to_string(),
+                task_type: TaskType::Fix,
+                prompt: "Fix failing route".to_string(),
+                files: vec![],
+                depends_on: vec![],
+                priority: 100,
+                estimated_tokens: None,
+            }],
+            files: vec![],
+            risks: vec![],
+        };
+        let checkpoint_id = daemon.create_plan_checkpoint(&plan).await.unwrap();
+        let result = ExecutionResult {
+            status: ExecutionStatus::Failed,
+            changes: vec![],
+            test_results: vec![],
+            error: Some("executor failed".to_string()),
+            logs: vec![],
+        };
+        let critique = CriticResult {
+            approved: true,
+            confidence: 0.95,
+            issues: vec![],
+            suggestions: vec![],
+        };
+        let outcome = PlanRunOutcome::from_execution(
+            &result,
+            &critique,
+            CostAccounting::estimate_as_actual(0.01, 0),
+        );
+
+        daemon
+            .finish_plan_execution(
+                &event,
+                &plan,
+                &checkpoint_id,
+                "claude-3-5-haiku-20241022",
+                &result,
+                &critique,
+                outcome.success,
+            )
+            .await;
+
+        assert!(!outcome.success);
+        assert_eq!(daemon.stats.read().await.prs_created, 0);
         assert!(daemon.checkpoint_mgr.read().await.list_active().is_empty());
     }
 

--- a/packages/ambient-agent-rs/src/lib.rs
+++ b/packages/ambient-agent-rs/src/lib.rs
@@ -49,6 +49,7 @@ pub mod policy;
 pub mod pr_creator;
 pub mod prompt;
 pub mod runtime_config;
+mod task_run;
 pub mod types;
 
 pub use cascader::Cascader;

--- a/packages/ambient-agent-rs/src/task_run.rs
+++ b/packages/ambient-agent-rs/src/task_run.rs
@@ -1,0 +1,293 @@
+//! Task run accounting for daemon plan execution.
+
+use crate::{cascader::TaskContext, learner::LearnerOutcome, types::*};
+use chrono::Utc;
+
+#[derive(Debug, Clone)]
+pub(crate) struct PlanRunContext {
+    task_id: String,
+    event_type: EventType,
+    task_type: TaskType,
+    complexity: Complexity,
+    labels: Vec<String>,
+    repo: String,
+}
+
+impl PlanRunContext {
+    pub(crate) fn from_plan(event: &NormalizedEvent, plan: &TaskPlan) -> Self {
+        Self {
+            task_id: plan.task_id.clone(),
+            event_type: event.event_type,
+            task_type: Self::main_task_type(plan),
+            complexity: plan.estimated_complexity,
+            labels: event.labels.clone(),
+            repo: event.repository.clone(),
+        }
+    }
+
+    pub(crate) fn main_task_type(plan: &TaskPlan) -> TaskType {
+        plan.tasks
+            .first()
+            .map(|task| task.task_type)
+            .unwrap_or(TaskType::Fix)
+    }
+
+    pub(crate) fn route_task(&self, event: &NormalizedEvent, plan: &TaskPlan) -> Task {
+        Task {
+            id: self.task_id.clone(),
+            task_type: self.task_type,
+            prompt: format!(
+                "{}\n\n{}",
+                event.title,
+                event.body.as_deref().unwrap_or_default()
+            ),
+            files: plan.files.clone(),
+            depends_on: vec![],
+            priority: event.priority,
+            estimated_tokens: None,
+        }
+    }
+
+    pub(crate) fn task_context(&self) -> TaskContext {
+        TaskContext {
+            complexity: self.complexity,
+            task_type: self.task_type,
+            estimated_tokens: None,
+            previous_attempts: 0,
+        }
+    }
+
+    pub(crate) fn learner_outcome(
+        &self,
+        model_used: &str,
+        duration_secs: u64,
+        outcome: &PlanRunOutcome,
+    ) -> LearnerOutcome {
+        LearnerOutcome {
+            task_id: self.task_id.clone(),
+            event_type: self.event_type,
+            task_type: self.task_type,
+            complexity: self.complexity,
+            model_used: model_used.to_string(),
+            success: outcome.success,
+            confidence_predicted: outcome.confidence_predicted,
+            tokens_used: outcome.costs.tokens_used,
+            estimated_cost_usd: outcome.costs.estimated_cost_usd,
+            cost_usd: outcome.costs.actual_cost_usd,
+            duration_secs,
+            failure_reason: outcome.failure_reason.clone(),
+            labels: self.labels.clone(),
+            repo: self.repo.clone(),
+            timestamp: Utc::now(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct CostAccounting {
+    pub(crate) estimated_cost_usd: f64,
+    pub(crate) actual_cost_usd: f64,
+    pub(crate) tokens_used: u64,
+}
+
+impl CostAccounting {
+    pub(crate) fn estimated_only(estimated_cost_usd: f64) -> Self {
+        Self {
+            estimated_cost_usd,
+            actual_cost_usd: 0.0,
+            tokens_used: 0,
+        }
+    }
+
+    pub(crate) fn estimate_as_actual(estimated_cost_usd: f64, tokens_used: u64) -> Self {
+        Self {
+            estimated_cost_usd,
+            actual_cost_usd: estimated_cost_usd,
+            tokens_used,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PlanRunOutcome {
+    pub(crate) success: bool,
+    pub(crate) confidence_predicted: f64,
+    pub(crate) failure_reason: Option<String>,
+    pub(crate) costs: CostAccounting,
+}
+
+impl PlanRunOutcome {
+    pub(crate) fn cost_limited(failure_reason: String, costs: CostAccounting) -> Self {
+        Self {
+            success: false,
+            confidence_predicted: 0.0,
+            failure_reason: Some(failure_reason),
+            costs,
+        }
+    }
+
+    pub(crate) fn from_execution(
+        result: &ExecutionResult,
+        critique: &CriticResult,
+        costs: CostAccounting,
+    ) -> Self {
+        Self {
+            success: critique.approved && result.status == ExecutionStatus::Success,
+            confidence_predicted: critique.confidence,
+            failure_reason: result.error.clone(),
+            costs,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    fn event() -> NormalizedEvent {
+        let repo = Repository {
+            owner: "evalops".to_string(),
+            name: "maestro".to_string(),
+            full_name: "evalops/maestro".to_string(),
+            default_branch: "main".to_string(),
+            path: "/tmp/maestro".to_string(),
+            url: "https://github.com/evalops/maestro".to_string(),
+            config: None,
+            agent_md: None,
+            test_coverage: None,
+            codeowners: vec![],
+        };
+
+        NormalizedEvent {
+            id: "evt".to_string(),
+            source: WatcherType::GitHubPoll,
+            event_type: EventType::Issue,
+            repo: repo.clone(),
+            repository: repo.full_name.clone(),
+            priority: 42,
+            title: "Fix route".to_string(),
+            body: Some("Body".to_string()),
+            labels: vec!["bug".to_string()],
+            context: EventContext {
+                repo,
+                history: vec![],
+                related: vec![],
+            },
+            payload: EventPayload {
+                title: None,
+                body: None,
+                number: None,
+                labels: vec![],
+                author: None,
+                url: None,
+                extra: HashMap::new(),
+            },
+            created_at: Utc::now(),
+            processed_at: None,
+            status: EventStatus::Pending,
+            flags: EventFlags::default(),
+        }
+    }
+
+    fn plan(tasks: Vec<Task>) -> TaskPlan {
+        TaskPlan {
+            task_id: "task-1".to_string(),
+            summary: "Fix route".to_string(),
+            estimated_complexity: Complexity::Medium,
+            event: event(),
+            strategy: ExecutionStrategy::Solo,
+            tasks,
+            estimated_duration_ms: 60_000,
+            files: vec!["src/lib.rs".to_string()],
+            risks: vec![],
+        }
+    }
+
+    #[test]
+    fn main_task_type_falls_back_to_fix_for_empty_plans() {
+        let plan = plan(vec![]);
+        assert_eq!(PlanRunContext::main_task_type(&plan), TaskType::Fix);
+    }
+
+    #[test]
+    fn route_task_uses_plan_files_and_event_prompt() {
+        let event = event();
+        let plan = plan(vec![Task {
+            id: "inner".to_string(),
+            task_type: TaskType::Refactor,
+            prompt: "unused".to_string(),
+            files: vec![],
+            depends_on: vec![],
+            priority: 1,
+            estimated_tokens: None,
+        }]);
+        let context = PlanRunContext::from_plan(&event, &plan);
+
+        let task = context.route_task(&event, &plan);
+
+        assert_eq!(task.task_type, TaskType::Refactor);
+        assert_eq!(task.files, vec!["src/lib.rs"]);
+        assert!(task.prompt.contains("Fix route"));
+        assert!(task.prompt.contains("Body"));
+    }
+
+    #[test]
+    fn cost_limited_outcome_keeps_estimate_separate_from_actual_spend() {
+        let outcome = PlanRunOutcome::cost_limited(
+            "too expensive".to_string(),
+            CostAccounting::estimated_only(0.5),
+        );
+
+        assert!(!outcome.success);
+        assert_eq!(outcome.costs.estimated_cost_usd, 0.5);
+        assert_eq!(outcome.costs.actual_cost_usd, 0.0);
+    }
+
+    #[test]
+    fn execution_outcome_requires_critic_approval_and_execution_success() {
+        let result = ExecutionResult {
+            status: ExecutionStatus::Failed,
+            changes: vec![],
+            test_results: vec![],
+            error: Some("executor failed".to_string()),
+            logs: vec![],
+        };
+        let critique = CriticResult {
+            approved: true,
+            confidence: 0.95,
+            issues: vec![],
+            suggestions: vec![],
+        };
+
+        let outcome = PlanRunOutcome::from_execution(
+            &result,
+            &critique,
+            CostAccounting::estimate_as_actual(0.2, 0),
+        );
+
+        assert!(!outcome.success);
+        assert_eq!(outcome.failure_reason.as_deref(), Some("executor failed"));
+    }
+
+    #[test]
+    fn learner_outcome_preserves_run_accounting() {
+        let event = event();
+        let plan = plan(vec![]);
+        let context = PlanRunContext::from_plan(&event, &plan);
+        let run_outcome = PlanRunOutcome::cost_limited(
+            "too expensive".to_string(),
+            CostAccounting::estimated_only(0.5),
+        );
+
+        let learner_outcome = context.learner_outcome("model-a", 7, &run_outcome);
+
+        assert_eq!(learner_outcome.task_id, "task-1");
+        assert_eq!(learner_outcome.model_used, "model-a");
+        assert_eq!(learner_outcome.duration_secs, 7);
+        assert_eq!(learner_outcome.estimated_cost_usd, 0.5);
+        assert_eq!(learner_outcome.cost_usd, 0.0);
+        assert_eq!(learner_outcome.labels, vec!["bug"]);
+    }
+}


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `e4fac8a73f18af286192f99cff2c626c568b6089`
- last generated public sync base: `16d60a565a5fa94dae3c59bdc180742bc32e3c88`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (e4fac8a73f18)`
- public projection: `https://github.com/evalops/maestro@main (16d60a565a5f)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/ambient-agent-rs/src/daemon.rs
- copy/update packages/ambient-agent-rs/src/lib.rs
- copy/update packages/ambient-agent-rs/src/task_run.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/ambient-agent-rs/src/daemon.rs
- copy/update packages/ambient-agent-rs/src/lib.rs
- copy/update packages/ambient-agent-rs/src/task_run.rs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode