### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/ambient-agent-rs/src/event_bus.rs
+++ b/packages/ambient-agent-rs/src/event_bus.rs
@@ -43,6 +43,7 @@ pub struct EventBusStats {
     pub total_processed: u64,
     pub total_deduplicated: u64,
     pub total_enriched: u64,
+    pub total_evicted_from_memory: u64,
     pub pending_count: usize,
     pub processing_count: usize,
 }
@@ -323,26 +324,24 @@ impl EventBus {
 
         // Cleanup events if over limit
         if state.events.len() > self.config.max_in_memory_events {
-            // First, remove completed/skipped events (oldest first)
-            let mut completed: Vec<_> = state
+            // First, remove terminal events (oldest first)
+            let mut terminal: Vec<_> = state
                 .events
                 .iter()
-                .filter(|(_, e)| {
-                    e.status == EventStatus::Completed || e.status == EventStatus::Skipped
-                })
+                .filter(|(_, e)| is_terminal_status(e.status))
                 .map(|(id, e)| (id.clone(), e.created_at))
                 .collect();
 
-            completed.sort_by(|a, b| a.1.cmp(&b.1));
+            terminal.sort_by(|a, b| a.1.cmp(&b.1));
 
             let excess = state
                 .events
                 .len()
                 .saturating_sub(self.config.max_in_memory_events);
-            let to_remove_completed = excess.min(completed.len());
+            let to_remove_terminal = excess.min(terminal.len());
 
-            for (id, _) in completed.into_iter().take(to_remove_completed) {
-                state.events.remove(&id);
+            for (id, _) in terminal.into_iter().take(to_remove_terminal) {
+                remove_event_from_memory(&mut state, &id);
             }
 
             // If still over limit, drop oldest active events to prevent unbounded growth
@@ -350,9 +349,7 @@ impl EventBus {
                 let mut active: Vec<_> = state
                     .events
                     .iter()
-                    .filter(|(_, e)| {
-                        e.status == EventStatus::Pending || e.status == EventStatus::Processing
-                    })
+                    .filter(|(_, e)| is_active_status(e.status))
                     .map(|(id, e)| (id.clone(), e.created_at))
                     .collect();
 
@@ -364,11 +361,37 @@ impl EventBus {
                     .saturating_sub(self.config.max_in_memory_events);
                 for (id, _) in active.into_iter().take(still_excess) {
                     warn!("Dropping active event {} due to memory pressure", id);
-                    state.events.remove(&id);
+                    remove_event_from_memory(&mut state, &id);
                 }
             }
         }
     }
+}
+
+fn is_terminal_status(status: EventStatus) -> bool {
+    matches!(
+        status,
+        EventStatus::Completed | EventStatus::Failed | EventStatus::Skipped
+    )
+}
+
+fn is_active_status(status: EventStatus) -> bool {
+    matches!(status, EventStatus::Pending | EventStatus::Processing)
+}
+
+fn remove_event_from_memory(state: &mut EventBusState, id: &str) -> Option<EventStatus> {
+    let event = state.events.remove(id)?;
+    match event.status {
+        EventStatus::Pending => {
+            state.stats.pending_count = state.stats.pending_count.saturating_sub(1);
+        }
+        EventStatus::Processing => {
+            state.stats.processing_count = state.stats.processing_count.saturating_sub(1);
+        }
+        _ => {}
+    }
+    state.stats.total_evicted_from_memory += 1;
+    Some(event.status)
 }
 
 /// Compute a hash for deduplication
@@ -380,18 +403,29 @@ fn compute_hash(raw: &RawEvent) -> String {
 
     // Include relevant payload fields but not timestamps
     if let Some(obj) = raw.payload.as_object() {
-        if let Some(number) = obj.get("number") {
-            hasher.update(number.to_string().as_bytes());
-        }
-        if let Some(title) = obj.get("title") {
-            hasher.update(title.to_string().as_bytes());
-        }
-        if let Some(action) = obj.get("action") {
-            hasher.update(action.to_string().as_bytes());
+        hash_payload_identity_fields(&mut hasher, obj);
+        if let Some(target) = obj
+            .get("issue")
+            .or_else(|| obj.get("pull_request"))
+            .and_then(|value| value.as_object())
+        {
+            hash_payload_identity_fields(&mut hasher, target);
         }
     }
 
     hex::encode(hasher.finalize())
+}
+
+fn hash_payload_identity_fields(
+    hasher: &mut Sha256,
+    obj: &serde_json::Map<String, serde_json::Value>,
+) {
+    for key in ["action", "number", "id", "node_id", "title", "html_url"] {
+        if let Some(value) = obj.get(key) {
+            hasher.update(key.as_bytes());
+            hasher.update(value.to_string().as_bytes());
+        }
+    }
 }
 
 /// Generate a unique event ID
@@ -724,6 +758,24 @@ mod tests {
         }
     }
 
+    fn raw_issue(number: u64, title: &str, timestamp: chrono::DateTime<Utc>) -> RawEvent {
+        RawEvent {
+            source: WatcherType::GitHubWebhook,
+            event_type: "issues".to_string(),
+            payload: serde_json::json!({
+                "action": "opened",
+                "issue": {
+                    "number": number,
+                    "title": title,
+                    "body": "Test body",
+                    "labels": ["bug"]
+                }
+            }),
+            timestamp,
+            repo: "test/repo".to_string(),
+        }
+    }
+
     #[tokio::test]
     async fn test_event_emission() {
         setup_test_repo().await;
@@ -735,21 +787,7 @@ mod tests {
 
         let bus = EventBus::new(config);
 
-        let raw = RawEvent {
-            source: WatcherType::GitHubWebhook,
-            event_type: "issues".to_string(),
-            payload: serde_json::json!({
-                "action": "opened",
-                "issue": {
-                    "number": 123,
-                    "title": "Test issue",
-                    "body": "Test body",
-                    "labels": ["bug"]
-                }
-            }),
-            timestamp: Utc::now(),
-            repo: "test/repo".to_string(),
-        };
+        let raw = raw_issue(123, "Test issue", Utc::now());
 
         let event = bus.emit(raw).await;
         assert!(event.is_some());
@@ -792,5 +830,113 @@ mod tests {
         let stats = bus.get_stats().await;
         assert_eq!(stats.total_received, 2);
         assert_eq!(stats.total_deduplicated, 1);
+    }
+
+    #[tokio::test]
+    async fn deduplication_keeps_distinct_nested_issue_numbers() {
+        setup_test_repo().await;
+        let dir = tempdir().unwrap();
+        let config = EventBusConfig {
+            persist_dir: dir.path().to_path_buf(),
+            ..Default::default()
+        };
+
+        let bus = EventBus::new(config);
+        let first = bus
+            .emit(raw_issue(201, "First issue", Utc::now()))
+            .await
+            .unwrap();
+        let second = bus
+            .emit(raw_issue(202, "Second issue", Utc::now()))
+            .await
+            .unwrap();
+
+        assert_ne!(first.id, second.id);
+        let stats = bus.get_stats().await;
+        assert_eq!(stats.total_received, 2);
+        assert_eq!(stats.total_deduplicated, 0);
+        assert_eq!(stats.pending_count, 2);
+    }
+
+    #[tokio::test]
+    async fn cleanup_eviction_removes_failed_terminal_events_before_active_events() {
+        setup_test_repo().await;
+        let dir = tempdir().unwrap();
+        let config = EventBusConfig {
+            persist_dir: dir.path().to_path_buf(),
+            max_in_memory_events: 2,
+            ..Default::default()
+        };
+        let bus = EventBus::new(config);
+        let now = Utc::now();
+
+        let failed = bus
+            .emit(raw_issue(1, "Failed terminal event", now))
+            .await
+            .unwrap();
+        let first_pending = bus
+            .emit(raw_issue(
+                2,
+                "First pending event",
+                now + chrono::Duration::seconds(1),
+            ))
+            .await
+            .unwrap();
+        bus.update_status(&failed.id, EventStatus::Failed).await;
+
+        let second_pending = bus
+            .emit(raw_issue(
+                3,
+                "Second pending event",
+                now + chrono::Duration::seconds(2),
+            ))
+            .await
+            .unwrap();
+
+        assert!(bus.get(&failed.id).await.is_none());
+        assert!(bus.get(&first_pending.id).await.is_some());
+        assert!(bus.get(&second_pending.id).await.is_some());
+
+        let stats = bus.get_stats().await;
+        assert_eq!(stats.pending_count, 2);
+        assert_eq!(stats.processing_count, 0);
+        assert_eq!(stats.total_evicted_from_memory, 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_eviction_updates_counts_when_active_events_are_dropped() {
+        setup_test_repo().await;
+        let dir = tempdir().unwrap();
+        let config = EventBusConfig {
+            persist_dir: dir.path().to_path_buf(),
+            max_in_memory_events: 1,
+            ..Default::default()
+        };
+        let bus = EventBus::new(config);
+        let now = Utc::now();
+
+        let processing = bus
+            .emit(raw_issue(10, "Processing event", now))
+            .await
+            .unwrap();
+        bus.update_status(&processing.id, EventStatus::Processing)
+            .await;
+
+        let pending = bus
+            .emit(raw_issue(
+                11,
+                "Pending event",
+                now + chrono::Duration::seconds(1),
+            ))
+            .await
+            .unwrap();
+
+        assert!(bus.get(&processing.id).await.is_none());
+        assert!(bus.get(&pending.id).await.is_some());
+
+        let stats = bus.get_stats().await;
+        assert_eq!(stats.pending_count, 1);
+        assert_eq!(stats.processing_count, 0);
+        assert_eq!(stats.total_evicted_from_memory, 1);
     }
 }


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `cf583d34aaac065f7f253294533598ee8ea754e9`
- last generated public sync base: `55cc75a6ad47339bd3200a5706b01ae415e55bda`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (cf583d34aaac)`
- public projection: `https://github.com/evalops/maestro@main (55cc75a6ad47)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/ambient-agent-rs/src/event_bus.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/ambient-agent-rs/src/event_bus.rs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode