### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/export-html.ts
+++ b/src/export-html.ts
@@ -26,7 +26,7 @@ import type {
 	SessionHeaderEntry,
 	SessionManager,
 } from "./session/manager.js";
-import type { SessionEntry } from "./session/types.js";
+import { type SessionEntry, parseSessionEntry } from "./session/types.js";
 import { getHomeDir } from "./utils/path-expansion.js";
 
 const normalizeForCompare = (value: string): string =>
@@ -64,7 +64,7 @@ async function parseSessionFile(
 				continue;
 			}
 			try {
-				const entry = JSON.parse(trimmed);
+				const entry = parseSessionEntry(trimmed);
 				if (entry.type === "session" && !header) {
 					header = entry as SessionHeaderEntry;
 					continue;
@@ -132,7 +132,7 @@ async function streamPortableEntries(
 			}
 			let entry: SessionEntry;
 			try {
-				entry = JSON.parse(trimmed) as SessionEntry;
+				entry = parseSessionEntry(trimmed);
 			} catch {
 				// Ignore malformed lines so partial or truncated session files remain exportable.
 				continue;

--- a/src/server/hosted-session-manager.ts
+++ b/src/server/hosted-session-manager.ts
@@ -25,6 +25,7 @@ import {
 	type SessionTreeEntry,
 	isSessionHeaderEntry,
 	isSessionTreeEntry,
+	parseSessionEntry,
 } from "../session/types.js";
 import { queueSharedMemoryUpdate } from "../shared-memory/client.js";
 import { recordMaestroPromptVariantSelected } from "../telemetry/maestro-event-bus.js";
@@ -38,7 +39,11 @@ function parseSessionEntryValue(value: unknown): SessionEntry | null {
 	if (typeof (value as { type?: unknown }).type !== "string") {
 		return null;
 	}
-	return value as SessionEntry;
+	try {
+		return parseSessionEntry(JSON.stringify(value));
+	} catch {
+		return null;
+	}
 }
 
 export interface HostedSessionMetadataUpdate {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -190,6 +190,114 @@ export interface SessionMigrationState {
 	total: number;
 }
 
+function renameOwnProperty(
+	value: Record<string, unknown>,
+	from: string,
+	to: string,
+): void {
+	if (!(from in value) || to in value) return;
+	value[to] = value[from];
+	delete value[from];
+}
+
+function normalizeModelMetadata(value: unknown): void {
+	if (!value || typeof value !== "object") return;
+	const metadata = value as Record<string, unknown>;
+	renameOwnProperty(metadata, "model_id", "modelId");
+	renameOwnProperty(metadata, "provider_name", "providerName");
+	renameOwnProperty(metadata, "base_url", "baseUrl");
+	renameOwnProperty(metadata, "context_window", "contextWindow");
+	renameOwnProperty(metadata, "max_tokens", "maxTokens");
+}
+
+function normalizeStopReasonValue(value: unknown): unknown {
+	switch (value) {
+		case "tool_use":
+		case "tool_calls":
+			return "toolUse";
+		case "max_tokens":
+			return "length";
+		case "end_turn":
+		case "stop_sequence":
+			return "stop";
+		default:
+			return value;
+	}
+}
+
+function normalizeMessageContentBlocks(content: unknown): void {
+	if (!Array.isArray(content)) return;
+	for (const block of content) {
+		if (!block || typeof block !== "object") continue;
+		const record = block as Record<string, unknown>;
+		if (record.type === "tool_call") {
+			record.type = "toolCall";
+		}
+		if (record.type === "toolCall") {
+			renameOwnProperty(record, "args", "arguments");
+		}
+		if (record.type === "thinking") {
+			renameOwnProperty(record, "text", "thinking");
+			renameOwnProperty(record, "signature", "thinkingSignature");
+		}
+	}
+}
+
+function normalizeSessionMessage(message: unknown): void {
+	if (!message || typeof message !== "object") return;
+	const record = message as Record<string, unknown>;
+	if (record.role === "assistant") {
+		renameOwnProperty(record, "stop_reason", "stopReason");
+		record.stopReason = normalizeStopReasonValue(record.stopReason);
+		normalizeMessageContentBlocks(record.content);
+		return;
+	}
+	if (record.role === "toolResult") {
+		renameOwnProperty(record, "tool_call_id", "toolCallId");
+		renameOwnProperty(record, "tool_name", "toolName");
+		renameOwnProperty(record, "is_error", "isError");
+		if (typeof record.content === "string") {
+			record.content = [{ type: "text", text: record.content }];
+		}
+	}
+}
+
+function normalizeSessionEntryShape(entry: SessionEntry): SessionEntry {
+	const record = entry as unknown as Record<string, unknown>;
+	switch (entry.type) {
+		case "session":
+			renameOwnProperty(record, "model_metadata", "modelMetadata");
+			renameOwnProperty(record, "thinking_level", "thinkingLevel");
+			renameOwnProperty(record, "system_prompt", "systemPrompt");
+			renameOwnProperty(record, "branched_from", "branchedFrom");
+			normalizeModelMetadata(record.modelMetadata);
+			break;
+		case "message":
+			normalizeSessionMessage(record.message);
+			break;
+		case "thinking_level_change":
+			renameOwnProperty(record, "thinking_level", "thinkingLevel");
+			break;
+		case "model_change":
+			renameOwnProperty(record, "model_metadata", "modelMetadata");
+			normalizeModelMetadata(record.modelMetadata);
+			break;
+		case "compaction":
+			renameOwnProperty(record, "first_kept_entry_id", "firstKeptEntryId");
+			renameOwnProperty(
+				record,
+				"first_kept_entry_index",
+				"firstKeptEntryIndex",
+			);
+			renameOwnProperty(record, "tokens_before", "tokensBefore");
+			renameOwnProperty(record, "custom_instructions", "customInstructions");
+			break;
+		default:
+			break;
+	}
+	return entry;
+}
+
 export function parseSessionEntry(line: string): SessionEntry {
 	const trimmed = line.trim();
 	if (!trimmed) {
@@ -202,7 +310,7 @@ export function parseSessionEntry(line: string): SessionEntry {
 	if (typeof (parsed as { type?: unknown }).type !== "string") {
 		throw new Error("Session entry missing type");
 	}
-	return parsed;
+	return normalizeSessionEntryShape(parsed);
 }
 
 export function tryParseSessionEntry(line: string): SessionEntry | null {

--- a/test/session/export-html.test.ts
+++ b/test/session/export-html.test.ts
@@ -57,6 +57,13 @@ const sessionJson = `
 {"type":"message","message":{"role":"toolResult","toolCallId":"tool-1","toolName":"bash","content":[{"type":"text","text":"src\\npackage.json"}],"isError":false,"timestamp":3}}
 `;
 
+const rustAuthoredSessionJson = `
+{"type":"session","id":"session-rust","timestamp":"2024-01-01T00:00:00.000Z","cwd":"/repo","model":"anthropic/claude-3","model_metadata":{"provider":"anthropic","model_id":"claude-3","provider_name":"Anthropic"},"thinking_level":"low","system_prompt":"Persisted system","tools":[{"name":"bash","description":"Run bash"}]}
+{"type":"message","message":{"role":"user","content":"inspect legacy output","timestamp":1}}
+{"type":"message","message":{"role":"assistant","content":[{"type":"thinking","text":"Need a shell command","signature":"sig-1"},{"type":"tool_call","id":"tool-legacy","name":"bash","args":{"command":"cat README.md"}}],"api":"anthropic-messages","provider":"anthropic","model":"claude-3","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stop_reason":"tool_use","timestamp":2}}
+{"type":"message","message":{"role":"toolResult","tool_call_id":"tool-legacy","tool_name":"bash","content":"legacy output","is_error":false,"timestamp":3}}
+`;
+
 const richSessionJson = `
 {"type":"session","id":"session-2","timestamp":"2024-02-01T00:00:00.000Z","cwd":"/repo","model":"anthropic/claude-3","thinkingLevel":"medium","systemPrompt":"Persisted system","tools":[{"name":"read","description":"Read files"},{"name":"bash","description":"Run bash"}]}
 {"type":"message","message":{"role":"user","content":[{"type":"text","text":"See attachment for context"}],"attachments":[{"id":"att-1","type":"image","fileName":"design.png","mimeType":"image/png","size":12345,"content":"base64-data","preview":"thumbnail"}],"timestamp":4}}
@@ -166,6 +173,33 @@ describe("exporters", () => {
 		expect(text).toContain("User:\nlist files");
 		expect(text).toContain("[tool call] bash");
 		expect(text).toContain("[tool result] bash");
+	});
+
+	it("exports Rust-authored legacy tool sessions without dropping tool data", async () => {
+		const sessionFile = createTempSessionFile(rustAuthoredSessionJson);
+		const manager = new SessionManager(false, sessionFile);
+		const htmlPath = join(dirname(sessionFile), "rust.html");
+		const textPath = join(dirname(sessionFile), "rust.txt");
+
+		const htmlOutputPath = await exportSessionToHtml(
+			manager,
+			buildAgentState(),
+			htmlPath,
+		);
+		const textOutputPath = await exportSessionToText(
+			manager,
+			buildAgentState(),
+			textPath,
+		);
+
+		const html = readFileSync(htmlOutputPath, "utf8");
+		const text = readFileSync(textOutputPath, "utf8");
+		expect(html).toContain("Need a shell command");
+		expect(html).toContain("$ cat README.md");
+		expect(html).toContain("legacy output");
+		expect(text).toContain("[tool call] bash");
+		expect(text).toContain("[tool result] bash");
+		expect(text).toContain("legacy output");
 	});
 
 	it("renders attachments, thinking, and multiple tool calls in HTML", async () => {
@@ -282,6 +316,50 @@ describe("exporters", () => {
 		expect(exported.format).toBe("maestro-session-export.v1");
 		expect(exported.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 		expect(exported.entries[0]?.type).toBe("session");
+	});
+
+	it("normalizes Rust-authored entries in portable JSON exports", async () => {
+		const sessionFile = createTempSessionFile(rustAuthoredSessionJson);
+		const manager = new SessionManager(false, sessionFile);
+		const jsonPath = join(dirname(sessionFile), "rust-portable.json");
+		const outputPath = await exportSessionToJson(manager, jsonPath);
+		const exported = JSON.parse(readFileSync(outputPath, "utf8")) as {
+			entries: Array<{
+				type: string;
+				thinkingLevel?: string;
+				modelMetadata?: { modelId?: string; providerName?: string };
+				message?: {
+					content?: Array<{
+						type: string;
+						thinking?: string;
+						arguments?: unknown;
+					}>;
+					stopReason?: string;
+					toolCallId?: string;
+					toolName?: string;
+					isError?: boolean;
+				};
+			}>;
+		};
+
+		expect(exported.entries[0]).toMatchObject({
+			type: "session",
+			thinkingLevel: "low",
+			modelMetadata: {
+				modelId: "claude-3",
+				providerName: "Anthropic",
+			},
+		});
+		expect(exported.entries[2]?.message?.content).toMatchObject([
+			{ type: "thinking", thinking: "Need a shell command" },
+			{ type: "toolCall", arguments: { command: "cat README.md" } },
+		]);
+		expect(exported.entries[2]?.message?.stopReason).toBe("toolUse");
+		expect(exported.entries[3]?.message).toMatchObject({
+			toolCallId: "tool-legacy",
+			toolName: "bash",
+			isError: false,
+		});
 	});
 
 	it("redacts secrets in portable JSONL exports", async () => {

--- a/test/session/session-context.test.ts
+++ b/test/session/session-context.test.ts
@@ -9,7 +9,10 @@ import {
 	generateEntryId,
 	isLikelyCompactionSummary,
 } from "../../src/session/session-context.js";
-import type { SessionEntry } from "../../src/session/types.js";
+import {
+	type SessionEntry,
+	tryParseSessionEntry,
+} from "../../src/session/types.js";
 
 describe("extractTextFromContent", () => {
 	it("returns string content as-is", () => {
@@ -215,6 +218,115 @@ describe("session context compatibility", () => {
 
 		expect(info?.messageCount).toBe(3);
 		expect(info?.firstMessage).toBe("Read README");
+		expect(info?.allMessagesText).toContain("[tool call] read");
+		expect(info?.allMessagesText).toContain("file contents");
+	});
+});
+
+function parseRustAuthoredToolSession(): SessionEntry[] {
+	return [
+		`{"type":"session","id":"session-1","timestamp":"${timestamp}","cwd":"/tmp","model":"openai/gpt-5.2","model_metadata":{"provider":"openai","model_id":"gpt-5.2","provider_name":"OpenAI","base_url":"https://example.test","context_window":100000,"max_tokens":4096},"thinking_level":"medium"}`,
+		`{"type":"message","timestamp":"${timestamp}","message":{"role":"user","content":"Read README","timestamp":0}}`,
+		`{"type":"message","timestamp":"${timestamp}","message":{"role":"assistant","api":"openai-responses","provider":"openai","model":"gpt-5.2","usage":{"input":10,"output":4,"cacheRead":2,"cacheWrite":1,"cost":{"input":0.1,"output":0.2,"cacheRead":0.01,"cacheWrite":0.02,"total":0.33}},"stop_reason":"tool_use","timestamp":1,"content":[{"type":"thinking","text":"Need a file read","signature":"sig-1"},{"type":"tool_call","id":"call-1","name":"read","args":{"path":"README.md"}}]}}`,
+		`{"type":"message","timestamp":"${timestamp}","message":{"role":"toolResult","tool_call_id":"call-1","tool_name":"read","content":"file contents","is_error":false,"timestamp":2}}`,
+		`{"type":"model_change","timestamp":"${timestamp}","model":"openai/gpt-5.2","model_metadata":{"provider":"openai","model_id":"gpt-5.2"}}`,
+		`{"type":"thinking_level_change","timestamp":"${timestamp}","thinking_level":"high"}`,
+		`{"type":"compaction","timestamp":"${timestamp}","summary":"Kept the useful work","first_kept_entry_index":0,"tokens_before":1234,"auto":true,"custom_instructions":"keep tool context"}`,
+	]
+		.map((line) => tryParseSessionEntry(line))
+		.filter((entry): entry is SessionEntry => Boolean(entry));
+}
+
+describe("Rust-authored session compatibility", () => {
+	it("normalizes legacy Rust snake_case transcript fields at parse time", () => {
+		const entries = parseRustAuthoredToolSession();
+
+		expect(entries[0]).toMatchObject({
+			type: "session",
+			thinkingLevel: "medium",
+			modelMetadata: {
+				modelId: "gpt-5.2",
+				providerName: "OpenAI",
+				baseUrl: "https://example.test",
+				contextWindow: 100000,
+				maxTokens: 4096,
+			},
+		});
+		expect(entries[2]).toMatchObject({
+			type: "message",
+			message: {
+				role: "assistant",
+				stopReason: "toolUse",
+				content: [
+					{
+						type: "thinking",
+						thinking: "Need a file read",
+						thinkingSignature: "sig-1",
+					},
+					{
+						type: "toolCall",
+						id: "call-1",
+						name: "read",
+						arguments: { path: "README.md" },
+					},
+				],
+			},
+		});
+		expect(entries[3]).toMatchObject({
+			type: "message",
+			message: {
+				role: "toolResult",
+				toolCallId: "call-1",
+				toolName: "read",
+				content: [{ type: "text", text: "file contents" }],
+				isError: false,
+			},
+		});
+		expect(entries[4]).toMatchObject({
+			type: "model_change",
+			modelMetadata: { modelId: "gpt-5.2" },
+		});
+		expect(entries[5]).toMatchObject({
+			type: "thinking_level_change",
+			thinkingLevel: "high",
+		});
+		expect(entries[6]).toMatchObject({
+			type: "compaction",
+			firstKeptEntryIndex: 0,
+			tokensBefore: 1234,
+			customInstructions: "keep tool context",
+		});
+	});
+
+	it("normalizes legacy Rust stop reason values to TypeScript values", () => {
+		const stopReasons = [
+			["tool_use", "toolUse"],
+			["tool_calls", "toolUse"],
+			["max_tokens", "length"],
+			["end_turn", "stop"],
+			["stop_sequence", "stop"],
+			["error", "error"],
+		] as const;
+
+		for (const [rustStopReason, expected] of stopReasons) {
+			const entry = tryParseSessionEntry(
+				`{"type":"message","timestamp":"${timestamp}","message":{"role":"assistant","stop_reason":"${rustStopReason}","content":[],"timestamp":1}}`,
+			);
+
+			expect(entry).toMatchObject({
+				type: "message",
+				message: { role: "assistant", stopReason: expected },
+			});
+		}
+	});
+
+	it("summarizes legacy Rust tool sessions without losing tool calls", () => {
+		const stats = { birthtime: new Date(timestamp) } as Stats;
+		const info = buildSessionFileInfo(parseRustAuthoredToolSession(), stats);
+
+		expect(info?.messageCount).toBe(3);
+		expect(info?.firstMessage).toBe("Read README");
+		expect(info?.allMessagesText).toContain("[thinking] Need a file read");
 		expect(info?.allMessagesText).toContain("[tool call] read");
 		expect(info?.allMessagesText).toContain("file contents");
 	});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `85c9ff032f525b744c840fb249580ff85e0fad82`
- last generated public sync base: `a89ffb6443736e7be5b6e4f9c75963721ab19f56`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (85c9ff032f52)`
- public projection: `https://github.com/evalops/maestro@main (a89ffb644373)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/export-html.ts
- copy/update src/server/hosted-session-manager.ts
- copy/update src/session/types.ts
- copy/update test/session/export-html.test.ts
- copy/update test/session/session-context.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/export-html.ts
- copy/update src/server/hosted-session-manager.ts
- copy/update src/session/types.ts
- copy/update test/session/export-html.test.ts
- copy/update test/session/session-context.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #229 to internal source `85c9ff032f525b744c840fb249580ff85e0fad82`