### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/scripts/session-wire-format-codegen.mjs
+++ b/scripts/session-wire-format-codegen.mjs
@@ -14,6 +14,48 @@ const rustOutputPath = resolve(
 	"packages/tui-rs/src/session/wire_format_generated.rs",
 );
 
+function isPlainObject(value) {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertStringMap(value, path) {
+	if (!isPlainObject(value)) {
+		throw new Error(`Session wire manifest ${path} must be an object`);
+	}
+	for (const [key, nested] of Object.entries(value)) {
+		if (typeof nested !== "string") {
+			throw new Error(
+				`Session wire manifest ${path}.${key} must be a string`,
+			);
+		}
+	}
+}
+
+function assertNestedStringMap(value, path) {
+	if (!isPlainObject(value)) {
+		throw new Error(`Session wire manifest ${path} must be an object`);
+	}
+	for (const [key, nested] of Object.entries(value)) {
+		assertStringMap(nested, `${path}.${key}`);
+	}
+}
+
+function validateManifest(manifest) {
+	if (!isPlainObject(manifest)) {
+		throw new Error("Session wire manifest must be an object");
+	}
+	if (typeof manifest.version !== "string" || manifest.version.length === 0) {
+		throw new Error("Session wire manifest version must be a non-empty string");
+	}
+	assertStringMap(manifest.stopReasonAliases, "stopReasonAliases");
+	assertNestedStringMap(manifest.fieldAliases, "fieldAliases");
+	assertStringMap(manifest.contentBlockTypeAliases, "contentBlockTypeAliases");
+	assertNestedStringMap(
+		manifest.contentBlockFieldAliases,
+		"contentBlockFieldAliases",
+	);
+}
+
 function renderObject(value, indent = "") {
 	if (!value || typeof value !== "object" || Array.isArray(value)) {
 		return JSON.stringify(value);
@@ -49,6 +91,33 @@ export const sessionWireFieldAliases = ${renderObject(manifest.fieldAliases)} as
 export const sessionWireContentBlockTypeAliases = ${renderObject(manifest.contentBlockTypeAliases)} as const;
 
 export const sessionWireContentBlockFieldAliases = ${renderObject(manifest.contentBlockFieldAliases)} as const;
+
+type SessionWireAliasSource = Readonly<Record<string, unknown>>;
+
+function getSessionWireAlias<T extends SessionWireAliasSource>(
+\taliases: T,
+\tkey: string,
+): T[keyof T] | undefined {
+\treturn Object.prototype.hasOwnProperty.call(aliases, key)
+\t\t? aliases[key as keyof T]
+\t\t: undefined;
+}
+
+export function canonicalSessionWireStopReason(reason: string): string {
+\treturn (
+\t\tgetSessionWireAlias(sessionWireStopReasonAliases, reason) ?? reason
+\t);
+}
+
+export function canonicalSessionWireContentBlockType(type: string): string {
+\treturn (
+\t\tgetSessionWireAlias(sessionWireContentBlockTypeAliases, type) ?? type
+\t);
+}
+
+export function getSessionWireContentBlockFieldAliases(type: string) {
+\treturn getSessionWireAlias(sessionWireContentBlockFieldAliases, type);
+}
 `;
 }
 
@@ -124,6 +193,7 @@ function formatTs(source, outputPath) {
 async function main() {
 	const check = process.argv.includes("--check");
 	const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+	validateManifest(manifest);
 	const rustSource = renderRust(manifest);
 	const targets = [
 		{

--- a/src/session/wire-format.generated.ts
+++ b/src/session/wire-format.generated.ts
@@ -62,3 +62,26 @@ export const sessionWireContentBlockFieldAliases = {
 		signature: "thinkingSignature",
 	},
 } as const;
+
+type SessionWireAliasSource = Readonly<Record<string, unknown>>;
+
+function getSessionWireAlias<T extends SessionWireAliasSource>(
+	aliases: T,
+	key: string,
+): T[keyof T] | undefined {
+	return Object.prototype.hasOwnProperty.call(aliases, key)
+		? aliases[key as keyof T]
+		: undefined;
+}
+
+export function canonicalSessionWireStopReason(reason: string): string {
+	return getSessionWireAlias(sessionWireStopReasonAliases, reason) ?? reason;
+}
+
+export function canonicalSessionWireContentBlockType(type: string): string {
+	return getSessionWireAlias(sessionWireContentBlockTypeAliases, type) ?? type;
+}
+
+export function getSessionWireContentBlockFieldAliases(type: string) {
+	return getSessionWireAlias(sessionWireContentBlockFieldAliases, type);
+}

--- a/src/session/wire-format.ts
+++ b/src/session/wire-format.ts
@@ -1,21 +1,12 @@
 import type { SessionEntry } from "./types.js";
 import {
-	sessionWireContentBlockFieldAliases,
-	sessionWireContentBlockTypeAliases,
+	canonicalSessionWireContentBlockType,
+	canonicalSessionWireStopReason,
+	getSessionWireContentBlockFieldAliases,
 	sessionWireFieldAliases,
-	sessionWireStopReasonAliases,
 } from "./wire-format.generated.js";
 
 type AliasMap = Readonly<Record<string, string>>;
-
-function getOwnProperty<T>(
-	value: Readonly<Record<string, T>>,
-	key: string,
-): T | undefined {
-	return Object.prototype.hasOwnProperty.call(value, key)
-		? value[key]
-		: undefined;
-}
 
 function renameOwnProperty(
 	value: Record<string, unknown>,
@@ -50,7 +41,7 @@ function normalizeModelMetadata(value: unknown): void {
 
 export function normalizeStopReasonValue(value: unknown): unknown {
 	if (typeof value !== "string") return value;
-	return getOwnProperty(sessionWireStopReasonAliases, value) ?? value;
+	return canonicalSessionWireStopReason(value);
 }
 
 function normalizeMessageContentBlocks(content: unknown): void {
@@ -59,14 +50,12 @@ function normalizeMessageContentBlocks(content: unknown): void {
 		if (!block || typeof block !== "object") continue;
 		const record = block as Record<string, unknown>;
 		if (typeof record.type === "string") {
-			record.type =
-				getOwnProperty(sessionWireContentBlockTypeAliases, record.type) ??
-				record.type;
+			record.type = canonicalSessionWireContentBlockType(record.type);
 		}
 		if (typeof record.type !== "string") continue;
 		renameOwnProperties(
 			record,
-			getOwnProperty(sessionWireContentBlockFieldAliases, record.type),
+			getSessionWireContentBlockFieldAliases(record.type),
 		);
 	}
 }


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `b023295d1cb7cf76a981deb2643b9db9ff0ab4ce`
- last generated public sync base: `f6b58c9b55f02e197ad6c839439694699322631e`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (b023295d1cb7)`
- public projection: `https://github.com/evalops/maestro@main (f6b58c9b55f0)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update scripts/session-wire-format-codegen.mjs
- copy/update src/session/wire-format.generated.ts
- copy/update src/session/wire-format.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update scripts/session-wire-format-codegen.mjs
- copy/update src/session/wire-format.generated.ts
- copy/update src/session/wire-format.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode