### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/tui-rs/src/app.rs
+++ b/packages/tui-rs/src/app.rs
@@ -1198,6 +1198,8 @@ Always use tools when they would be helpful. Be concise and direct in your respo
         }
 
         let entry = SessionEntry::Message(MessageEntry {
+            id: None,
+            parent_id: None,
             timestamp: Utc::now().to_rfc3339(),
             message: AppMessage::User {
                 content: MessageContent::Text(content.to_string()),
@@ -1254,6 +1256,8 @@ Always use tools when they would be helpful. Be concise and direct in your respo
             .or_else(|| message.usage.as_ref().map(to_session_usage));
 
         let entry = SessionEntry::Message(MessageEntry {
+            id: None,
+            parent_id: None,
             timestamp: Utc::now().to_rfc3339(),
             message: AppMessage::Assistant {
                 content: blocks,
@@ -1299,6 +1303,8 @@ Always use tools when they would be helpful. Be concise and direct in your respo
         };
 
         let entry = SessionEntry::Message(MessageEntry {
+            id: None,
+            parent_id: None,
             timestamp: Utc::now().to_rfc3339(),
             message: AppMessage::ToolResult {
                 tool_call_id: call_id.to_string(),
@@ -1351,9 +1357,12 @@ Always use tools when they would be helpful. Be concise and direct in your respo
         }
 
         let entry = SessionEntry::Compaction(CompactionEntry {
+            id: None,
+            parent_id: None,
             timestamp: Utc::now().to_rfc3339(),
             summary,
-            first_kept_entry_index,
+            first_kept_entry_id: None,
+            first_kept_entry_index: Some(first_kept_entry_index),
             tokens_before,
             auto,
             custom_instructions,
@@ -4543,11 +4552,14 @@ fn restore_visible_session_messages(state: &mut AppState, session: &ParsedSessio
     }
 
     for compaction in &session.compactions {
-        state.apply_compaction(
-            compaction.summary.clone(),
-            compaction.first_kept_entry_index,
-            parse_rfc3339_system_time(&compaction.timestamp).unwrap_or_else(|_| SystemTime::now()),
-        );
+        if let Some(first_kept_entry_index) = compaction.first_kept_entry_index {
+            state.apply_compaction(
+                compaction.summary.clone(),
+                first_kept_entry_index,
+                parse_rfc3339_system_time(&compaction.timestamp)
+                    .unwrap_or_else(|_| SystemTime::now()),
+            );
+        }
     }
 }
 
@@ -5145,9 +5157,12 @@ mod tests {
             thinking_level_changes: Vec::new(),
             model_changes: Vec::new(),
             compactions: vec![CompactionEntry {
+                id: None,
+                parent_id: None,
                 timestamp: "2026-03-31T12:05:00Z".to_string(),
                 summary: "## Conversation Summary".to_string(),
-                first_kept_entry_index: 4,
+                first_kept_entry_id: None,
+                first_kept_entry_index: Some(4),
                 tokens_before: 1000,
                 auto: true,
                 custom_instructions: None,
@@ -5256,17 +5271,23 @@ mod tests {
             model_changes: Vec::new(),
             compactions: vec![
                 CompactionEntry {
+                    id: None,
+                    parent_id: None,
                     timestamp: "2026-03-31T12:05:00Z".to_string(),
                     summary: "## First Summary".to_string(),
-                    first_kept_entry_index: 4,
+                    first_kept_entry_id: None,
+                    first_kept_entry_index: Some(4),
                     tokens_before: 1000,
                     auto: true,
                     custom_instructions: None,
                 },
                 CompactionEntry {
+                    id: None,
+                    parent_id: None,
                     timestamp: "2026-03-31T12:10:00Z".to_string(),
                     summary: "## Second Summary".to_string(),
-                    first_kept_entry_index: 2,
+                    first_kept_entry_id: None,
+                    first_kept_entry_index: Some(2),
                     tokens_before: 1200,
                     auto: true,
                     custom_instructions: None,

--- a/packages/tui-rs/src/session/entries.rs
+++ b/packages/tui-rs/src/session/entries.rs
@@ -470,6 +470,14 @@ impl ThinkingLevel {
 /// A message entry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(
+        rename = "parentId",
+        alias = "parent_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parent_id: Option<String>,
     pub timestamp: String,
     pub message: AppMessage,
 }
@@ -851,10 +859,29 @@ pub struct SessionMeta {
 /// Context compaction entry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompactionEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(
+        rename = "parentId",
+        alias = "parent_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parent_id: Option<String>,
     pub timestamp: String,
     pub summary: String,
-    #[serde(rename = "firstKeptEntryIndex", alias = "first_kept_entry_index")]
-    pub first_kept_entry_index: usize,
+    #[serde(
+        rename = "firstKeptEntryId",
+        alias = "first_kept_entry_id",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub first_kept_entry_id: Option<String>,
+    #[serde(
+        default,
+        rename = "firstKeptEntryIndex",
+        alias = "first_kept_entry_index",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub first_kept_entry_index: Option<usize>,
     #[serde(rename = "tokensBefore", alias = "tokens_before")]
     pub tokens_before: u64,
     #[serde(default)]
@@ -916,7 +943,13 @@ impl SessionStats {
 
 #[cfg(test)]
 mod tests {
+    use super::super::wire_format_generated::{
+        canonical_content_block_type, content_block_field_aliases, field_aliases,
+        CONTENT_BLOCK_FIELD_ALIASES, CONTENT_BLOCK_TYPE_ALIASES, FIELD_ALIASES,
+        STOP_REASON_ALIASES,
+    };
     use super::*;
+    use serde_json::{json, Map, Value};
 
     fn repo_fixture(name: &str) -> String {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -932,6 +965,78 @@ mod tests {
             .filter(|line| !line.trim().is_empty())
             .map(|line| serde_json::from_str(line).unwrap())
             .collect()
+    }
+
+    fn as_object(value: Value) -> Map<String, Value> {
+        match value {
+            Value::Object(object) => object,
+            _ => panic!("expected JSON object"),
+        }
+    }
+
+    fn sample_wire_value(canonical: &str) -> Value {
+        match canonical {
+            "modelId" => json!("gpt-5.2"),
+            "providerName" => json!("OpenAI"),
+            "baseUrl" => json!("https://example.test"),
+            "contextWindow" => json!(100_000),
+            "maxTokens" => json!(4096),
+            "modelMetadata" => json!({
+                "provider": "openai",
+                "modelId": "gpt-5.2"
+            }),
+            "thinkingLevel" => json!("high"),
+            "systemPrompt" => json!("Persisted system"),
+            "branchedFrom" => json!("parent-session"),
+            "stopReason" => json!("tool_use"),
+            "toolCallId" => json!("call-1"),
+            "toolName" => json!("read"),
+            "isError" => json!(true),
+            "firstKeptEntryId" => json!("assistant-1"),
+            "firstKeptEntryIndex" => json!(1),
+            "tokensBefore" => json!(1234),
+            "customInstructions" => json!("keep tool context"),
+            "arguments" => json!({ "path": "README.md" }),
+            "thinking" => json!("Need a file read"),
+            "thinkingSignature" => json!("sig-1"),
+            other => panic!("missing sample value for canonical field {other}"),
+        }
+    }
+
+    fn insert_alias_fields(object: &mut Map<String, Value>, aliases: &[(&str, &str)]) {
+        for &(alias, canonical) in aliases {
+            object.insert(alias.to_string(), sample_wire_value(canonical));
+        }
+    }
+
+    fn assert_serialized_uses_canonical_fields(value: &Value, aliases: &[(&str, &str)]) {
+        for &(alias, canonical) in aliases {
+            assert!(
+                value.get(canonical).is_some(),
+                "missing canonical field {canonical} after parsing alias {alias}"
+            );
+            assert!(
+                value.get(alias).is_none(),
+                "serialized entry kept legacy alias {alias}"
+            );
+        }
+    }
+
+    fn serialized_entry(value: Value) -> Value {
+        let entry: SessionEntry = serde_json::from_value(value).unwrap();
+        serde_json::to_value(entry).unwrap()
+    }
+
+    fn serialized_assistant_block(block: Value) -> Value {
+        serialized_entry(json!({
+            "type": "message",
+            "timestamp": "2024-01-15T10:30:00Z",
+            "message": {
+                "role": "assistant",
+                "content": [block],
+                "timestamp": 0
+            }
+        }))
     }
 
     #[test]
@@ -1064,6 +1169,154 @@ mod tests {
         ] {
             let entries = parse_fixture(fixture);
             assert!(!entries.is_empty(), "fixture {fixture} should not be empty");
+        }
+    }
+
+    #[test]
+    fn generated_stop_reason_aliases_match_rust_serializer() {
+        for &(alias, canonical) in STOP_REASON_ALIASES {
+            let serialized = serialized_entry(json!({
+                "type": "message",
+                "timestamp": "2024-01-15T10:30:00Z",
+                "message": {
+                    "role": "assistant",
+                    "stopReason": alias,
+                    "content": [],
+                    "timestamp": 0
+                }
+            }));
+
+            assert_eq!(serialized["message"]["stopReason"], canonical);
+        }
+    }
+
+    #[test]
+    fn generated_content_block_aliases_match_rust_deserializer() {
+        for &(alias, canonical) in CONTENT_BLOCK_TYPE_ALIASES {
+            assert_eq!(canonical_content_block_type(alias), canonical);
+            let serialized = serialized_assistant_block(json!({
+                "type": alias,
+                "id": "call-1",
+                "name": "read",
+                "arguments": { "path": "README.md" }
+            }));
+
+            assert_eq!(serialized["message"]["content"][0]["type"], canonical);
+        }
+
+        for &(block_type, aliases) in CONTENT_BLOCK_FIELD_ALIASES {
+            assert_eq!(content_block_field_aliases(block_type), aliases);
+            let mut block = match block_type {
+                "toolCall" => as_object(json!({
+                    "type": "toolCall",
+                    "id": "call-1",
+                    "name": "read"
+                })),
+                "thinking" => as_object(json!({
+                    "type": "thinking"
+                })),
+                other => panic!("generated content block alias test missing {other}"),
+            };
+            insert_alias_fields(&mut block, aliases);
+
+            let serialized = serialized_assistant_block(Value::Object(block));
+            let serialized_block = &serialized["message"]["content"][0];
+            assert_serialized_uses_canonical_fields(serialized_block, aliases);
+        }
+    }
+
+    #[test]
+    fn generated_field_aliases_match_rust_deserializer() {
+        for &(section, aliases) in FIELD_ALIASES {
+            assert_eq!(field_aliases(section), aliases);
+
+            match section {
+                "modelMetadata" => {
+                    let mut metadata = as_object(json!({ "provider": "openai" }));
+                    insert_alias_fields(&mut metadata, aliases);
+                    let serialized = serialized_entry(json!({
+                        "type": "session",
+                        "id": "session-1",
+                        "timestamp": "2024-01-15T10:30:00Z",
+                        "cwd": "/tmp",
+                        "model": "openai/gpt-5.2",
+                        "modelMetadata": Value::Object(metadata)
+                    }));
+                    assert_serialized_uses_canonical_fields(&serialized["modelMetadata"], aliases);
+                }
+                "session" => {
+                    let mut session = as_object(json!({
+                        "type": "session",
+                        "id": "session-1",
+                        "timestamp": "2024-01-15T10:30:00Z",
+                        "cwd": "/tmp",
+                        "model": "openai/gpt-5.2"
+                    }));
+                    insert_alias_fields(&mut session, aliases);
+                    let serialized = serialized_entry(Value::Object(session));
+                    assert_serialized_uses_canonical_fields(&serialized, aliases);
+                }
+                "assistantMessage" => {
+                    let mut message = as_object(json!({
+                        "role": "assistant",
+                        "content": [],
+                        "timestamp": 0
+                    }));
+                    insert_alias_fields(&mut message, aliases);
+                    let serialized = serialized_entry(json!({
+                        "type": "message",
+                        "timestamp": "2024-01-15T10:30:00Z",
+                        "message": Value::Object(message)
+                    }));
+                    assert_serialized_uses_canonical_fields(&serialized["message"], aliases);
+                    assert_eq!(serialized["message"]["stopReason"], "toolUse");
+                }
+                "toolResultMessage" => {
+                    let mut message = as_object(json!({
+                        "role": "toolResult",
+                        "content": "file contents",
+                        "timestamp": 0
+                    }));
+                    insert_alias_fields(&mut message, aliases);
+                    let serialized = serialized_entry(json!({
+                        "type": "message",
+                        "timestamp": "2024-01-15T10:30:00Z",
+                        "message": Value::Object(message)
+                    }));
+                    assert_serialized_uses_canonical_fields(&serialized["message"], aliases);
+                }
+                "thinkingLevelChange" => {
+                    let mut entry = as_object(json!({
+                        "type": "thinking_level_change",
+                        "timestamp": "2024-01-15T10:30:00Z"
+                    }));
+                    insert_alias_fields(&mut entry, aliases);
+                    let serialized = serialized_entry(Value::Object(entry));
+                    assert_serialized_uses_canonical_fields(&serialized, aliases);
+                }
+                "modelChange" => {
+                    let mut entry = as_object(json!({
+                        "type": "model_change",
+                        "timestamp": "2024-01-15T10:30:00Z",
+                        "model": "openai/gpt-5.2"
+                    }));
+                    insert_alias_fields(&mut entry, aliases);
+                    let serialized = serialized_entry(Value::Object(entry));
+                    assert_serialized_uses_canonical_fields(&serialized, aliases);
+                }
+                "compaction" => {
+                    let mut entry = as_object(json!({
+                        "type": "compaction",
+                        "timestamp": "2024-01-15T10:30:00Z",
+                        "summary": "Kept the useful work",
+                        "auto": true
+                    }));
+                    insert_alias_fields(&mut entry, aliases);
+                    let serialized = serialized_entry(Value::Object(entry));
+                    assert_serialized_uses_canonical_fields(&serialized, aliases);
+                }
+                other => panic!("generated field alias test missing section {other}"),
+            }
         }
     }
 

--- a/packages/tui-rs/src/session/reader.rs
+++ b/packages/tui-rs/src/session/reader.rs
@@ -494,6 +494,7 @@ impl SessionReader {
         let mut model_changes: Vec<ModelChange> = Vec::new();
         let mut compactions: Vec<CompactionEntry> = Vec::new();
         let mut usage_entries: Vec<UsageEntry> = Vec::new();
+        let mut visible_message_ids: Vec<Option<String>> = Vec::new();
 
         for (line_num, line) in reader.lines().enumerate() {
             let line = line?;
@@ -515,6 +516,9 @@ impl SessionReader {
                     header = Some(h);
                 }
                 SessionEntry::Message(m) => {
+                    if !matches!(&m.message, AppMessage::ToolResult { .. }) {
+                        visible_message_ids.push(m.id.clone());
+                    }
                     // Update stats
                     match &m.message {
                         AppMessage::User { .. } => stats.user_messages += 1,
@@ -564,7 +568,22 @@ impl SessionReader {
                 SessionEntry::ModelChange(change) => {
                     model_changes.push(change);
                 }
-                SessionEntry::Compaction(entry) => {
+                SessionEntry::Compaction(mut entry) => {
+                    let first_kept_entry_index = entry
+                        .first_kept_entry_id
+                        .as_deref()
+                        .and_then(|first_kept_entry_id| {
+                            visible_message_ids
+                                .iter()
+                                .position(|id| id.as_deref() == Some(first_kept_entry_id))
+                        })
+                        .or(entry.first_kept_entry_index);
+
+                    if let Some(index) = first_kept_entry_index {
+                        entry.first_kept_entry_index = Some(index);
+                        let keep_from = index.min(visible_message_ids.len());
+                        visible_message_ids.drain(..keep_from);
+                    }
                     compactions.push(entry);
                 }
             }
@@ -704,5 +723,33 @@ mod tests {
         assert_eq!(session.usage_entries.len(), 1);
         assert_eq!(session.usage_entries[0].model, "gpt-5.2");
         assert_eq!(session.usage_entries[0].usage.cache_read, 2);
+    }
+
+    #[test]
+    fn read_typescript_compaction_cut_point_by_entry_id() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, r#"{{"type":"session","id":"test123","timestamp":"2024-01-15T10:30:00Z","cwd":"/tmp","model":"openai/gpt-5.2","thinkingLevel":"medium"}}"#).unwrap();
+        writeln!(file, r#"{{"type":"message","id":"user-1","parentId":null,"timestamp":"2024-01-15T10:30:00Z","message":{{"role":"user","content":"Read README","timestamp":0}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"message","id":"assistant-1","parentId":"user-1","timestamp":"2024-01-15T10:30:01Z","message":{{"role":"assistant","content":[{{"type":"toolCall","id":"call-1","name":"read","arguments":{{"path":"README.md"}}}}],"timestamp":1}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"message","id":"tool-1","parentId":"assistant-1","timestamp":"2024-01-15T10:30:02Z","message":{{"role":"toolResult","toolCallId":"call-1","toolName":"read","content":"file contents","isError":false,"timestamp":2}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"message","id":"assistant-2","parentId":"tool-1","timestamp":"2024-01-15T10:30:03Z","message":{{"role":"assistant","content":[{{"type":"text","text":"Done"}}],"timestamp":3}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"compaction","id":"compact-1","parentId":"assistant-2","timestamp":"2024-01-15T10:30:04Z","summary":"Kept assistant result","firstKeptEntryId":"assistant-2","tokensBefore":1234,"auto":true}}"#).unwrap();
+        writeln!(file, r#"{{"type":"message","id":"user-2","parentId":"compact-1","timestamp":"2024-01-15T10:30:05Z","message":{{"role":"user","content":"Summarize","timestamp":4}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"message","id":"assistant-3","parentId":"user-2","timestamp":"2024-01-15T10:30:06Z","message":{{"role":"assistant","content":[{{"type":"text","text":"Summary"}}],"timestamp":5}}}}"#).unwrap();
+        writeln!(file, r#"{{"type":"compaction","id":"compact-2","parentId":"assistant-3","timestamp":"2024-01-15T10:30:07Z","summary":"Kept summary","firstKeptEntryId":"assistant-3","tokensBefore":2345,"auto":true}}"#).unwrap();
+
+        let session = SessionReader::read_file(file.path()).unwrap();
+
+        assert_eq!(session.compactions.len(), 2);
+        assert_eq!(
+            session.compactions[0].first_kept_entry_id.as_deref(),
+            Some("assistant-2")
+        );
+        assert_eq!(session.compactions[0].first_kept_entry_index, Some(2));
+        assert_eq!(
+            session.compactions[1].first_kept_entry_id.as_deref(),
+            Some("assistant-3")
+        );
+        assert_eq!(session.compactions[1].first_kept_entry_index, Some(2));
     }
 }

--- a/packages/tui-rs/src/session/wire_format_generated.rs
+++ b/packages/tui-rs/src/session/wire_format_generated.rs
@@ -12,6 +12,61 @@ pub const STOP_REASON_ALIASES: &[(&str, &str)] = &[
     ("stop_sequence", "stop"),
 ];
 
+pub const CONTENT_BLOCK_TYPE_ALIASES: &[(&str, &str)] = &[("tool_call", "toolCall")];
+
+pub const CONTENT_BLOCK_FIELD_ALIASES: &[(&str, &[(&str, &str)])] = &[
+    ("toolCall", &[("args", "arguments")]),
+    (
+        "thinking",
+        &[("text", "thinking"), ("signature", "thinkingSignature")],
+    ),
+];
+
+pub const FIELD_ALIASES: &[(&str, &[(&str, &str)])] = &[
+    (
+        "modelMetadata",
+        &[
+            ("model_id", "modelId"),
+            ("provider_name", "providerName"),
+            ("base_url", "baseUrl"),
+            ("context_window", "contextWindow"),
+            ("max_tokens", "maxTokens"),
+        ],
+    ),
+    (
+        "session",
+        &[
+            ("model_metadata", "modelMetadata"),
+            ("thinking_level", "thinkingLevel"),
+            ("system_prompt", "systemPrompt"),
+            ("branched_from", "branchedFrom"),
+        ],
+    ),
+    ("assistantMessage", &[("stop_reason", "stopReason")]),
+    (
+        "toolResultMessage",
+        &[
+            ("tool_call_id", "toolCallId"),
+            ("tool_name", "toolName"),
+            ("is_error", "isError"),
+        ],
+    ),
+    (
+        "thinkingLevelChange",
+        &[("thinking_level", "thinkingLevel")],
+    ),
+    ("modelChange", &[("model_metadata", "modelMetadata")]),
+    (
+        "compaction",
+        &[
+            ("first_kept_entry_id", "firstKeptEntryId"),
+            ("first_kept_entry_index", "firstKeptEntryIndex"),
+            ("tokens_before", "tokensBefore"),
+            ("custom_instructions", "customInstructions"),
+        ],
+    ),
+];
+
 #[must_use]
 pub fn canonical_stop_reason(reason: &str) -> &str {
     match reason {
@@ -21,5 +76,56 @@ pub fn canonical_stop_reason(reason: &str) -> &str {
         "end_turn" => "stop",
         "stop_sequence" => "stop",
         other => other,
+    }
+}
+
+#[must_use]
+pub fn canonical_content_block_type(block_type: &str) -> &str {
+    match block_type {
+        "tool_call" => "toolCall",
+        other => other,
+    }
+}
+
+#[must_use]
+pub fn content_block_field_aliases(block_type: &str) -> &'static [(&'static str, &'static str)] {
+    match block_type {
+        "toolCall" => &[("args", "arguments")],
+        "thinking" => &[("text", "thinking"), ("signature", "thinkingSignature")],
+        _ => &[],
+    }
+}
+
+#[must_use]
+pub fn field_aliases(section: &str) -> &'static [(&'static str, &'static str)] {
+    match section {
+        "modelMetadata" => &[
+            ("model_id", "modelId"),
+            ("provider_name", "providerName"),
+            ("base_url", "baseUrl"),
+            ("context_window", "contextWindow"),
+            ("max_tokens", "maxTokens"),
+        ],
+        "session" => &[
+            ("model_metadata", "modelMetadata"),
+            ("thinking_level", "thinkingLevel"),
+            ("system_prompt", "systemPrompt"),
+            ("branched_from", "branchedFrom"),
+        ],
+        "assistantMessage" => &[("stop_reason", "stopReason")],
+        "toolResultMessage" => &[
+            ("tool_call_id", "toolCallId"),
+            ("tool_name", "toolName"),
+            ("is_error", "isError"),
+        ],
+        "thinkingLevelChange" => &[("thinking_level", "thinkingLevel")],
+        "modelChange" => &[("model_metadata", "modelMetadata")],
+        "compaction" => &[
+            ("first_kept_entry_id", "firstKeptEntryId"),
+            ("first_kept_entry_index", "firstKeptEntryIndex"),
+            ("tokens_before", "tokensBefore"),
+            ("custom_instructions", "customInstructions"),
+        ],
+        _ => &[],
     }
 }

--- a/scripts/session-wire-format-codegen.mjs
+++ b/scripts/session-wire-format-codegen.mjs
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -124,26 +130,85 @@ export function getSessionWireContentBlockFieldAliases(type: string) {
 const RUST_MAX_WIDTH = 100;
 const STOP_REASON_ALIASES_PREFIX =
 	"pub const STOP_REASON_ALIASES: &[(&str, &str)] = ";
+const CONTENT_BLOCK_TYPE_ALIASES_PREFIX =
+	"pub const CONTENT_BLOCK_TYPE_ALIASES: &[(&str, &str)] = ";
 
-function toRustArray(entries, prefixLength = 0) {
+function toRustArray(
+	entries,
+	prefixLength = 0,
+	indent = "",
+	forceMultiline = false,
+) {
 	if (entries.length === 0) {
 		return "&[]";
 	}
 	const inline = `&[${entries
 		.map(([from, to]) => `(${JSON.stringify(from)}, ${JSON.stringify(to)})`)
 		.join(", ")}]`;
-	if (prefixLength + inline.length + ";".length <= RUST_MAX_WIDTH) {
+	if (!forceMultiline && prefixLength + inline.length + ";".length <= RUST_MAX_WIDTH) {
 		return inline;
 	}
+	const itemIndent = `${indent}    `;
 	return `&[\n${entries
-		.map(([from, to]) => `    (${JSON.stringify(from)}, ${JSON.stringify(to)}),`)
-		.join("\n")}\n]`;
+		.map(
+			([from, to]) =>
+				`${itemIndent}(${JSON.stringify(from)}, ${JSON.stringify(to)}),`,
+		)
+		.join("\n")}\n${indent}]`;
+}
+
+function toRustNestedArray(entries) {
+	if (entries.length === 0) {
+		return "&[]";
+	}
+	const renderedEntries = entries.map(([section, aliases]) => {
+		const aliasEntries = Object.entries(aliases ?? {});
+		const aliasArray = toRustArray(
+			aliasEntries,
+			8,
+			"        ",
+			aliasEntries.length > 2,
+		);
+		if (aliasEntries.length <= 1 && section.length <= 16) {
+			return `    (${JSON.stringify(section)}, ${aliasArray}),`;
+		}
+		return `    (\n        ${JSON.stringify(section)},\n        ${aliasArray},\n    ),`;
+	});
+	return `&[\n${renderedEntries.join("\n")}\n]`;
+}
+
+function toRustMatchArms(entries) {
+	return [
+		...entries.map(([key, aliases]) => {
+			const aliasEntries = Object.entries(aliases ?? {});
+			return `        ${JSON.stringify(key)} => ${toRustArray(
+				aliasEntries,
+				8,
+				"        ",
+				aliasEntries.length > 2,
+			)},`;
+		}),
+		"        _ => &[],",
+	].join("\n");
 }
 
 function renderRust(manifest) {
 	const stopAliases = Object.entries(manifest.stopReasonAliases ?? {});
-	const matchArms = [
+	const contentBlockTypeAliases = Object.entries(
+		manifest.contentBlockTypeAliases ?? {},
+	);
+	const contentBlockFieldAliases = Object.entries(
+		manifest.contentBlockFieldAliases ?? {},
+	);
+	const fieldAliases = Object.entries(manifest.fieldAliases ?? {});
+	const stopReasonMatchArms = [
 		...stopAliases.map(
+			([from, to]) => `        ${JSON.stringify(from)} => ${JSON.stringify(to)},`,
+		),
+		"        other => other,",
+	].join("\n");
+	const contentBlockTypeMatchArms = [
+		...contentBlockTypeAliases.map(
 			([from, to]) => `        ${JSON.stringify(from)} => ${JSON.stringify(to)},`,
 		),
 		"        other => other,",
@@ -157,10 +222,39 @@ pub const SESSION_WIRE_FORMAT_VERSION: &str = ${JSON.stringify(manifest.version)
 
 ${STOP_REASON_ALIASES_PREFIX}${toRustArray(stopAliases, STOP_REASON_ALIASES_PREFIX.length)};
 
+${CONTENT_BLOCK_TYPE_ALIASES_PREFIX}${toRustArray(contentBlockTypeAliases, CONTENT_BLOCK_TYPE_ALIASES_PREFIX.length)};
+
+pub const CONTENT_BLOCK_FIELD_ALIASES: &[(&str, &[(&str, &str)])] = ${toRustNestedArray(
+		contentBlockFieldAliases,
+	)};
+
+pub const FIELD_ALIASES: &[(&str, &[(&str, &str)])] = ${toRustNestedArray(fieldAliases)};
+
 #[must_use]
 pub fn canonical_stop_reason(reason: &str) -> &str {
     match reason {
-${matchArms}
+${stopReasonMatchArms}
+    }
+}
+
+#[must_use]
+pub fn canonical_content_block_type(block_type: &str) -> &str {
+    match block_type {
+${contentBlockTypeMatchArms}
+    }
+}
+
+#[must_use]
+pub fn content_block_field_aliases(block_type: &str) -> &'static [(&'static str, &'static str)] {
+    match block_type {
+${toRustMatchArms(contentBlockFieldAliases)}
+    }
+}
+
+#[must_use]
+pub fn field_aliases(section: &str) -> &'static [(&'static str, &'static str)] {
+    match section {
+${toRustMatchArms(fieldAliases)}
     }
 }
 `;
@@ -171,14 +265,15 @@ function formatTs(source, outputPath) {
 	const tempPath = join(tempDir, "wire-format.generated.ts");
 	try {
 		writeFileSync(tempPath, source, "utf8");
-		const result = spawnSync(
-			"bunx",
-			["biome", "check", "--write", "--unsafe", tempPath],
-			{
-				cwd: rootDir,
-				encoding: "utf8",
-			},
-		);
+		const localBiome = join(rootDir, "node_modules/.bin/biome");
+		const command = existsSync(localBiome) ? localBiome : "bunx";
+		const args = existsSync(localBiome)
+			? ["check", "--write", "--unsafe", tempPath]
+			: ["@biomejs/biome@1.9.4", "check", "--write", "--unsafe", tempPath];
+		const result = spawnSync(command, args, {
+			cwd: rootDir,
+			encoding: "utf8",
+		});
 		if (result.status !== 0) {
 			throw new Error(
 				`Failed to format generated TypeScript session wire file: ${result.stderr || result.stdout}`,


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `c99939b298596299d9b812c0bc2a8e46a03725e1`
- last generated public sync base: `057512008315f4019eaf0641c19c9c335e36f195`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (c99939b29859)`
- public projection: `https://github.com/evalops/maestro@main (057512008315)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/tui-rs/src/app.rs
- copy/update packages/tui-rs/src/session/entries.rs
- copy/update packages/tui-rs/src/session/reader.rs
- copy/update packages/tui-rs/src/session/wire_format_generated.rs
- copy/update scripts/session-wire-format-codegen.mjs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/tui-rs/src/app.rs
- copy/update packages/tui-rs/src/session/entries.rs
- copy/update packages/tui-rs/src/session/reader.rs
- copy/update packages/tui-rs/src/session/wire_format_generated.rs
- copy/update scripts/session-wire-format-codegen.mjs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode