### PR TITLE
refactor: share generated contract helpers

### DIFF
--- a/scripts/codegen-utils.mjs
+++ b/scripts/codegen-utils.mjs
@@ -1,0 +1,170 @@
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+export function formatTsWithBiome(
+	source,
+	outputPath,
+	{ rootDir, label, tempPrefix = ".codegen-" },
+) {
+	const tempDir = mkdtempSync(join(dirname(outputPath), tempPrefix));
+	const tempPath = join(tempDir, basename(outputPath));
+	try {
+		writeFileSync(tempPath, source, "utf8");
+		const localBiome = join(rootDir, "node_modules/.bin/biome");
+		const command = existsSync(localBiome) ? localBiome : "bunx";
+		const args = existsSync(localBiome)
+			? ["check", "--write", "--unsafe", tempPath]
+			: ["@biomejs/biome@1.9.4", "check", "--write", "--unsafe", tempPath];
+		const result = spawnSync(command, args, {
+			cwd: rootDir,
+			encoding: "utf8",
+		});
+		if (result.error) {
+			throw new Error(
+				`Failed to launch Biome while formatting ${label}: ${result.error.message}`,
+			);
+		}
+		if (result.status !== 0) {
+			throw new Error(
+				`Failed to format ${label}: ${result.stderr || result.stdout}`,
+			);
+		}
+		return readFileSync(tempPath, "utf8");
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+function resolveRustfmt(envNames) {
+	for (const envName of envNames) {
+		const command = process.env[envName];
+		if (command) {
+			return command;
+		}
+	}
+	return process.env.MAESTRO_RUSTFMT ?? "rustfmt";
+}
+
+export function formatRustWithRustfmt(
+	source,
+	outputPath,
+	{
+		rootDir,
+		label,
+		check = false,
+		envNames = [],
+		tempPrefix = ".codegen-",
+	} = {},
+) {
+	const tempDir = mkdtempSync(join(dirname(outputPath), tempPrefix));
+	const tempPath = join(tempDir, basename(outputPath));
+	try {
+		writeFileSync(tempPath, source, "utf8");
+		const rustfmt = resolveRustfmt(envNames);
+		const result = spawnSync(rustfmt, [tempPath], {
+			cwd: rootDir,
+			encoding: "utf8",
+		});
+		if (result.error?.code === "ENOENT") {
+			if (!check) {
+				throw new Error(
+					`${rustfmt} is required to write ${label}. Install rustfmt or run with --check.`,
+				);
+			}
+			return { content: source, rustfmtAvailable: false };
+		}
+		if (result.error) {
+			throw result.error;
+		}
+		if (result.status !== 0) {
+			throw new Error(
+				`Failed to format ${label}: ${result.stderr || result.stdout}`,
+			);
+		}
+		return { content: readFileSync(tempPath, "utf8"), rustfmtAvailable: true };
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+function stripRustWhitespaceOutsideStrings(source) {
+	let output = "";
+	let inString = false;
+	let escaped = false;
+	for (let index = 0; index < source.length; index += 1) {
+		const char = source[index];
+		if (inString) {
+			output += char;
+			if (escaped) {
+				escaped = false;
+			} else if (char === "\\") {
+				escaped = true;
+			} else if (char === '"') {
+				inString = false;
+			}
+			continue;
+		}
+		if (char === '"') {
+			inString = true;
+			output += char;
+			continue;
+		}
+		if (char === ",") {
+			let nextIndex = index + 1;
+			while (/\s/.test(source[nextIndex] ?? "")) {
+				nextIndex += 1;
+			}
+			if (/[\])}]/.test(source[nextIndex] ?? "")) {
+				continue;
+			}
+		}
+		if (!/\s/.test(char)) {
+			output += char;
+		}
+	}
+	return output;
+}
+
+export function rustGeneratedMatches(current, expected, { rustfmtAvailable }) {
+	if (rustfmtAvailable) {
+		return current === expected;
+	}
+	return (
+		stripRustWhitespaceOutsideStrings(current) ===
+		stripRustWhitespaceOutsideStrings(expected)
+	);
+}
+
+export async function checkOrWriteGeneratedTargets(
+	targets,
+	{ check, outOfDateLabel },
+) {
+	if (check) {
+		let failed = false;
+		for (const target of targets) {
+			const current = await readFile(target.path, "utf8").catch(() => null);
+			const matches = target.matches ?? ((current, expected) => current === expected);
+			if (current === null || !matches(current, target.content)) {
+				failed = true;
+				console.error(`${outOfDateLabel}: ${target.path}`);
+			}
+		}
+		if (failed) {
+			process.exitCode = 1;
+		}
+		return;
+	}
+
+	for (const target of targets) {
+		await mkdir(dirname(target.path), { recursive: true });
+		await writeFile(target.path, target.content);
+	}
+}

--- a/scripts/headless-protocol-codegen.mjs
+++ b/scripts/headless-protocol-codegen.mjs
@@ -1,13 +1,12 @@
-import { spawnSync } from "node:child_process";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import {
-	mkdtempSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+	checkOrWriteGeneratedTargets,
+	formatRustWithRustfmt,
+	formatTsWithBiome,
+	rustGeneratedMatches,
+} from "./codegen-utils.mjs";
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const protoPath = resolve(rootDir, "proto/maestro/v1/headless.proto");
@@ -438,36 +437,6 @@ ${renderEntries(runtimeSchemaEntries)}
 `;
 }
 
-function formatTs(source, filePath = tsOutputPath) {
-	return formatTsViaTempFile(source, filePath);
-}
-
-function formatTsViaTempFile(source, filePath) {
-	const tempDir = mkdtempSync(join(dirname(filePath), ".headless-codegen-"));
-	const tempPath = join(tempDir, basename(filePath));
-
-	try {
-		writeFileSync(tempPath, source);
-		const result = spawnSync("bunx", ["biome", "format", "--write", tempPath], {
-			cwd: rootDir,
-			encoding: "utf8",
-		});
-		if (result.error) {
-			throw new Error(
-				`Failed to launch Biome while formatting generated TypeScript protocol file: ${result.error.message}`,
-			);
-		}
-		if (result.status !== 0) {
-			throw new Error(
-				`Failed to format generated TypeScript protocol file: ${result.stderr || result.stdout}`,
-			);
-		}
-		return readFileSync(tempPath, "utf8");
-	} finally {
-		rmSync(tempDir, { recursive: true, force: true });
-	}
-}
-
 function renderRust(protocolSpec) {
 	return `#![allow(dead_code)]
 
@@ -526,68 +495,52 @@ pub const HEADLESS_FROM_AGENT_MESSAGE_TYPES: &[&str] = ${toRustArray(
 `;
 }
 
-function formatRust(source) {
-	const result = spawnSync("rustfmt", ["--emit", "stdout"], {
-		cwd: rootDir,
-		encoding: "utf8",
-		input: source,
-	});
-	if (result.error) {
-		throw new Error(
-			`Failed to launch rustfmt while formatting generated Rust protocol file: ${result.error.message}`,
-		);
-	}
-	if (result.status !== 0) {
-		throw new Error(
-			`Failed to format generated Rust protocol file: ${result.stderr || result.stdout}`,
-		);
-	}
-	return result.stdout;
-}
-
 async function main() {
 	const check = process.argv.includes("--check");
 	const protocolSpec = buildProtocolSpec(await readFile(protoPath, "utf8"));
 	const payloadManifest = JSON.parse(await readFile(payloadManifestPath, "utf8"));
+	const rustOutput = formatRustWithRustfmt(renderRust(protocolSpec), rustOutputPath, {
+		rootDir,
+		label: "generated Rust headless protocol file",
+		check,
+		envNames: ["HEADLESS_PROTOCOL_RUSTFMT"],
+		tempPrefix: ".headless-codegen-",
+	});
 	const targets = [
 		{
 			path: tsOutputPath,
-			content: formatTs(renderTs(protocolSpec), tsOutputPath),
+			content: formatTsWithBiome(renderTs(protocolSpec), tsOutputPath, {
+				rootDir,
+				label: "generated TypeScript headless protocol file",
+				tempPrefix: ".headless-codegen-",
+			}),
 		},
 		{
 			path: tsSchemaOutputPath,
-			content: formatTs(
+			content: formatTsWithBiome(
 				renderTsSchemas(payloadManifest),
 				tsSchemaOutputPath,
+				{
+					rootDir,
+					label: "generated TypeScript headless protocol schema file",
+					tempPrefix: ".headless-codegen-",
+				},
 			),
 		},
 		{
 			path: rustOutputPath,
-			content: formatRust(renderRust(protocolSpec)),
+			content: rustOutput.content,
+			matches: (current, expected) =>
+				rustGeneratedMatches(current, expected, {
+					rustfmtAvailable: rustOutput.rustfmtAvailable,
+				}),
 		},
 	];
 
-	if (check) {
-		let failed = false;
-		for (const target of targets) {
-			const current = await readFile(target.path, "utf8").catch(() => null);
-			if (current !== target.content) {
-				failed = true;
-				console.error(
-					`Headless protocol generated file is out of date: ${target.path}`,
-				);
-			}
-		}
-		if (failed) {
-			process.exitCode = 1;
-		}
-		return;
-	}
-
-	for (const target of targets) {
-		await mkdir(dirname(target.path), { recursive: true });
-		await writeFile(target.path, target.content);
-	}
+	await checkOrWriteGeneratedTargets(targets, {
+		check,
+		outOfDateLabel: "Headless protocol generated file is out of date",
+	});
 }
 
 await main();

--- a/scripts/session-wire-format-codegen.mjs
+++ b/scripts/session-wire-format-codegen.mjs
@@ -1,16 +1,14 @@
 #!/usr/bin/env node
 
-import { spawnSync } from "node:child_process";
-import {
-	existsSync,
-	mkdtempSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+	checkOrWriteGeneratedTargets,
+	formatRustWithRustfmt,
+	formatTsWithBiome,
+	rustGeneratedMatches,
+} from "./codegen-utils.mjs";
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const manifestPath = resolve(rootDir, "src/session/wire-format.manifest.json");
@@ -353,141 +351,26 @@ ${toRustStringMatcher("is_compaction_context_excluded_message_role", "role", com
 `;
 }
 
-function formatTs(source, outputPath) {
-	const tempDir = mkdtempSync(join(dirname(outputPath), ".session-wire-codegen-"));
-	const tempPath = join(tempDir, "wire-format.generated.ts");
-	try {
-		writeFileSync(tempPath, source, "utf8");
-		const localBiome = join(rootDir, "node_modules/.bin/biome");
-		const command = existsSync(localBiome) ? localBiome : "bunx";
-		const args = existsSync(localBiome)
-			? ["check", "--write", "--unsafe", tempPath]
-			: ["@biomejs/biome@1.9.4", "check", "--write", "--unsafe", tempPath];
-		const result = spawnSync(command, args, {
-			cwd: rootDir,
-			encoding: "utf8",
-		});
-		if (result.status !== 0) {
-			throw new Error(
-				`Failed to format generated TypeScript session wire file: ${result.stderr || result.stdout}`,
-			);
-		}
-		return readFileSync(tempPath, "utf8");
-	} finally {
-		rmSync(tempDir, { recursive: true, force: true });
-	}
-}
-
-function removeRustTrailingCommasOutsideStrings(source) {
-	let output = "";
-	let inString = false;
-	let escaped = false;
-	for (let index = 0; index < source.length; index += 1) {
-		const char = source[index];
-		if (inString) {
-			output += char;
-			if (escaped) {
-				escaped = false;
-			} else if (char === "\\") {
-				escaped = true;
-			} else if (char === '"') {
-				inString = false;
-			}
-			continue;
-		}
-		if (char === '"') {
-			inString = true;
-			output += char;
-			continue;
-		}
-		if (char === "," && /[\])}]/.test(source[index + 1] ?? "")) {
-			continue;
-		}
-		output += char;
-	}
-	return output;
-}
-
-function stripRustWhitespaceOutsideStrings(source) {
-	let output = "";
-	let inString = false;
-	let escaped = false;
-	for (const char of source) {
-		if (inString) {
-			output += char;
-			if (escaped) {
-				escaped = false;
-			} else if (char === "\\") {
-				escaped = true;
-			} else if (char === '"') {
-				inString = false;
-			}
-			continue;
-		}
-		if (char === '"') {
-			inString = true;
-			output += char;
-			continue;
-		}
-		if (!/\s/.test(char)) {
-			output += char;
-		}
-	}
-	return removeRustTrailingCommasOutsideStrings(output);
-}
-
-function rustGeneratedMatches(current, expected, { rustfmtAvailable }) {
-	if (rustfmtAvailable) {
-		return current === expected;
-	}
-	return (
-		stripRustWhitespaceOutsideStrings(current) ===
-		stripRustWhitespaceOutsideStrings(expected)
-	);
-}
-
-function formatRust(source, outputPath, { check = false } = {}) {
-	const tempDir = mkdtempSync(join(dirname(outputPath), ".session-wire-codegen-"));
-	const tempPath = join(tempDir, "wire_format_generated.rs");
-	try {
-		writeFileSync(tempPath, source, "utf8");
-		const rustfmt = process.env.SESSION_WIRE_FORMAT_RUSTFMT ?? "rustfmt";
-		const result = spawnSync(rustfmt, [tempPath], {
-			cwd: rootDir,
-			encoding: "utf8",
-		});
-		if (result.error?.code === "ENOENT") {
-			if (!check) {
-				throw new Error(
-					`${rustfmt} is required to write generated Rust session wire output. Install rustfmt or run with --check.`,
-				);
-			}
-			return { content: source, rustfmtAvailable: false };
-		}
-		if (result.error) {
-			throw result.error;
-		}
-		if (result.status !== 0) {
-			throw new Error(
-				`Failed to format generated Rust session wire file: ${result.stderr || result.stdout}`,
-			);
-		}
-		return { content: readFileSync(tempPath, "utf8"), rustfmtAvailable: true };
-	} finally {
-		rmSync(tempDir, { recursive: true, force: true });
-	}
-}
-
 async function main() {
 	const check = process.argv.includes("--check");
 	const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
 	validateManifest(manifest);
 	const rustSource = renderRust(manifest);
-	const rustOutput = formatRust(rustSource, rustOutputPath, { check });
+	const rustOutput = formatRustWithRustfmt(rustSource, rustOutputPath, {
+		rootDir,
+		label: "generated Rust session wire file",
+		check,
+		envNames: ["SESSION_WIRE_FORMAT_RUSTFMT"],
+		tempPrefix: ".session-wire-codegen-",
+	});
 	const targets = [
 		{
 			path: tsOutputPath,
-			content: formatTs(renderTs(manifest), tsOutputPath),
+			content: formatTsWithBiome(renderTs(manifest), tsOutputPath, {
+				rootDir,
+				label: "generated TypeScript session wire file",
+				tempPrefix: ".session-wire-codegen-",
+			}),
 			matches: (current, expected) => current === expected,
 		},
 		{
@@ -500,27 +383,10 @@ async function main() {
 		},
 	];
 
-	if (check) {
-		let failed = false;
-		for (const target of targets) {
-			const current = await readFile(target.path, "utf8").catch(() => null);
-			if (current === null || !target.matches(current, target.content)) {
-				failed = true;
-				console.error(
-					`Session wire generated file is out of date: ${target.path}`,
-				);
-			}
-		}
-		if (failed) {
-			process.exitCode = 1;
-		}
-		return;
-	}
-
-	for (const target of targets) {
-		await mkdir(dirname(target.path), { recursive: true });
-		await writeFile(target.path, target.content);
-	}
+	await checkOrWriteGeneratedTargets(targets, {
+		check,
+		outOfDateLabel: "Session wire generated file is out of date",
+	});
 }
 
 await main();


### PR DESCRIPTION
## Summary
- add shared codegen helpers for generated TypeScript/Rust artifacts
- route the session wire and headless protocol generators through the shared formatter/check/write path
- give the proto-derived headless Rust generator the same missing-rustfmt check-mode behavior as session wire generation

Internal source PR: evalops/maestro-internal#1574

## Verification
- `node --check scripts/codegen-utils.mjs && node --check scripts/session-wire-format-codegen.mjs && node --check scripts/headless-protocol-codegen.mjs`
- `bun run check:session-wire-format:generated`
- `bun run check:headless-proto:generated`
- `MAESTRO_RUSTFMT=__missing_rustfmt__ node scripts/headless-protocol-codegen.mjs --check`
- `MAESTRO_RUSTFMT=__missing_rustfmt__ node scripts/session-wire-format-codegen.mjs --check`
- `bun run bun:lint`