### PR TITLE
fix: keep migration runtime in rust image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,13 @@ RUN apk add --no-cache tini git ca-certificates libstdc++ nodejs npm && \
     addgroup --system --gid 1001 appgroup && \
     adduser --system --uid 1001 appuser
 
+# Keep the Rust control plane as the default runtime while preserving the
+# JavaScript migration entrypoint used by the deploy PreSync hook.
+COPY --from=web-builder /app/dist ./dist
+COPY --from=web-builder /app/src/db/migrations ./dist/db/migrations
+COPY --from=web-builder /app/node_modules ./node_modules
+COPY --from=web-builder /app/package.json ./
+COPY --from=web-builder /app/skills ./skills
 COPY --from=web-builder /app/packages/web/dist ./packages/web/dist
 COPY --from=rust-builder /app/target-bin/maestro-control-plane ./bin/maestro-control-plane
 


### PR DESCRIPTION
## Summary
- keep the Rust control-plane binary as the container default
- restore the built JS dist, db migrations, runtime dependencies, package metadata, and skills in the runner image
- preserve compatibility with deploy's PreSync migration hook, which still runs node /app/dist/db/migrate.js

## Source of truth
- evalops/maestro-internal#1575

## Live findings
- staging is currently running node --enable-source-maps dist/web-server.js
- current main Dockerfile defaults to ./bin/maestro-control-plane, but the runner image no longer carries the JS migration runtime expected by deploy
- fixing packaging lets us promote the Rust backend image without breaking database migrations

## Verification
- git diff --check

## Notes
- Local Docker is unavailable in this environment, so image build verification is left to GHCR Publish CI.