### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,13 @@ RUN apk add --no-cache tini git ca-certificates libstdc++ nodejs npm && \
     addgroup --system --gid 1001 appgroup && \
     adduser --system --uid 1001 appuser
 
+# Keep the Rust control plane as the default runtime while preserving the
+# JavaScript migration entrypoint used by the deploy PreSync hook.
+COPY --from=web-builder /app/dist ./dist
+COPY --from=web-builder /app/src/db/migrations ./dist/db/migrations
+COPY --from=web-builder /app/node_modules ./node_modules
+COPY --from=web-builder /app/package.json ./
+COPY --from=web-builder /app/skills ./skills
 COPY --from=web-builder /app/packages/web/dist ./packages/web/dist
 COPY --from=rust-builder /app/target-bin/maestro-control-plane ./bin/maestro-control-plane
 


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `1d189a43b515b0f3957df51282b28fea75d0e3f0`
- last generated public sync base: `1f0c22de1c17cea74b8f67ebb2176e23de6630ba`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (1d189a43b515)`
- public projection: `https://github.com/evalops/maestro@main (563f8d662a00)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update Dockerfile

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update Dockerfile

## Public-only commits since last generated sync

- 563f8d66 Merge pull request #235 from evalops/codex/deeper-codegen-parity-20260429

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode