### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -52,6 +52,8 @@ export * from "./memory.js";
 export * from "./memory-utils.js";
 export * from "./onboarding-utils.js";
 export * from "./proto/maestro/v1/headless_pb.js";
+export * from "./runtime-app-server.js";
+export * from "./runtime-server-request.js";
 
 /**
  * Role of a message in the conversation.

--- a/packages/contracts/src/runtime-app-server.ts
+++ b/packages/contracts/src/runtime-app-server.ts
@@ -1,0 +1,131 @@
+import { type Static, Type } from "@sinclair/typebox";
+import { RuntimeServerRequestLifecycleEventSchema } from "./runtime-server-request.js";
+import { stringLiteralUnion } from "./typebox-utils.js";
+
+export const runtimeAppServerProtocolVersion = "runtime-app-server.v1" as const;
+
+export const runtimeAppServerClientMethods = [
+	"runtime.initialize",
+	"runtime.model_provider_capabilities.read",
+	"runtime.ping",
+] as const;
+export type RuntimeAppServerClientMethod =
+	(typeof runtimeAppServerClientMethods)[number];
+
+export const runtimeAppServerServerMethods = [
+	"runtime.initialized",
+	"runtime.server_request.registered",
+	"runtime.server_request.resolved",
+] as const;
+export type RuntimeAppServerServerMethod =
+	(typeof runtimeAppServerServerMethods)[number];
+
+const RuntimeJsonRpcIdSchema = Type.Union([Type.String(), Type.Number()]);
+const RuntimeJsonRpcResponseIdSchema = Type.Union([
+	RuntimeJsonRpcIdSchema,
+	Type.Null(),
+]);
+
+export const RuntimeAppServerClientRequestSchema = Type.Object({
+	jsonrpc: Type.Literal("2.0"),
+	id: RuntimeJsonRpcIdSchema,
+	method: stringLiteralUnion(runtimeAppServerClientMethods),
+	params: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+export type RuntimeAppServerClientRequest = Static<
+	typeof RuntimeAppServerClientRequestSchema
+>;
+
+export const RuntimeAppServerCapabilitiesSchema = Type.Object({
+	chat: Type.Boolean(),
+	serverRequests: Type.Boolean(),
+	modelCapabilities: Type.Boolean(),
+});
+export type RuntimeAppServerCapabilities = Static<
+	typeof RuntimeAppServerCapabilitiesSchema
+>;
+
+export const RuntimeAppServerInitializeResultSchema = Type.Object({
+	protocolVersion: Type.Literal(runtimeAppServerProtocolVersion),
+	serverInfo: Type.Object({
+		name: Type.String(),
+	}),
+	capabilities: RuntimeAppServerCapabilitiesSchema,
+});
+export type RuntimeAppServerInitializeResult = Static<
+	typeof RuntimeAppServerInitializeResultSchema
+>;
+
+export const RuntimeAppServerModelCapabilitiesSchema = Type.Object({
+	streaming: Type.Boolean(),
+	tools: Type.Boolean(),
+	vision: Type.Boolean(),
+	reasoning: Type.Boolean(),
+	local: Type.Boolean(),
+});
+export type RuntimeAppServerModelCapabilities = Static<
+	typeof RuntimeAppServerModelCapabilitiesSchema
+>;
+
+export const RuntimeAppServerProviderModelSchema = Type.Object({
+	id: Type.String(),
+	name: Type.String(),
+	api: Type.String(),
+	provider: Type.String(),
+	source: Type.Union([Type.Literal("builtin"), Type.Literal("custom")]),
+	contextWindow: Type.Optional(Type.Number()),
+	maxTokens: Type.Optional(Type.Number()),
+	capabilities: RuntimeAppServerModelCapabilitiesSchema,
+});
+export type RuntimeAppServerProviderModel = Static<
+	typeof RuntimeAppServerProviderModelSchema
+>;
+
+export const RuntimeAppServerModelProviderCapabilitiesResultSchema =
+	Type.Object({
+		providers: Type.Array(
+			Type.Object({
+				id: Type.String(),
+				name: Type.String(),
+				models: Type.Array(RuntimeAppServerProviderModelSchema),
+			}),
+		),
+	});
+export type RuntimeAppServerModelProviderCapabilitiesResult = Static<
+	typeof RuntimeAppServerModelProviderCapabilitiesResultSchema
+>;
+
+export const RuntimeAppServerResponseSchema = Type.Object({
+	jsonrpc: Type.Literal("2.0"),
+	id: RuntimeJsonRpcResponseIdSchema,
+	result: Type.Optional(
+		Type.Union([
+			RuntimeAppServerInitializeResultSchema,
+			RuntimeAppServerModelProviderCapabilitiesResultSchema,
+			Type.Unknown(),
+		]),
+	),
+	error: Type.Optional(
+		Type.Object({
+			code: Type.Number(),
+			message: Type.String(),
+		}),
+	),
+});
+export type RuntimeAppServerResponse = Static<
+	typeof RuntimeAppServerResponseSchema
+>;
+
+export const RuntimeAppServerServerNotificationSchema = Type.Object({
+	jsonrpc: Type.Literal("2.0"),
+	method: stringLiteralUnion(runtimeAppServerServerMethods),
+	params: Type.Optional(
+		Type.Union([
+			RuntimeAppServerInitializeResultSchema,
+			RuntimeServerRequestLifecycleEventSchema,
+		]),
+	),
+});
+export type RuntimeAppServerServerNotification = Static<
+	typeof RuntimeAppServerServerNotificationSchema
+>;

--- a/packages/contracts/src/runtime-server-request.ts
+++ b/packages/contracts/src/runtime-server-request.ts
@@ -1,0 +1,103 @@
+import { type Static, Type } from "@sinclair/typebox";
+import { stringLiteralUnion } from "./typebox-utils.js";
+
+export const runtimeServerRequestKinds = [
+	"approval",
+	"client_tool",
+	"mcp_elicitation",
+	"user_input",
+	"tool_retry",
+] as const;
+export type RuntimeServerRequestKind =
+	(typeof runtimeServerRequestKinds)[number];
+
+export const runtimeServerRequestResolutions = [
+	"approved",
+	"denied",
+	"completed",
+	"failed",
+	"answered",
+	"retried",
+	"skipped",
+	"aborted",
+	"cancelled",
+] as const;
+export type RuntimeServerRequestResolution =
+	(typeof runtimeServerRequestResolutions)[number];
+
+export const runtimeServerRequestResolvedBy = [
+	"user",
+	"policy",
+	"client",
+	"runtime",
+] as const;
+export type RuntimeServerRequestResolvedBy =
+	(typeof runtimeServerRequestResolvedBy)[number];
+
+export const RuntimeServerRequestKindSchema = stringLiteralUnion(
+	runtimeServerRequestKinds,
+);
+export const RuntimeServerRequestResolutionSchema = stringLiteralUnion(
+	runtimeServerRequestResolutions,
+);
+export const RuntimeServerRequestResolvedBySchema = stringLiteralUnion(
+	runtimeServerRequestResolvedBy,
+);
+
+export const RuntimeServerRequestPlatformRefSchema = Type.Object({
+	source: Type.Union([
+		Type.Literal("approvals_service"),
+		Type.Literal("tool_execution"),
+	]),
+	toolExecutionId: Type.Optional(Type.String()),
+	approvalRequestId: Type.Optional(Type.String()),
+});
+export type RuntimeServerRequestPlatformRef = Static<
+	typeof RuntimeServerRequestPlatformRefSchema
+>;
+
+export const RuntimeServerRequestSnapshotSchema = Type.Object({
+	id: Type.String(),
+	kind: RuntimeServerRequestKindSchema,
+	sessionId: Type.Optional(Type.String()),
+	callId: Type.String(),
+	toolName: Type.String(),
+	displayName: Type.Optional(Type.String()),
+	summaryLabel: Type.Optional(Type.String()),
+	actionDescription: Type.Optional(Type.String()),
+	args: Type.Unknown(),
+	reason: Type.String(),
+	timestamp: Type.Number(),
+	timeoutMs: Type.Number(),
+	platform: Type.Optional(RuntimeServerRequestPlatformRefSchema),
+});
+export type RuntimeServerRequestSnapshot = Static<
+	typeof RuntimeServerRequestSnapshotSchema
+>;
+
+export const RuntimeServerRequestRegisteredEventSchema = Type.Object({
+	type: Type.Literal("registered"),
+	request: RuntimeServerRequestSnapshotSchema,
+});
+export type RuntimeServerRequestRegisteredEvent = Static<
+	typeof RuntimeServerRequestRegisteredEventSchema
+>;
+
+export const RuntimeServerRequestResolvedEventSchema = Type.Object({
+	type: Type.Literal("resolved"),
+	request: RuntimeServerRequestSnapshotSchema,
+	resolution: RuntimeServerRequestResolutionSchema,
+	reason: Type.Optional(Type.String()),
+	resolvedBy: RuntimeServerRequestResolvedBySchema,
+});
+export type RuntimeServerRequestResolvedEvent = Static<
+	typeof RuntimeServerRequestResolvedEventSchema
+>;
+
+export const RuntimeServerRequestLifecycleEventSchema = Type.Union([
+	RuntimeServerRequestRegisteredEventSchema,
+	RuntimeServerRequestResolvedEventSchema,
+]);
+export type RuntimeServerRequestLifecycleEvent = Static<
+	typeof RuntimeServerRequestLifecycleEventSchema
+>;

--- a/scripts/codegen-utils.mjs
+++ b/scripts/codegen-utils.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import {
 	existsSync,
+	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	rmSync,
@@ -14,6 +15,7 @@ export function formatTsWithBiome(
 	outputPath,
 	{ rootDir, label, tempPrefix = ".codegen-" },
 ) {
+	mkdirSync(dirname(outputPath), { recursive: true });
 	const tempDir = mkdtempSync(join(dirname(outputPath), tempPrefix));
 	const tempPath = join(tempDir, basename(outputPath));
 	try {
@@ -64,6 +66,7 @@ export function formatRustWithRustfmt(
 		tempPrefix = ".codegen-",
 	} = {},
 ) {
+	mkdirSync(dirname(outputPath), { recursive: true });
 	const tempDir = mkdtempSync(join(dirname(outputPath), tempPrefix));
 	const tempPath = join(tempDir, basename(outputPath));
 	try {

--- a/src/agent/providers/openai-codex-responses.ts
+++ b/src/agent/providers/openai-codex-responses.ts
@@ -1,5 +1,3 @@
-import { arch, platform, release } from "node:os";
-import { extractOpenAICodexAccountId } from "../../oauth/openai-codex.js";
 import { fetchWithRetry } from "../../providers/network-config.js";
 import {
 	createTimeoutReader,
@@ -18,6 +16,7 @@ import type {
 	ToolCall,
 	Usage,
 } from "../types.js";
+import { resolveOpenAICodexSession } from "./openai-codex-session.js";
 import type { OpenAIOptions } from "./openai-shared.js";
 import { filterResponsesApiTools } from "./openai-shared.js";
 import { sanitizeSurrogates } from "./sanitize-unicode.js";
@@ -29,9 +28,6 @@ const toolArgumentNormalizer = createToolArgumentNormalizer({
 	logger,
 	providerLabel: "OpenAI Codex",
 });
-
-const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
-const ORIGINATOR = "codex_cli_rs";
 
 type ResponsesInputContent =
 	| { type: "input_text"; text: string }
@@ -152,20 +148,19 @@ export async function* streamOpenAICodexResponses(
 
 	try {
 		const token = options.apiKey;
-		const accountId = resolveAccountId(token, options.headers);
 		const body = buildRequestBody(model, context, options);
-		const headers = buildHeaders(
-			model.headers,
-			options.headers,
-			accountId,
+		const session = resolveOpenAICodexSession({
 			token,
-			options.sessionId,
-		);
+			modelBaseUrl: model.baseUrl,
+			modelHeaders: model.headers,
+			optionHeaders: options.headers,
+			sessionId: options.sessionId,
+		});
 		const response = await fetchWithRetry(
-			resolveCodexUrl(model.baseUrl),
+			session.url,
 			{
 				method: "POST",
-				headers,
+				headers: session.headers,
 				body: JSON.stringify(body),
 				signal: options.signal,
 			},
@@ -683,61 +678,6 @@ function normalizeStatus(status: unknown): CodexResponseStatus | undefined {
 		return status;
 	}
 	return undefined;
-}
-
-function resolveCodexUrl(baseUrl?: string): string {
-	const raw =
-		baseUrl && baseUrl.trim().length > 0 ? baseUrl : DEFAULT_CODEX_BASE_URL;
-	const normalized = raw.replace(/\/+$/u, "");
-	if (normalized.endsWith("/codex/responses")) return normalized;
-	if (normalized.endsWith("/codex")) return `${normalized}/responses`;
-	return `${normalized}/codex/responses`;
-}
-
-function buildHeaders(
-	modelHeaders: Record<string, string> | undefined,
-	optionHeaders: Record<string, string> | undefined,
-	accountId: string,
-	token: string,
-	sessionId?: string,
-): Headers {
-	const headers = new Headers(modelHeaders);
-	for (const [key, value] of Object.entries(optionHeaders ?? {})) {
-		headers.set(key, value);
-	}
-	headers.set("Authorization", `Bearer ${token}`);
-	headers.set("chatgpt-account-id", accountId);
-	headers.set("originator", ORIGINATOR);
-	headers.set("User-Agent", `maestro (${platform()} ${release()}; ${arch()})`);
-	headers.set("OpenAI-Beta", "responses=experimental");
-	headers.set("accept", "text/event-stream");
-	headers.set("content-type", "application/json");
-	if (sessionId) {
-		headers.set("session_id", sessionId);
-		headers.set("x-client-request-id", sessionId);
-	}
-	return headers;
-}
-
-function resolveAccountId(
-	token: string,
-	headers: Record<string, string> | undefined,
-): string {
-	for (const [key, value] of Object.entries(headers ?? {})) {
-		if (key.toLowerCase() === "chatgpt-account-id" && value.trim()) {
-			return value.trim();
-		}
-	}
-	const accountId =
-		process.env.OPENAI_CODEX_ACCOUNT_ID?.trim() ??
-		process.env.CHATGPT_ACCOUNT_ID?.trim() ??
-		extractOpenAICodexAccountId(token);
-	if (!accountId) {
-		throw new Error(
-			"OpenAI Codex account id is required. Log in with /login openai-codex or set OPENAI_CODEX_ACCOUNT_ID.",
-		);
-	}
-	return accountId;
 }
 
 function mapCodexReasoningEffort(

--- a/src/agent/providers/openai-codex-session.ts
+++ b/src/agent/providers/openai-codex-session.ts
@@ -1,0 +1,80 @@
+import { arch, platform, release } from "node:os";
+import { extractOpenAICodexAccountId } from "../../oauth/openai-codex.js";
+
+export const DEFAULT_OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
+export const OPENAI_CODEX_ORIGINATOR = "codex_cli_rs";
+
+export interface ResolveOpenAICodexSessionOptions {
+	token: string;
+	modelBaseUrl?: string;
+	modelHeaders?: Record<string, string>;
+	optionHeaders?: Record<string, string>;
+	sessionId?: string;
+}
+
+export interface OpenAICodexSession {
+	url: string;
+	accountId: string;
+	headers: Headers;
+}
+
+export function resolveOpenAICodexUrl(baseUrl?: string): string {
+	const raw =
+		baseUrl && baseUrl.trim().length > 0
+			? baseUrl
+			: DEFAULT_OPENAI_CODEX_BASE_URL;
+	const normalized = raw.replace(/\/+$/u, "");
+	if (normalized.endsWith("/codex/responses")) return normalized;
+	if (normalized.endsWith("/codex")) return `${normalized}/responses`;
+	return `${normalized}/codex/responses`;
+}
+
+export function resolveOpenAICodexAccountId(
+	token: string,
+	headers: Record<string, string> | undefined,
+): string {
+	for (const [key, value] of Object.entries(headers ?? {})) {
+		if (key.toLowerCase() === "chatgpt-account-id" && value.trim()) {
+			return value.trim();
+		}
+	}
+	const accountId =
+		process.env.OPENAI_CODEX_ACCOUNT_ID?.trim() ??
+		process.env.CHATGPT_ACCOUNT_ID?.trim() ??
+		extractOpenAICodexAccountId(token);
+	if (!accountId) {
+		throw new Error(
+			"OpenAI Codex account id is required. Log in with /login openai-codex or set OPENAI_CODEX_ACCOUNT_ID.",
+		);
+	}
+	return accountId;
+}
+
+export function resolveOpenAICodexSession(
+	options: ResolveOpenAICodexSessionOptions,
+): OpenAICodexSession {
+	const accountId = resolveOpenAICodexAccountId(
+		options.token,
+		options.optionHeaders,
+	);
+	const headers = new Headers(options.modelHeaders);
+	for (const [key, value] of Object.entries(options.optionHeaders ?? {})) {
+		headers.set(key, value);
+	}
+	headers.set("Authorization", `Bearer ${options.token}`);
+	headers.set("chatgpt-account-id", accountId);
+	headers.set("originator", OPENAI_CODEX_ORIGINATOR);
+	headers.set("User-Agent", `maestro (${platform()} ${release()}; ${arch()})`);
+	headers.set("OpenAI-Beta", "responses=experimental");
+	headers.set("accept", "text/event-stream");
+	headers.set("content-type", "application/json");
+	if (options.sessionId) {
+		headers.set("session_id", options.sessionId);
+		headers.set("x-client-request-id", options.sessionId);
+	}
+	return {
+		url: resolveOpenAICodexUrl(options.modelBaseUrl),
+		accountId,
+		headers,
+	};
+}

--- a/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
+++ b/src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
@@ -154,6 +154,7 @@ BEGIN
 		AND column_name = 'status';
 
 	IF status_type IS NOT NULL AND status_type <> 'webhook_delivery_status' THEN
+		ALTER TABLE "webhook_deliveries" ALTER COLUMN "status" DROP DEFAULT;
 		ALTER TABLE "webhook_deliveries"
 			ALTER COLUMN "status" TYPE "webhook_delivery_status"
 			USING (
@@ -196,7 +197,7 @@ BEGIN
 	WHERE "url" = '' AND "status"::text IN ('pending', 'retrying');
 
 	ALTER TABLE "webhook_deliveries" ALTER COLUMN "payload" SET NOT NULL;
-	ALTER TABLE "webhook_deliveries" ALTER COLUMN "status" SET DEFAULT 'pending';
+	ALTER TABLE "webhook_deliveries" ALTER COLUMN "status" SET DEFAULT 'pending'::"webhook_delivery_status";
 	ALTER TABLE "webhook_deliveries" ALTER COLUMN "status" SET NOT NULL;
 	ALTER TABLE "webhook_deliveries" ALTER COLUMN "attempts" SET DEFAULT 0;
 	ALTER TABLE "webhook_deliveries" ALTER COLUMN "attempts" SET NOT NULL;

--- a/src/server/handlers/runtime-app-server-ws.ts
+++ b/src/server/handlers/runtime-app-server-ws.ts
@@ -1,0 +1,257 @@
+import {
+	type RuntimeAppServerClientRequest,
+	type RuntimeAppServerInitializeResult,
+	type RuntimeAppServerModelProviderCapabilitiesResult,
+	type RuntimeAppServerResponse,
+	type RuntimeAppServerServerNotification,
+	runtimeAppServerProtocolVersion,
+} from "@evalops/contracts";
+import type { WebSocket } from "ws";
+import { getRegisteredModels } from "../../models/registry.js";
+import {
+	type ServerRequestLifecycleEvent,
+	type ServerRequestManager,
+	serverRequestManager as defaultServerRequestManager,
+} from "../server-request-manager.js";
+
+interface RuntimeAppServerOptions {
+	serverRequestManager?: ServerRequestManager;
+	sessionId?: string;
+	validateSessionAccess?: (sessionId: string) => boolean | Promise<boolean>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function canWrite(ws: WebSocket): boolean {
+	return ws.readyState === 1;
+}
+
+function send(
+	ws: WebSocket,
+	payload: RuntimeAppServerResponse | RuntimeAppServerServerNotification,
+): void {
+	if (!canWrite(ws)) return;
+	try {
+		ws.send(JSON.stringify(payload));
+	} catch {
+		// Disconnect races can close the socket after readyState is checked.
+	}
+}
+
+function toErrorResponse(
+	id: string | number | null,
+	code: number,
+	message: string,
+): RuntimeAppServerResponse {
+	return {
+		jsonrpc: "2.0",
+		id,
+		error: { code, message },
+	};
+}
+
+function parseClientRequest(raw: unknown): RuntimeAppServerClientRequest {
+	if (!isRecord(raw)) {
+		throw new Error("Runtime app-server request must be an object");
+	}
+	if (raw.jsonrpc !== "2.0") {
+		throw new Error("Runtime app-server request must use JSON-RPC 2.0");
+	}
+	if (typeof raw.id !== "string" && typeof raw.id !== "number") {
+		throw new Error("Runtime app-server request id must be a string or number");
+	}
+	if (
+		raw.method !== "runtime.initialize" &&
+		raw.method !== "runtime.model_provider_capabilities.read" &&
+		raw.method !== "runtime.ping"
+	) {
+		throw new Error("Unsupported runtime app-server method");
+	}
+	return raw as RuntimeAppServerClientRequest;
+}
+
+function initializeResult(): RuntimeAppServerInitializeResult {
+	return {
+		protocolVersion: runtimeAppServerProtocolVersion,
+		serverInfo: { name: "maestro" },
+		capabilities: {
+			chat: false,
+			serverRequests: true,
+			modelCapabilities: true,
+		},
+	};
+}
+
+function modelProviderCapabilities(): RuntimeAppServerModelProviderCapabilitiesResult {
+	const providers = new Map<
+		string,
+		RuntimeAppServerModelProviderCapabilitiesResult["providers"][number]
+	>();
+	for (const model of getRegisteredModels()) {
+		const provider = providers.get(model.provider) ?? {
+			id: model.provider,
+			name: model.providerName,
+			models: [],
+		};
+		provider.models.push({
+			id: model.id,
+			name: model.name,
+			api: model.api,
+			provider: model.provider,
+			source: model.source,
+			contextWindow: model.contextWindow,
+			maxTokens: model.maxTokens,
+			capabilities: {
+				streaming: true,
+				tools: Boolean(model.toolUse),
+				vision: model.input.includes("image"),
+				reasoning: Boolean(model.reasoning),
+				local: model.isLocal,
+			},
+		});
+		providers.set(model.provider, provider);
+	}
+	return {
+		providers: Array.from(providers.values()).sort((left, right) =>
+			left.id.localeCompare(right.id),
+		),
+	};
+}
+
+function serverRequestMethod(event: ServerRequestLifecycleEvent) {
+	return event.type === "registered"
+		? "runtime.server_request.registered"
+		: "runtime.server_request.resolved";
+}
+
+export function handleRuntimeAppServerWebSocket(
+	ws: WebSocket,
+	options: RuntimeAppServerOptions = {},
+): void {
+	const manager = options.serverRequestManager ?? defaultServerRequestManager;
+	let sessionId = options.sessionId;
+	let bindingSessionId: string | undefined;
+	const sentRegisteredRequestIds = new Set<string>();
+	const sendServerRequestEvent = (event: ServerRequestLifecycleEvent): void => {
+		if (event.type === "registered") {
+			sentRegisteredRequestIds.add(event.request.id);
+		}
+		send(ws, {
+			jsonrpc: "2.0",
+			method: serverRequestMethod(event),
+			params: event,
+		});
+	};
+	const replayPendingServerRequests = (): void => {
+		if (!sessionId) {
+			return;
+		}
+		for (const request of manager.listPending({ sessionId })) {
+			if (sentRegisteredRequestIds.has(request.id)) {
+				continue;
+			}
+			sendServerRequestEvent({
+				type: "registered",
+				request,
+			});
+		}
+	};
+	const bindSessionId = async (requestedSessionId: unknown): Promise<void> => {
+		if (typeof requestedSessionId !== "string" || !requestedSessionId.trim()) {
+			return;
+		}
+		const nextSessionId = requestedSessionId.trim();
+		if (sessionId && sessionId !== nextSessionId) {
+			throw new Error("Runtime app-server session is already bound");
+		}
+		if (bindingSessionId && bindingSessionId !== nextSessionId) {
+			throw new Error(
+				"Runtime app-server session binding is already in progress",
+			);
+		}
+		bindingSessionId = nextSessionId;
+		try {
+			if (
+				options.validateSessionAccess &&
+				!(await options.validateSessionAccess(nextSessionId))
+			) {
+				throw new Error("Runtime app-server session access denied");
+			}
+			if (sessionId && sessionId !== nextSessionId) {
+				throw new Error("Runtime app-server session is already bound");
+			}
+			sessionId = nextSessionId;
+		} finally {
+			if (bindingSessionId === nextSessionId) {
+				bindingSessionId = undefined;
+			}
+		}
+	};
+	const unsubscribe = manager.subscribe((event) => {
+		if (!sessionId || event.request.sessionId !== sessionId) {
+			return;
+		}
+		sendServerRequestEvent(event);
+	});
+	replayPendingServerRequests();
+
+	ws.on("message", async (data) => {
+		let parsed: unknown;
+		try {
+			try {
+				parsed = JSON.parse(String(data));
+			} catch {
+				send(ws, toErrorResponse(null, -32700, "Parse error"));
+				return;
+			}
+			const request = parseClientRequest(parsed);
+			if (request.method === "runtime.initialize") {
+				const requestedSessionId = isRecord(request.params)
+					? request.params.sessionId
+					: undefined;
+				await bindSessionId(requestedSessionId);
+				const result = initializeResult();
+				send(ws, { jsonrpc: "2.0", id: request.id, result });
+				send(ws, {
+					jsonrpc: "2.0",
+					method: "runtime.initialized",
+					params: result,
+				});
+				replayPendingServerRequests();
+				return;
+			}
+			if (request.method === "runtime.model_provider_capabilities.read") {
+				send(ws, {
+					jsonrpc: "2.0",
+					id: request.id,
+					result: modelProviderCapabilities(),
+				});
+				return;
+			}
+			send(ws, { jsonrpc: "2.0", id: request.id, result: { ok: true } });
+		} catch (error) {
+			const id =
+				isRecord(parsed) &&
+				(typeof parsed.id === "string" || typeof parsed.id === "number")
+					? parsed.id
+					: null;
+			send(
+				ws,
+				toErrorResponse(
+					id,
+					error instanceof Error &&
+						error.message === "Unsupported runtime app-server method"
+						? -32601
+						: -32600,
+					error instanceof Error ? error.message : "Invalid request",
+				),
+			);
+		}
+	});
+
+	ws.on("close", () => {
+		unsubscribe();
+	});
+}

--- a/src/server/runtime-ws-access.ts
+++ b/src/server/runtime-ws-access.ts
@@ -1,0 +1,51 @@
+import type { IncomingMessage } from "node:http";
+
+type RuntimeWebSocketAccessValidator = (
+	req: IncomingMessage,
+	sessionId: string,
+) => boolean | Promise<boolean>;
+
+interface RuntimeWebSocketUpgradeSocket {
+	write(payload: string): unknown;
+	destroy(): unknown;
+}
+
+interface RuntimeWebSocketSessionAuthorizationOptions {
+	req: IncomingMessage;
+	socket: RuntimeWebSocketUpgradeSocket;
+	requestedSessionId: string | null;
+	validateSessionAccess: RuntimeWebSocketAccessValidator;
+	logAccessError?: (error: Error) => void;
+}
+
+function rejectUpgrade(
+	socket: RuntimeWebSocketUpgradeSocket,
+	statusLine: string,
+): null {
+	socket.write(`${statusLine}\r\n\r\n`);
+	socket.destroy();
+	return null;
+}
+
+export async function authorizeRuntimeWebSocketSession({
+	req,
+	socket,
+	requestedSessionId,
+	validateSessionAccess,
+	logAccessError,
+}: RuntimeWebSocketSessionAuthorizationOptions): Promise<
+	string | null | undefined
+> {
+	if (!requestedSessionId) {
+		return undefined;
+	}
+	try {
+		if (await validateSessionAccess(req, requestedSessionId)) {
+			return requestedSessionId;
+		}
+		return rejectUpgrade(socket, "HTTP/1.1 403 Forbidden");
+	} catch (error) {
+		logAccessError?.(error instanceof Error ? error : new Error(String(error)));
+		return rejectUpgrade(socket, "HTTP/1.1 500 Internal Server Error");
+	}
+}

--- a/src/server/server-request-manager.ts
+++ b/src/server/server-request-manager.ts
@@ -1,4 +1,13 @@
 import type {
+	RuntimeServerRequestKind,
+	RuntimeServerRequestLifecycleEvent,
+	RuntimeServerRequestRegisteredEvent,
+	RuntimeServerRequestResolution,
+	RuntimeServerRequestResolvedBy,
+	RuntimeServerRequestResolvedEvent,
+	RuntimeServerRequestSnapshot,
+} from "@evalops/contracts";
+import type {
 	ActionApprovalDecision,
 	ActionApprovalRequest,
 	ActionApprovalService,
@@ -12,55 +21,13 @@ import type { ImageContent, TextContent } from "../agent/types.js";
 
 type ToolResultContent = TextContent | ImageContent;
 
-export type ServerRequestKind =
-	| "approval"
-	| "client_tool"
-	| "mcp_elicitation"
-	| "user_input"
-	| "tool_retry";
-export type ServerRequestResolution =
-	| "approved"
-	| "denied"
-	| "completed"
-	| "failed"
-	| "answered"
-	| "retried"
-	| "skipped"
-	| "aborted"
-	| "cancelled";
-
-export interface PendingServerRequestSnapshot {
-	id: string;
-	kind: ServerRequestKind;
-	sessionId?: string;
-	callId: string;
-	toolName: string;
-	displayName?: string;
-	summaryLabel?: string;
-	actionDescription?: string;
-	args: unknown;
-	reason: string;
-	timestamp: number;
-	timeoutMs: number;
-	platform?: ActionApprovalRequest["platform"];
-}
-
-export interface ServerRequestRegisteredEvent {
-	type: "registered";
-	request: PendingServerRequestSnapshot;
-}
-
-export interface ServerRequestResolvedEvent {
-	type: "resolved";
-	request: PendingServerRequestSnapshot;
-	resolution: ServerRequestResolution;
-	reason?: string;
-	resolvedBy: "user" | "policy" | "client" | "runtime";
-}
-
-export type ServerRequestLifecycleEvent =
-	| ServerRequestRegisteredEvent
-	| ServerRequestResolvedEvent;
+export type ServerRequestKind = RuntimeServerRequestKind;
+export type ServerRequestResolution = RuntimeServerRequestResolution;
+export type ServerRequestResolvedBy = RuntimeServerRequestResolvedBy;
+export type PendingServerRequestSnapshot = RuntimeServerRequestSnapshot;
+export type ServerRequestRegisteredEvent = RuntimeServerRequestRegisteredEvent;
+export type ServerRequestResolvedEvent = RuntimeServerRequestResolvedEvent;
+export type ServerRequestLifecycleEvent = RuntimeServerRequestLifecycleEvent;
 
 type ServerRequestListener = (event: ServerRequestLifecycleEvent) => void;
 

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -122,10 +122,15 @@ const getDbModule = (() => {
 	};
 })();
 import { WebActionApprovalService } from "./server/approval-service.js";
-import { checkApiAuth } from "./server/authz.js";
+import { checkApiAuth, getAuthSubject } from "./server/authz.js";
 import { startAutomationScheduler } from "./server/automations/scheduler.js";
 import { clientToolService } from "./server/client-tools-service.js";
 import { handleChatWebSocket } from "./server/handlers/chat-ws.js";
+import { handleRuntimeAppServerWebSocket } from "./server/handlers/runtime-app-server-ws.js";
+import {
+	sessionIdPattern,
+	verifySessionOwnership,
+} from "./server/handlers/sessions.js";
 import { HeadlessRuntimeService } from "./server/headless-runtime-service.js";
 import {
 	isOverloaded,
@@ -149,6 +154,7 @@ import {
 import { requestTracker } from "./server/request-tracker.js";
 import { createRequestHandler } from "./server/router.js";
 import { createRoutes } from "./server/routes.js";
+import { authorizeRuntimeWebSocketSession } from "./server/runtime-ws-access.js";
 import {
 	createAuthMiddleware,
 	createCorsMiddleware,
@@ -163,6 +169,7 @@ import {
 	createCorsHeaders,
 	sendJson,
 } from "./server/server-utils.js";
+import { createWebSessionManagerForRequest } from "./server/session-scope.js";
 import { serveStatic } from "./server/static-server.js";
 import { resolveWebRoot } from "./server/web-root.js";
 
@@ -189,6 +196,21 @@ function registerCrashHandlers() {
 		logger.error("FATAL: Unhandled Rejection. Exiting...");
 		process.exit(1);
 	});
+}
+
+async function validateRuntimeSessionAccess(
+	req: IncomingMessage,
+	sessionId: string,
+): Promise<boolean> {
+	if (!sessionIdPattern.test(sessionId)) {
+		return false;
+	}
+	const sessionManager = createWebSessionManagerForRequest(req, false);
+	const session = await sessionManager.loadSession(sessionId);
+	if (!session) {
+		return false;
+	}
+	return verifySessionOwnership(session, getAuthSubject(req));
 }
 
 function normalizeAuthMode(value?: string | null): AuthMode {
@@ -857,7 +879,7 @@ export async function startWebServer(
 			req.url || "/",
 			`http://${req.headers.host || "localhost"}`,
 		);
-		if (url.pathname !== "/api/chat/ws") {
+		if (url.pathname !== "/api/chat/ws" && url.pathname !== "/api/runtime/ws") {
 			socket.destroy();
 			return;
 		}
@@ -877,7 +899,30 @@ export async function startWebServer(
 			return;
 		}
 
+		let runtimeSessionId: string | undefined;
+		if (url.pathname === "/api/runtime/ws") {
+			const authorization = await authorizeRuntimeWebSocketSession({
+				req,
+				socket,
+				requestedSessionId: url.searchParams.get("sessionId"),
+				validateSessionAccess: validateRuntimeSessionAccess,
+				logAccessError: logError,
+			});
+			if (authorization === null) {
+				return;
+			}
+			runtimeSessionId = authorization;
+		}
+
 		wsServer.handleUpgrade(req, socket, head, (ws) => {
+			if (url.pathname === "/api/runtime/ws") {
+				handleRuntimeAppServerWebSocket(ws, {
+					sessionId: runtimeSessionId,
+					validateSessionAccess: (sessionId) =>
+						validateRuntimeSessionAccess(req, sessionId),
+				});
+				return;
+			}
 			handleChatWebSocket(ws, req, context);
 		});
 	});

--- a/test/agent/openai-codex-session.test.ts
+++ b/test/agent/openai-codex-session.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+	resolveOpenAICodexSession,
+	resolveOpenAICodexUrl,
+} from "../../src/agent/providers/openai-codex-session.js";
+
+function encodeBase64Url(value: unknown): string {
+	return Buffer.from(JSON.stringify(value))
+		.toString("base64")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/g, "");
+}
+
+function fakeCodexToken(accountId = "acct_chatgpt"): string {
+	return [
+		encodeBase64Url({ alg: "none" }),
+		encodeBase64Url({
+			"https://api.openai.com/auth": { chatgpt_account_id: accountId },
+		}),
+		"sig",
+	].join(".");
+}
+
+describe("OpenAI Codex session helpers", () => {
+	it("normalizes ChatGPT Codex URLs without leaking transport details into providers", () => {
+		expect(resolveOpenAICodexUrl()).toBe(
+			"https://chatgpt.com/backend-api/codex/responses",
+		);
+		expect(resolveOpenAICodexUrl("https://chatgpt.com/backend-api/")).toBe(
+			"https://chatgpt.com/backend-api/codex/responses",
+		);
+		expect(resolveOpenAICodexUrl("https://example.test/codex")).toBe(
+			"https://example.test/codex/responses",
+		);
+	});
+
+	it("builds the first-party account session headers in one boundary", () => {
+		const session = resolveOpenAICodexSession({
+			token: fakeCodexToken("acct_from_token"),
+			sessionId: "session_123",
+			optionHeaders: { "x-extra": "1" },
+		});
+
+		expect(session.accountId).toBe("acct_from_token");
+		expect(session.url).toBe("https://chatgpt.com/backend-api/codex/responses");
+		expect(session.headers.get("authorization")).toMatch(/^Bearer /);
+		expect(session.headers.get("chatgpt-account-id")).toBe("acct_from_token");
+		expect(session.headers.get("originator")).toBe("codex_cli_rs");
+		expect(session.headers.get("openai-beta")).toBe("responses=experimental");
+		expect(session.headers.get("session_id")).toBe("session_123");
+		expect(session.headers.get("x-client-request-id")).toBe("session_123");
+		expect(session.headers.get("x-extra")).toBe("1");
+	});
+
+	it("lets explicit account headers override token-derived account ids", () => {
+		const session = resolveOpenAICodexSession({
+			token: fakeCodexToken("acct_from_token"),
+			optionHeaders: { "chatgpt-account-id": "acct_from_header" },
+		});
+
+		expect(session.accountId).toBe("acct_from_header");
+		expect(session.headers.get("chatgpt-account-id")).toBe("acct_from_header");
+	});
+});

--- a/test/contracts/headless-schema-fixtures.test.ts
+++ b/test/contracts/headless-schema-fixtures.test.ts
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { headlessProtocolVersion } from "../../packages/contracts/src/headless-protocol-generated.js";
+
+describe("headless schema fixtures", () => {
+	it("publishes protocol and payload fixtures for drift review", async () => {
+		const protocol = JSON.parse(
+			await readFile(
+				"packages/contracts/schema/headless/protocol.json",
+				"utf8",
+			),
+		) as {
+			protocolVersion: string;
+			fromAgentMessageTypes: string[];
+			serverRequestTypes: string[];
+		};
+		const payloads = JSON.parse(
+			await readFile(
+				"packages/contracts/schema/headless/payload-schemas.json",
+				"utf8",
+			),
+		) as { fromAgentSchemas: Record<string, unknown> };
+
+		expect(protocol.protocolVersion).toBe(headlessProtocolVersion);
+		expect(protocol.fromAgentMessageTypes).toContain("server_request");
+		expect(protocol.serverRequestTypes).toEqual([
+			"approval",
+			"client_tool",
+			"mcp_elicitation",
+			"user_input",
+			"tool_retry",
+		]);
+		expect(payloads.fromAgentSchemas).toHaveProperty(
+			"HeadlessServerRequestMessageSchema",
+		);
+	});
+});

--- a/test/server/runtime-app-server-ws.test.ts
+++ b/test/server/runtime-app-server-ws.test.ts
@@ -1,0 +1,413 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { ActionApprovalService } from "../../src/agent/action-approval.js";
+import { handleRuntimeAppServerWebSocket } from "../../src/server/handlers/runtime-app-server-ws.js";
+import { ServerRequestManager } from "../../src/server/server-request-manager.js";
+
+class FakeSocket extends EventEmitter {
+	readyState = 1;
+	readonly sent: string[] = [];
+	closed = false;
+
+	send(payload: string) {
+		this.sent.push(payload);
+	}
+
+	close() {
+		this.closed = true;
+		this.readyState = 3;
+	}
+}
+
+class ThrowingSocket extends FakeSocket {
+	override send(_payload: string) {
+		throw new Error("peer disconnected mid-send");
+	}
+}
+
+describe("runtime app-server WebSocket", () => {
+	it("responds to initialize with a typed runtime protocol handshake", async () => {
+		const socket = new FakeSocket();
+		handleRuntimeAppServerWebSocket(socket as unknown as WebSocket, {
+			serverRequestManager: new ServerRequestManager(),
+		});
+
+		socket.emit(
+			"message",
+			JSON.stringify({
+				jsonrpc: "2.0",
+				id: "init-1",
+				method: "runtime.initialize",
+				params: { clientInfo: { name: "test-client" }, sessionId: "sess_1" },
+			}),
+		);
+		await Promise.resolve();
+
+		const response = JSON.parse(socket.sent[0] ?? "{}");
+		expect(response).toMatchObject({
+			jsonrpc: "2.0",
+			id: "init-1",
+			result: {
+				protocolVersion: "runtime-app-server.v1",
+				capabilities: {
+					chat: false,
+					serverRequests: true,
+					modelCapabilities: true,
+				},
+			},
+		});
+	});
+
+	it("exposes registered model provider capabilities", async () => {
+		const socket = new FakeSocket();
+		handleRuntimeAppServerWebSocket(socket as unknown as WebSocket, {
+			serverRequestManager: new ServerRequestManager(),
+		});
+
+		socket.emit(
+			"message",
+			JSON.stringify({
+				jsonrpc: "2.0",
+				id: "models-1",
+				method: "runtime.model_provider_capabilities.read",
+			}),
+		);
+		await Promise.resolve();
+
+		const response = JSON.parse(socket.sent[0] ?? "{}");
+		expect(response).toMatchObject({
+			jsonrpc: "2.0",
+			id: "models-1",
+			result: {
+				providers: expect.arrayContaining([
+					expect.objectContaining({
+						id: "openai-codex",
+						models: expect.arrayContaining([
+							expect.objectContaining({
+								api: "openai-codex-responses",
+								capabilities: expect.objectContaining({
+									streaming: true,
+									reasoning: true,
+								}),
+							}),
+						]),
+					}),
+				]),
+			},
+		});
+	});
+
+	it("streams server request lifecycle notifications", async () => {
+		const socket = new FakeSocket();
+		const manager = new ServerRequestManager();
+		const approvalService = new ActionApprovalService("prompt");
+		vi.spyOn(approvalService, "resolve").mockReturnValue(true);
+
+		handleRuntimeAppServerWebSocket(socket as unknown as WebSocket, {
+			serverRequestManager: manager,
+			sessionId: "sess_1",
+		});
+
+		manager.registerApproval({
+			sessionId: "sess_other",
+			request: {
+				id: "approval_other",
+				toolName: "bash",
+				args: { command: "cat secret.txt" },
+				reason: "Approval required",
+			},
+			service: approvalService,
+		});
+		manager.registerApproval({
+			sessionId: "sess_1",
+			request: {
+				id: "approval_1",
+				toolName: "bash",
+				args: { command: "git status" },
+				reason: "Approval required",
+			},
+			service: approvalService,
+		});
+		manager.resolveApproval("approval_1", {
+			approved: true,
+			reason: "ok",
+			resolvedBy: "user",
+		});
+
+		const notifications = socket.sent.map((payload) => JSON.parse(payload));
+		expect(notifications).toEqual([
+			expect.objectContaining({
+				jsonrpc: "2.0",
+				method: "runtime.server_request.registered",
+				params: expect.objectContaining({
+					type: "registered",
+					request: expect.objectContaining({
+						id: "approval_1",
+						kind: "approval",
+						sessionId: "sess_1",
+					}),
+				}),
+			}),
+			expect.objectContaining({
+				jsonrpc: "2.0",
+				method: "runtime.server_request.resolved",
+				params: expect.objectContaining({
+					resolution: "approved",
+					resolvedBy: "user",
+				}),
+			}),
+		]);
+	});
+
+	it("does not let disconnect-race send failures escape server request notifications", () => {
+		const socket = new ThrowingSocket();
+		const manager = new ServerRequestManager();
+		const approvalService = new ActionApprovalService("prompt");
+
+		handleRuntimeAppServerWebSocket(socket as unknown as WebSocket, {
+			serverRequestManager: manager,
+			sessionId: "sess_1",
+		});
+
+		expect(() =>
+			manager.registerApproval({
+				sessionId: "sess_1",
+				request: {
+					id: "approval_1",
+					toolName: "bash",
+					args: { command: "git status" },
+					reason: "Approval required",
+				},
+				service: approvalService,
+			}),
+		).not.toThrow();
+	});
+
+	it("replays pending server requests after session initialization", async () => {
+		const socket = new FakeSocket();
+		const manager = new ServerRequestManager();
+		const approvalService = new ActionApprovalService("prompt");
+
+		manager.registerApproval({
+			sessionId: "sess_other",
+			request: {
+				id: "approval_other",
+				toolName: "bash",
+				args: { command: "cat secret.txt" },
+				reason: "Approval required",
+			},
+			service: approvalService,
+		});
+		manager.registerApproval({
+			sessionId: "sess_1",
+			request: {
+				id: "approval_pending",
+				toolName: "bash",
+				args: { command: "git diff" },
+				reason: "Approval required",
+			},
+			service: approvalService,
+		});
+
+		handleRuntimeAppServerWebSocket(socket as unknown as WebSocket, {
+			serverRequestManager: manager,
+		});
+
+		socket.emit(
+			"message",
+			JSON.stringify({
+				jsonrpc: "2.0",
+				id: "init-1",
+				method: "runtime.initialize",
+				params: { sessionId: "sess_1" },
+			}),
+		);
+		await Promise.resolve();
+
+		const notifications = socket.sent.map((payload) => JSON.parse(payload));
+		expect(notifications).toEqual([
+			expect.objectContaining({
+				jsonrpc: "2.0",
+				id: "init-1",
+			}),
+			expect.objectContaining({
+				jsonrpc: "2.0",
+				method: "runtime.initialized",
+			}),
+			expect.objectContaining({
+				jsonrpc: "2.0",
+				method: "runtime.server_request.registered",
+				params: expect.objectContaining({
+					type: "registered",
+					request: expect.objectContaining({
+						id: "approval_pending",
+						kind: "approval",
+						sessionId: "sess_1",
+					}),
+				}),
+			}),
+		]);
+		expect(
+			notifications.some(
+				(notification) => notification.params?.request?.id === "approval_other",
+			),
+		).toBe(false);
+	});
+
+	it("rejects session initialization when access validation fails", async () => {
+		const socket = new FakeSocket();
+		const manager = new ServerRequestManager();
+		const approvalService = new ActionApprovalService("prompt");
+
+		manager.registerApproval({
+			sessionId: "sess_private",
+			request: {
+				id: "approval_private",
+				toolName: "bash",
+				args: { command: "cat secret.txt" },
+				reason: "Approval required",
+			},
+			service: approvalService,
+		});
+
+		handleRuntimeAppServerWebSocket(socket as unknown as WebSocket, {
+			serverRequestManager: manager,
+			validateSessionAccess: (sessionId) => sessionId === "sess_allowed",
+		});
+
+		socket.emit(
+			"message",
+			JSON.stringify({
+				jsonrpc: "2.0",
+				id: "init-private",
+				method: "runtime.initialize",
+				params: { sessionId: "sess_private" },
+			}),
+		);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		const messages = socket.sent.map((payload) => JSON.parse(payload));
+		expect(messages).toEqual([
+			expect.objectContaining({
+				jsonrpc: "2.0",
+				id: "init-private",
+				error: expect.objectContaining({
+					code: -32600,
+					message: "Runtime app-server session access denied",
+				}),
+			}),
+		]);
+	});
+
+	it("returns a JSON-RPC parse error with a null id for malformed frames", async () => {
+		const socket = new FakeSocket();
+		handleRuntimeAppServerWebSocket(socket as unknown as WebSocket, {
+			serverRequestManager: new ServerRequestManager(),
+		});
+
+		socket.emit("message", "{");
+		await Promise.resolve();
+
+		expect(socket.sent.map((payload) => JSON.parse(payload))).toEqual([
+			{
+				jsonrpc: "2.0",
+				id: null,
+				error: {
+					code: -32700,
+					message: "Parse error",
+				},
+			},
+		]);
+	});
+
+	it("returns a JSON-RPC invalid request error with a null id when the request id is invalid", async () => {
+		const socket = new FakeSocket();
+		handleRuntimeAppServerWebSocket(socket as unknown as WebSocket, {
+			serverRequestManager: new ServerRequestManager(),
+		});
+
+		socket.emit(
+			"message",
+			JSON.stringify({
+				jsonrpc: "2.0",
+				id: null,
+				method: "runtime.ping",
+			}),
+		);
+		await Promise.resolve();
+
+		expect(socket.sent.map((payload) => JSON.parse(payload))).toEqual([
+			{
+				jsonrpc: "2.0",
+				id: null,
+				error: {
+					code: -32600,
+					message: "Runtime app-server request id must be a string or number",
+				},
+			},
+		]);
+	});
+
+	it("rejects concurrent initialization that races session binding", async () => {
+		const socket = new FakeSocket();
+		let finishFirstValidation: (() => void) | undefined;
+
+		handleRuntimeAppServerWebSocket(socket as unknown as WebSocket, {
+			serverRequestManager: new ServerRequestManager(),
+			validateSessionAccess: (sessionId) => {
+				if (sessionId !== "sess_a") {
+					return true;
+				}
+				return new Promise<boolean>((resolve) => {
+					finishFirstValidation = () => resolve(true);
+				});
+			},
+		});
+
+		socket.emit(
+			"message",
+			JSON.stringify({
+				jsonrpc: "2.0",
+				id: "init-a",
+				method: "runtime.initialize",
+				params: { sessionId: "sess_a" },
+			}),
+		);
+		await Promise.resolve();
+		socket.emit(
+			"message",
+			JSON.stringify({
+				jsonrpc: "2.0",
+				id: "init-b",
+				method: "runtime.initialize",
+				params: { sessionId: "sess_b" },
+			}),
+		);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		finishFirstValidation?.();
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		const messages = socket.sent.map((payload) => JSON.parse(payload));
+		expect(messages).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					jsonrpc: "2.0",
+					id: "init-a",
+					result: expect.objectContaining({
+						protocolVersion: "runtime-app-server.v1",
+					}),
+				}),
+				expect.objectContaining({
+					jsonrpc: "2.0",
+					id: "init-b",
+					error: expect.objectContaining({
+						code: -32600,
+						message:
+							"Runtime app-server session binding is already in progress",
+					}),
+				}),
+			]),
+		);
+	});
+});

--- a/test/server/runtime-ws-access.test.ts
+++ b/test/server/runtime-ws-access.test.ts
@@ -1,0 +1,76 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { authorizeRuntimeWebSocketSession } from "../../src/server/runtime-ws-access.js";
+
+class FakeSocket extends EventEmitter {
+	readonly writes: string[] = [];
+	destroyed = false;
+
+	write(payload: string) {
+		this.writes.push(payload);
+	}
+
+	destroy() {
+		this.destroyed = true;
+	}
+}
+
+describe("authorizeRuntimeWebSocketSession", () => {
+	const request = {} as IncomingMessage;
+
+	it("returns the requested session id when access validation allows it", async () => {
+		const socket = new FakeSocket();
+
+		await expect(
+			authorizeRuntimeWebSocketSession({
+				req: request,
+				socket,
+				requestedSessionId: "sess_1",
+				validateSessionAccess: async (_req, sessionId) =>
+					sessionId === "sess_1",
+			}),
+		).resolves.toBe("sess_1");
+		expect(socket.writes).toEqual([]);
+		expect(socket.destroyed).toBe(false);
+	});
+
+	it("rejects denied session ids before upgrading the socket", async () => {
+		const socket = new FakeSocket();
+
+		await expect(
+			authorizeRuntimeWebSocketSession({
+				req: request,
+				socket,
+				requestedSessionId: "sess_private",
+				validateSessionAccess: async () => false,
+			}),
+		).resolves.toBeNull();
+		expect(socket.writes).toEqual(["HTTP/1.1 403 Forbidden\r\n\r\n"]);
+		expect(socket.destroyed).toBe(true);
+	});
+
+	it("returns an HTTP failure instead of leaking access-check exceptions", async () => {
+		const socket = new FakeSocket();
+		const logAccessError = vi.fn();
+
+		await expect(
+			authorizeRuntimeWebSocketSession({
+				req: request,
+				socket,
+				requestedSessionId: "sess_1",
+				validateSessionAccess: async () => {
+					throw new Error("session store unavailable");
+				},
+				logAccessError,
+			}),
+		).resolves.toBeNull();
+		expect(socket.writes).toEqual([
+			"HTTP/1.1 500 Internal Server Error\r\n\r\n",
+		]);
+		expect(socket.destroyed).toBe(true);
+		expect(logAccessError).toHaveBeenCalledWith(
+			expect.objectContaining({ message: "session store unavailable" }),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `41821052c077fcb27408d7bb3d2feedf4a6ac266`
- last generated public sync base: `dfdc761788d2c184001d8c6f35d52014f21e9355`
- previewed public-tree drift: `15` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (41821052c077)`
- public projection: `https://github.com/evalops/maestro@main (4625f155fc3d)`
- files to copy or update: `15`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/contracts/src/index.ts
- copy/update packages/contracts/src/runtime-app-server.ts
- copy/update packages/contracts/src/runtime-server-request.ts
- copy/update scripts/codegen-utils.mjs
- copy/update src/agent/providers/openai-codex-responses.ts
- copy/update src/agent/providers/openai-codex-session.ts
- copy/update src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
- copy/update src/server/handlers/runtime-app-server-ws.ts
- copy/update src/server/runtime-ws-access.ts
- copy/update src/server/server-request-manager.ts
- copy/update src/web-server.ts
- copy/update test/agent/openai-codex-session.test.ts
- copy/update test/contracts/headless-schema-fixtures.test.ts
- copy/update test/server/runtime-app-server-ws.test.ts
- copy/update test/server/runtime-ws-access.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/contracts/src/index.ts
- copy/update packages/contracts/src/runtime-app-server.ts
- copy/update packages/contracts/src/runtime-server-request.ts
- copy/update scripts/codegen-utils.mjs
- copy/update src/agent/providers/openai-codex-responses.ts
- copy/update src/agent/providers/openai-codex-session.ts
- copy/update src/db/migrations/0008_reconcile_legacy_webhook_deliveries.sql
- copy/update src/server/handlers/runtime-app-server-ws.ts
- copy/update src/server/runtime-ws-access.ts
- copy/update src/server/server-request-manager.ts
- copy/update src/web-server.ts
- copy/update test/agent/openai-codex-session.test.ts
- copy/update test/contracts/headless-schema-fixtures.test.ts
- copy/update test/server/runtime-app-server-ws.test.ts
- copy/update test/server/runtime-ws-access.test.ts

## Public-only commits since last generated sync

- 4625f155 [maestro] sync headless protocol codegen cleanup

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #239 to internal source `41821052c077fcb27408d7bb3d2feedf4a6ac266`