### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/providers/anthropic-auth.ts
+++ b/src/providers/anthropic-auth.ts
@@ -52,6 +52,7 @@ import { rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { getAgentDir } from "../config/constants.js";
 import { safeJsonParse } from "../utils/json.js";
+import { fetchOAuthHttp } from "../utils/oauth-http.js";
 
 // Portions of this module are derived from https://github.com/sst/opencode-anthropic-auth (MIT).
 
@@ -65,6 +66,7 @@ export interface AnthropicOAuthCredential {
 }
 
 const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const ANTHROPIC_OAUTH_SERVICE_NAME = "Anthropic OAuth service";
 
 const CLAUDE_LOGIN_HOST: Record<AnthropicLoginMode, string> = {
 	pro: "claude.ai",
@@ -226,18 +228,22 @@ export async function exchangeAnthropicAuthorizationCode(
 	if (!actualCode || !state) {
 		return null;
 	}
-	const response = await fetch("https://console.anthropic.com/v1/oauth/token", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			code: actualCode,
-			state,
-			grant_type: "authorization_code",
-			client_id: CLIENT_ID,
-			redirect_uri: "https://console.anthropic.com/oauth/code/callback",
-			code_verifier: verifier,
-		}),
-	});
+	const response = await fetchOAuthHttp(
+		"https://console.anthropic.com/v1/oauth/token",
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				code: actualCode,
+				state,
+				grant_type: "authorization_code",
+				client_id: CLIENT_ID,
+				redirect_uri: "https://console.anthropic.com/oauth/code/callback",
+				code_verifier: verifier,
+			}),
+		},
+		{ serviceName: ANTHROPIC_OAUTH_SERVICE_NAME },
+	);
 	if (!response.ok) {
 		return null;
 	}
@@ -259,15 +265,19 @@ export async function refreshAnthropicOAuthToken(
 	refreshToken?: string;
 	expiresAt: number;
 } | null> {
-	const response = await fetch("https://console.anthropic.com/v1/oauth/token", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			grant_type: "refresh_token",
-			refresh_token: refreshToken,
-			client_id: CLIENT_ID,
-		}),
-	});
+	const response = await fetchOAuthHttp(
+		"https://console.anthropic.com/v1/oauth/token",
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				grant_type: "refresh_token",
+				refresh_token: refreshToken,
+				client_id: CLIENT_ID,
+			}),
+		},
+		{ serviceName: ANTHROPIC_OAUTH_SERVICE_NAME },
+	);
 	if (!response.ok) {
 		return null;
 	}
@@ -285,7 +295,7 @@ export async function refreshAnthropicOAuthToken(
 export async function fetchClaudeApiKey(
 	accessToken: string,
 ): Promise<string | null> {
-	const response = await fetch(
+	const response = await fetchOAuthHttp(
 		"https://api.anthropic.com/api/oauth/claude_cli/create_api_key",
 		{
 			method: "POST",
@@ -294,6 +304,7 @@ export async function fetchClaudeApiKey(
 				authorization: `Bearer ${accessToken}`,
 			},
 		},
+		{ serviceName: ANTHROPIC_OAUTH_SERVICE_NAME },
 	);
 	if (!response.ok) {
 		return null;

--- a/src/utils/oauth-http.ts
+++ b/src/utils/oauth-http.ts
@@ -1,0 +1,58 @@
+import { fetchDownstream } from "./downstream-http.js";
+
+const DEFAULT_OAUTH_HTTP_MAX_ATTEMPTS = 1;
+const DEFAULT_OAUTH_HTTP_TIMEOUT_MS = 10_000;
+const MAX_ATTEMPTS_ENV_VARS = [
+	"MAESTRO_OAUTH_HTTP_MAX_ATTEMPTS",
+	"OAUTH_HTTP_MAX_ATTEMPTS",
+] as const;
+const TIMEOUT_ENV_VARS = [
+	"MAESTRO_OAUTH_HTTP_TIMEOUT_MS",
+	"OAUTH_HTTP_TIMEOUT_MS",
+] as const;
+
+interface OAuthHttpOptions {
+	maxAttempts?: number;
+	serviceName: string;
+	timeoutMs?: number;
+}
+
+function getEnvPositiveInt(names: readonly string[], fallback: number): number {
+	for (const name of names) {
+		const value = process.env[name]?.trim();
+		if (!value) {
+			continue;
+		}
+		const parsed = Number.parseInt(value, 10);
+		if (Number.isFinite(parsed) && parsed > 0) {
+			return parsed;
+		}
+	}
+	return fallback;
+}
+
+function getOAuthHttpMaxAttempts(): number {
+	return getEnvPositiveInt(
+		MAX_ATTEMPTS_ENV_VARS,
+		DEFAULT_OAUTH_HTTP_MAX_ATTEMPTS,
+	);
+}
+
+function getOAuthHttpTimeoutMs(): number {
+	return getEnvPositiveInt(TIMEOUT_ENV_VARS, DEFAULT_OAUTH_HTTP_TIMEOUT_MS);
+}
+
+export function fetchOAuthHttp(
+	input: Parameters<typeof fetch>[0],
+	init: RequestInit,
+	options: OAuthHttpOptions,
+): Promise<Response> {
+	return fetchDownstream(input, init, {
+		serviceName: options.serviceName,
+		failureMode: "required",
+		timeoutMs: options.timeoutMs ?? getOAuthHttpTimeoutMs(),
+		maxAttempts: options.maxAttempts ?? getOAuthHttpMaxAttempts(),
+		initialDelayMs: 100,
+		maxDelayMs: 1_000,
+	});
+}

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -334,6 +334,14 @@ describe("OAuth Index", () => {
 		});
 
 		it("should remove credentials and return null when refresh fails for expired token", async () => {
+			const fetchMock = vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ error: "invalid_grant" }), {
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+			vi.stubGlobal("fetch", fetchMock);
+
 			// Save expired credentials
 			saveOAuthCredentials("anthropic", {
 				type: "oauth",
@@ -342,10 +350,10 @@ describe("OAuth Index", () => {
 				expires: Date.now() - 1000, // Already expired
 			});
 
-			// The refresh will fail (no mock for the API), credentials should be removed
 			const token = await getOAuthToken("anthropic");
 			expect(token).toBeNull();
 			expect(hasOAuthCredentials("anthropic")).toBe(false);
+			expect(fetchMock).toHaveBeenCalledTimes(1);
 		});
 
 		it("should refresh EvalOps credentials when the access token expires", async () => {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `b54f1b509c16c9aa1ad45417f777b2f1e660f530`
- last generated public sync base: `ff2a3f8320b22e5fc64c299952e2495094c58c80`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (b54f1b509c16)`
- public projection: `https://github.com/evalops/maestro@main (ff2a3f8320b2)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/providers/anthropic-auth.ts
- copy/update src/utils/oauth-http.ts
- copy/update test/oauth.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/providers/anthropic-auth.ts
- copy/update src/utils/oauth-http.ts
- copy/update test/oauth.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode