### PR TITLE
Improve desktop runtime wiring and enterprise settings

### DIFF
--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -16,6 +16,8 @@ import {
 	nativeTheme,
 	shell,
 } from "electron";
+import { getDeviceIdentityStatus } from "./device-identity";
+import { getServerApiConfig } from "./server";
 
 export function setupIpc(): void {
 	// App info
@@ -25,6 +27,14 @@ export function setupIpc(): void {
 
 	ipcMain.handle("app:getName", () => {
 		return app.getName();
+	});
+
+	ipcMain.handle("deviceIdentity:getStatus", () => {
+		return getDeviceIdentityStatus();
+	});
+
+	ipcMain.handle("server:getApiConfig", () => {
+		return getServerApiConfig();
 	});
 
 	// Theme

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -16,7 +16,6 @@ import {
 	nativeTheme,
 	shell,
 } from "electron";
-import { getDeviceIdentityStatus } from "./device-identity";
 import { getServerApiConfig } from "./server";
 
 export function setupIpc(): void {
@@ -27,10 +26,6 @@ export function setupIpc(): void {
 
 	ipcMain.handle("app:getName", () => {
 		return app.getName();
-	});
-
-	ipcMain.handle("deviceIdentity:getStatus", () => {
-		return getDeviceIdentityStatus();
 	});
 
 	ipcMain.handle("server:getApiConfig", () => {

--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -14,7 +14,6 @@ import {
 	DESKTOP_DEFAULT_CSRF_TOKEN,
 	DESKTOP_DEV_API_KEY,
 } from "../shared/runtime-defaults.js";
-import { getDeviceIdentityHelperPath } from "./device-identity-helper-path.js";
 
 // ESM equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -9,6 +9,12 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { app } from "electron";
+import {
+	DESKTOP_DEFAULT_API_PORT,
+	DESKTOP_DEFAULT_CSRF_TOKEN,
+	DESKTOP_DEV_API_KEY,
+} from "../shared/runtime-defaults.js";
+import { getDeviceIdentityHelperPath } from "./device-identity-helper-path.js";
 
 // ESM equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -17,21 +23,22 @@ const __dirname = dirname(__filename);
 let serverProcess: ChildProcess | null = null;
 let serverReady = false;
 
-const SERVER_PORT = Number(process.env.MAESTRO_DESKTOP_PORT ?? 8080);
+const SERVER_PORT = Number(
+	process.env.MAESTRO_DESKTOP_PORT ?? DESKTOP_DEFAULT_API_PORT,
+);
 const SERVER_HOST = "127.0.0.1";
 const RENDERER_SERVER_HOST = "localhost";
 const IS_DEV_SERVER = Boolean(process.env.VITE_DEV_SERVER_URL);
-const DEV_API_KEY = "maestro-desktop-local-api-key";
 const DEV_UI_PORT =
 	process.env.MAESTRO_DESKTOP_UI_PORT ?? process.env.VITE_PORT;
 const DEV_UI_ORIGIN = process.env.VITE_DEV_SERVER_URL
 	? process.env.VITE_DEV_SERVER_URL.replace(/\/$/, "")
 	: `http://localhost:${DEV_UI_PORT ?? "5173"}`;
 const CSRF_TOKEN =
-	process.env.MAESTRO_DESKTOP_CSRF_TOKEN ?? "maestro-desktop-csrf";
+	process.env.MAESTRO_DESKTOP_CSRF_TOKEN ?? DESKTOP_DEFAULT_CSRF_TOKEN;
 const API_KEY =
 	process.env.MAESTRO_DESKTOP_API_KEY ??
-	(IS_DEV_SERVER ? DEV_API_KEY : randomUUID());
+	(IS_DEV_SERVER ? DESKTOP_DEV_API_KEY : randomUUID());
 const JWT_SECRET =
 	process.env.MAESTRO_DESKTOP_JWT_SECRET ?? randomBytes(32).toString("hex");
 

--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -5,6 +5,7 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
+import { randomBytes, randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { app } from "electron";
@@ -18,6 +19,9 @@ let serverReady = false;
 
 const SERVER_PORT = Number(process.env.MAESTRO_DESKTOP_PORT ?? 8080);
 const SERVER_HOST = "127.0.0.1";
+const RENDERER_SERVER_HOST = "localhost";
+const IS_DEV_SERVER = Boolean(process.env.VITE_DEV_SERVER_URL);
+const DEV_API_KEY = "maestro-desktop-local-api-key";
 const DEV_UI_PORT =
 	process.env.MAESTRO_DESKTOP_UI_PORT ?? process.env.VITE_PORT;
 const DEV_UI_ORIGIN = process.env.VITE_DEV_SERVER_URL
@@ -25,6 +29,17 @@ const DEV_UI_ORIGIN = process.env.VITE_DEV_SERVER_URL
 	: `http://localhost:${DEV_UI_PORT ?? "5173"}`;
 const CSRF_TOKEN =
 	process.env.MAESTRO_DESKTOP_CSRF_TOKEN ?? "maestro-desktop-csrf";
+const API_KEY =
+	process.env.MAESTRO_DESKTOP_API_KEY ??
+	(IS_DEV_SERVER ? DEV_API_KEY : randomUUID());
+const JWT_SECRET =
+	process.env.MAESTRO_DESKTOP_JWT_SECRET ?? randomBytes(32).toString("hex");
+
+export interface DesktopApiConfig {
+	baseUrl: string;
+	apiKey: string;
+	csrfToken: string;
+}
 
 /**
  * Get the path to the web server module
@@ -90,10 +105,10 @@ export async function startServer(): Promise<boolean> {
 					NODE_ENV: "production",
 					// Disable API key requirement for local desktop use
 					MAESTRO_WEB_REQUIRE_KEY: "0",
+					MAESTRO_WEB_API_KEY: API_KEY,
 					MAESTRO_WEB_REQUIRE_REDIS: "0",
 					MAESTRO_WEB_CSRF_TOKEN: CSRF_TOKEN,
-					// Set a JWT secret for local desktop use (not exposed externally)
-					MAESTRO_JWT_SECRET: "maestro-desktop-local-jwt-secret-key-32chars",
+					MAESTRO_JWT_SECRET: JWT_SECRET,
 					// Allow CORS from Vite dev server and Electron
 					MAESTRO_WEB_ORIGIN: DEV_UI_ORIGIN,
 				},
@@ -171,5 +186,13 @@ export function isServerReady(): boolean {
  * Get the server URL
  */
 export function getServerUrl(): string {
-	return `http://${SERVER_HOST}:${SERVER_PORT}`;
+	return `http://${RENDERER_SERVER_HOST}:${SERVER_PORT}`;
+}
+
+export function getServerApiConfig(): DesktopApiConfig {
+	return {
+		baseUrl: getServerUrl(),
+		apiKey: API_KEY,
+		csrfToken: CSRF_TOKEN,
+	};
 }

--- a/packages/desktop/src/main/window.ts
+++ b/packages/desktop/src/main/window.ts
@@ -24,6 +24,12 @@ const DEFAULT_WIDTH = 1200;
 const DEFAULT_HEIGHT = 800;
 const MIN_WIDTH = 900;
 const MIN_HEIGHT = 600;
+const OPEN_DEVTOOLS =
+	process.env.MAESTRO_DESKTOP_OPEN_DEVTOOLS === "1" ||
+	process.env.VITE_DESKTOP_OPEN_DEVTOOLS === "1";
+const LOG_RENDERER_CONSOLE =
+	process.env.MAESTRO_DESKTOP_LOG_RENDERER === "1" ||
+	process.env.VITE_DESKTOP_LOG_RENDERER === "1";
 
 export function createMainWindow(preloadPath: string): BrowserWindow {
 	// Restore previous window bounds if available
@@ -75,12 +81,22 @@ export function createMainWindow(preloadPath: string): BrowserWindow {
 		return { action: "deny" };
 	});
 
+	if (LOG_RENDERER_CONSOLE) {
+		mainWindow.webContents.on(
+			"console-message",
+			(_event, level, message, line, sourceId) => {
+				console.log(`[Renderer:${level}] ${message} (${sourceId}:${line})`);
+			},
+		);
+	}
+
 	// Load the app
 	if (process.env.VITE_DEV_SERVER_URL) {
 		// Development: load from Vite dev server
 		mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL);
-		// Open DevTools in development
-		mainWindow.webContents.openDevTools();
+		if (OPEN_DEVTOOLS) {
+			mainWindow.webContents.openDevTools();
+		}
 	} else {
 		// Production: load from bundled files
 		mainWindow.loadFile(join(__dirname, "../../dist/index.html"));

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -13,6 +13,8 @@ const electronAPI = {
 	// App
 	getVersion: () => ipcRenderer.invoke("app:getVersion"),
 	getName: () => ipcRenderer.invoke("app:getName"),
+	getDeviceIdentityStatus: () => ipcRenderer.invoke("deviceIdentity:getStatus"),
+	getApiConfig: () => ipcRenderer.invoke("server:getApiConfig"),
 
 	// Theme
 	getTheme: () => ipcRenderer.invoke("theme:get"),

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -13,7 +13,6 @@ const electronAPI = {
 	// App
 	getVersion: () => ipcRenderer.invoke("app:getVersion"),
 	getName: () => ipcRenderer.invoke("app:getName"),
-	getDeviceIdentityStatus: () => ipcRenderer.invoke("deviceIdentity:getStatus"),
 	getApiConfig: () => ipcRenderer.invoke("server:getApiConfig"),
 
 	// Theme

--- a/packages/desktop/src/renderer/components/Settings/EnterpriseControlsSection.tsx
+++ b/packages/desktop/src/renderer/components/Settings/EnterpriseControlsSection.tsx
@@ -1,0 +1,119 @@
+import type { ApprovalMode } from "../../lib/api-client";
+
+export interface EnterpriseControlsSectionProps {
+	approvalMode: ApprovalMode;
+	guardianEnabled: boolean;
+	hasSession: boolean;
+	mcpServerCount: number;
+	modelCount: number;
+}
+
+interface EnterpriseControlArea {
+	name: string;
+	status: string;
+	scope: string;
+	surface: string;
+}
+
+const pluralize = (count: number, singular: string, plural = `${singular}s`) =>
+	`${count} ${count === 1 ? singular : plural}`;
+
+export function EnterpriseControlsSection({
+	approvalMode,
+	guardianEnabled,
+	hasSession,
+	mcpServerCount,
+	modelCount,
+}: EnterpriseControlsSectionProps) {
+	const areas: EnterpriseControlArea[] = [
+		{
+			name: "Session Defaults",
+			status: hasSession ? "Session active" : "Default profile",
+			scope: "Mode, approvals, queueing",
+			surface: "session + policy.json",
+		},
+		{
+			name: "Model Access",
+			status:
+				modelCount > 0 ? pluralize(modelCount, "model") : "No models loaded",
+			scope: "Provider allowlists",
+			surface: "models + policy.json",
+		},
+		{
+			name: "Command Policy",
+			status: `Approval: ${approvalMode}`,
+			scope: "Shell and tool gates",
+			surface: "approvals + tools",
+		},
+		{
+			name: "MCP Server Policy",
+			status:
+				mcpServerCount > 0
+					? pluralize(mcpServerCount, "server")
+					: "No servers configured",
+			scope: "Servers, auth presets",
+			surface: "enterprise/mcp.json",
+		},
+		{
+			name: "Security",
+			status: guardianEnabled ? "Guardian on" : "Guardian off",
+			scope: "Secrets and writes",
+			surface: "guardian + paths",
+		},
+		{
+			name: "Network Policy",
+			status: "Runtime scoped",
+			scope: "Remote transports",
+			surface: "network + MCP",
+		},
+		{
+			name: "Git",
+			status: "Workspace scoped",
+			scope: "Commits and branches",
+			surface: "tools + paths",
+		},
+		{
+			name: "Session Retention",
+			status: "Local history",
+			scope: "Limits and cleanup",
+			surface: "limits + storage",
+		},
+	];
+
+	return (
+		<section className="border border-line-subtle rounded-xl overflow-hidden">
+			<div className="px-4 py-2 border-b border-line-subtle">
+				<div className="text-xs font-semibold text-text-tertiary uppercase tracking-wide">
+					Enterprise Controls
+				</div>
+				<div className="mt-1 text-[11px] text-text-muted">
+					Policy map for desktop rollout, runtime access, and governed agent
+					behavior.
+				</div>
+			</div>
+			<div className="divide-y divide-line-subtle/70">
+				{areas.map((area) => (
+					<div
+						key={area.name}
+						className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)_minmax(0,1fr)] gap-3 px-4 py-3 text-xs"
+					>
+						<div className="min-w-0">
+							<div className="font-medium text-text-primary truncate">
+								{area.name}
+							</div>
+							<div className="mt-1 text-text-tertiary truncate">
+								{area.surface}
+							</div>
+						</div>
+						<div className="min-w-0 text-text-secondary truncate">
+							{area.scope}
+						</div>
+						<div className="min-w-0 text-right text-text-muted truncate">
+							{area.status}
+						</div>
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/packages/desktop/src/renderer/components/Settings/SettingsModal.tsx
+++ b/packages/desktop/src/renderer/components/Settings/SettingsModal.tsx
@@ -40,6 +40,7 @@ import { dedupeModels, getModelKey } from "../../lib/model-utils";
 import type { Model, ThinkingLevel } from "../../lib/types";
 import { AppearanceSection } from "./AppearanceSection";
 import { BackgroundTasksSection } from "./BackgroundTasksSection";
+import { EnterpriseControlsSection } from "./EnterpriseControlsSection";
 import { FrameworkSection } from "./FrameworkSection";
 import { MemorySection } from "./MemorySection";
 import {
@@ -1011,6 +1012,14 @@ export function SettingsModal({
 						onUpdateModel={updateModel}
 						onUpdateMode={updateMode}
 						onThinkingLevelChange={setThinkingLevel}
+					/>
+
+					<EnterpriseControlsSection
+						approvalMode={approvalMode}
+						guardianEnabled={guardianStatus?.enabled ?? true}
+						hasSession={hasSession}
+						mcpServerCount={mcpStatus?.servers.length ?? 0}
+						modelCount={availableModels.length}
 					/>
 
 					<SafetyApprovalsSection

--- a/packages/desktop/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/packages/desktop/src/renderer/components/Sidebar/Sidebar.tsx
@@ -11,6 +11,8 @@ import {
 import { useState } from "react";
 import type { SessionSummary } from "../../lib/types";
 
+const APP_VERSION = import.meta.env.VITE_MAESTRO_DESKTOP_VERSION ?? "dev";
+
 export interface SidebarProps {
 	open: boolean;
 	activeView: "chat" | "automations";
@@ -329,7 +331,7 @@ export function Sidebar({
 							</svg>
 						</button>
 						<span className="font-mono text-[10px] px-2 py-0.5 rounded-md bg-bg-tertiary/50">
-							v0.10.0
+							v{APP_VERSION}
 						</span>
 					</div>
 				</div>

--- a/packages/desktop/src/renderer/lib/api-client.ts
+++ b/packages/desktop/src/renderer/lib/api-client.ts
@@ -21,6 +21,11 @@ import type {
 	TeamMemoryStatus,
 	TeamMemoryStatusResponse,
 } from "@evalops/contracts";
+import {
+	DESKTOP_CONFIG_TIMEOUT_MS,
+	DESKTOP_DEFAULT_API_PORT,
+	DESKTOP_DEFAULT_CSRF_TOKEN,
+} from "../../shared/runtime-defaults";
 import type {
 	AgentEvent,
 	AutomationTask,
@@ -33,11 +38,12 @@ import type {
 } from "./types";
 
 const DEFAULT_BASE_URL =
-	import.meta.env.VITE_MAESTRO_BASE_URL ?? "http://localhost:8080";
+	import.meta.env.VITE_MAESTRO_BASE_URL ??
+	`http://localhost:${DESKTOP_DEFAULT_API_PORT}`;
 const DEFAULT_API_KEY = import.meta.env.VITE_MAESTRO_API_KEY ?? null;
 const DEFAULT_CSRF_TOKEN =
-	import.meta.env.VITE_MAESTRO_CSRF_TOKEN ?? "maestro-desktop-csrf";
-const DESKTOP_CONFIG_TIMEOUT_MS = 500;
+	import.meta.env.VITE_MAESTRO_CSRF_TOKEN ?? DESKTOP_DEFAULT_CSRF_TOKEN;
+const DESKTOP_CONFIG_TIMEOUT = Symbol("desktop-config-timeout");
 const MAX_SSE_BUFFER = 1024 * 1024; // 1MB
 
 interface DesktopApiConfig {
@@ -681,26 +687,44 @@ export class ApiClient {
 		if (!window.electron?.getApiConfig) {
 			return;
 		}
-		const configTimeout = new Promise<null>((resolve) => {
-			window.setTimeout(() => resolve(null), DESKTOP_CONFIG_TIMEOUT_MS);
-		});
+		const configTimeout = new Promise<typeof DESKTOP_CONFIG_TIMEOUT>(
+			(resolve) => {
+				window.setTimeout(
+					() => resolve(DESKTOP_CONFIG_TIMEOUT),
+					DESKTOP_CONFIG_TIMEOUT_MS,
+				);
+			},
+		);
 		const configRequest = window.electron
 			.getApiConfig()
 			.then((config: DesktopApiConfig | null | undefined) => config ?? null);
 		this.configPromise = Promise.race([configRequest, configTimeout])
-			.then((config: DesktopApiConfig | null | undefined) => {
-				if (!config) return;
-				if (config.baseUrl) {
-					this.baseUrl = config.baseUrl.replace(/\/$/, "");
-				}
-				if (config.apiKey) {
-					this.apiKey = config.apiKey;
-				}
-				if (config.csrfToken) {
-					this.csrfToken = config.csrfToken;
-				}
-			})
+			.then(
+				(
+					config:
+						| DesktopApiConfig
+						| null
+						| typeof DESKTOP_CONFIG_TIMEOUT
+						| undefined,
+				) => {
+					if (config === DESKTOP_CONFIG_TIMEOUT) {
+						this.configPromise = null;
+						return;
+					}
+					if (!config) return;
+					if (config.baseUrl) {
+						this.baseUrl = config.baseUrl.replace(/\/$/, "");
+					}
+					if (config.apiKey) {
+						this.apiKey = config.apiKey;
+					}
+					if (config.csrfToken) {
+						this.csrfToken = config.csrfToken;
+					}
+				},
+			)
 			.catch((err: unknown) => {
+				this.configPromise = null;
 				console.warn("Failed to load desktop API config:", err);
 			});
 		await this.configPromise;

--- a/packages/desktop/src/renderer/lib/api-client.ts
+++ b/packages/desktop/src/renderer/lib/api-client.ts
@@ -675,6 +675,9 @@ export class ApiClient {
 			await this.configPromise;
 			return;
 		}
+		if (typeof window === "undefined") {
+			return;
+		}
 		if (!window.electron?.getApiConfig) {
 			return;
 		}

--- a/packages/desktop/src/renderer/lib/api-client.ts
+++ b/packages/desktop/src/renderer/lib/api-client.ts
@@ -689,6 +689,7 @@ export class ApiClient {
 			return;
 		}
 		const loadConfig = async (): Promise<void> => {
+			let lastConfigError: unknown;
 			for (let attempt = 0; attempt < DESKTOP_CONFIG_MAX_ATTEMPTS; attempt++) {
 				const configTimeout = new Promise<typeof DESKTOP_CONFIG_TIMEOUT>(
 					(resolve) => {
@@ -703,7 +704,13 @@ export class ApiClient {
 					.then(
 						(config: DesktopApiConfig | null | undefined) => config ?? null,
 					);
-				const config = await Promise.race([configRequest, configTimeout]);
+				let config: DesktopApiConfig | null | typeof DESKTOP_CONFIG_TIMEOUT;
+				try {
+					config = await Promise.race([configRequest, configTimeout]);
+				} catch (err: unknown) {
+					lastConfigError = err;
+					continue;
+				}
 
 				if (config === DESKTOP_CONFIG_TIMEOUT) {
 					continue;
@@ -722,9 +729,10 @@ export class ApiClient {
 				}
 				return;
 			}
-			throw new Error(
-				`Timed out loading desktop API config after ${DESKTOP_CONFIG_MAX_ATTEMPTS} attempts`,
-			);
+			const message = `Failed to load desktop API config after ${DESKTOP_CONFIG_MAX_ATTEMPTS} attempts`;
+			throw lastConfigError instanceof Error
+				? new Error(message, { cause: lastConfigError })
+				: new Error(message);
 		};
 		this.configPromise = loadConfig().catch((err: unknown) => {
 			this.configPromise = null;

--- a/packages/desktop/src/renderer/lib/api-client.ts
+++ b/packages/desktop/src/renderer/lib/api-client.ts
@@ -22,6 +22,7 @@ import type {
 	TeamMemoryStatusResponse,
 } from "@evalops/contracts";
 import {
+	DESKTOP_CONFIG_MAX_ATTEMPTS,
 	DESKTOP_CONFIG_TIMEOUT_MS,
 	DESKTOP_DEFAULT_API_PORT,
 	DESKTOP_DEFAULT_CSRF_TOKEN,
@@ -687,46 +688,49 @@ export class ApiClient {
 		if (!window.electron?.getApiConfig) {
 			return;
 		}
-		const configTimeout = new Promise<typeof DESKTOP_CONFIG_TIMEOUT>(
-			(resolve) => {
-				window.setTimeout(
-					() => resolve(DESKTOP_CONFIG_TIMEOUT),
-					DESKTOP_CONFIG_TIMEOUT_MS,
+		const loadConfig = async (): Promise<void> => {
+			for (let attempt = 0; attempt < DESKTOP_CONFIG_MAX_ATTEMPTS; attempt++) {
+				const configTimeout = new Promise<typeof DESKTOP_CONFIG_TIMEOUT>(
+					(resolve) => {
+						window.setTimeout(
+							() => resolve(DESKTOP_CONFIG_TIMEOUT),
+							DESKTOP_CONFIG_TIMEOUT_MS,
+						);
+					},
 				);
-			},
-		);
-		const configRequest = window.electron
-			.getApiConfig()
-			.then((config: DesktopApiConfig | null | undefined) => config ?? null);
-		this.configPromise = Promise.race([configRequest, configTimeout])
-			.then(
-				(
-					config:
-						| DesktopApiConfig
-						| null
-						| typeof DESKTOP_CONFIG_TIMEOUT
-						| undefined,
-				) => {
-					if (config === DESKTOP_CONFIG_TIMEOUT) {
-						this.configPromise = null;
-						return;
-					}
-					if (!config) return;
-					if (config.baseUrl) {
-						this.baseUrl = config.baseUrl.replace(/\/$/, "");
-					}
-					if (config.apiKey) {
-						this.apiKey = config.apiKey;
-					}
-					if (config.csrfToken) {
-						this.csrfToken = config.csrfToken;
-					}
-				},
-			)
-			.catch((err: unknown) => {
-				this.configPromise = null;
-				console.warn("Failed to load desktop API config:", err);
-			});
+				const configRequest = window.electron
+					.getApiConfig()
+					.then(
+						(config: DesktopApiConfig | null | undefined) => config ?? null,
+					);
+				const config = await Promise.race([configRequest, configTimeout]);
+
+				if (config === DESKTOP_CONFIG_TIMEOUT) {
+					continue;
+				}
+				if (!config) {
+					return;
+				}
+				if (config.baseUrl) {
+					this.baseUrl = config.baseUrl.replace(/\/$/, "");
+				}
+				if (config.apiKey) {
+					this.apiKey = config.apiKey;
+				}
+				if (config.csrfToken) {
+					this.csrfToken = config.csrfToken;
+				}
+				return;
+			}
+			throw new Error(
+				`Timed out loading desktop API config after ${DESKTOP_CONFIG_MAX_ATTEMPTS} attempts`,
+			);
+		};
+		this.configPromise = loadConfig().catch((err: unknown) => {
+			this.configPromise = null;
+			console.warn("Failed to load desktop API config:", err);
+			throw err;
+		});
 		await this.configPromise;
 	}
 

--- a/packages/desktop/src/renderer/lib/api-client.ts
+++ b/packages/desktop/src/renderer/lib/api-client.ts
@@ -34,9 +34,17 @@ import type {
 
 const DEFAULT_BASE_URL =
 	import.meta.env.VITE_MAESTRO_BASE_URL ?? "http://localhost:8080";
+const DEFAULT_API_KEY = import.meta.env.VITE_MAESTRO_API_KEY ?? null;
 const DEFAULT_CSRF_TOKEN =
 	import.meta.env.VITE_MAESTRO_CSRF_TOKEN ?? "maestro-desktop-csrf";
+const DESKTOP_CONFIG_TIMEOUT_MS = 500;
 const MAX_SSE_BUFFER = 1024 * 1024; // 1MB
+
+interface DesktopApiConfig {
+	baseUrl?: string;
+	apiKey?: string;
+	csrfToken?: string;
+}
 
 export type ApprovalMode = "auto" | "prompt" | "fail";
 export type QueueMode = "one" | "all";
@@ -651,15 +659,56 @@ export interface ComposerStatus {
 }
 
 export class ApiClient {
+	private apiKey: string | null;
 	private baseUrl: string;
+	private configPromise: Promise<void> | null = null;
 	private csrfToken: string;
 
 	constructor(baseUrl: string = DEFAULT_BASE_URL) {
+		this.apiKey = DEFAULT_API_KEY;
 		this.baseUrl = baseUrl.replace(/\/$/, "");
 		this.csrfToken = DEFAULT_CSRF_TOKEN;
 	}
 
+	private async ensureDesktopConfig(): Promise<void> {
+		if (this.configPromise) {
+			await this.configPromise;
+			return;
+		}
+		if (!window.electron?.getApiConfig) {
+			return;
+		}
+		const configTimeout = new Promise<null>((resolve) => {
+			window.setTimeout(() => resolve(null), DESKTOP_CONFIG_TIMEOUT_MS);
+		});
+		const configRequest = window.electron
+			.getApiConfig()
+			.then((config: DesktopApiConfig | null | undefined) => config ?? null);
+		this.configPromise = Promise.race([configRequest, configTimeout])
+			.then((config: DesktopApiConfig | null | undefined) => {
+				if (!config) return;
+				if (config.baseUrl) {
+					this.baseUrl = config.baseUrl.replace(/\/$/, "");
+				}
+				if (config.apiKey) {
+					this.apiKey = config.apiKey;
+				}
+				if (config.csrfToken) {
+					this.csrfToken = config.csrfToken;
+				}
+			})
+			.catch((err: unknown) => {
+				console.warn("Failed to load desktop API config:", err);
+			});
+		await this.configPromise;
+	}
+
+	private getAuthHeaders(): Record<string, string> {
+		return this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {};
+	}
+
 	private async fetchJson<T>(path: string, options?: RequestInit): Promise<T> {
+		await this.ensureDesktopConfig();
 		const method = (options?.method || "GET").toUpperCase();
 		const needsCsrf =
 			method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
@@ -667,6 +716,7 @@ export class ApiClient {
 			...options,
 			headers: {
 				"Content-Type": "application/json",
+				...this.getAuthHeaders(),
 				...(needsCsrf
 					? {
 							"x-composer-csrf": this.csrfToken,
@@ -839,9 +889,11 @@ export class ApiClient {
 	}
 
 	async deleteSession(sessionId: string): Promise<void> {
+		await this.ensureDesktopConfig();
 		await fetch(`${this.baseUrl}/api/sessions/${sessionId}`, {
 			method: "DELETE",
 			headers: {
+				...this.getAuthHeaders(),
 				"x-composer-csrf": this.csrfToken,
 				"x-maestro-csrf": this.csrfToken,
 			},
@@ -855,10 +907,12 @@ export class ApiClient {
 		model?: string;
 		thinkingLevel?: ThinkingLevel;
 	}): AsyncGenerator<AgentEvent, void, unknown> {
+		await this.ensureDesktopConfig();
 		const response = await fetch(`${this.baseUrl}/api/chat`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
+				...this.getAuthHeaders(),
 				"x-composer-slim-events": "1",
 				"x-maestro-slim-events": "1",
 				"x-composer-csrf": this.csrfToken,

--- a/packages/desktop/src/shared/runtime-defaults.ts
+++ b/packages/desktop/src/shared/runtime-defaults.ts
@@ -1,4 +1,5 @@
 export const DESKTOP_DEFAULT_API_PORT = "8080";
 export const DESKTOP_DEFAULT_CSRF_TOKEN = "maestro-desktop-csrf";
 export const DESKTOP_DEV_API_KEY = "maestro-desktop-local-api-key";
+export const DESKTOP_CONFIG_MAX_ATTEMPTS = 3;
 export const DESKTOP_CONFIG_TIMEOUT_MS = 500;

--- a/packages/desktop/src/shared/runtime-defaults.ts
+++ b/packages/desktop/src/shared/runtime-defaults.ts
@@ -1,0 +1,4 @@
+export const DESKTOP_DEFAULT_API_PORT = "8080";
+export const DESKTOP_DEFAULT_CSRF_TOKEN = "maestro-desktop-csrf";
+export const DESKTOP_DEV_API_KEY = "maestro-desktop-local-api-key";
+export const DESKTOP_CONFIG_TIMEOUT_MS = 500;

--- a/packages/desktop/src/vite-env.d.ts
+++ b/packages/desktop/src/vite-env.d.ts
@@ -1,8 +1,10 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+	readonly VITE_MAESTRO_API_KEY?: string;
 	readonly VITE_MAESTRO_BASE_URL?: string;
 	readonly VITE_MAESTRO_CSRF_TOKEN?: string;
+	readonly VITE_MAESTRO_DESKTOP_VERSION?: string;
 }
 
 interface ImportMeta {

--- a/packages/desktop/vite.config.ts
+++ b/packages/desktop/vite.config.ts
@@ -3,6 +3,11 @@ import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import electron from "vite-plugin-electron/simple";
+import {
+	DESKTOP_DEFAULT_API_PORT,
+	DESKTOP_DEFAULT_CSRF_TOKEN,
+	DESKTOP_DEV_API_KEY,
+} from "./src/shared/runtime-defaults";
 
 const desktopPackage = JSON.parse(
 	readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
@@ -11,17 +16,17 @@ const desktopPackage = JSON.parse(
 const DEV_PORT = Number(
 	process.env.MAESTRO_DESKTOP_UI_PORT ?? process.env.VITE_PORT ?? 5173,
 );
-const DESKTOP_API_PORT = process.env.MAESTRO_DESKTOP_PORT ?? "8080";
+const DESKTOP_API_PORT =
+	process.env.MAESTRO_DESKTOP_PORT ?? DESKTOP_DEFAULT_API_PORT;
 const IS_PRODUCTION_BUILD = process.env.NODE_ENV === "production";
-const DEV_API_KEY = "maestro-desktop-local-api-key";
 
 process.env.VITE_MAESTRO_BASE_URL ??= `http://localhost:${DESKTOP_API_PORT}`;
 if (!IS_PRODUCTION_BUILD || process.env.MAESTRO_DESKTOP_API_KEY) {
 	process.env.VITE_MAESTRO_API_KEY ??=
-		process.env.MAESTRO_DESKTOP_API_KEY ?? DEV_API_KEY;
+		process.env.MAESTRO_DESKTOP_API_KEY ?? DESKTOP_DEV_API_KEY;
 }
 process.env.VITE_MAESTRO_CSRF_TOKEN ??=
-	process.env.MAESTRO_DESKTOP_CSRF_TOKEN ?? "maestro-desktop-csrf";
+	process.env.MAESTRO_DESKTOP_CSRF_TOKEN ?? DESKTOP_DEFAULT_CSRF_TOKEN;
 process.env.VITE_MAESTRO_DESKTOP_VERSION ??= desktopPackage.version ?? "dev";
 
 export default defineConfig({

--- a/packages/desktop/vite.config.ts
+++ b/packages/desktop/vite.config.ts
@@ -1,11 +1,28 @@
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import electron from "vite-plugin-electron/simple";
 
+const desktopPackage = JSON.parse(
+	readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
+) as { version?: string };
+
 const DEV_PORT = Number(
 	process.env.MAESTRO_DESKTOP_UI_PORT ?? process.env.VITE_PORT ?? 5173,
 );
+const DESKTOP_API_PORT = process.env.MAESTRO_DESKTOP_PORT ?? "8080";
+const IS_PRODUCTION_BUILD = process.env.NODE_ENV === "production";
+const DEV_API_KEY = "maestro-desktop-local-api-key";
+
+process.env.VITE_MAESTRO_BASE_URL ??= `http://localhost:${DESKTOP_API_PORT}`;
+if (!IS_PRODUCTION_BUILD || process.env.MAESTRO_DESKTOP_API_KEY) {
+	process.env.VITE_MAESTRO_API_KEY ??=
+		process.env.MAESTRO_DESKTOP_API_KEY ?? DEV_API_KEY;
+}
+process.env.VITE_MAESTRO_CSRF_TOKEN ??=
+	process.env.MAESTRO_DESKTOP_CSRF_TOKEN ?? "maestro-desktop-csrf";
+process.env.VITE_MAESTRO_DESKTOP_VERSION ??= desktopPackage.version ?? "dev";
 
 export default defineConfig({
 	plugins: [

--- a/test/desktop/api-client.test.ts
+++ b/test/desktop/api-client.test.ts
@@ -28,7 +28,9 @@ const makeJsonResponse = (payload: unknown) =>
 describe("desktop api client", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
+		vi.useRealTimers();
 		global.fetch = originalFetch;
+		delete (globalThis as { window?: unknown }).window;
 	});
 
 	it("sends both composer and maestro headers for streaming chat", async () => {
@@ -213,5 +215,46 @@ describe("desktop api client", () => {
 			"http://localhost:8080/api/automations/magic-docs",
 		);
 		expect(response.template?.contextPaths).toEqual(["docs/architecture.md"]);
+	});
+
+	it("retries desktop API config after an IPC timeout", async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn()
+			.mockImplementation(() =>
+				Promise.resolve(makeJsonResponse({ topics: [] })),
+			);
+		global.fetch = fetchMock;
+		const getApiConfig = vi
+			.fn()
+			.mockReturnValueOnce(new Promise(() => {}))
+			.mockResolvedValueOnce({
+				baseUrl: "http://localhost:8123",
+				apiKey: "desktop-key",
+				csrfToken: "desktop-csrf",
+			});
+		(globalThis as unknown as { window: unknown }).window = {
+			electron: { getApiConfig },
+			setTimeout,
+		};
+
+		const client = new ApiClient("http://localhost:8080");
+		const firstRequest = client.listMemoryTopics();
+		await vi.advanceTimersByTimeAsync(500);
+		await firstRequest;
+
+		await client.listMemoryTopics();
+
+		expect(getApiConfig).toHaveBeenCalledTimes(2);
+		expect(fetchMock.mock.calls[0]?.[0]).toBe(
+			"http://localhost:8080/api/memory?action=list",
+		);
+		expect(fetchMock.mock.calls[1]?.[0]).toBe(
+			"http://localhost:8123/api/memory?action=list",
+		);
+		const retryHeaders = new Headers(
+			(fetchMock.mock.calls[1]?.[1] as RequestInit).headers,
+		);
+		expect(retryHeaders.get("authorization")).toBe("Bearer desktop-key");
 	});
 });

--- a/test/desktop/api-client.test.ts
+++ b/test/desktop/api-client.test.ts
@@ -217,7 +217,7 @@ describe("desktop api client", () => {
 		expect(response.template?.contextPaths).toEqual(["docs/architecture.md"]);
 	});
 
-	it("retries desktop API config after an IPC timeout", async () => {
+	it("retries desktop API config before sending after an IPC timeout", async () => {
 		vi.useFakeTimers();
 		const fetchMock = vi
 			.fn()
@@ -239,21 +239,16 @@ describe("desktop api client", () => {
 		};
 
 		const client = new ApiClient("http://localhost:8080");
-		const firstRequest = client.listMemoryTopics();
+		const request = client.listMemoryTopics();
 		await vi.advanceTimersByTimeAsync(500);
-		await firstRequest;
-
-		await client.listMemoryTopics();
+		await request;
 
 		expect(getApiConfig).toHaveBeenCalledTimes(2);
 		expect(fetchMock.mock.calls[0]?.[0]).toBe(
-			"http://localhost:8080/api/memory?action=list",
-		);
-		expect(fetchMock.mock.calls[1]?.[0]).toBe(
 			"http://localhost:8123/api/memory?action=list",
 		);
 		const retryHeaders = new Headers(
-			(fetchMock.mock.calls[1]?.[1] as RequestInit).headers,
+			(fetchMock.mock.calls[0]?.[1] as RequestInit).headers,
 		);
 		expect(retryHeaders.get("authorization")).toBe("Bearer desktop-key");
 	});

--- a/test/desktop/api-client.test.ts
+++ b/test/desktop/api-client.test.ts
@@ -252,4 +252,37 @@ describe("desktop api client", () => {
 		);
 		expect(retryHeaders.get("authorization")).toBe("Bearer desktop-key");
 	});
+
+	it("retries rejected desktop API config requests before sending", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockImplementation(() =>
+				Promise.resolve(makeJsonResponse({ topics: [] })),
+			);
+		global.fetch = fetchMock;
+		const getApiConfig = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("ipc busy"))
+			.mockResolvedValueOnce({
+				baseUrl: "http://localhost:8124",
+				apiKey: "desktop-key",
+				csrfToken: "desktop-csrf",
+			});
+		(globalThis as unknown as { window: unknown }).window = {
+			electron: { getApiConfig },
+			setTimeout,
+		};
+
+		const client = new ApiClient("http://localhost:8080");
+		await client.listMemoryTopics();
+
+		expect(getApiConfig).toHaveBeenCalledTimes(2);
+		expect(fetchMock.mock.calls[0]?.[0]).toBe(
+			"http://localhost:8124/api/memory?action=list",
+		);
+		const retryHeaders = new Headers(
+			(fetchMock.mock.calls[0]?.[1] as RequestInit).headers,
+		);
+		expect(retryHeaders.get("authorization")).toBe("Bearer desktop-key");
+	});
 });


### PR DESCRIPTION
## Summary
- Port desktop runtime API config wiring from internal PR https://github.com/evalops/maestro-internal/pull/1589 to the public repo
- Add shared desktop runtime defaults and bounded IPC config retries before authenticated requests
- Add the enterprise settings surface and version-driven sidebar badge

## Verification
- node scripts/run-vitest.js --run test/desktop/api-client.test.ts
- bun run --filter @evalops/maestro-desktop check
- bun run --filter @evalops/maestro-desktop build

Note: the public pre-commit hook reached its frozen-lockfile install step and failed due the local Bun client reporting an outdated lockfile version; the staged source checks before that point passed, and the focused commands above pass after dependencies are installed locally.