### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/tui-rs/src/mcp/config.rs
+++ b/packages/tui-rs/src/mcp/config.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::path_utils::{dedupe_paths, env_path};
+use crate::path_utils::{dedupe_paths, env_path, legacy_composer_home_dir, maestro_home_dir};
 
 /// Transport type for MCP server communication
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -246,12 +246,11 @@ fn user_config_paths() -> Vec<PathBuf> {
         return vec![path];
     }
     let mut paths = Vec::new();
-    if let Some(maestro_home) = env_path("MAESTRO_HOME") {
+    if let Some(maestro_home) = maestro_home_dir() {
         paths.push(maestro_home.join("mcp.json"));
     }
-    if let Some(home) = dirs::home_dir() {
-        paths.push(home.join(".maestro").join("mcp.json"));
-        paths.push(home.join(".composer").join("mcp.json"));
+    if let Some(composer_home) = legacy_composer_home_dir() {
+        paths.push(composer_home.join("mcp.json"));
     }
     dedupe_paths(paths)
 }
@@ -261,12 +260,11 @@ fn enterprise_config_paths() -> Vec<PathBuf> {
         return vec![path];
     }
     let mut paths = Vec::new();
-    if let Some(maestro_home) = env_path("MAESTRO_HOME") {
+    if let Some(maestro_home) = maestro_home_dir() {
         paths.push(maestro_home.join("enterprise").join("mcp.json"));
     }
-    if let Some(home) = dirs::home_dir() {
-        paths.push(home.join(".maestro").join("enterprise").join("mcp.json"));
-        paths.push(home.join(".composer").join("enterprise").join("mcp.json"));
+    if let Some(composer_home) = legacy_composer_home_dir() {
+        paths.push(composer_home.join("enterprise").join("mcp.json"));
     }
     dedupe_paths(paths)
 }
@@ -559,6 +557,56 @@ mod tests {
             enterprise_config_paths(),
             vec![PathBuf::from("/tmp/override-enterprise-mcp.json")]
         );
+
+        restore_env_var("MAESTRO_ENTERPRISE_MCP_PATH", previous_override);
+        restore_env_var("MAESTRO_HOME", previous_home);
+    }
+
+    #[test]
+    fn test_user_config_paths_use_custom_maestro_home_without_default_maestro_fallback() {
+        let _lock = ENV_MUTEX.lock().expect("lock env");
+        let previous_override = std::env::var("MAESTRO_USER_MCP_PATH").ok();
+        let previous_home = std::env::var("MAESTRO_HOME").ok();
+        let home = dirs::home_dir().expect("home dir");
+
+        std::env::remove_var("MAESTRO_USER_MCP_PATH");
+        std::env::set_var("MAESTRO_HOME", "/tmp/custom-maestro-home");
+
+        let paths = user_config_paths();
+
+        assert_eq!(
+            paths,
+            dedupe_paths(vec![
+                PathBuf::from("/tmp/custom-maestro-home/mcp.json"),
+                home.join(".composer").join("mcp.json"),
+            ])
+        );
+        assert!(!paths.contains(&home.join(".maestro").join("mcp.json")));
+
+        restore_env_var("MAESTRO_USER_MCP_PATH", previous_override);
+        restore_env_var("MAESTRO_HOME", previous_home);
+    }
+
+    #[test]
+    fn test_enterprise_config_paths_use_custom_maestro_home_without_default_maestro_fallback() {
+        let _lock = ENV_MUTEX.lock().expect("lock env");
+        let previous_override = std::env::var("MAESTRO_ENTERPRISE_MCP_PATH").ok();
+        let previous_home = std::env::var("MAESTRO_HOME").ok();
+        let home = dirs::home_dir().expect("home dir");
+
+        std::env::remove_var("MAESTRO_ENTERPRISE_MCP_PATH");
+        std::env::set_var("MAESTRO_HOME", "/tmp/custom-maestro-home");
+
+        let paths = enterprise_config_paths();
+
+        assert_eq!(
+            paths,
+            dedupe_paths(vec![
+                PathBuf::from("/tmp/custom-maestro-home/enterprise/mcp.json"),
+                home.join(".composer").join("enterprise").join("mcp.json"),
+            ])
+        );
+        assert!(!paths.contains(&home.join(".maestro").join("enterprise").join("mcp.json")));
 
         restore_env_var("MAESTRO_ENTERPRISE_MCP_PATH", previous_override);
         restore_env_var("MAESTRO_HOME", previous_home);

--- a/packages/tui-rs/src/path_utils.rs
+++ b/packages/tui-rs/src/path_utils.rs
@@ -31,6 +31,14 @@ pub(crate) fn resolve_env_path(value: &str) -> Option<PathBuf> {
     })
 }
 
+pub(crate) fn maestro_home_dir() -> Option<PathBuf> {
+    env_path("MAESTRO_HOME").or_else(|| dirs::home_dir().map(|home| home.join(".maestro")))
+}
+
+pub(crate) fn legacy_composer_home_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".composer"))
+}
+
 pub(crate) fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
     let mut result = Vec::new();
     for path in paths {
@@ -44,6 +52,9 @@ pub(crate) fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     fn restore_env_var(name: &str, value: Option<String>) {
         match value {
@@ -54,6 +65,7 @@ mod tests {
 
     #[test]
     fn env_path_expands_tilde() {
+        let _lock = ENV_MUTEX.lock().expect("lock env");
         let previous = env::var("MAESTRO_TEST_ENV_PATH").ok();
         let home = dirs::home_dir().expect("home dir");
 
@@ -65,5 +77,33 @@ mod tests {
         );
 
         restore_env_var("MAESTRO_TEST_ENV_PATH", previous);
+    }
+
+    #[test]
+    fn maestro_home_dir_uses_env_override() {
+        let _lock = ENV_MUTEX.lock().expect("lock env");
+        let previous = env::var("MAESTRO_HOME").ok();
+
+        env::set_var("MAESTRO_HOME", "/tmp/custom-maestro-home");
+
+        assert_eq!(
+            maestro_home_dir(),
+            Some(PathBuf::from("/tmp/custom-maestro-home"))
+        );
+
+        restore_env_var("MAESTRO_HOME", previous);
+    }
+
+    #[test]
+    fn maestro_home_dir_falls_back_to_default_home() {
+        let _lock = ENV_MUTEX.lock().expect("lock env");
+        let previous = env::var("MAESTRO_HOME").ok();
+        let home = dirs::home_dir().expect("home dir");
+
+        env::remove_var("MAESTRO_HOME");
+
+        assert_eq!(maestro_home_dir(), Some(home.join(".maestro")));
+
+        restore_env_var("MAESTRO_HOME", previous);
     }
 }

--- a/packages/tui-rs/src/runtime_badges.rs
+++ b/packages/tui-rs/src/runtime_badges.rs
@@ -4,9 +4,9 @@
 
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use crate::path_utils::resolve_env_path;
+use crate::path_utils::{legacy_composer_home_dir, maestro_home_dir, resolve_env_path};
 use crate::safety::is_safe_mode_enabled;
 use crate::sandbox::SANDBOX_ENV_VAR;
 use crate::session::ThinkingLevel;
@@ -193,7 +193,7 @@ fn rust_policy_config_exists() -> bool {
         || maestro_home_dir()
             .map(|home| home.join("policy.json").is_file())
             .unwrap_or(false)
-        || legacy_composer_dir()
+        || legacy_composer_home_dir()
             .map(|home| home.join("policy.json").is_file())
             .unwrap_or(false)
 }
@@ -203,20 +203,9 @@ fn rust_enterprise_mcp_config_exists() -> bool {
         || maestro_home_dir()
             .map(|home| home.join("enterprise").join("mcp.json").is_file())
             .unwrap_or(false)
-        || legacy_composer_dir()
+        || legacy_composer_home_dir()
             .map(|home| home.join("enterprise").join("mcp.json").is_file())
             .unwrap_or(false)
-}
-
-fn legacy_composer_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|home| home.join(".composer"))
-}
-
-fn maestro_home_dir() -> Option<PathBuf> {
-    env::var("MAESTRO_HOME")
-        .ok()
-        .and_then(|value| resolve_env_path(&value))
-        .or_else(|| dirs::home_dir().map(|home| home.join(".maestro")))
 }
 
 fn env_path_exists(name: &str) -> bool {

--- a/packages/tui-rs/src/safety/policy.rs
+++ b/packages/tui-rs/src/safety/policy.rs
@@ -13,7 +13,7 @@ use std::time::SystemTime;
 use regex::Regex;
 use url::Url;
 
-use crate::path_utils::env_path;
+use crate::path_utils::{env_path, legacy_composer_home_dir, maestro_home_dir};
 
 use super::dangerous_patterns::check_dangerous_patterns;
 use super::path_containment::{expand_tilde, is_tilde_path};
@@ -164,20 +164,11 @@ fn policy_path_candidates() -> Vec<PolicyPathCandidate> {
     if let Some(path) = env_path("MAESTRO_POLICY_PATH") {
         push_policy_path_candidate(&mut candidates, path, true);
     }
-    if let Some(maestro_home) = env_path("MAESTRO_HOME") {
+    if let Some(maestro_home) = maestro_home_dir() {
         push_policy_path_candidate(&mut candidates, maestro_home.join("policy.json"), false);
     }
-    if let Some(home) = dirs::home_dir() {
-        push_policy_path_candidate(
-            &mut candidates,
-            home.join(".maestro").join("policy.json"),
-            false,
-        );
-        push_policy_path_candidate(
-            &mut candidates,
-            home.join(".composer").join("policy.json"),
-            false,
-        );
+    if let Some(composer_home) = legacy_composer_home_dir() {
+        push_policy_path_candidate(&mut candidates, composer_home.join("policy.json"), false);
     }
     candidates
 }
@@ -947,6 +938,17 @@ fn is_private_ip(ip: &IpAddr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    fn restore_env_var(name: &str, previous: Option<String>) {
+        if let Some(value) = previous {
+            std::env::set_var(name, value);
+        } else {
+            std::env::remove_var(name);
+        }
+    }
 
     // ========================================================================
     // Private IP Detection Tests
@@ -1063,6 +1065,32 @@ mod tests {
             let p = path.unwrap();
             assert!(p.ends_with("policy.json"));
         }
+    }
+
+    #[test]
+    fn test_policy_path_candidates_use_custom_maestro_home_without_default_maestro_fallback() {
+        let _lock = ENV_MUTEX.lock().expect("lock env");
+        let previous_enterprise = std::env::var("MAESTRO_ENTERPRISE_POLICY_PATH").ok();
+        let previous_policy = std::env::var("MAESTRO_POLICY_PATH").ok();
+        let previous_home = std::env::var("MAESTRO_HOME").ok();
+        let home = dirs::home_dir().expect("home dir");
+
+        std::env::remove_var("MAESTRO_ENTERPRISE_POLICY_PATH");
+        std::env::remove_var("MAESTRO_POLICY_PATH");
+        std::env::set_var("MAESTRO_HOME", "/tmp/custom-maestro-home");
+
+        let paths: Vec<PathBuf> = policy_path_candidates()
+            .into_iter()
+            .map(|candidate| candidate.path)
+            .collect();
+
+        assert!(paths.contains(&PathBuf::from("/tmp/custom-maestro-home/policy.json")));
+        assert!(paths.contains(&home.join(".composer").join("policy.json")));
+        assert!(!paths.contains(&home.join(".maestro").join("policy.json")));
+
+        restore_env_var("MAESTRO_ENTERPRISE_POLICY_PATH", previous_enterprise);
+        restore_env_var("MAESTRO_POLICY_PATH", previous_policy);
+        restore_env_var("MAESTRO_HOME", previous_home);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `2598c4430aa24887fd378556a73f070038d84658`
- last generated public sync base: `eefb246dd89761c6d96b769b870c75ea68844451`
- previewed public-tree drift: `4` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (2598c4430aa2)`
- public projection: `https://github.com/evalops/maestro@main (eefb246dd897)`
- files to copy or update: `4`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/tui-rs/src/mcp/config.rs
- copy/update packages/tui-rs/src/path_utils.rs
- copy/update packages/tui-rs/src/runtime_badges.rs
- copy/update packages/tui-rs/src/safety/policy.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/tui-rs/src/mcp/config.rs
- copy/update packages/tui-rs/src/path_utils.rs
- copy/update packages/tui-rs/src/runtime_badges.rs
- copy/update packages/tui-rs/src/safety/policy.rs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode