### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/server/headless-runtime-service.ts
+++ b/src/server/headless-runtime-service.ts
@@ -106,7 +106,7 @@ export function inferFleetModelTier(
 	model: string,
 ): string | undefined {
 	const normalized = `${provider}/${model}`.toLowerCase();
-	if (normalized.includes("haiku") || normalized.includes("mini")) {
+	if (normalized.includes("haiku") || hasMiniModelVariant(normalized)) {
 		return "fast";
 	}
 	if (
@@ -122,7 +122,11 @@ export function inferFleetModelTier(
 	return undefined;
 }
 
-function getFleetPlatformEventBusStatus():
+function hasMiniModelVariant(normalizedProviderModel: string): boolean {
+	return /(?:^|[/:._-])mini(?:$|[/:._-])/.test(normalizedProviderModel);
+}
+
+export function getFleetPlatformEventBusStatus():
 	| NonNullable<FleetAgentInstance["platformEventBus"]>
 	| undefined {
 	const explicitFlag = parseBooleanEnv(
@@ -131,7 +135,11 @@ function getFleetPlatformEventBusStatus():
 	if (explicitFlag === false) {
 		return { enabled: false, reason: "flag disabled" };
 	}
-	if (process.env.MAESTRO_EVENT_BUS_URL || process.env.EVALOPS_NATS_URL) {
+	if (
+		process.env.MAESTRO_EVENT_BUS_URL ||
+		process.env.EVALOPS_NATS_URL ||
+		process.env.NATS_URL
+	) {
 		return { enabled: true, reason: "nats", subject: AMBIENT_ROUTING_SUBJECT };
 	}
 	if (

--- a/test/server/headless-runtime-service.test.ts
+++ b/test/server/headless-runtime-service.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { inferFleetModelTier } from "../../src/server/headless-runtime-service.js";
+import {
+	getFleetPlatformEventBusStatus,
+	inferFleetModelTier,
+} from "../../src/server/headless-runtime-service.js";
 
 describe("inferFleetModelTier", () => {
 	it("classifies mini variants as fast before GPT-5 frontier matching", () => {
@@ -13,5 +16,30 @@ describe("inferFleetModelTier", () => {
 		expect(inferFleetModelTier("anthropic", "claude-opus-4-1")).toBe(
 			"frontier",
 		);
+	});
+
+	it("does not classify gemini model names as mini variants", () => {
+		expect(inferFleetModelTier("google", "gemini-2.5-pro")).toBeUndefined();
+		expect(
+			inferFleetModelTier("google", "gemini-3-pro-preview"),
+		).toBeUndefined();
+	});
+});
+
+describe("getFleetPlatformEventBusStatus", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("recognizes NATS_URL like the Rust event bus config", () => {
+		vi.stubEnv("NATS_URL", "nats://bus.example:4222");
+		vi.stubEnv("MAESTRO_EVENT_BUS_URL", "");
+		vi.stubEnv("EVALOPS_NATS_URL", "");
+
+		expect(getFleetPlatformEventBusStatus()).toEqual({
+			enabled: true,
+			reason: "nats",
+			subject: "maestro.ambient_agent.routing.selected",
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `12885b8b2270681352befd874148007b71dec83e`
- last generated public sync base: `7eee9ef4422fd1cec8f75c17dca300a618629d9a`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (12885b8b2270)`
- public projection: `https://github.com/evalops/maestro@main (7eee9ef4422f)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/server/headless-runtime-service.ts
- copy/update test/server/headless-runtime-service.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/server/headless-runtime-service.ts
- copy/update test/server/headless-runtime-service.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode