### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/server/handlers/runtime-app-server-ws.ts
+++ b/src/server/handlers/runtime-app-server-ws.ts
@@ -133,6 +133,7 @@ export function handleRuntimeAppServerWebSocket(
 	const manager = options.serverRequestManager ?? defaultServerRequestManager;
 	let sessionId = options.sessionId;
 	let bindingSessionId: string | undefined;
+	let initialized = false;
 	const sentRegisteredRequestIds = new Set<string>();
 	const sendServerRequestEvent = (event: ServerRequestLifecycleEvent): void => {
 		if (event.type === "registered") {
@@ -145,7 +146,7 @@ export function handleRuntimeAppServerWebSocket(
 		});
 	};
 	const replayPendingServerRequests = (): void => {
-		if (!sessionId) {
+		if (!initialized || !sessionId) {
 			return;
 		}
 		for (const request of manager.listPending({ sessionId })) {
@@ -190,12 +191,11 @@ export function handleRuntimeAppServerWebSocket(
 		}
 	};
 	const unsubscribe = manager.subscribe((event) => {
-		if (!sessionId || event.request.sessionId !== sessionId) {
+		if (!initialized || !sessionId || event.request.sessionId !== sessionId) {
 			return;
 		}
 		sendServerRequestEvent(event);
 	});
-	replayPendingServerRequests();
 
 	ws.on("message", async (data) => {
 		let parsed: unknown;
@@ -219,6 +219,7 @@ export function handleRuntimeAppServerWebSocket(
 					method: "runtime.initialized",
 					params: result,
 				});
+				initialized = true;
 				replayPendingServerRequests();
 				return;
 			}

--- a/test/server/runtime-app-server-ws.test.ts
+++ b/test/server/runtime-app-server-ws.test.ts
@@ -108,6 +108,17 @@ describe("runtime app-server WebSocket", () => {
 			serverRequestManager: manager,
 			sessionId: "sess_1",
 		});
+		socket.emit(
+			"message",
+			JSON.stringify({
+				jsonrpc: "2.0",
+				id: "init-1",
+				method: "runtime.initialize",
+				params: { sessionId: "sess_1" },
+			}),
+		);
+		await Promise.resolve();
+		socket.sent.length = 0;
 
 		manager.registerApproval({
 			sessionId: "sess_other",
@@ -253,6 +264,60 @@ describe("runtime app-server WebSocket", () => {
 				(notification) => notification.params?.request?.id === "approval_other",
 			),
 		).toBe(false);
+	});
+
+	it("delays pre-bound pending request replay until initialization completes", async () => {
+		const socket = new FakeSocket();
+		const manager = new ServerRequestManager();
+		const approvalService = new ActionApprovalService("prompt");
+
+		manager.registerApproval({
+			sessionId: "sess_1",
+			request: {
+				id: "approval_prebound",
+				toolName: "bash",
+				args: { command: "git status" },
+				reason: "Approval required",
+			},
+			service: approvalService,
+		});
+
+		handleRuntimeAppServerWebSocket(socket as unknown as WebSocket, {
+			serverRequestManager: manager,
+			sessionId: "sess_1",
+		});
+
+		expect(socket.sent).toEqual([]);
+
+		socket.emit(
+			"message",
+			JSON.stringify({
+				jsonrpc: "2.0",
+				id: "init-1",
+				method: "runtime.initialize",
+				params: { sessionId: "sess_1" },
+			}),
+		);
+		await Promise.resolve();
+
+		const messages = socket.sent.map((payload) => JSON.parse(payload));
+		expect(messages).toEqual([
+			expect.objectContaining({
+				jsonrpc: "2.0",
+				id: "init-1",
+			}),
+			expect.objectContaining({
+				jsonrpc: "2.0",
+				method: "runtime.initialized",
+			}),
+			expect.objectContaining({
+				jsonrpc: "2.0",
+				method: "runtime.server_request.registered",
+				params: expect.objectContaining({
+					request: expect.objectContaining({ id: "approval_prebound" }),
+				}),
+			}),
+		]);
 	});
 
 	it("rejects session initialization when access validation fails", async () => {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `a7a5b49ead0ad6610349e30b5391760ca1cd046f`
- last generated public sync base: `cdec34ba464728ce6f4b9250d10245828d38716d`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (a7a5b49ead0a)`
- public projection: `https://github.com/evalops/maestro@main (cdec34ba4647)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/server/handlers/runtime-app-server-ws.ts
- copy/update test/server/runtime-app-server-ws.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/server/handlers/runtime-app-server-ws.ts
- copy/update test/server/runtime-app-server-ws.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode