### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -33,9 +33,78 @@ export const MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG =
 export const MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG =
 	"maestro.platform_runtime.tool_execution_bridge";
 
+export type FeatureFlagDecision = {
+	key: string;
+	metadata: Record<string, unknown>;
+	reason: string;
+	value: boolean;
+	variant: string;
+};
+
+export type ExperimentAssignment = {
+	assigned: boolean;
+	bucket: number;
+	experimentId: string;
+	exposureRecorded: boolean;
+	flagKey: string;
+	holdoutId?: string;
+	inHoldout: boolean;
+	layerId?: string;
+	metadata: Record<string, unknown>;
+	namespaceEnd: number;
+	namespaceStart: number;
+	reason: string;
+	subject: string;
+	variant: string;
+	variantBucket: number;
+};
+
+export type FeatureFlagRequestContext = {
+	attributes?: Record<string, string | number | boolean | null | undefined>;
+	subject: string;
+};
+
+export type FeatureFlagRemoteOptions = {
+	baseUrl?: string;
+	headers?: Record<string, string>;
+	timeoutMs?: number;
+};
+
+const DEFAULT_IN_CLUSTER_FLAG_CONTROL_URL =
+	"http://flag-control-service.evalops.svc.cluster.local:8080";
+const DEFAULT_OUT_OF_CLUSTER_FLAG_CONTROL_URL =
+	"https://flags.internal.evalops.dev";
+const DEFAULT_REMOTE_TIMEOUT_MS = 2_000;
+
 function getFeatureFlagsPath(): string | undefined {
 	const configured = process.env.EVALOPS_FEATURE_FLAGS_PATH?.trim();
 	return configured ? configured : undefined;
+}
+
+function getFeatureFlagRemoteBaseUrl(): string {
+	return (
+		process.env.EVALOPS_FEATURE_FLAGS_URL?.trim() ||
+		process.env.EVALOPS_FLAG_CONTROL_URL?.trim() ||
+		(process.env.KUBERNETES_SERVICE_HOST
+			? DEFAULT_IN_CLUSTER_FLAG_CONTROL_URL
+			: DEFAULT_OUT_OF_CLUSTER_FLAG_CONTROL_URL)
+	).replace(/\/+$/, "");
+}
+
+function getFeatureFlagRemoteHeaders(
+	headers?: Record<string, string>,
+): Record<string, string> {
+	const merged: Record<string, string> = { ...(headers ?? {}) };
+	const token =
+		process.env.EVALOPS_FEATURE_FLAGS_BEARER_TOKEN?.trim() ||
+		process.env.EVALOPS_FLAG_CONTROL_BEARER_TOKEN?.trim();
+	const hasAuthorization = Object.keys(merged).some(
+		(key) => key.toLowerCase() === "authorization",
+	);
+	if (token && !hasAuthorization) {
+		merged.Authorization = `Bearer ${token}`;
+	}
+	return merged;
 }
 
 function readFeatureFlagSnapshot(): FeatureFlagSnapshot | null {
@@ -111,6 +180,290 @@ export function isPlatformToolExecutionBridgeEnabled(): boolean {
 	return isFeatureFlagEnabled(
 		MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
 	);
+}
+
+export async function evaluateFeatureFlag(
+	key: string,
+	context: FeatureFlagRequestContext,
+	defaultValue = false,
+	options: FeatureFlagRemoteOptions = {},
+): Promise<FeatureFlagDecision> {
+	const normalizedKey = key.trim();
+	if (!normalizedKey) {
+		return fallbackDecision(
+			normalizedKey,
+			context,
+			defaultValue,
+			"missing_key",
+		);
+	}
+
+	try {
+		const response = await postJSON(
+			`${remoteBaseUrl(options)}/ofrep/v1/evaluate/flags/${encodeURIComponent(normalizedKey)}`,
+			JSON.stringify({ context: remoteContext(context) }),
+			options,
+		);
+		if (response.status === 404) {
+			return fallbackDecision(
+				normalizedKey,
+				context,
+				defaultValue,
+				"not_found",
+			);
+		}
+		if (!response.ok) {
+			return fallbackDecision(
+				normalizedKey,
+				context,
+				defaultValue,
+				`remote_status_${response.status}`,
+			);
+		}
+
+		const payload = (await response.json()) as {
+			key?: string;
+			metadata?: Record<string, unknown>;
+			reason?: string;
+			value?: unknown;
+			variant?: string;
+		};
+		if (typeof payload.value !== "boolean") {
+			return fallbackDecision(
+				normalizedKey,
+				context,
+				defaultValue,
+				"invalid_remote_value",
+			);
+		}
+		const metadata = getRecord(payload.metadata);
+		return {
+			key: payload.key?.trim() || normalizedKey,
+			metadata,
+			reason:
+				getString(metadata.flag_reason) || payload.reason?.trim() || "remote",
+			value: payload.value,
+			variant: payload.variant?.trim() || booleanVariant(payload.value),
+		};
+	} catch (error) {
+		return fallbackDecision(
+			normalizedKey,
+			context,
+			defaultValue,
+			error instanceof Error ? error.message : "remote_error",
+		);
+	}
+}
+
+export async function assignExperiment(
+	experimentId: string,
+	context: FeatureFlagRequestContext,
+	options: FeatureFlagRemoteOptions & {
+		metadata?: Record<string, unknown>;
+		recordExposure?: boolean;
+	} = {},
+): Promise<ExperimentAssignment> {
+	const normalizedExperimentId = experimentId.trim();
+	if (!normalizedExperimentId) {
+		return missingAssignment(
+			normalizedExperimentId,
+			context,
+			"missing_experiment_id",
+		);
+	}
+	const subject = context.subject.trim();
+	if (!subject) {
+		return missingAssignment(
+			normalizedExperimentId,
+			context,
+			"missing_subject",
+		);
+	}
+
+	try {
+		const response = await postJSON(
+			`${remoteBaseUrl(options)}/api/experiments/${encodeURIComponent(normalizedExperimentId)}/assign`,
+			JSON.stringify({
+				context: remoteContext(context),
+				metadata: options.metadata ?? {},
+				record_exposure: options.recordExposure,
+				subject,
+			}),
+			options,
+		);
+		if (response.status === 404) {
+			return missingAssignment(
+				normalizedExperimentId,
+				context,
+				"missing_experiment",
+			);
+		}
+		if (!response.ok) {
+			return missingAssignment(
+				normalizedExperimentId,
+				context,
+				`remote_status_${response.status}`,
+			);
+		}
+
+		const payload = (await response.json()) as Record<string, unknown>;
+		return {
+			assigned: payload.assigned === true,
+			bucket: getNumber(payload.bucket),
+			experimentId: getString(payload.experiment_id) || normalizedExperimentId,
+			exposureRecorded: payload.exposure_recorded === true,
+			flagKey: getString(payload.flag_key),
+			holdoutId: getString(payload.holdout_id) || undefined,
+			inHoldout: payload.in_holdout === true,
+			layerId: getString(payload.layer_id) || undefined,
+			metadata: getRecord(payload.metadata),
+			namespaceEnd: getNumber(payload.namespace_end),
+			namespaceStart: getNumber(payload.namespace_start),
+			reason: getString(payload.reason) || "remote",
+			subject: getString(payload.subject) || subject,
+			variant: getString(payload.variant),
+			variantBucket: getNumber(payload.variant_bucket),
+		};
+	} catch (error) {
+		return missingAssignment(
+			normalizedExperimentId,
+			context,
+			error instanceof Error ? error.message : "remote_error",
+		);
+	}
+}
+
+function remoteBaseUrl(options: FeatureFlagRemoteOptions): string {
+	const configured = options.baseUrl?.trim().replace(/\/+$/, "");
+	return configured || getFeatureFlagRemoteBaseUrl();
+}
+
+function remoteContext(
+	context: FeatureFlagRequestContext,
+): Record<string, string | number | boolean> {
+	const remote: Record<string, string | number | boolean> = {};
+	for (const [key, value] of Object.entries(context.attributes ?? {})) {
+		const normalizedKey = key.trim();
+		if (!normalizedKey || value == null) {
+			continue;
+		}
+		if (normalizedKey === "subject" || normalizedKey === "targetingKey") {
+			continue;
+		}
+		if (typeof value === "string") {
+			const normalizedValue = value.trim();
+			if (normalizedValue) {
+				remote[normalizedKey] = normalizedValue;
+			}
+			continue;
+		}
+		remote[normalizedKey] = value;
+	}
+	const subject = context.subject.trim();
+	if (subject) {
+		remote.subject = subject;
+		remote.targetingKey = subject;
+	}
+	return remote;
+}
+
+function remoteTimeoutMs(
+	options: FeatureFlagRemoteOptions,
+): number | undefined {
+	if (options.timeoutMs == null) {
+		return DEFAULT_REMOTE_TIMEOUT_MS;
+	}
+	if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
+		return undefined;
+	}
+	return Math.max(1, Math.trunc(options.timeoutMs));
+}
+
+async function postJSON(
+	url: string,
+	body: string,
+	options: FeatureFlagRemoteOptions,
+): Promise<Response> {
+	const controller = new AbortController();
+	const timeoutMs = remoteTimeoutMs(options);
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	if (timeoutMs != null) {
+		timeout = setTimeout(() => controller.abort(), timeoutMs);
+	}
+	try {
+		return await fetch(url, {
+			body,
+			headers: {
+				accept: "application/json",
+				"content-type": "application/json",
+				...getFeatureFlagRemoteHeaders(options.headers),
+			},
+			method: "POST",
+			signal: controller.signal,
+		});
+	} finally {
+		if (timeout != null) {
+			clearTimeout(timeout);
+		}
+	}
+}
+
+function fallbackDecision(
+	key: string,
+	context: FeatureFlagRequestContext,
+	defaultValue: boolean,
+	reason: string,
+): FeatureFlagDecision {
+	return {
+		key,
+		metadata: {
+			fallback_used: true,
+			flag_subject: context.subject.trim(),
+		},
+		reason,
+		value: defaultValue,
+		variant: booleanVariant(defaultValue),
+	};
+}
+
+function missingAssignment(
+	experimentId: string,
+	context: FeatureFlagRequestContext,
+	reason: string,
+): ExperimentAssignment {
+	return {
+		assigned: false,
+		bucket: 0,
+		experimentId,
+		exposureRecorded: false,
+		flagKey: "",
+		inHoldout: false,
+		metadata: { fallback_used: true },
+		namespaceEnd: 0,
+		namespaceStart: 0,
+		reason,
+		subject: context.subject.trim(),
+		variant: "",
+		variantBucket: 0,
+	};
+}
+
+function booleanVariant(value: boolean): string {
+	return value ? "true" : "false";
+}
+
+function getRecord(value: unknown): Record<string, unknown> {
+	return value != null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+function getString(value: unknown): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function getNumber(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
 export function resetFeatureFlagCacheForTests(): void {

--- a/test/config/feature-flags.test.ts
+++ b/test/config/feature-flags.test.ts
@@ -1,4 +1,9 @@
 import { writeFileSync } from "node:fs";
+import {
+	type IncomingMessage,
+	type ServerResponse,
+	createServer,
+} from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +15,8 @@ import {
 	MAESTRO_PLATFORM_RUNTIME_BRIDGE_KILL_SWITCH,
 	MAESTRO_PLATFORM_RUNTIME_TOOL_EXECUTION_BRIDGE_FLAG,
 	areAutonomousActionsDisabled,
+	assignExperiment,
+	evaluateFeatureFlag,
 	isDraftAndConfirmDefaultEnabled,
 	isFeatureFlagEnabled,
 	isPlatformRuntimeBridgeDisabled,
@@ -21,6 +28,11 @@ import {
 describe("feature flags", () => {
 	afterEach(() => {
 		Reflect.deleteProperty(process.env, "EVALOPS_FEATURE_FLAGS_PATH");
+		Reflect.deleteProperty(process.env, "EVALOPS_FEATURE_FLAGS_URL");
+		Reflect.deleteProperty(process.env, "EVALOPS_FEATURE_FLAGS_BEARER_TOKEN");
+		Reflect.deleteProperty(process.env, "EVALOPS_FLAG_CONTROL_URL");
+		Reflect.deleteProperty(process.env, "EVALOPS_FLAG_CONTROL_BEARER_TOKEN");
+		Reflect.deleteProperty(process.env, "KUBERNETES_SERVICE_HOST");
 		resetFeatureFlagCacheForTests();
 	});
 
@@ -141,4 +153,300 @@ describe("feature flags", () => {
 
 		expect(isPlatformRuntimeBridgeDisabled()).toBe(true);
 	});
+
+	it("evaluates a remote flag through the OFREP-compatible endpoint", async () => {
+		const server = await startJSONServer(async (request, response) => {
+			expect(request.method).toBe("POST");
+			expect(request.url).toBe(
+				"/ofrep/v1/evaluate/flags/maestro.platform_runtime.agent_runtime_observe",
+			);
+			expect(request.headers.authorization).toBe("Bearer test-token");
+			const payload = await readJSON(request);
+			expect(payload).toMatchObject({
+				context: {
+					cohort_enabled: true,
+					rollout_bucket: 17,
+					subject: "workspace-1",
+					surface: "maestro",
+					targetingKey: "workspace-1",
+				},
+			});
+
+			writeJSON(response, {
+				key: "maestro.platform_runtime.agent_runtime_observe",
+				metadata: {
+					flag_found: true,
+					flag_reason: "included",
+					flag_subject: "workspace-1",
+					rollout_bucket: 17,
+				},
+				reason: "SPLIT",
+				value: true,
+				variant: "true",
+			});
+		});
+		try {
+			process.env.EVALOPS_FEATURE_FLAGS_URL = server.url;
+			process.env.EVALOPS_FEATURE_FLAGS_BEARER_TOKEN = "test-token";
+
+			await expect(
+				evaluateFeatureFlag(
+					"maestro.platform_runtime.agent_runtime_observe",
+					{
+						attributes: {
+							cohort_enabled: true,
+							rollout_bucket: 17,
+							surface: "maestro",
+						},
+						subject: "workspace-1",
+					},
+					false,
+				),
+			).resolves.toMatchObject({
+				key: "maestro.platform_runtime.agent_runtime_observe",
+				reason: "included",
+				value: true,
+				variant: "true",
+			});
+		} finally {
+			await server.close();
+		}
+	});
+
+	it("falls back when remote flag values are not boolean", async () => {
+		const server = await startJSONServer(async (_request, response) => {
+			writeJSON(response, {
+				key: "maestro.platform_runtime.agent_runtime_observe",
+				value: "true",
+				variant: "enabled",
+			});
+		});
+		try {
+			await expect(
+				evaluateFeatureFlag(
+					"maestro.platform_runtime.agent_runtime_observe",
+					{ subject: "workspace-1" },
+					false,
+					{ baseUrl: server.url },
+				),
+			).resolves.toMatchObject({
+				reason: "invalid_remote_value",
+				value: false,
+				variant: "false",
+			});
+		} finally {
+			await server.close();
+		}
+	});
+
+	it("ignores non-object remote flag metadata", async () => {
+		const server = await startJSONServer(async (_request, response) => {
+			writeJSON(response, {
+				key: "maestro.platform_runtime.agent_runtime_observe",
+				metadata: ["flag_reason", "included"],
+				reason: "REMOTE_DEFAULT",
+				value: true,
+				variant: "true",
+			});
+		});
+		try {
+			await expect(
+				evaluateFeatureFlag(
+					"maestro.platform_runtime.agent_runtime_observe",
+					{ subject: "workspace-1" },
+					false,
+					{ baseUrl: server.url },
+				),
+			).resolves.toMatchObject({
+				metadata: {},
+				reason: "REMOTE_DEFAULT",
+				value: true,
+				variant: "true",
+			});
+		} finally {
+			await server.close();
+		}
+	});
+
+	it("treats empty remote base URL overrides as unset", async () => {
+		const server = await startJSONServer(async (_request, response) => {
+			writeJSON(response, {
+				key: "maestro.platform_runtime.agent_runtime_observe",
+				value: true,
+			});
+		});
+		try {
+			process.env.EVALOPS_FEATURE_FLAGS_URL = server.url;
+
+			await expect(
+				evaluateFeatureFlag(
+					"maestro.platform_runtime.agent_runtime_observe",
+					{ subject: "workspace-1" },
+					false,
+					{ baseUrl: "  /  " },
+				),
+			).resolves.toMatchObject({
+				value: true,
+				variant: "true",
+			});
+		} finally {
+			await server.close();
+		}
+	});
+
+	for (const timeoutMs of [0, -1]) {
+		it(`treats timeoutMs=${timeoutMs} as disabling the remote timeout`, async () => {
+			const server = await startJSONServer(async (_request, response) => {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				writeJSON(response, {
+					key: "maestro.platform_runtime.agent_runtime_observe",
+					metadata: { flag_reason: "included" },
+					value: true,
+					variant: "true",
+				});
+			});
+			try {
+				await expect(
+					evaluateFeatureFlag(
+						"maestro.platform_runtime.agent_runtime_observe",
+						{ subject: "workspace-1" },
+						false,
+						{ baseUrl: server.url, timeoutMs },
+					),
+				).resolves.toMatchObject({
+					key: "maestro.platform_runtime.agent_runtime_observe",
+					reason: "included",
+					value: true,
+					variant: "true",
+				});
+			} finally {
+				await server.close();
+			}
+		});
+	}
+
+	it("assigns a remote experiment and records caller metadata", async () => {
+		const server = await startJSONServer(async (request, response) => {
+			expect(request.method).toBe("POST");
+			expect(request.url).toBe(
+				"/api/experiments/maestro.router_quality_ab/assign",
+			);
+			const payload = await readJSON(request);
+			expect(payload).toMatchObject({
+				context: {
+					plan_tier: "enterprise",
+					subject: "workspace-1",
+					targetingKey: "workspace-1",
+				},
+				metadata: {
+					surface: "maestro",
+				},
+				record_exposure: false,
+				subject: "workspace-1",
+			});
+
+			writeJSON(response, {
+				assigned: true,
+				bucket: 42,
+				experiment_id: "maestro.router_quality_ab",
+				exposure_recorded: false,
+				flag_key: "maestro.model_router.candidate",
+				in_holdout: false,
+				layer_id: "maestro-routing",
+				metadata: { surface: "maestro" },
+				namespace_end: 100,
+				namespace_start: 0,
+				reason: "assigned",
+				subject: "workspace-1",
+				variant: "candidate",
+				variant_bucket: 73,
+			});
+		});
+		try {
+			await expect(
+				assignExperiment(
+					"maestro.router_quality_ab",
+					{
+						attributes: {
+							plan_tier: "enterprise",
+							subject: "spoofed-workspace",
+							targetingKey: "spoofed-workspace",
+						},
+						subject: "workspace-1",
+					},
+					{
+						baseUrl: server.url,
+						metadata: { surface: "maestro" },
+						recordExposure: false,
+					},
+				),
+			).resolves.toMatchObject({
+				assigned: true,
+				experimentId: "maestro.router_quality_ab",
+				exposureRecorded: false,
+				flagKey: "maestro.model_router.candidate",
+				layerId: "maestro-routing",
+				reason: "assigned",
+				variant: "candidate",
+				variantBucket: 73,
+			});
+		} finally {
+			await server.close();
+		}
+	});
+
+	it("rejects blank experiment assignment subjects before remote calls", async () => {
+		await expect(
+			assignExperiment(
+				"maestro.router_quality_ab",
+				{ subject: "   " },
+				{ baseUrl: "https://flags.internal.evalops.dev" },
+			),
+		).resolves.toMatchObject({
+			assigned: false,
+			reason: "missing_subject",
+			subject: "",
+		});
+	});
 });
+
+async function startJSONServer(
+	handler: (
+		request: IncomingMessage,
+		response: ServerResponse,
+	) => Promise<void>,
+): Promise<{ close: () => Promise<void>; url: string }> {
+	const server = createServer((request, response) => {
+		handler(request, response).catch((error: unknown) => {
+			response.statusCode = 500;
+			response.end(error instanceof Error ? error.message : String(error));
+		});
+	});
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	if (address == null || typeof address === "string") {
+		throw new Error("test server did not bind a TCP address");
+	}
+	return {
+		close: () =>
+			new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			}),
+		url: `http://127.0.0.1:${address.port}`,
+	};
+}
+
+async function readJSON(request: IncomingMessage): Promise<unknown> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of request) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function writeJSON(response: ServerResponse, payload: unknown): void {
+	response.setHeader("content-type", "application/json");
+	response.end(JSON.stringify(payload));
+}


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `8565e8691d4916f5f25f1d77014081b93592837a`
- last generated public sync base: `ab3feb9c649ef865e8a5b19c1a192f55301a84ed`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (8565e8691d49)`
- public projection: `https://github.com/evalops/maestro@main (ab3feb9c649e)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/config/feature-flags.ts
- copy/update test/config/feature-flags.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/config/feature-flags.ts
- copy/update test/config/feature-flags.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #250 to internal source `8565e8691d4916f5f25f1d77014081b93592837a`