### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/run-timeline.md
+++ b/docs/protocols/run-timeline.md
@@ -5,9 +5,19 @@ Maestro exposes a session-scoped run timeline at
 answering what happened in a run without exposing raw tool arguments, raw diffs,
 or secret-bearing payloads.
 
-The current source is local session state. Platform-backed population can replace
-or augment this projection later as long as it preserves the same redaction and
-visibility rules.
+Local sessions use local session state. Hosted/Platform-backed sessions prefer
+Platform `MaestroTimelineService/ListRunTimeline` when Maestro has an
+`agent_run_id` or `remote_runner_session_id`, then fall back to the local
+projection if Platform is not configured or unavailable. That keeps the visible
+workflow understandable: start or attach a Maestro session, run governed tools,
+and inspect the same run in Platform's timeline.
+
+Required Platform configuration follows the shared EvalOps client conventions:
+
+- `MAESTRO_PLATFORM_BASE_URL` or `MAESTRO_TIMELINE_SERVICE_URL`
+- `MAESTRO_EVALOPS_ACCESS_TOKEN` or `MAESTRO_TIMELINE_SERVICE_TOKEN`
+- `MAESTRO_EVALOPS_ORG_ID`
+- `MAESTRO_REMOTE_RUNNER_WORKSPACE_ID` or `MAESTRO_TIMELINE_WORKSPACE_ID`
 
 ## Visibility Classes
 
@@ -39,7 +49,7 @@ Do not put raw tool arguments, raw diffs, command strings, file contents, or
 full secret-bearing payloads in `summary` or `metadata`. Prefer counts, stable
 IDs, display paths, result classifications, and booleans such as `hasDiff`.
 
-Known local event families:
+Known event families:
 
 - `session.*`, `message.*`, `tool.*`, and `wait.pending`
 - `file.changed` for write/edit tool results

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint:headless-proto": "buf lint && bun run verify:headless-proto:sync && bun run check:headless-proto:generated",
     "lint:evals": "bun run lint:headless-proto && node scripts/verify-evals.js && node scripts/verify-tool-versions.js && node scripts/validate-system-paths.js && node scripts/validate-package-boundaries.js && node scripts/validate-public-package-deps.js && node scripts/session-wire-format-codegen.mjs --check && node scripts/headless-protocol-codegen.mjs --check && npm run developer-surface:check",
     "platform:sdk-smoke": "tsx scripts/check-platform-sdk-contract.ts",
+    "platform:timeline-e2e": "tsx scripts/smoke-platform-timeline-e2e.ts",
     "developer-surface:check": "node scripts/check-developer-surface.mjs",
     "format": "biome format .",
     "check": "npm run lint && npm run check --workspaces --if-present && tsc -p tsconfig.build.json --noEmit",

--- a/packages/ai/tsconfig.build.json
+++ b/packages/ai/tsconfig.build.json
@@ -51,6 +51,7 @@
 		"../../src/telemetry.ts",
 		"../../src/opentelemetry.ts",
 		"../../src/training.ts",
+		"../../src/timeline/**/*.ts",
 		"../../src/mcp/elicitation.ts",
 		"../../src/guardian/**/*.ts",
 		"../../src/lsp/**/*.ts",

--- a/scripts/check-platform-sdk-contract.ts
+++ b/scripts/check-platform-sdk-contract.ts
@@ -19,6 +19,10 @@ import {
 const EXPECTED_PACKAGE_NAME = "@evalops/sdk-ts";
 
 const serviceModules = {
+	agentRuntime: {
+		specifier: "agentruntime/v1/runtime_pb",
+		exportName: "AgentRuntimeService",
+	},
 	approvals: {
 		specifier: "approvals/v1/approvals_pb",
 		exportName: "ApprovalService",
@@ -35,6 +39,10 @@ const serviceModules = {
 		specifier: "llmgateway/v1/gateway_pb",
 		exportName: "GatewayService",
 	},
+	maestroTimeline: {
+		specifier: "maestro/v1/timeline_pb",
+		exportName: "MaestroTimelineService",
+	},
 	meter: {
 		specifier: "meter/v1/meter_pb",
 		exportName: "MeterService",
@@ -42,6 +50,14 @@ const serviceModules = {
 	prompts: {
 		specifier: "prompts/v1/prompts_pb",
 		exportName: "PromptService",
+	},
+	remoteRunner: {
+		specifier: "remoterunner/v1/remoterunner_pb",
+		exportName: "RemoteRunnerService",
+	},
+	toolexecution: {
+		specifier: "toolexecution/v1/toolexecution_pb",
+		exportName: "ToolExecutionService",
 	},
 } as const;
 

--- a/scripts/smoke-platform-timeline-e2e.ts
+++ b/scripts/smoke-platform-timeline-e2e.ts
@@ -1,0 +1,323 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { listMaestroTimelineWithPlatform } from "../src/platform/maestro-timeline-client.js";
+
+const GO_SERVER = String.raw`
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	agentruntimev1 "github.com/evalops/platform/gen/go/agentruntime/v1"
+	approvalsv1 "github.com/evalops/platform/gen/go/approvals/v1"
+	"github.com/evalops/platform/gen/go/maestro/v1/maestrov1connect"
+	toolexecutionv1 "github.com/evalops/platform/gen/go/toolexecution/v1"
+	"github.com/evalops/platform/internal/agentruntime/agentruntime"
+	"github.com/evalops/platform/internal/approvals/approvals"
+	auditevents "github.com/evalops/platform/internal/audit/events"
+	"github.com/evalops/platform/internal/maestro/timeline"
+	"github.com/evalops/platform/internal/toolexecution/toolexecution"
+	"github.com/evalops/platform/pkg/authmw"
+	"github.com/evalops/platform/pkg/connectkit"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	ctx := context.Background()
+	base := time.Date(2026, 4, 30, 18, 0, 0, 0, time.UTC)
+	runtimeStore := agentruntime.NewMemoryStore()
+	toolStore := toolexecution.NewMemoryStore()
+	approvalStore := approvals.NewMemoryStore()
+	auditStore := auditevents.NewStore()
+
+	run := &agentruntimev1.AgentRun{
+		Id: "run_1",
+		Trigger: &agentruntimev1.NormalizedTrigger{
+			WorkspaceId:    "ws_1",
+			AgentId:        "maestro",
+			ChannelId:      "maestro-session:session_1",
+			IdempotencyKey: "maestro-session:ws_1:session_1",
+		},
+		Linkage: &agentruntimev1.AgentRunLinkage{
+			RunId:       "run_1",
+			WorkspaceId: "ws_1",
+			AgentId:     "maestro",
+			ObjectiveId: "obj_1",
+		},
+		CreatedAt: timestamppb.New(base),
+		UpdatedAt: timestamppb.New(base),
+	}
+	_, _, _, err := runtimeStore.CreateRun(ctx, run, []*agentruntimev1.RuntimeEvent{
+		{
+			Id:         "evt_wait",
+			Type:       agentruntimev1.RuntimeEventType_RUNTIME_EVENT_TYPE_RUN_WAITING,
+			Message:    "waiting for approval",
+			OccurredAt: timestamppb.New(base.Add(2 * time.Minute)),
+			WaitId:     "wait_1",
+		},
+	})
+	must(err)
+
+	approvalRequest := approvals.ApprovalRequestRecord{
+		ID:             "approval_1",
+		WorkspaceID:    "ws_1",
+		ApproverUserID: "manager_1",
+		AgentID:        "maestro",
+		Surface:        "maestro",
+		ActionType:     "run governed shell command",
+		RiskLevel:      approvalsv1.RiskLevel_RISK_LEVEL_HIGH,
+		State:          "pending",
+		CreatedAt:      base.Add(time.Minute),
+		UpdatedAt:      base.Add(time.Minute),
+		ExpiresAt:      base.Add(time.Hour),
+	}
+	_, err = approvalStore.CreateApprovalRequest(ctx, approvalRequest)
+	must(err)
+
+	execution := &toolexecutionv1.ToolExecution{
+		Id: "texec_1",
+		Linkage: &toolexecutionv1.ToolExecutionLinkage{
+			WorkspaceId:    "ws_1",
+			OrganizationId: "org_1",
+			AgentId:        "maestro",
+			RunId:          "run_1",
+			ObjectiveId:    "obj_1",
+			StepId:         "step_1",
+			CorrelationId:  "corr_1",
+		},
+		Tool: &toolexecutionv1.ToolRef{
+			Namespace:  "shell",
+			Name:       "npm test",
+			Capability: "command",
+		},
+		IdempotencyKey: "tool_idem_1",
+		State:          toolexecutionv1.ToolExecutionState_TOOL_EXECUTION_STATE_WAITING_APPROVAL,
+		ApprovalWait: &toolexecutionv1.ToolApprovalWait{
+			Id:                "wait_tool_1",
+			ApprovalRequestId: "approval_1",
+			ResumeToken:       "resume_1",
+			CreatedAt:         timestamppb.New(base.Add(time.Minute)),
+		},
+		CreatedAt: timestamppb.New(base.Add(time.Minute)),
+		UpdatedAt: timestamppb.New(base.Add(time.Minute)),
+	}
+	_, _, err = toolStore.CreateExecution(ctx, execution, &toolexecutionv1.ExecuteToolRequest{
+		Linkage:        execution.GetLinkage(),
+		Tool:           execution.GetTool(),
+		IdempotencyKey: "tool_idem_1",
+	})
+	must(err)
+
+	_, err = auditStore.Append(auditevents.Event{
+		Timestamp:      base.Add(4 * time.Minute),
+		OrganizationID: "org_1",
+		WorkspaceID:    "ws_1",
+		Surface:        "maestro",
+		Action:         "maestro.events.tool_call.completed",
+		Resource:       auditevents.Resource{Type: "tool_call", ID: "tool_call_1"},
+		Outcome:        "success",
+		Classification: "internal",
+		Metadata: map[string]any{
+			"maestro_event_type": "maestro.events.tool_call.completed",
+			"session_id":         "session_1",
+			"agent_run_id":       "run_1",
+			"tool_call_id":       "tool_call_1",
+			"tool_execution_id":  "texec_1",
+			"summary":            "npm test completed successfully",
+		},
+	})
+	must(err)
+
+	service := timeline.NewService(
+		timeline.WithRuntimeStore(runtimeStore),
+		timeline.WithToolExecutionStore(toolStore),
+		timeline.WithApprovalStore(approvalStore),
+		timeline.WithAuditStore(auditStore),
+	)
+	path, handler := maestrov1connect.NewMaestroTimelineServiceHandler(service, connectkit.StandardHandlerOptions()...)
+	principal := authmw.Principal{
+		OrganizationID: "org_1",
+		WorkspaceID:    "ws_1",
+		Subject:        "user_1",
+		Scopes:         []string{"maestro:timeline:read", "maestro:timeline:audit"},
+		IsHuman:        true,
+	}
+	mux := http.NewServeMux()
+	mux.Handle(path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := authmw.ContextWithPrincipal(r.Context(), principal)
+		handler.ServeHTTP(w, r.WithContext(ctx))
+	}))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	must(err)
+	fmt.Printf("PLATFORM_TIMELINE_URL=http://%s\n", listener.Addr().String())
+	_ = os.Stdout.Sync()
+	must(http.Serve(listener, mux))
+}
+`;
+
+function resolvePlatformRepo(): string {
+	const configured =
+		process.env.MAESTRO_PLATFORM_REPO?.trim() ||
+		process.env.PLATFORM_REPO?.trim();
+	if (configured) {
+		return resolve(configured);
+	}
+	return resolve(process.cwd(), "..", "platform");
+}
+
+async function waitForServer(
+	child: ReturnType<typeof spawn>,
+): Promise<string> {
+	return await new Promise((resolveUrl, reject) => {
+		let output = "";
+		const timeout = setTimeout(() => {
+			reject(new Error(`timed out waiting for Platform server: ${output}`));
+		}, 30_000);
+		child.stdout?.on("data", (chunk: Buffer) => {
+			output += chunk.toString("utf8");
+			const match = output.match(/PLATFORM_TIMELINE_URL=(http:\/\/[^\s]+)/u);
+			if (match?.[1]) {
+				clearTimeout(timeout);
+				resolveUrl(match[1]);
+			}
+		});
+		child.stderr?.on("data", (chunk: Buffer) => {
+			output += chunk.toString("utf8");
+		});
+		child.on("exit", (code, signal) => {
+			clearTimeout(timeout);
+			reject(
+				new Error(
+					`Platform timeline server exited before readiness code=${code} signal=${signal}: ${output}`,
+				),
+			);
+		});
+		child.on("error", (error) => {
+			clearTimeout(timeout);
+			reject(error);
+		});
+	});
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+	if (!condition) {
+		throw new Error(message);
+	}
+}
+
+async function terminateChild(
+	child: ReturnType<typeof spawn>,
+	exited: Promise<void>,
+): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return;
+	}
+	const killProcessGroup = process.platform !== "win32" && child.pid;
+	if (killProcessGroup) {
+		try {
+			process.kill(-child.pid, "SIGTERM");
+		} catch {
+			child.kill();
+		}
+	} else {
+		child.kill();
+	}
+	await Promise.race([
+		exited,
+		new Promise((resolve) => setTimeout(resolve, 5_000)),
+	]);
+	if (child.exitCode === null && child.signalCode === null) {
+		try {
+			if (killProcessGroup) {
+				process.kill(-child.pid, "SIGKILL");
+			} else {
+				child.kill("SIGKILL");
+			}
+		} catch {
+			child.kill("SIGKILL");
+		}
+		await Promise.race([
+			exited,
+			new Promise((resolve) => setTimeout(resolve, 1_000)),
+		]);
+	}
+}
+
+async function main(): Promise<void> {
+	const platformRepo = resolvePlatformRepo();
+	const tempDir = mkdtempSync(join(platformRepo, ".tmp-maestro-timeline-e2e-"));
+	writeFileSync(join(tempDir, "main.go"), GO_SERVER, "utf8");
+	const child = spawn("go", ["run", "."], {
+		cwd: tempDir,
+		detached: process.platform !== "win32",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	const exited = new Promise<void>((resolve) => {
+		child.once("exit", () => resolve());
+	});
+	try {
+		const baseUrl = await waitForServer(child);
+		const timeline = await listMaestroTimelineWithPlatform(
+			{
+				baseUrl,
+				token: "smoke",
+				organizationId: "org_1",
+				workspaceId: "ws_1",
+				timeoutMs: 5_000,
+				maxAttempts: 1,
+			},
+			{
+				sessionId: "session_1",
+				agentRunId: "run_1",
+				remoteRunnerSessionId: "rrs_1",
+				pendingRequestCount: 0,
+				includeAuditOnly: true,
+			},
+		);
+		const types = new Set(timeline.items.map((item) => item.type));
+		assert(timeline.platformBacked, "timeline was not marked Platform-backed");
+		assert(timeline.source === "platform", "timeline source was not Platform");
+		assert(types.has("wait.pending"), "missing wait.pending from Platform timeline");
+		assert(
+			types.has("tool.completed"),
+			"missing tool.completed from Platform audit event",
+		);
+		assert(
+			timeline.items.some(
+				(item) =>
+					item.toolExecutionId === "texec_1" &&
+					item.approvalRequestId === "approval_1" &&
+					item.platformOperation === "ResumeToolExecution",
+			),
+			"missing ToolExecution approval correlation",
+		);
+		assert(
+			timeline.items.some(
+				(item) =>
+					item.remoteRunnerSessionId === "rrs_1" ||
+					item.metadata?.agentRunId === "run_1",
+			),
+			"missing run or remote-runner correlation",
+		);
+		console.log(
+			`Validated Maestro timeline client against live Platform handler at ${baseUrl} (${timeline.items.length} entries)`,
+		);
+	} finally {
+		await terminateChild(child, exited);
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+await main();

--- a/src/platform/core-services.ts
+++ b/src/platform/core-services.ts
@@ -9,6 +9,7 @@ export const PLATFORM_CONNECT_SERVICES = {
 	connectors: "connectors.v1.ConnectorService",
 	governance: "governance.v1.GovernanceService",
 	llmGateway: "llmgateway.v1.GatewayService",
+	maestroTimeline: "maestro.v1.MaestroTimelineService",
 	meter: "meter.v1.MeterService",
 	prompts: "prompts.v1.PromptService",
 	remoteRunner: "remoterunner.v1.RemoteRunnerService",
@@ -136,6 +137,12 @@ export const PLATFORM_CONNECT_METHODS = {
 		getInfo: {
 			service: PLATFORM_CONNECT_SERVICES.llmGateway,
 			method: "GetInfo",
+		},
+	},
+	maestroTimeline: {
+		listRunTimeline: {
+			service: PLATFORM_CONNECT_SERVICES.maestroTimeline,
+			method: "ListRunTimeline",
 		},
 	},
 	meter: {

--- a/src/platform/maestro-timeline-client.ts
+++ b/src/platform/maestro-timeline-client.ts
@@ -1,0 +1,499 @@
+import type {
+	ComposerPendingRequestPlatformOperation,
+	ComposerRunTimelineEventType,
+	ComposerRunTimelineItem,
+	ComposerRunTimelineResponse,
+	ComposerRunTimelineStatus,
+	ComposerRunTimelineVisibility,
+} from "@evalops/contracts";
+import {
+	compactTimelineMetadata,
+	compactTimelineSummary,
+	redactTimelineMetadata,
+} from "../timeline/redaction.js";
+import {
+	type PlatformServiceConfig,
+	postPlatformConnect,
+	resolvePlatformServiceConfig,
+	trimString,
+} from "./client.js";
+import {
+	PLATFORM_CONNECT_METHODS,
+	platformConnectMethodPath,
+	platformConnectServicePath,
+} from "./core-services.js";
+
+const DEFAULT_TIMEOUT_MS = 2_500;
+const DEFAULT_MAX_ATTEMPTS = 2;
+
+const LIST_RUN_TIMELINE_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.maestroTimeline.listRunTimeline,
+);
+
+const TIMELINE_BASE_URL_ENV_VARS = [
+	"MAESTRO_TIMELINE_SERVICE_URL",
+	"MAESTRO_PLATFORM_TIMELINE_SERVICE_URL",
+	"MAESTRO_PLATFORM_BASE_URL",
+	"MAESTRO_EVALOPS_BASE_URL",
+	"EVALOPS_BASE_URL",
+] as const;
+
+const TIMELINE_TOKEN_ENV_VARS = [
+	"MAESTRO_TIMELINE_SERVICE_TOKEN",
+	"MAESTRO_PLATFORM_TIMELINE_SERVICE_TOKEN",
+	"MAESTRO_EVALOPS_ACCESS_TOKEN",
+	"EVALOPS_TOKEN",
+] as const;
+
+const TIMELINE_ORGANIZATION_ENV_VARS = [
+	"MAESTRO_TIMELINE_ORG_ID",
+	"MAESTRO_PLATFORM_TIMELINE_ORG_ID",
+	"MAESTRO_EVALOPS_ORG_ID",
+	"EVALOPS_ORGANIZATION_ID",
+	"MAESTRO_ENTERPRISE_ORG_ID",
+] as const;
+
+const TIMELINE_WORKSPACE_ENV_VARS = [
+	"MAESTRO_TIMELINE_WORKSPACE_ID",
+	"MAESTRO_PLATFORM_TIMELINE_WORKSPACE_ID",
+	"MAESTRO_REMOTE_RUNNER_WORKSPACE_ID",
+	"MAESTRO_EVALOPS_WORKSPACE_ID",
+	"EVALOPS_WORKSPACE_ID",
+	"MAESTRO_WORKSPACE_ID",
+] as const;
+
+const TIMELINE_TIMEOUT_ENV_VARS = [
+	"MAESTRO_TIMELINE_SERVICE_TIMEOUT_MS",
+	"MAESTRO_PLATFORM_TIMELINE_SERVICE_TIMEOUT_MS",
+] as const;
+
+const TIMELINE_MAX_ATTEMPTS_ENV_VARS = [
+	"MAESTRO_TIMELINE_SERVICE_MAX_ATTEMPTS",
+	"MAESTRO_PLATFORM_TIMELINE_SERVICE_MAX_ATTEMPTS",
+] as const;
+
+export interface MaestroTimelineServiceConfig extends PlatformServiceConfig {}
+
+export interface PlatformMaestroTimelineQuery {
+	sessionId: string;
+	workspaceId?: string;
+	organizationId?: string;
+	agentRunId?: string;
+	remoteRunnerSessionId?: string;
+	pageToken?: string;
+	includeAdminSummaries?: boolean;
+	includeAuditOnly?: boolean;
+	pendingRequestCount?: number;
+}
+
+interface PlatformTimelineEntry {
+	id?: string;
+	timestamp?: unknown;
+	type?: string;
+	title?: string;
+	summary?: string;
+	adminSummary?: string;
+	visibility?: string;
+	sensitivity?: string;
+	relatedIds?: Record<string, unknown>;
+	redactions?: string[];
+	sourceObject?: {
+		source?: string;
+		id?: string;
+		type?: string;
+	};
+	metadata?: Record<string, unknown>;
+}
+
+interface PlatformTimelineResponse {
+	organizationId?: string;
+	workspaceId?: string;
+	sessionId?: string;
+	agentRunId?: string;
+	remoteRunnerSessionId?: string;
+	entries?: PlatformTimelineEntry[];
+	partial?: boolean;
+	missingSources?: string[];
+	nextPageToken?: string;
+}
+
+export async function resolveMaestroTimelineServiceConfig(
+	overrides: Partial<MaestroTimelineServiceConfig> = {},
+): Promise<MaestroTimelineServiceConfig | null> {
+	const config = await resolvePlatformServiceConfig({
+		baseUrlEnvVars: TIMELINE_BASE_URL_ENV_VARS,
+		tokenEnvVars: TIMELINE_TOKEN_ENV_VARS,
+		organizationEnvVars: TIMELINE_ORGANIZATION_ENV_VARS,
+		workspaceEnvVars: TIMELINE_WORKSPACE_ENV_VARS,
+		timeoutEnvVars: TIMELINE_TIMEOUT_ENV_VARS,
+		maxAttemptsEnvVars: TIMELINE_MAX_ATTEMPTS_ENV_VARS,
+		baseUrlSuffixes: [
+			LIST_RUN_TIMELINE_PATH,
+			platformConnectServicePath(
+				PLATFORM_CONNECT_METHODS.maestroTimeline.listRunTimeline.service,
+			),
+		],
+		defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+		defaultMaxAttempts: DEFAULT_MAX_ATTEMPTS,
+		requireOrganizationId: true,
+		requireToken: true,
+	});
+	if (!config?.baseUrl || !config.workspaceId) {
+		return null;
+	}
+	return {
+		...config,
+		baseUrl: trimString(overrides.baseUrl ?? config.baseUrl) ?? config.baseUrl,
+		organizationId:
+			trimString(overrides.organizationId ?? config.organizationId) ??
+			config.organizationId,
+		workspaceId:
+			trimString(overrides.workspaceId ?? config.workspaceId) ??
+			config.workspaceId,
+		token: trimString(overrides.token ?? config.token) ?? config.token,
+		timeoutMs: overrides.timeoutMs ?? config.timeoutMs,
+		maxAttempts: overrides.maxAttempts ?? config.maxAttempts,
+		teamId: trimString(overrides.teamId ?? config.teamId),
+	};
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+function relatedString(
+	relatedIds: Record<string, unknown> | undefined,
+	...keys: string[]
+): string | undefined {
+	for (const key of keys) {
+		const value = stringValue(relatedIds?.[key]);
+		if (value) return value;
+	}
+	return undefined;
+}
+
+function normalizeTimestamp(value: unknown, fallback: string): string {
+	if (typeof value === "string" || typeof value === "number") {
+		const date = new Date(value);
+		if (!Number.isNaN(date.getTime())) {
+			return date.toISOString();
+		}
+	}
+	if (value && typeof value === "object" && !Array.isArray(value)) {
+		const record = value as Record<string, unknown>;
+		const seconds =
+			typeof record.seconds === "number"
+				? record.seconds
+				: Number.parseInt(String(record.seconds ?? ""), 10);
+		const nanos =
+			typeof record.nanos === "number"
+				? record.nanos
+				: Number.parseInt(String(record.nanos ?? "0"), 10);
+		if (Number.isFinite(seconds)) {
+			return new Date(
+				seconds * 1000 + Math.floor((nanos || 0) / 1_000_000),
+			).toISOString();
+		}
+	}
+	return fallback;
+}
+
+function normalizeVisibility(
+	value: string | undefined,
+): ComposerRunTimelineVisibility {
+	switch (value) {
+		case "MAESTRO_TIMELINE_VISIBILITY_USER_VISIBLE":
+		case "user":
+			return "user";
+		case "MAESTRO_TIMELINE_VISIBILITY_AUDIT_ONLY":
+		case "audit":
+			return "audit";
+		case "MAESTRO_TIMELINE_VISIBILITY_ADMIN_VISIBLE":
+		case "admin":
+			return "admin";
+		default:
+			return "audit";
+	}
+}
+
+function normalizeType(
+	value: string | undefined,
+): ComposerRunTimelineEventType {
+	switch (value) {
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_SESSION_STARTED":
+			return "session.started";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_TOOL_CALL_ATTEMPTED":
+			return "tool.requested";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_TOOL_CALL_COMPLETED":
+			return "tool.completed";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_TOOL_EXECUTION_WAITING_APPROVAL":
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_APPROVAL_REQUIRED":
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_RUN_WAITING":
+			return "wait.pending";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_RUN_FAILED":
+			return "session.updated";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_ARTIFACT_RECORDED":
+			return "artifact.linked";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_APPROVAL_RESOLVED":
+			return "policy.decision";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_SESSION_CLOSED":
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_RUN_RESUMED":
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_RUN_SUCCEEDED":
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_RUNTIME_EVENT":
+			return "session.updated";
+		default:
+			return "custom.event";
+	}
+}
+
+function normalizeStatus(value: string | undefined): ComposerRunTimelineStatus {
+	switch (value) {
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_TOOL_EXECUTION_WAITING_APPROVAL":
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_APPROVAL_REQUIRED":
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_RUN_WAITING":
+			return "pending";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_TOOL_CALL_COMPLETED":
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_RUN_SUCCEEDED":
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_SESSION_CLOSED":
+			return "completed";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_RUN_FAILED":
+			return "failed";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_APPROVAL_RESOLVED":
+			return "approved";
+		default:
+			return "info";
+	}
+}
+
+function platformOperationForType(
+	value: string | undefined,
+): ComposerPendingRequestPlatformOperation | undefined {
+	switch (value) {
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_TOOL_EXECUTION_WAITING_APPROVAL":
+			return "ResumeToolExecution";
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_APPROVAL_REQUIRED":
+		case "MAESTRO_TIMELINE_ENTRY_TYPE_RUN_WAITING":
+			return "ResumeRun";
+		default:
+			return undefined;
+	}
+}
+
+function normalizePlatformEntry(
+	entry: PlatformTimelineEntry,
+	query: PlatformMaestroTimelineQuery,
+	response: PlatformTimelineResponse,
+	index: number,
+	generatedAt: string,
+): ComposerRunTimelineItem {
+	const relatedIds = entry.relatedIds;
+	const sessionId =
+		relatedString(relatedIds, "sessionId", "session_id") ??
+		response.sessionId ??
+		query.sessionId;
+	const agentRunId =
+		relatedString(relatedIds, "agentRunId", "agent_run_id") ??
+		response.agentRunId ??
+		query.agentRunId;
+	const remoteRunnerSessionId =
+		relatedString(
+			relatedIds,
+			"remoteRunnerSessionId",
+			"remote_runner_session_id",
+		) ??
+		response.remoteRunnerSessionId ??
+		query.remoteRunnerSessionId;
+	const platformOperation = platformOperationForType(entry.type);
+	const summary = compactTimelineSummary(entry.summary);
+	const metadata = compactTimelineMetadata({
+		...(redactTimelineMetadata(entry.metadata) ?? {}),
+		agentRunId,
+		agentRunStepId: relatedString(
+			relatedIds,
+			"agentRunStepId",
+			"agent_run_step_id",
+		),
+		correlationId: relatedString(relatedIds, "correlationId", "correlation_id"),
+		sensitivity: entry.sensitivity,
+		sourceObjectSource: entry.sourceObject?.source,
+		sourceObjectId: entry.sourceObject?.id,
+		sourceObjectType: entry.sourceObject?.type,
+		redactions: entry.redactions,
+		platformPartial: response.partial === true ? true : undefined,
+		platformMissingSources:
+			response.partial && response.missingSources?.length
+				? response.missingSources
+				: undefined,
+	});
+	return {
+		id: entry.id ?? `platform:${sessionId}:${index}`,
+		sessionId,
+		timestamp: normalizeTimestamp(entry.timestamp, generatedAt),
+		type: normalizeType(entry.type),
+		title: compactTimelineSummary(entry.title) ?? "Platform timeline event",
+		visibility: normalizeVisibility(entry.visibility),
+		source: "platform",
+		status: normalizeStatus(entry.type),
+		...(summary ? { summary } : {}),
+		toolCallId: relatedString(relatedIds, "toolCallId", "tool_call_id"),
+		toolExecutionId: relatedString(
+			relatedIds,
+			"toolExecutionId",
+			"tool_execution_id",
+		),
+		approvalRequestId: relatedString(
+			relatedIds,
+			"approvalRequestId",
+			"approval_request_id",
+		),
+		artifactId: relatedString(relatedIds, "artifactId", "artifact_id"),
+		...(remoteRunnerSessionId ? { remoteRunnerSessionId } : {}),
+		...(platformOperation ? { platformOperation } : {}),
+		...(metadata ? { metadata } : {}),
+	};
+}
+
+function parseTimelineResponse(
+	payload: Record<string, unknown>,
+): PlatformTimelineResponse {
+	return {
+		organizationId: stringValue(
+			payload.organizationId ?? payload.organization_id,
+		),
+		workspaceId: stringValue(payload.workspaceId ?? payload.workspace_id),
+		sessionId: stringValue(payload.sessionId ?? payload.session_id),
+		agentRunId: stringValue(payload.agentRunId ?? payload.agent_run_id),
+		remoteRunnerSessionId: stringValue(
+			payload.remoteRunnerSessionId ?? payload.remote_runner_session_id,
+		),
+		entries: Array.isArray(payload.entries)
+			? (payload.entries as PlatformTimelineEntry[])
+			: [],
+		partial: payload.partial === true,
+		missingSources: Array.isArray(payload.missingSources)
+			? (payload.missingSources as string[])
+			: Array.isArray(payload.missing_sources)
+				? (payload.missing_sources as string[])
+				: [],
+		nextPageToken: stringValue(
+			payload.nextPageToken ?? payload.next_page_token,
+		),
+	};
+}
+
+function normalizeTimelineResponse(
+	responses: PlatformTimelineResponse[],
+	query: PlatformMaestroTimelineQuery,
+): ComposerRunTimelineResponse {
+	const generatedAt = new Date().toISOString();
+	const firstResponse = responses[0] ?? {};
+	let index = 0;
+	return {
+		sessionId: firstResponse.sessionId ?? query.sessionId,
+		source: "platform",
+		generatedAt,
+		platformBacked: true,
+		pendingRequestCount: query.pendingRequestCount ?? 0,
+		items: responses.flatMap(
+			(response) =>
+				response.entries?.map((entry) =>
+					normalizePlatformEntry(entry, query, response, index++, generatedAt),
+				) ?? [],
+		),
+	};
+}
+
+async function parseJsonResponse(
+	response: Response,
+): Promise<Record<string, unknown>> {
+	const text = await response.text();
+	if (!response.ok) {
+		throw new Error(
+			`maestro timeline service returned ${response.status}: ${
+				text || response.statusText
+			}`,
+		);
+	}
+	if (!text.trim()) {
+		throw new Error("maestro timeline service returned empty response");
+	}
+	return JSON.parse(text) as Record<string, unknown>;
+}
+
+export async function listMaestroTimelineWithPlatform(
+	config: MaestroTimelineServiceConfig,
+	query: PlatformMaestroTimelineQuery,
+	signal?: AbortSignal,
+): Promise<ComposerRunTimelineResponse> {
+	const organizationId =
+		trimString(query.organizationId) ?? config.organizationId;
+	const workspaceId = trimString(query.workspaceId) ?? config.workspaceId;
+	if (!organizationId || !workspaceId) {
+		throw new Error(
+			"maestro timeline service requires organization and workspace",
+		);
+	}
+	const normalizedQuery = {
+		...query,
+		organizationId,
+		workspaceId,
+	};
+	const responses: PlatformTimelineResponse[] = [];
+	let pageToken = query.pageToken;
+	for (let page = 0; page < 20; page += 1) {
+		const response = await postPlatformConnect(
+			config,
+			LIST_RUN_TIMELINE_PATH,
+			{
+				organizationId,
+				workspaceId,
+				sessionId: query.sessionId,
+				agentRunId: query.agentRunId,
+				remoteRunnerSessionId: query.remoteRunnerSessionId,
+				pageToken,
+				includeAdminSummaries: query.includeAdminSummaries ?? true,
+				includeAuditOnly: query.includeAuditOnly ?? false,
+			},
+			{
+				serviceName: "maestro timeline service",
+				failureMode: "optional",
+				timeoutMs: config.timeoutMs,
+				maxAttempts: config.maxAttempts,
+				signal,
+			},
+		);
+		const payload = await parseJsonResponse(response);
+		const parsed = parseTimelineResponse(payload);
+		responses.push(parsed);
+		pageToken = parsed.nextPageToken;
+		if (!pageToken) {
+			return normalizeTimelineResponse(responses, normalizedQuery);
+		}
+	}
+	throw new Error("maestro timeline service returned too many pages");
+}
+
+export async function tryListMaestroTimelineWithPlatform(
+	query: PlatformMaestroTimelineQuery,
+	options?: {
+		config?: MaestroTimelineServiceConfig;
+		signal?: AbortSignal;
+	},
+): Promise<ComposerRunTimelineResponse | null> {
+	const config =
+		options?.config ?? (await resolveMaestroTimelineServiceConfig());
+	if (!config) {
+		return null;
+	}
+	try {
+		return await listMaestroTimelineWithPlatform(
+			config,
+			query,
+			options?.signal,
+		);
+	} catch {
+		return null;
+	}
+}

--- a/src/server/handlers/session-timeline.ts
+++ b/src/server/handlers/session-timeline.ts
@@ -1,6 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ComposerRunTimelineResponse } from "@evalops/contracts";
+import { tryListMaestroTimelineWithPlatform } from "../../platform/maestro-timeline-client.js";
 import { safeReadSessionEntries } from "../../session/session-context.js";
+import type { HostedRunnerContext } from "../app-context.js";
 import { getAuthSubject } from "../authz.js";
 import { getPendingComposerRequests } from "../pending-request-payload.js";
 import { ApiError, respondWithApiError, sendJson } from "../server-utils.js";
@@ -12,6 +14,10 @@ interface SessionTimelineParams {
 	id?: string;
 }
 
+interface SessionTimelineOptions {
+	hostedRunner?: HostedRunnerContext;
+}
+
 function requireSessionId(params: SessionTimelineParams): string {
 	const sessionId = params.id?.trim();
 	if (!sessionId || !sessionIdPattern.test(sessionId)) {
@@ -20,11 +26,48 @@ function requireSessionId(params: SessionTimelineParams): string {
 	return sessionId;
 }
 
+function hostedRunnerMatchesSession(
+	hostedRunner: HostedRunnerContext | undefined,
+	sessionId: string,
+): boolean {
+	if (!hostedRunner?.enabled) {
+		return false;
+	}
+	const activeSessionId =
+		hostedRunner.activeMaestroSessionId ??
+		hostedRunner.configuredMaestroSessionId;
+	return activeSessionId === sessionId;
+}
+
+async function tryBuildPlatformTimeline(
+	sessionId: string,
+	pendingRequestCount: number,
+	options: SessionTimelineOptions | undefined,
+): Promise<ComposerRunTimelineResponse | null> {
+	const hostedRunner = options?.hostedRunner;
+	if (!hostedRunnerMatchesSession(hostedRunner, sessionId)) {
+		return null;
+	}
+	const agentRunId = hostedRunner?.agentRunId;
+	const remoteRunnerSessionId = hostedRunner?.runnerSessionId;
+	if (!agentRunId && !remoteRunnerSessionId) {
+		return null;
+	}
+	return await tryListMaestroTimelineWithPlatform({
+		sessionId,
+		agentRunId,
+		remoteRunnerSessionId,
+		workspaceId: hostedRunner?.workspaceId,
+		pendingRequestCount,
+	});
+}
+
 export async function handleSessionTimeline(
 	req: IncomingMessage,
 	res: ServerResponse,
 	params: SessionTimelineParams,
 	cors: Record<string, string>,
+	options?: SessionTimelineOptions,
 ): Promise<void> {
 	try {
 		if (req.method !== "GET") {
@@ -48,12 +91,18 @@ export async function handleSessionTimeline(
 		const sessionPath = sessionManager.getSessionFileById(sessionId);
 		const entries = sessionPath ? safeReadSessionEntries(sessionPath) : [];
 		const pendingRequests = getPendingComposerRequests(session.id);
-		const responseBody: ComposerRunTimelineResponse = buildComposerRunTimeline({
-			sessionId: session.id,
-			entries,
-			messages: session.messages || [],
-			pendingRequests,
-		});
+		const responseBody: ComposerRunTimelineResponse =
+			(await tryBuildPlatformTimeline(
+				session.id,
+				pendingRequests.length,
+				options,
+			)) ??
+			buildComposerRunTimeline({
+				sessionId: session.id,
+				entries,
+				messages: session.messages || [],
+				pendingRequests,
+			});
 
 		sendJson(res, 200, responseBody, cors, req);
 	} catch (error) {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -866,7 +866,9 @@ export function createRoutes(context: WebServerContext): Route[] {
 			method: "GET",
 			path: "/api/sessions/:id/timeline",
 			handler: (req, res, params) =>
-				handleSessionTimeline(req, res, params as { id: string }, corsHeaders),
+				handleSessionTimeline(req, res, params as { id: string }, corsHeaders, {
+					hostedRunner: context.hostedRunner,
+				}),
 		},
 		{
 			method: "GET",

--- a/src/server/session-timeline.ts
+++ b/src/server/session-timeline.ts
@@ -14,16 +14,11 @@ import type {
 import { getDiagnosticDeltaFromToolResult } from "../lsp/diagnostic-repair.js";
 import type { SessionEntry } from "../session/types.js";
 import { getSkillArtifactMetadataFromDetails } from "../skills/artifact-metadata.js";
-
-const SUMMARY_LIMIT = 180;
-
-const SECRET_PATTERNS: Array<[RegExp, string]> = [
-	[/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{16,}/gi, "$1[redacted]"],
-	[/\b(sk-[A-Za-z0-9_-]{16,})\b/g, "[redacted-secret]"],
-	[/\b(gh[pousr]_[A-Za-z0-9_]{16,})\b/g, "[redacted-token]"],
-	[/\b(xox[a-zA-Z]?-[A-Za-z0-9-]{16,})\b/g, "[redacted-token]"],
-	[/\b(AKIA[0-9A-Z]{16})\b/g, "[redacted-access-key]"],
-];
+import {
+	compactTimelineMetadata,
+	compactTimelineSummary,
+	redactTimelineSecrets,
+} from "../timeline/redaction.js";
 
 interface BuildComposerRunTimelineOptions {
 	sessionId: string;
@@ -52,22 +47,6 @@ function normalizeTimestamp(value: unknown, fallback: string): string {
 	return fallback;
 }
 
-function redactSecrets(value: string): string {
-	let redacted = value;
-	for (const [pattern, replacement] of SECRET_PATTERNS) {
-		redacted = redacted.replace(pattern, replacement);
-	}
-	return redacted;
-}
-
-function compactSummary(value: string | undefined): string | undefined {
-	if (!value) return undefined;
-	const singleLine = redactSecrets(value.replace(/\s+/g, " ").trim());
-	if (!singleLine) return undefined;
-	if (singleLine.length <= SUMMARY_LIMIT) return singleLine;
-	return `${singleLine.slice(0, SUMMARY_LIMIT - 3)}...`;
-}
-
 function detailsRecord(value: unknown): Record<string, unknown> | undefined {
 	if (!value || typeof value !== "object" || Array.isArray(value)) {
 		return undefined;
@@ -78,7 +57,7 @@ function detailsRecord(value: unknown): Record<string, unknown> | undefined {
 function redactedString(value: unknown): string | undefined {
 	if (typeof value !== "string") return undefined;
 	const trimmed = value.trim();
-	return trimmed ? redactSecrets(trimmed) : undefined;
+	return trimmed ? redactTimelineSecrets(trimmed) : undefined;
 }
 
 function finiteNumber(value: unknown): number | undefined {
@@ -89,15 +68,6 @@ function finiteNumber(value: unknown): number | undefined {
 
 function booleanValue(value: unknown): boolean | undefined {
 	return typeof value === "boolean" ? value : undefined;
-}
-
-function compactMetadata(
-	values: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-	const metadata = Object.fromEntries(
-		Object.entries(values).filter(([, value]) => value !== undefined),
-	);
-	return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
 
 function textFromContent(content: unknown): string | undefined {
@@ -184,7 +154,7 @@ function addDerivedToolResultItems(
 					? "created"
 					: "wrote"
 				: "edited";
-		const summary = compactSummary(
+		const summary = compactTimelineSummary(
 			[
 				displayPath,
 				bytesWritten !== undefined ? `${bytesWritten} bytes` : undefined,
@@ -195,7 +165,7 @@ function addDerivedToolResultItems(
 		);
 		const hasDiff =
 			typeof details?.diff === "string" && details.diff.length > 0;
-		const metadata = compactMetadata({
+		const metadata = compactTimelineMetadata({
 			path: displayPath,
 			action,
 			previousExists,
@@ -222,7 +192,7 @@ function addDerivedToolResultItems(
 
 	const diagnosticDelta = getDiagnosticDeltaFromToolResult(toolResult);
 	if (diagnosticDelta) {
-		const summary = compactSummary(
+		const summary = compactTimelineSummary(
 			`Diagnostic delta: ${diagnosticDelta.introducedCount} introduced, ${diagnosticDelta.repairedCount} repaired, ${diagnosticDelta.remainingCount} remaining.`,
 		);
 		appendItem(items, {
@@ -252,7 +222,7 @@ function addDerivedToolResultItems(
 
 	const skillMetadata = getSkillArtifactMetadataFromDetails(toolResult.details);
 	if (skillMetadata) {
-		const summary = compactSummary(
+		const summary = compactTimelineSummary(
 			[
 				skillMetadata.name,
 				skillMetadata.version ? `v${skillMetadata.version}` : undefined,
@@ -262,7 +232,7 @@ function addDerivedToolResultItems(
 				.filter(Boolean)
 				.join(" | "),
 		);
-		const metadata = compactMetadata({
+		const metadata = compactTimelineMetadata({
 			name: skillMetadata.name,
 			version: skillMetadata.version,
 			source: skillMetadata.source,
@@ -292,7 +262,7 @@ function addDerivedToolResultItems(
 
 	const governed = governedToolMetadata(toolResult.details);
 	if (governed.governedOutcome || governed.errorCode) {
-		const summary = compactSummary(
+		const summary = compactTimelineSummary(
 			[
 				governed.governedOutcome
 					? `Outcome: ${governed.governedOutcome}`
@@ -302,7 +272,7 @@ function addDerivedToolResultItems(
 				.filter(Boolean)
 				.join(" | "),
 		);
-		const metadata = compactMetadata({
+		const metadata = compactTimelineMetadata({
 			governedOutcome: governed.governedOutcome,
 			errorCode: governed.errorCode,
 		});
@@ -346,7 +316,9 @@ function addMessageItems(
 ): void {
 	if (message.role === "user") {
 		const userMessage = message as UserMessage;
-		const summary = compactSummary(textFromContent(userMessage.content));
+		const summary = compactTimelineSummary(
+			textFromContent(userMessage.content),
+		);
 		appendItem(items, {
 			id: `message:${options.baseId}`,
 			sessionId,
@@ -364,7 +336,9 @@ function addMessageItems(
 
 	if (message.role === "assistant") {
 		const assistantMessage = message as AssistantMessage;
-		const summary = compactSummary(textFromContent(assistantMessage.content));
+		const summary = compactTimelineSummary(
+			textFromContent(assistantMessage.content),
+		);
 		appendItem(items, {
 			id: `message:${options.baseId}`,
 			sessionId,
@@ -411,7 +385,7 @@ function addMessageItems(
 		const approvalRequestId =
 			governed.approvalRequestId ?? redactedString(details?.approvalRequestId);
 		const toolExecutionId = redactedString(details?.toolExecutionId);
-		const metadata = compactMetadata({
+		const metadata = compactTimelineMetadata({
 			governedOutcome: governed.governedOutcome,
 			errorCode: governed.errorCode,
 		});
@@ -494,7 +468,7 @@ function addPendingRequestItems(
 	generatedAt: string,
 ): void {
 	for (const request of pendingRequests) {
-		const summary = compactSummary(
+		const summary = compactTimelineSummary(
 			request.actionDescription || request.summaryLabel || request.reason,
 		);
 		const platformOperation = platformOperationForPending(request);
@@ -555,7 +529,7 @@ function addEntryItems(
 				break;
 			}
 			case "session_meta": {
-				const summary = compactSummary(
+				const summary = compactTimelineSummary(
 					entry.title || entry.resumeSummary || entry.summary,
 				);
 				appendItem(items, {
@@ -582,7 +556,7 @@ function addEntryItems(
 				break;
 			}
 			case "compaction": {
-				const summary = compactSummary(entry.summary);
+				const summary = compactTimelineSummary(entry.summary);
 				appendItem(items, {
 					id: `compaction:${entry.id}`,
 					sessionId,
@@ -602,7 +576,7 @@ function addEntryItems(
 				break;
 			}
 			case "branch_summary": {
-				const summary = compactSummary(entry.summary);
+				const summary = compactTimelineSummary(entry.summary);
 				appendItem(items, {
 					id: `branch:${entry.id}`,
 					sessionId,
@@ -618,7 +592,7 @@ function addEntryItems(
 				break;
 			}
 			case "model_change": {
-				const summary = compactSummary(entry.model);
+				const summary = compactTimelineSummary(entry.model);
 				appendItem(items, {
 					id: `model-change:${entry.id}`,
 					sessionId,
@@ -633,7 +607,7 @@ function addEntryItems(
 				break;
 			}
 			case "thinking_level_change": {
-				const summary = compactSummary(entry.thinkingLevel);
+				const summary = compactTimelineSummary(entry.thinkingLevel);
 				appendItem(items, {
 					id: `thinking-change:${entry.id}`,
 					sessionId,
@@ -649,7 +623,7 @@ function addEntryItems(
 			}
 			case "custom_message": {
 				if (!entry.display) break;
-				const summary = compactSummary(textFromContent(entry.content));
+				const summary = compactTimelineSummary(textFromContent(entry.content));
 				appendItem(items, {
 					id: `custom-message:${entry.id}`,
 					sessionId,

--- a/src/timeline/redaction.ts
+++ b/src/timeline/redaction.ts
@@ -1,0 +1,74 @@
+const SUMMARY_LIMIT = 180;
+
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+	[/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{16,}/gi, "$1[redacted]"],
+	[/\b(sk-[A-Za-z0-9_-]{16,})\b/g, "[redacted-secret]"],
+	[/\b(gh[pousr]_[A-Za-z0-9_]{16,})\b/g, "[redacted-token]"],
+	[/\b(xox[a-zA-Z]?-[A-Za-z0-9-]{16,})\b/g, "[redacted-token]"],
+	[/\b(AKIA[0-9A-Z]{16})\b/g, "[redacted-access-key]"],
+];
+
+const SENSITIVE_METADATA_KEY_PATTERN =
+	/(?:arg|body|command|content|credential|env|header|input|output|password|prompt|request|response|secret|stderr|stdout|token|transcript)/i;
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+export function redactTimelineSecrets(value: string): string {
+	let redacted = value;
+	for (const [pattern, replacement] of SECRET_PATTERNS) {
+		redacted = redacted.replace(pattern, replacement);
+	}
+	return redacted;
+}
+
+export function compactTimelineSummary(value: unknown): string | undefined {
+	const text = stringValue(value);
+	if (!text) return undefined;
+	const singleLine = redactTimelineSecrets(text.replace(/\s+/g, " ").trim());
+	if (!singleLine) return undefined;
+	if (singleLine.length <= SUMMARY_LIMIT) return singleLine;
+	return `${singleLine.slice(0, SUMMARY_LIMIT - 3)}...`;
+}
+
+export function compactTimelineMetadata(
+	values: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+	const metadata = Object.fromEntries(
+		Object.entries(values).filter(([, value]) => value !== undefined),
+	);
+	return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+function redactMetadataValue(value: unknown): unknown {
+	if (typeof value === "string") {
+		return compactTimelineSummary(value);
+	}
+	if (Array.isArray(value)) {
+		return value.map(redactMetadataValue).filter((item) => item !== undefined);
+	}
+	if (value && typeof value === "object") {
+		return redactTimelineMetadata(value as Record<string, unknown>);
+	}
+	return value;
+}
+
+export function redactTimelineMetadata(
+	metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	if (!metadata) {
+		return undefined;
+	}
+	const redacted = Object.fromEntries(
+		Object.entries(metadata)
+			.filter(
+				([key, value]) =>
+					value !== undefined && !SENSITIVE_METADATA_KEY_PATTERN.test(key),
+			)
+			.map(([key, value]) => [key, redactMetadataValue(value)]),
+	);
+	return Object.keys(redacted).length > 0 ? redacted : undefined;
+}

--- a/test/platform/core-services.test.ts
+++ b/test/platform/core-services.test.ts
@@ -81,6 +81,11 @@ describe("Platform core service contract names", () => {
 		).toBe("/remoterunner.v1.RemoteRunnerService/GetStatus");
 		expect(
 			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.maestroTimeline.listRunTimeline,
+			),
+		).toBe("/maestro.v1.MaestroTimelineService/ListRunTimeline");
+		expect(
+			platformConnectMethodPath(
 				PLATFORM_CONNECT_METHODS.toolexecution.executeTool,
 			),
 		).toBe("/toolexecution.v1.ToolExecutionService/ExecuteTool");

--- a/test/platform/maestro-timeline-client.test.ts
+++ b/test/platform/maestro-timeline-client.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	listMaestroTimelineWithPlatform,
+	resolveMaestroTimelineServiceConfig,
+} from "../../src/platform/maestro-timeline-client.js";
+
+type CapturedRequest = {
+	body?: Record<string, unknown>;
+	headers: Record<string, string>;
+	method?: string;
+	pathname: string;
+	url: string;
+};
+
+function headersToRecord(
+	headers: HeadersInit | undefined,
+): Record<string, string> {
+	return Object.fromEntries(new Headers(headers).entries());
+}
+
+function parseRequestBody(
+	body: BodyInit | null | undefined,
+): Record<string, unknown> | undefined {
+	return typeof body === "string"
+		? (JSON.parse(body) as Record<string, unknown>)
+		: undefined;
+}
+
+describe("maestro timeline client", () => {
+	let requests: CapturedRequest[];
+
+	beforeEach(() => {
+		requests = [];
+		for (const name of [
+			"MAESTRO_TIMELINE_SERVICE_URL",
+			"MAESTRO_PLATFORM_TIMELINE_SERVICE_URL",
+			"MAESTRO_PLATFORM_BASE_URL",
+			"MAESTRO_EVALOPS_BASE_URL",
+			"EVALOPS_BASE_URL",
+			"MAESTRO_TIMELINE_SERVICE_TOKEN",
+			"MAESTRO_PLATFORM_TIMELINE_SERVICE_TOKEN",
+			"MAESTRO_EVALOPS_ACCESS_TOKEN",
+			"EVALOPS_TOKEN",
+			"MAESTRO_TIMELINE_ORG_ID",
+			"MAESTRO_PLATFORM_TIMELINE_ORG_ID",
+			"MAESTRO_EVALOPS_ORG_ID",
+			"EVALOPS_ORGANIZATION_ID",
+			"MAESTRO_ENTERPRISE_ORG_ID",
+			"MAESTRO_TIMELINE_WORKSPACE_ID",
+			"MAESTRO_PLATFORM_TIMELINE_WORKSPACE_ID",
+			"MAESTRO_REMOTE_RUNNER_WORKSPACE_ID",
+			"MAESTRO_EVALOPS_WORKSPACE_ID",
+			"EVALOPS_WORKSPACE_ID",
+			"MAESTRO_WORKSPACE_ID",
+		]) {
+			vi.stubEnv(name, "");
+		}
+		vi.stubEnv("MAESTRO_PLATFORM_BASE_URL", "https://platform.test/");
+		vi.stubEnv("MAESTRO_EVALOPS_ACCESS_TOKEN", "evalops-token");
+		vi.stubEnv("MAESTRO_EVALOPS_ORG_ID", "org_evalops");
+		vi.stubEnv("MAESTRO_REMOTE_RUNNER_WORKSPACE_ID", "ws_evalops");
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+
+				if (
+					parsed.pathname ===
+					"/maestro.v1.MaestroTimelineService/ListRunTimeline"
+				) {
+					const requestBody = parseRequestBody(init?.body);
+					if (requestBody?.pageToken === "page_2") {
+						return new Response(
+							JSON.stringify({
+								organizationId: "org_evalops",
+								workspaceId: "ws_evalops",
+								sessionId: "sess_1",
+								agentRunId: "run_1",
+								remoteRunnerSessionId: "mrs_1",
+								entries: [
+									{
+										id: "entry_audit_unknown",
+										timestamp: "2026-04-30T18:02:00Z",
+										type: "MAESTRO_TIMELINE_ENTRY_TYPE_RUNTIME_EVENT",
+										title: "Unknown visibility",
+										visibility: "MAESTRO_TIMELINE_VISIBILITY_FUTURE_INTERNAL",
+										relatedIds: {
+											sessionId: "sess_1",
+											agentRunId: "run_1",
+											remoteRunnerSessionId: "mrs_1",
+										},
+									},
+								],
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					return new Response(
+						JSON.stringify({
+							organizationId: "org_evalops",
+							workspaceId: "ws_evalops",
+							sessionId: "sess_1",
+							agentRunId: "run_1",
+							remoteRunnerSessionId: "mrs_1",
+							partial: true,
+							missingSources: ["audit"],
+							nextPageToken: "page_2",
+							entries: [
+								{
+									id: "entry_tool_1",
+									timestamp: "2026-04-30T18:00:00Z",
+									type: "MAESTRO_TIMELINE_ENTRY_TYPE_TOOL_CALL_COMPLETED",
+									title: "Ran tests",
+									summary: "npm test completed successfully",
+									visibility: "MAESTRO_TIMELINE_VISIBILITY_USER_VISIBLE",
+									sensitivity: "MAESTRO_TIMELINE_SENSITIVITY_INTERNAL",
+									relatedIds: {
+										sessionId: "sess_1",
+										agentRunId: "run_1",
+										agentRunStepId: "step_1",
+										toolCallId: "tool_call_1",
+										toolExecutionId: "texec_1",
+										remoteRunnerSessionId: "mrs_1",
+									},
+									sourceObject: {
+										source: "MAESTRO_TIMELINE_SOURCE_TOOL_EXECUTION",
+										id: "texec_1",
+										type: "toolexecution.v1.ToolExecution",
+									},
+									metadata: {
+										command:
+											"curl -H 'Authorization: Bearer leaked-token-1234567890'",
+										prompt: "send sk-leaked1234567890",
+										safeNote: "see ghp_leakedtoken1234567890",
+										nested: {
+											requestBody: "raw payload",
+											status: "ok",
+										},
+									},
+								},
+								{
+									id: "entry_approval_1",
+									timestamp: "2026-04-30T18:01:00Z",
+									type: "MAESTRO_TIMELINE_ENTRY_TYPE_TOOL_EXECUTION_WAITING_APPROVAL",
+									title: "Approval required",
+									visibility: "MAESTRO_TIMELINE_VISIBILITY_USER_VISIBLE",
+									relatedIds: {
+										sessionId: "sess_1",
+										agentRunId: "run_1",
+										toolExecutionId: "texec_2",
+										approvalRequestId: "approval_1",
+										remoteRunnerSessionId: "mrs_1",
+									},
+								},
+							],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				throw new Error(`Unexpected timeline request: ${url}`);
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+	});
+
+	it("resolves shared platform configuration for Maestro timelines", async () => {
+		await expect(resolveMaestroTimelineServiceConfig()).resolves.toMatchObject({
+			baseUrl: "https://platform.test",
+			token: "evalops-token",
+			organizationId: "org_evalops",
+			workspaceId: "ws_evalops",
+		});
+	});
+
+	it("maps Platform timeline entries into the composer timeline contract", async () => {
+		const config = await resolveMaestroTimelineServiceConfig();
+		if (!config) {
+			throw new Error("expected timeline config");
+		}
+
+		const response = await listMaestroTimelineWithPlatform(config, {
+			sessionId: "sess_1",
+			agentRunId: "run_1",
+			remoteRunnerSessionId: "mrs_1",
+			pendingRequestCount: 1,
+		});
+
+		expect(response).toMatchObject({
+			sessionId: "sess_1",
+			source: "platform",
+			platformBacked: true,
+			pendingRequestCount: 1,
+			items: [
+				{
+					id: "entry_tool_1",
+					type: "tool.completed",
+					source: "platform",
+					status: "completed",
+					toolCallId: "tool_call_1",
+					toolExecutionId: "texec_1",
+					remoteRunnerSessionId: "mrs_1",
+					metadata: expect.objectContaining({
+						agentRunId: "run_1",
+						agentRunStepId: "step_1",
+						platformPartial: true,
+						platformMissingSources: ["audit"],
+						sourceObjectId: "texec_1",
+						safeNote: "see [redacted-token]",
+						nested: { status: "ok" },
+					}),
+				},
+				{
+					id: "entry_approval_1",
+					type: "wait.pending",
+					status: "pending",
+					toolExecutionId: "texec_2",
+					approvalRequestId: "approval_1",
+					platformOperation: "ResumeToolExecution",
+				},
+				{
+					id: "entry_audit_unknown",
+					type: "session.updated",
+					visibility: "audit",
+				},
+			],
+		});
+
+		expect(requests[0]).toMatchObject({
+			method: "POST",
+			url: "https://platform.test/maestro.v1.MaestroTimelineService/ListRunTimeline",
+			headers: expect.objectContaining({
+				authorization: "Bearer evalops-token",
+				"connect-protocol-version": "1",
+				"x-organization-id": "org_evalops",
+			}),
+			body: expect.objectContaining({
+				organizationId: "org_evalops",
+				workspaceId: "ws_evalops",
+				sessionId: "sess_1",
+				agentRunId: "run_1",
+				remoteRunnerSessionId: "mrs_1",
+				includeAdminSummaries: true,
+				includeAuditOnly: false,
+			}),
+		});
+		expect(requests[1]).toMatchObject({
+			body: expect.objectContaining({
+				pageToken: "page_2",
+			}),
+		});
+		const serialized = JSON.stringify(
+			response.items.find((item) => item.id === "entry_tool_1")?.metadata,
+		);
+		expect(serialized).not.toContain("Authorization");
+		expect(serialized).not.toContain("leaked-token");
+		expect(serialized).not.toContain("sk-leaked");
+		expect(serialized).not.toContain("raw payload");
+	});
+});

--- a/test/session-endpoints.test.ts
+++ b/test/session-endpoints.test.ts
@@ -208,6 +208,8 @@ describe("Session Endpoints", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
 		delete process.env.MAESTRO_STRICT_SESSION_ACCESS;
 	});
 
@@ -367,6 +369,8 @@ describe("Session Endpoints", () => {
 
 		it("should return 400 for invalid session id", async () => {
 			const req = createMockRequest("GET");
+			req.url =
+				"/api/sessions/test-session-1/timeline?agent_run_id=run_attacker&remote_runner_session_id=mrs_attacker&workspace_id=ws_attacker";
 			const { res, getStatus, getBody } = createMockResponse();
 
 			await handleSessions(req, res, { id: "../malicious/path" }, corsHeaders);
@@ -566,6 +570,8 @@ describe("Session Endpoints", () => {
 			]);
 
 			const req = createMockRequest("GET");
+			req.url =
+				"/api/sessions/test-session-1/timeline?agent_run_id=run_attacker&remote_runner_session_id=mrs_attacker&workspace_id=ws_attacker";
 			const { res, getStatus, getBody } = createMockResponse();
 
 			await handleSessionTimeline(
@@ -680,6 +686,167 @@ describe("Session Endpoints", () => {
 			const serialized = JSON.stringify(body);
 			expect(serialized).not.toContain(secret);
 			expect(serialized).not.toContain("rm -rf /tmp/demo");
+		});
+
+		it("uses Platform MaestroTimeline for hosted runner sessions with run correlation", async () => {
+			vi.stubEnv("MAESTRO_PLATFORM_BASE_URL", "https://platform.test/");
+			vi.stubEnv("MAESTRO_EVALOPS_ACCESS_TOKEN", "evalops-token");
+			vi.stubEnv("MAESTRO_EVALOPS_ORG_ID", "org_evalops");
+			vi.stubEnv("MAESTRO_REMOTE_RUNNER_WORKSPACE_ID", "ws_evalops");
+			const fetchMock = vi.fn(
+				async (input: RequestInfo | URL, init?: RequestInit) => {
+					expect(String(input)).toBe(
+						"https://platform.test/maestro.v1.MaestroTimelineService/ListRunTimeline",
+					);
+					expect(JSON.parse(String(init?.body))).toMatchObject({
+						organizationId: "org_evalops",
+						workspaceId: "ws_hosted",
+						sessionId: "test-session-1",
+						agentRunId: "run_hosted_1",
+						remoteRunnerSessionId: "mrs_1",
+					});
+					return new Response(
+						JSON.stringify({
+							organizationId: "org_evalops",
+							workspaceId: "ws_hosted",
+							sessionId: "test-session-1",
+							agentRunId: "run_hosted_1",
+							remoteRunnerSessionId: "mrs_1",
+							entries: [
+								{
+									id: "platform-tool-completed",
+									timestamp: "2026-04-30T18:00:00Z",
+									type: "MAESTRO_TIMELINE_ENTRY_TYPE_TOOL_CALL_COMPLETED",
+									title: "Bash completed",
+									summary: "tests passed",
+									visibility: "MAESTRO_TIMELINE_VISIBILITY_USER_VISIBLE",
+									relatedIds: {
+										sessionId: "test-session-1",
+										agentRunId: "run_hosted_1",
+										toolCallId: "tool_call_1",
+										toolExecutionId: "texec_1",
+										remoteRunnerSessionId: "mrs_1",
+									},
+								},
+							],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				},
+			);
+			vi.stubGlobal("fetch", fetchMock);
+			vi.spyOn(serverRequestManager, "listPending").mockReturnValue([]);
+
+			const req = createMockRequest("GET");
+			const { res, getStatus, getBody } = createMockResponse();
+
+			await handleSessionTimeline(
+				req,
+				res,
+				{ id: "test-session-1" },
+				corsHeaders,
+				{
+					hostedRunner: {
+						enabled: true,
+						runnerSessionId: "mrs_1",
+						workspaceRoot: "/workspace",
+						workspaceId: "ws_hosted",
+						agentRunId: "run_hosted_1",
+						activeMaestroSessionId: "test-session-1",
+					},
+				},
+			);
+
+			expect(getStatus()).toBe(200);
+			expect(getBody()).toEqual(
+				expect.objectContaining({
+					sessionId: "test-session-1",
+					source: "platform",
+					platformBacked: true,
+					items: [
+						expect.objectContaining({
+							id: "platform-tool-completed",
+							type: "tool.completed",
+							source: "platform",
+							toolCallId: "tool_call_1",
+							toolExecutionId: "texec_1",
+							remoteRunnerSessionId: "mrs_1",
+							metadata: expect.objectContaining({
+								agentRunId: "run_hosted_1",
+							}),
+						}),
+					],
+				}),
+			);
+		});
+
+		it("ignores untrusted query correlation for unrelated sessions", async () => {
+			const fetchMock = vi.fn(async () => {
+				throw new Error("unexpected Platform timeline request");
+			});
+			vi.stubGlobal("fetch", fetchMock);
+			vi.spyOn(serverRequestManager, "listPending").mockReturnValue([]);
+
+			const req = createMockRequest("GET");
+			req.url =
+				"/api/sessions/test-session-1/timeline?agent_run_id=run_attacker&remote_runner_session_id=mrs_attacker&workspace_id=ws_attacker";
+			const { res, getStatus, getBody } = createMockResponse();
+
+			await handleSessionTimeline(
+				req,
+				res,
+				{ id: "test-session-1" },
+				corsHeaders,
+				{
+					hostedRunner: {
+						enabled: true,
+						runnerSessionId: "mrs_unbound",
+						workspaceRoot: "/workspace",
+						workspaceId: "ws_hosted",
+						agentRunId: "run_unbound",
+					},
+				},
+			);
+
+			expect(getStatus()).toBe(200);
+			expect(fetchMock).not.toHaveBeenCalled();
+			expect(getBody()).toEqual(
+				expect.objectContaining({
+					sessionId: "test-session-1",
+					source: "local",
+					platformBacked: false,
+				}),
+			);
+		});
+
+		it("ignores client-provided Platform correlation for local sessions", async () => {
+			const fetchMock = vi.fn(async () => {
+				throw new Error("unexpected Platform timeline request");
+			});
+			vi.stubGlobal("fetch", fetchMock);
+			vi.spyOn(serverRequestManager, "listPending").mockReturnValue([]);
+
+			const req = createMockRequest("GET");
+			req.url =
+				"/api/sessions/test-session-1/timeline?agent_run_id=run_other&remote_runner_session_id=mrs_other&workspace_id=ws_other";
+			const { res, getStatus, getBody } = createMockResponse();
+
+			await handleSessionTimeline(
+				req,
+				res,
+				{ id: "test-session-1" },
+				corsHeaders,
+			);
+
+			expect(getStatus()).toBe(200);
+			expect(fetchMock).not.toHaveBeenCalled();
+			expect(getBody()).toEqual(
+				expect.objectContaining({
+					sessionId: "test-session-1",
+					source: "local",
+					platformBacked: false,
+				}),
+			);
 		});
 
 		it("returns 400 for invalid timeline session ids", async () => {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `e77500045f05c89714fba0184e25db9effbe28bb`
- last generated public sync base: `179e89f0ef77ced04601f1e92b935f1220113ad8`
- previewed public-tree drift: `14` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (e77500045f05)`
- public projection: `https://github.com/evalops/maestro@main (179e89f0ef77)`
- files to copy or update: `14`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/run-timeline.md
- copy/update package.json
- copy/update packages/ai/tsconfig.build.json
- copy/update scripts/check-platform-sdk-contract.ts
- copy/update scripts/smoke-platform-timeline-e2e.ts
- copy/update src/platform/core-services.ts
- copy/update src/platform/maestro-timeline-client.ts
- copy/update src/server/handlers/session-timeline.ts
- copy/update src/server/routes.ts
- copy/update src/server/session-timeline.ts
- copy/update src/timeline/redaction.ts
- copy/update test/platform/core-services.test.ts
- copy/update test/platform/maestro-timeline-client.test.ts
- copy/update test/session-endpoints.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/run-timeline.md
- copy/update package.json
- copy/update packages/ai/tsconfig.build.json
- copy/update scripts/check-platform-sdk-contract.ts
- copy/update scripts/smoke-platform-timeline-e2e.ts
- copy/update src/platform/core-services.ts
- copy/update src/platform/maestro-timeline-client.ts
- copy/update src/server/handlers/session-timeline.ts
- copy/update src/server/routes.ts
- copy/update src/server/session-timeline.ts
- copy/update src/timeline/redaction.ts
- copy/update test/platform/core-services.test.ts
- copy/update test/platform/maestro-timeline-client.test.ts
- copy/update test/session-endpoints.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode