### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/scripts/session-wire-format-codegen.mjs
+++ b/scripts/session-wire-format-codegen.mjs
@@ -189,6 +189,10 @@ function toRustArray(
 	if (!forceMultiline && prefixLength + inline.length + ";".length <= RUST_MAX_WIDTH) {
 		return inline;
 	}
+	if (entries.length === 1) {
+		const [[from, to]] = entries;
+		return `&[(\n${indent}    ${JSON.stringify(from)},\n${indent}    ${JSON.stringify(to)},\n${indent})]`;
+	}
 	const itemIndent = `${indent}    `;
 	return `&[\n${entries
 		.map(

--- a/src/platform/maestro-timeline-client.ts
+++ b/src/platform/maestro-timeline-client.ts
@@ -163,6 +163,10 @@ function stringValue(value: unknown): string | undefined {
 		: undefined;
 }
 
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
+}
+
 function relatedString(
 	relatedIds: Record<string, unknown> | undefined,
 	...keys: string[]
@@ -329,6 +333,7 @@ function platformOperationForType(
 		case "MAESTRO_TIMELINE_ENTRY_TYPE_TOOL_EXECUTION_WAITING_APPROVAL":
 			return "ResumeToolExecution";
 		case "MAESTRO_TIMELINE_ENTRY_TYPE_APPROVAL_REQUIRED":
+			return "ResolveApproval";
 		case "MAESTRO_TIMELINE_ENTRY_TYPE_RUN_WAITING":
 			return "ResumeRun";
 		default:
@@ -548,7 +553,10 @@ export async function tryListMaestroTimelineWithPlatform(
 			query,
 			options?.signal,
 		);
-	} catch {
+	} catch (error) {
+		if (isAbortError(error)) {
+			throw error;
+		}
 		return null;
 	}
 }

--- a/test/platform/maestro-timeline-client.test.ts
+++ b/test/platform/maestro-timeline-client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	listMaestroTimelineWithPlatform,
 	resolveMaestroTimelineServiceConfig,
+	tryListMaestroTimelineWithPlatform,
 } from "../../src/platform/maestro-timeline-client.js";
 
 type CapturedRequest = {
@@ -166,6 +167,19 @@ describe("maestro timeline client", () => {
 									},
 								},
 								{
+									id: "entry_approval_required",
+									timestamp: "2026-04-30T18:01:15Z",
+									type: "MAESTRO_TIMELINE_ENTRY_TYPE_APPROVAL_REQUIRED",
+									title: "Approval required",
+									visibility: "MAESTRO_TIMELINE_VISIBILITY_USER_VISIBLE",
+									relatedIds: {
+										sessionId: "sess_1",
+										agentRunId: "run_1",
+										approvalRequestId: "approval_2",
+										remoteRunnerSessionId: "mrs_1",
+									},
+								},
+								{
 									id: "entry_approval_denied",
 									timestamp: "2026-04-30T18:01:30Z",
 									type: "MAESTRO_TIMELINE_ENTRY_TYPE_APPROVAL_RESOLVED",
@@ -263,6 +277,13 @@ describe("maestro timeline client", () => {
 					platformOperation: "ResumeToolExecution",
 				},
 				{
+					id: "entry_approval_required",
+					type: "wait.pending",
+					status: "pending",
+					approvalRequestId: "approval_2",
+					platformOperation: "ResolveApproval",
+				},
+				{
 					id: "entry_approval_denied",
 					type: "policy.decision",
 					status: "denied",
@@ -310,5 +331,29 @@ describe("maestro timeline client", () => {
 		expect(serialized).not.toContain("leaked-token");
 		expect(serialized).not.toContain("sk-leaked");
 		expect(serialized).not.toContain("raw payload");
+	});
+
+	it("rethrows AbortError instead of falling back to the local timeline", async () => {
+		const config = await resolveMaestroTimelineServiceConfig();
+		if (!config) {
+			throw new Error("expected timeline config");
+		}
+		const abortError = new Error("aborted");
+		abortError.name = "AbortError";
+		const controller = new AbortController();
+		controller.abort(abortError);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw abortError;
+			}),
+		);
+
+		await expect(
+			tryListMaestroTimelineWithPlatform(
+				{ sessionId: "sess_1", agentRunId: "run_1" },
+				{ config, signal: controller.signal },
+			),
+		).rejects.toMatchObject({ name: "AbortError" });
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `92333372c3a16b76a3386588e6b57a7fdf7c48d8`
- last generated public sync base: `11bd54896ba4a73b82eac42219ac963556d31691`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (92333372c3a1)`
- public projection: `https://github.com/evalops/maestro@main (11bd54896ba4)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update scripts/session-wire-format-codegen.mjs
- copy/update src/platform/maestro-timeline-client.ts
- copy/update test/platform/maestro-timeline-client.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update scripts/session-wire-format-codegen.mjs
- copy/update src/platform/maestro-timeline-client.ts
- copy/update test/platform/maestro-timeline-client.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #253 to internal source `92333372c3a16b76a3386588e6b57a7fdf7c48d8`