### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/scripts/session-wire-format-codegen.mjs
+++ b/scripts/session-wire-format-codegen.mjs
@@ -191,6 +191,11 @@ function toRustArray(
 	}
 	if (entries.length === 1) {
 		const [[from, to]] = entries;
+		const tuple = `(${JSON.stringify(from)}, ${JSON.stringify(to)})`;
+		const itemIndent = `${indent}    `;
+		if (itemIndent.length + tuple.length + ",".length <= RUST_MAX_WIDTH) {
+			return `&[\n${itemIndent}${tuple},\n${indent}]`;
+		}
 		return `&[(\n${indent}    ${JSON.stringify(from)},\n${indent}    ${JSON.stringify(to)},\n${indent})]`;
 	}
 	const itemIndent = `${indent}    `;


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `6881f9201f2e3c0cd760c97b6b1985789079e2f2`
- last generated public sync base: `453999fcaad41e3f930b815a78a0cbeb4ec33edb`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (6881f9201f2e)`
- public projection: `https://github.com/evalops/maestro@main (453999fcaad4)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update scripts/session-wire-format-codegen.mjs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update scripts/session-wire-format-codegen.mjs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode