### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lint:headless-proto": "buf lint && bun run verify:headless-proto:sync && bun run check:headless-proto:generated",
     "lint:evals": "bun run lint:headless-proto && node scripts/verify-evals.js && node scripts/verify-tool-versions.js && node scripts/validate-system-paths.js && node scripts/validate-package-boundaries.js && node scripts/validate-public-package-deps.js && node scripts/session-wire-format-codegen.mjs --check && node scripts/headless-protocol-codegen.mjs --check && npm run developer-surface:check",
     "platform:sdk-smoke": "tsx scripts/check-platform-sdk-contract.ts",
+    "platform:agentruntime-e2e": "tsx scripts/smoke-platform-agentruntime-lifecycle.ts",
     "platform:timeline-e2e": "tsx scripts/smoke-platform-timeline-e2e.ts",
     "developer-surface:check": "node scripts/check-developer-surface.mjs",
     "format": "biome format .",

--- a/scripts/smoke-platform-agentruntime-lifecycle.ts
+++ b/scripts/smoke-platform-agentruntime-lifecycle.ts
@@ -1,0 +1,358 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+	PlatformAgentRunStateValue,
+	PlatformAgentRunStepKindValue,
+	PlatformAgentRunStepStateValue,
+	PlatformAgentRunWaitTypeValue,
+	PlatformRuntimeEventTypeValue,
+	buildMaestroSessionRuntimeTrigger,
+	claimNextAgentRuntimeRun,
+	completeAgentRuntimeRun,
+	getAgentRuntimeRun,
+	handleAgentRuntimeTrigger,
+	listAgentRuntimeRunEvents,
+	recordAgentRuntimeRunStep,
+	resumeAgentRuntimeRun,
+	waitAgentRuntimeRun,
+} from "../src/platform/agent-runtime-client.js";
+
+const GO_SERVER = String.raw`
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	agentruntimev1 "github.com/evalops/platform/gen/go/agentruntime/v1"
+	"github.com/evalops/platform/gen/go/agentruntime/v1/agentruntimev1connect"
+	agentsv1 "github.com/evalops/platform/gen/go/agents/v1"
+	objectivesv1 "github.com/evalops/platform/gen/go/objectives/v1"
+	"github.com/evalops/platform/internal/agentruntime/agentruntime"
+	"github.com/evalops/platform/pkg/connectkit"
+)
+
+type fakeRegistry struct{}
+
+func (fakeRegistry) ResolveAgentConfig(_ context.Context, trigger agentruntime.TriggerContext) (*agentsv1.Agent, *agentsv1.AgentConfig, error) {
+	workspaceID := trigger.Trigger.GetWorkspaceId()
+	agentID := trigger.Trigger.GetAgentId()
+	return &agentsv1.Agent{
+			Id:                  agentID,
+			WorkspaceId:         workspaceID,
+			Status:              agentsv1.AgentStatus_AGENT_STATUS_ACTIVE,
+			ActiveConfigVersion: 1,
+		}, &agentsv1.AgentConfig{
+			AgentId: agentID,
+			Version: 1,
+		}, nil
+}
+
+type fakeObjectives struct{}
+
+func (fakeObjectives) ResolveActiveObjective(_ context.Context, trigger agentruntime.TriggerContext) (*objectivesv1.Objective, error) {
+	return &objectivesv1.Objective{
+		Id:          "objective_1",
+		WorkspaceId: trigger.Trigger.GetWorkspaceId(),
+		AgentId:     trigger.Trigger.GetAgentId(),
+		Title:       "Maestro governed tool smoke",
+		State:       objectivesv1.ObjectiveState_OBJECTIVE_STATE_RUNNING,
+	}, nil
+}
+
+type recordingWorker struct{}
+
+func (recordingWorker) DispatchAgentRun(context.Context, *agentruntimev1.AgentRun) (*agentruntime.DispatchResult, error) {
+	return &agentruntime.DispatchResult{
+		Queue:       "runs.default",
+		ReferenceID: "maestro-smoke-dispatch",
+		Attributes:  map[string]string{"worker": "maestro-smoke"},
+	}, nil
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	service := agentruntime.NewService(
+		agentruntime.NewMemoryStore(),
+		agentruntime.WithClients(agentruntime.ClientSet{
+			Registry:   fakeRegistry{},
+			Objectives: fakeObjectives{},
+			Worker:     recordingWorker{},
+		}),
+	)
+	path, handler := agentruntimev1connect.NewAgentRuntimeServiceHandler(service, connectkit.StandardHandlerOptions()...)
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	must(err)
+	fmt.Printf("PLATFORM_AGENTRUNTIME_URL=http://%s\n", listener.Addr().String())
+	_ = os.Stdout.Sync()
+	must(http.Serve(listener, mux))
+}
+`;
+
+function resolvePlatformRepo(): string {
+	const configured =
+		process.env.MAESTRO_PLATFORM_REPO?.trim() ||
+		process.env.PLATFORM_REPO?.trim();
+	if (configured) {
+		return resolve(configured);
+	}
+	return resolve(process.cwd(), "..", "platform");
+}
+
+async function waitForServer(child: ReturnType<typeof spawn>): Promise<string> {
+	return await new Promise((resolveUrl, reject) => {
+		let output = "";
+		const timeout = setTimeout(() => {
+			reject(new Error(`timed out waiting for Platform server: ${output}`));
+		}, 30_000);
+		child.stdout?.on("data", (chunk: Buffer) => {
+			output += chunk.toString("utf8");
+			const match = output.match(/PLATFORM_AGENTRUNTIME_URL=(http:\/\/[^\s]+)/u);
+			if (match?.[1]) {
+				clearTimeout(timeout);
+				resolveUrl(match[1]);
+			}
+		});
+		child.stderr?.on("data", (chunk: Buffer) => {
+			output += chunk.toString("utf8");
+		});
+		child.on("exit", (code, signal) => {
+			clearTimeout(timeout);
+			reject(
+				new Error(
+					`Platform AgentRuntime server exited before readiness code=${code} signal=${signal}: ${output}`,
+				),
+			);
+		});
+		child.on("error", (error) => {
+			clearTimeout(timeout);
+			reject(error);
+		});
+	});
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+	if (!condition) {
+		throw new Error(message);
+	}
+}
+
+async function terminateChild(
+	child: ReturnType<typeof spawn>,
+	exited: Promise<void>,
+): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return;
+	}
+	const killProcessGroup = process.platform !== "win32" && child.pid;
+	if (killProcessGroup) {
+		try {
+			process.kill(-child.pid, "SIGTERM");
+		} catch {
+			child.kill();
+		}
+	} else {
+		child.kill();
+	}
+	await Promise.race([exited, new Promise((resolve) => setTimeout(resolve, 5_000))]);
+	if (child.exitCode === null && child.signalCode === null) {
+		try {
+			if (killProcessGroup) {
+				process.kill(-child.pid, "SIGKILL");
+			} else {
+				child.kill("SIGKILL");
+			}
+		} catch {
+			child.kill("SIGKILL");
+		}
+		await Promise.race([
+			exited,
+			new Promise((resolve) => setTimeout(resolve, 1_000)),
+		]);
+	}
+}
+
+async function main(): Promise<void> {
+	const platformRepo = resolvePlatformRepo();
+	const tempDir = mkdtempSync(
+		join(platformRepo, ".tmp-maestro-agentruntime-e2e-"),
+	);
+	writeFileSync(join(tempDir, "main.go"), GO_SERVER, "utf8");
+	const child = spawn("go", ["run", "."], {
+		cwd: tempDir,
+		detached: process.platform !== "win32",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	const exited = new Promise<void>((resolve) => {
+		child.once("exit", () => resolve());
+	});
+	try {
+		const baseUrl = await waitForServer(child);
+		const config = {
+			baseUrl,
+			token: "smoke",
+			organizationId: "org_1",
+			workspaceId: "ws_1",
+			timeoutMs: 5_000,
+			maxAttempts: 1,
+		};
+		const trigger = buildMaestroSessionRuntimeTrigger(
+			{
+				workspaceId: "ws_1",
+				sessionId: "session_1",
+				actorId: "user_1",
+				metadata: {
+					path: "agentruntime.lifecycle",
+					tool: "shell.echo",
+				},
+			},
+			"ws_1",
+		);
+		assert(trigger, "failed to build Maestro session trigger");
+		const triggerResult = await handleAgentRuntimeTrigger(trigger, { config });
+		const runId = triggerResult.run.id;
+		assert(runId, "Platform returned no run id");
+
+		const firstClaim = await claimNextAgentRuntimeRun(
+			{
+				workerId: "maestro-smoke-worker-1",
+				workerQueue: "runs.default",
+				leaseSeconds: 30,
+			},
+			{ config },
+		);
+		assert(
+			firstClaim.run.state === PlatformAgentRunStateValue.Running,
+			`first claim state ${firstClaim.run.state}`,
+		);
+		const firstLeaseToken = firstClaim.lease?.token ?? firstClaim.run.lease?.token;
+		assert(firstLeaseToken, "first claim did not return a lease token");
+
+		await recordAgentRuntimeRunStep(
+			{
+				runId,
+				leaseToken: firstLeaseToken,
+				step: {
+					id: "step_tool_1",
+					name: "governed shell echo",
+					stepKind: PlatformAgentRunStepKindValue.ToolCallIntent,
+					state: PlatformAgentRunStepStateValue.Running,
+				},
+			},
+			{ config },
+		);
+		const waiting = await waitAgentRuntimeRun(
+			{
+				runId,
+				leaseToken: firstLeaseToken,
+				wait: {
+					id: "wait_approval_1",
+					stepId: "step_tool_1",
+					type: PlatformAgentRunWaitTypeValue.Approval,
+					externalRef: "approval_1",
+					reason: "governed tool call requires approval",
+					payload: {
+						toolExecutionId: "texec_1",
+						command: "echo platform-governed-tool",
+					},
+				},
+				checkpoint: {
+					id: "checkpoint_approval_1",
+					stepId: "step_tool_1",
+					resumeToken: "resume-after-approval",
+					payload: { cursor: "after-tool-approval" },
+				},
+			},
+			{ config },
+		);
+		assert(
+			waiting.run.state === PlatformAgentRunStateValue.Waiting,
+			`waiting state ${waiting.run.state}`,
+		);
+		assert(
+			waiting.wait?.externalRef === "approval_1",
+			"approval wait was not recorded",
+		);
+
+		await resumeAgentRuntimeRun(
+			{
+				runId,
+				waitId: "wait_approval_1",
+				resumeEventId: "approval_event_1",
+				payload: { decision: "approved" },
+			},
+			{ config },
+		);
+		const secondClaim = await claimNextAgentRuntimeRun(
+			{
+				workerId: "maestro-smoke-worker-2",
+				workerQueue: "runs.default",
+				leaseSeconds: 30,
+			},
+			{ config },
+		);
+		const secondLeaseToken =
+			secondClaim.lease?.token ?? secondClaim.run.lease?.token;
+		assert(secondLeaseToken, "second claim did not return a lease token");
+
+		await recordAgentRuntimeRunStep(
+			{
+				runId,
+				leaseToken: secondLeaseToken,
+				step: {
+					id: "step_tool_1",
+					name: "governed shell echo",
+					stepKind: PlatformAgentRunStepKindValue.ToolCallIntent,
+					state: PlatformAgentRunStepStateValue.Succeeded,
+					output: { text: "platform-governed-tool" },
+				},
+			},
+			{ config },
+		);
+		const completed = await completeAgentRuntimeRun(
+			{
+				runId,
+				leaseToken: secondLeaseToken,
+				result: { status: "ok", toolExecutionId: "texec_1" },
+			},
+			{ config },
+		);
+		assert(
+			completed.run.state === PlatformAgentRunStateValue.Succeeded,
+			`completed state ${completed.run.state}`,
+		);
+
+		const finalRun = await getAgentRuntimeRun({ runId }, { config });
+		const eventList = await listAgentRuntimeRunEvents({ runId }, { config });
+		const eventTypes = new Set(eventList.events.map((event) => event.type));
+		assert(finalRun.run.steps?.length === 1, "final run is missing tool step");
+		assert(finalRun.run.waits?.length === 1, "final run is missing approval wait");
+		assert(
+			eventTypes.has(PlatformRuntimeEventTypeValue.RunWaiting),
+			"runtime events are missing the approval wait",
+		);
+		assert(
+			eventTypes.has(PlatformRuntimeEventTypeValue.RunSucceeded),
+			"runtime events are missing run completion",
+		);
+		console.log(
+			`Validated Maestro AgentRuntime lifecycle against live Platform handler at ${baseUrl} (run ${runId}, ${eventList.events.length} events)`,
+		);
+	} finally {
+		await terminateChild(child, exited);
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+}
+
+await main();

--- a/src/platform/agent-runtime-client.ts
+++ b/src/platform/agent-runtime-client.ts
@@ -21,6 +21,30 @@ const DEFAULT_MAX_ATTEMPTS = 2;
 const HANDLE_TRIGGER_PATH = platformConnectMethodPath(
 	PLATFORM_CONNECT_METHODS.agentRuntime.handleTrigger,
 );
+const CLAIM_NEXT_RUN_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.agentRuntime.claimNextRun,
+);
+const RECORD_RUN_STEP_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.agentRuntime.recordRunStep,
+);
+const WAIT_RUN_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.agentRuntime.waitRun,
+);
+const RESUME_RUN_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.agentRuntime.resumeRun,
+);
+const COMPLETE_RUN_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.agentRuntime.completeRun,
+);
+const FAIL_RUN_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.agentRuntime.failRun,
+);
+const GET_RUN_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.agentRuntime.getRun,
+);
+const LIST_RUN_EVENTS_PATH = platformConnectMethodPath(
+	PLATFORM_CONNECT_METHODS.agentRuntime.listRunEvents,
+);
 
 function isAbortError(error: unknown): boolean {
 	return error instanceof Error && error.name === "AbortError";
@@ -82,6 +106,12 @@ export enum PlatformRuntimeTriggerKindValue {
 
 export enum PlatformRuntimeEventTypeValue {
 	TriggerAccepted = "RUNTIME_EVENT_TYPE_TRIGGER_ACCEPTED",
+	RunClaimed = "RUNTIME_EVENT_TYPE_RUN_CLAIMED",
+	StepRecorded = "RUNTIME_EVENT_TYPE_STEP_RECORDED",
+	RunWaiting = "RUNTIME_EVENT_TYPE_RUN_WAITING",
+	RunResumed = "RUNTIME_EVENT_TYPE_RUN_RESUMED",
+	RunSucceeded = "RUNTIME_EVENT_TYPE_RUN_SUCCEEDED",
+	RunFailed = "RUNTIME_EVENT_TYPE_RUN_FAILED",
 }
 
 export enum PlatformAgentRunStateValue {
@@ -92,6 +122,32 @@ export enum PlatformAgentRunStateValue {
 	Succeeded = "AGENT_RUN_STATE_SUCCEEDED",
 	Failed = "AGENT_RUN_STATE_FAILED",
 	Cancelled = "AGENT_RUN_STATE_CANCELLED",
+}
+
+export enum PlatformAgentRunStepKindValue {
+	ModelCall = "AGENT_RUN_STEP_KIND_MODEL_CALL",
+	ToolCallIntent = "AGENT_RUN_STEP_KIND_TOOL_CALL_INTENT",
+	ToolResult = "AGENT_RUN_STEP_KIND_TOOL_RESULT",
+	ApprovalWait = "AGENT_RUN_STEP_KIND_APPROVAL_WAIT",
+	Error = "AGENT_RUN_STEP_KIND_ERROR",
+	System = "AGENT_RUN_STEP_KIND_SYSTEM",
+}
+
+export enum PlatformAgentRunStepStateValue {
+	Pending = "AGENT_RUN_STEP_STATE_PENDING",
+	Running = "AGENT_RUN_STEP_STATE_RUNNING",
+	Waiting = "AGENT_RUN_STEP_STATE_WAITING",
+	Succeeded = "AGENT_RUN_STEP_STATE_SUCCEEDED",
+	Failed = "AGENT_RUN_STEP_STATE_FAILED",
+	Cancelled = "AGENT_RUN_STEP_STATE_CANCELLED",
+	Skipped = "AGENT_RUN_STEP_STATE_SKIPPED",
+}
+
+export enum PlatformAgentRunWaitTypeValue {
+	Approval = "AGENT_RUN_WAIT_TYPE_APPROVAL",
+	Input = "AGENT_RUN_WAIT_TYPE_INPUT",
+	Event = "AGENT_RUN_WAIT_TYPE_EVENT",
+	Timer = "AGENT_RUN_WAIT_TYPE_TIMER",
 }
 
 export enum MaestroAgentRuntimeSourceEventType {
@@ -125,6 +181,10 @@ export interface PlatformAgentRuntimeTrigger {
 export interface PlatformAgentRun {
 	id: string;
 	state?: PlatformAgentRunStateValue | string;
+	lease?: PlatformAgentRunLease;
+	steps?: PlatformAgentRunStep[];
+	waits?: PlatformAgentRunWait[];
+	latestCheckpoint?: PlatformAgentRunCheckpoint;
 	linkage?: {
 		runId?: string;
 		workspaceId?: string;
@@ -141,6 +201,10 @@ export interface PlatformRuntimeEvent {
 	sequence?: number;
 	type?: string;
 	message?: string;
+	stepId?: string;
+	waitId?: string;
+	checkpointId?: string;
+	attributes?: Record<string, unknown>;
 	occurredAt?: string;
 }
 
@@ -148,6 +212,138 @@ export interface PlatformAgentRuntimeHandleTriggerResult {
 	run: PlatformAgentRun;
 	events: PlatformRuntimeEvent[];
 	idempotentReplay: boolean;
+}
+
+export interface PlatformAgentRunLease {
+	id?: string;
+	token?: string;
+	workerId?: string;
+	workerQueue?: string;
+	expiresAt?: string;
+	heartbeatAt?: string;
+}
+
+export interface PlatformAgentRunStep {
+	id?: string;
+	name?: string;
+	stepKind?: PlatformAgentRunStepKindValue | string;
+	state?: PlatformAgentRunStepStateValue | string;
+	attempt?: number;
+	input?: Record<string, unknown>;
+	output?: Record<string, unknown>;
+	errorMessage?: string;
+	checkpointId?: string;
+	startedAt?: string;
+	endedAt?: string;
+	linkage?: PlatformAgentRun["linkage"];
+}
+
+export interface PlatformAgentRunCheckpoint {
+	id?: string;
+	stepId?: string;
+	sequence?: number;
+	resumeToken?: string;
+	payload?: Record<string, unknown>;
+	createdAt?: string;
+	linkage?: PlatformAgentRun["linkage"];
+}
+
+export interface PlatformAgentRunWait {
+	id?: string;
+	stepId?: string;
+	type?: PlatformAgentRunWaitTypeValue | string;
+	externalRef?: string;
+	reason?: string;
+	payload?: Record<string, unknown>;
+	createdAt?: string;
+	resumeAfter?: string;
+	expiresAt?: string;
+	resolvedAt?: string;
+	resolvedByEventId?: string;
+	linkage?: PlatformAgentRun["linkage"];
+}
+
+export interface PlatformAgentRuntimeClaimNextRunInput {
+	workerId: string;
+	workerQueue?: string;
+	leaseSeconds?: number;
+}
+
+export interface PlatformAgentRuntimeClaimNextRunResult {
+	run: PlatformAgentRun;
+	lease?: PlatformAgentRunLease;
+	events: PlatformRuntimeEvent[];
+}
+
+export interface PlatformAgentRuntimeRecordRunStepInput {
+	runId: string;
+	leaseToken: string;
+	step: PlatformAgentRunStep;
+}
+
+export interface PlatformAgentRuntimeRecordRunStepResult {
+	run: PlatformAgentRun;
+	step?: PlatformAgentRunStep;
+	event?: PlatformRuntimeEvent;
+}
+
+export interface PlatformAgentRuntimeWaitRunInput {
+	runId: string;
+	leaseToken: string;
+	wait: PlatformAgentRunWait;
+	checkpoint?: PlatformAgentRunCheckpoint;
+}
+
+export interface PlatformAgentRuntimeWaitRunResult {
+	run: PlatformAgentRun;
+	wait?: PlatformAgentRunWait;
+	checkpoint?: PlatformAgentRunCheckpoint;
+	event?: PlatformRuntimeEvent;
+}
+
+export interface PlatformAgentRuntimeResumeRunInput {
+	runId: string;
+	waitId: string;
+	resumeEventId?: string;
+	payload?: Record<string, unknown>;
+}
+
+export interface PlatformAgentRuntimeRunEventResult {
+	run: PlatformAgentRun;
+	event?: PlatformRuntimeEvent;
+}
+
+export interface PlatformAgentRuntimeCompleteRunInput {
+	runId: string;
+	leaseToken: string;
+	result?: Record<string, unknown>;
+	checkpoint?: PlatformAgentRunCheckpoint;
+}
+
+export interface PlatformAgentRuntimeCompleteRunResult {
+	run: PlatformAgentRun;
+	checkpoint?: PlatformAgentRunCheckpoint;
+	event?: PlatformRuntimeEvent;
+}
+
+export interface PlatformAgentRuntimeFailRunInput {
+	runId: string;
+	leaseToken: string;
+	errorMessage: string;
+	retryable?: boolean;
+	retryDelaySeconds?: number;
+}
+
+export interface PlatformAgentRuntimeGetRunInput {
+	runId: string;
+}
+
+export interface PlatformAgentRuntimeListRunEventsInput {
+	runId: string;
+}
+
+export interface PlatformAgentRuntimeListRunEventsResult {
+	events: PlatformRuntimeEvent[];
 }
 
 export interface MaestroSessionRuntimeTriggerInput {
@@ -228,6 +424,21 @@ function pickNumber(
 	return undefined;
 }
 
+function normalizeLinkage(
+	value: unknown,
+): PlatformAgentRun["linkage"] | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const linkage = value as Record<string, unknown>;
+	return {
+		runId: pickString(linkage, "runId", "run_id"),
+		workspaceId: pickString(linkage, "workspaceId", "workspace_id"),
+		agentId: pickString(linkage, "agentId", "agent_id"),
+		objectiveId: pickString(linkage, "objectiveId", "objective_id"),
+	};
+}
+
 function compactStringRecord(
 	record: Record<string, string | undefined>,
 ): Record<string, string> | undefined {
@@ -240,6 +451,85 @@ function compactStringRecord(
 	return Object.keys(compacted).length > 0 ? compacted : undefined;
 }
 
+function normalizeLease(value: unknown): PlatformAgentRunLease | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	return {
+		id: pickString(record, "id"),
+		token: pickString(record, "token"),
+		workerId: pickString(record, "workerId", "worker_id"),
+		workerQueue: pickString(record, "workerQueue", "worker_queue"),
+		expiresAt: pickString(record, "expiresAt", "expires_at"),
+		heartbeatAt: pickString(record, "heartbeatAt", "heartbeat_at"),
+	};
+}
+
+function normalizeStep(value: unknown): PlatformAgentRunStep | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	return {
+		id: pickString(record, "id"),
+		name: pickString(record, "name"),
+		stepKind: pickString(record, "stepKind", "step_kind", "kind"),
+		state: pickString(record, "state"),
+		attempt: pickNumber(record, "attempt"),
+		input: pickRecord(record, "input"),
+		output: pickRecord(record, "output"),
+		errorMessage: pickString(record, "errorMessage", "error_message"),
+		checkpointId: pickString(record, "checkpointId", "checkpoint_id"),
+		startedAt: pickString(record, "startedAt", "started_at"),
+		endedAt: pickString(record, "endedAt", "ended_at"),
+		linkage: normalizeLinkage(record.linkage),
+	};
+}
+
+function normalizeCheckpoint(
+	value: unknown,
+): PlatformAgentRunCheckpoint | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	return {
+		id: pickString(record, "id"),
+		stepId: pickString(record, "stepId", "step_id"),
+		sequence: pickNumber(record, "sequence"),
+		resumeToken: pickString(record, "resumeToken", "resume_token"),
+		payload: pickRecord(record, "payload"),
+		createdAt: pickString(record, "createdAt", "created_at"),
+		linkage: normalizeLinkage(record.linkage),
+	};
+}
+
+function normalizeWait(value: unknown): PlatformAgentRunWait | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	return {
+		id: pickString(record, "id"),
+		stepId: pickString(record, "stepId", "step_id"),
+		type: pickString(record, "type"),
+		externalRef: pickString(record, "externalRef", "external_ref"),
+		reason: pickString(record, "reason"),
+		payload: pickRecord(record, "payload"),
+		createdAt: pickString(record, "createdAt", "created_at"),
+		resumeAfter: pickString(record, "resumeAfter", "resume_after"),
+		expiresAt: pickString(record, "expiresAt", "expires_at"),
+		resolvedAt: pickString(record, "resolvedAt", "resolved_at"),
+		resolvedByEventId: pickString(
+			record,
+			"resolvedByEventId",
+			"resolved_by_event_id",
+		),
+		linkage: normalizeLinkage(record.linkage),
+	};
+}
+
 function normalizeRun(value: unknown): PlatformAgentRun | undefined {
 	if (!value || typeof value !== "object" || Array.isArray(value)) {
 		return undefined;
@@ -249,18 +539,20 @@ function normalizeRun(value: unknown): PlatformAgentRun | undefined {
 	if (!id) {
 		return undefined;
 	}
-	const linkage = pickRecord(record, "linkage");
 	return {
 		id,
 		state: pickString(record, "state"),
-		linkage: linkage
-			? {
-					runId: pickString(linkage, "runId", "run_id"),
-					workspaceId: pickString(linkage, "workspaceId", "workspace_id"),
-					agentId: pickString(linkage, "agentId", "agent_id"),
-					objectiveId: pickString(linkage, "objectiveId", "objective_id"),
-				}
-			: undefined,
+		lease: normalizeLease(record.lease),
+		steps: pickArray(record, "steps")
+			?.map(normalizeStep)
+			.filter((step): step is PlatformAgentRunStep => Boolean(step)),
+		waits: pickArray(record, "waits")
+			?.map(normalizeWait)
+			.filter((wait): wait is PlatformAgentRunWait => Boolean(wait)),
+		latestCheckpoint: normalizeCheckpoint(
+			record.latestCheckpoint ?? record.latest_checkpoint,
+		),
+		linkage: normalizeLinkage(record.linkage),
 		createdAt: pickString(record, "createdAt", "created_at"),
 		updatedAt: pickString(record, "updatedAt", "updated_at"),
 	};
@@ -277,6 +569,10 @@ function normalizeEvent(value: unknown): PlatformRuntimeEvent | undefined {
 		sequence: pickNumber(record, "sequence"),
 		type: pickString(record, "type"),
 		message: pickString(record, "message"),
+		stepId: pickString(record, "stepId", "step_id"),
+		waitId: pickString(record, "waitId", "wait_id"),
+		checkpointId: pickString(record, "checkpointId", "checkpoint_id"),
+		attributes: pickRecord(record, "attributes"),
 		occurredAt: pickString(record, "occurredAt", "occurred_at"),
 	};
 }
@@ -284,22 +580,63 @@ function normalizeEvent(value: unknown): PlatformRuntimeEvent | undefined {
 function normalizeHandleTriggerResponse(
 	payload: Record<string, unknown>,
 ): PlatformAgentRuntimeHandleTriggerResult {
-	const run = normalizeRun(payload.run);
-	if (!run) {
-		throw new Error("agent runtime service returned no run");
-	}
 	return {
-		run,
-		events:
-			pickArray(payload, "events")
-				?.map(normalizeEvent)
-				.filter((event): event is PlatformRuntimeEvent => Boolean(event)) ?? [],
+		run: normalizeRequiredRun(payload),
+		events: normalizeEvents(payload),
 		idempotentReplay: pickBoolean(
 			payload,
 			"idempotentReplay",
 			"idempotent_replay",
 		),
 	};
+}
+
+function normalizeRequiredRun(
+	payload: Record<string, unknown>,
+): PlatformAgentRun {
+	const run = normalizeRun(payload.run);
+	if (!run) {
+		throw new Error("agent runtime service returned no run");
+	}
+	return run;
+}
+
+function normalizeEvents(
+	payload: Record<string, unknown>,
+): PlatformRuntimeEvent[] {
+	return (
+		pickArray(payload, "events")
+			?.map(normalizeEvent)
+			.filter((event): event is PlatformRuntimeEvent => Boolean(event)) ?? []
+	);
+}
+
+async function postAgentRuntimeOperation(
+	path: string,
+	body: Record<string, unknown>,
+	options?: {
+		config?: PlatformServiceConfig;
+		signal?: AbortSignal;
+	},
+): Promise<Record<string, unknown>> {
+	const config = options?.config ?? (await resolveAgentRuntimeServiceConfig());
+	if (!config) {
+		throw new Error("agent runtime service is not configured");
+	}
+	const response = await postPlatformConnect(config, path, body, {
+		serviceName: "agent runtime service",
+		failureMode: "optional",
+		timeoutMs: config.timeoutMs,
+		maxAttempts: config.maxAttempts,
+		signal: options?.signal,
+	});
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`agent runtime service returned ${response.status}: ${text || response.statusText}`,
+		);
+	}
+	return (await response.json()) as Record<string, unknown>;
 }
 
 export async function resolveAgentRuntimeServiceConfig(): Promise<PlatformServiceConfig | null> {
@@ -374,31 +711,187 @@ export async function handleAgentRuntimeTrigger(
 		signal?: AbortSignal;
 	},
 ): Promise<PlatformAgentRuntimeHandleTriggerResult> {
-	const config = options?.config ?? (await resolveAgentRuntimeServiceConfig());
-	if (!config) {
-		throw new Error("agent runtime service is not configured");
-	}
-	const response = await postPlatformConnect(
-		config,
-		HANDLE_TRIGGER_PATH,
-		{ trigger },
-		{
-			serviceName: "agent runtime service",
-			failureMode: "optional",
-			timeoutMs: config.timeoutMs,
-			maxAttempts: config.maxAttempts,
-			signal: options?.signal,
-		},
-	);
-	if (!response.ok) {
-		const text = await response.text();
-		throw new Error(
-			`agent runtime service returned ${response.status}: ${text || response.statusText}`,
-		);
-	}
 	return normalizeHandleTriggerResponse(
-		(await response.json()) as Record<string, unknown>,
+		await postAgentRuntimeOperation(HANDLE_TRIGGER_PATH, { trigger }, options),
 	);
+}
+
+export async function claimNextAgentRuntimeRun(
+	input: PlatformAgentRuntimeClaimNextRunInput,
+	options?: {
+		config?: PlatformServiceConfig;
+		signal?: AbortSignal;
+	},
+): Promise<PlatformAgentRuntimeClaimNextRunResult> {
+	const payload = await postAgentRuntimeOperation(
+		CLAIM_NEXT_RUN_PATH,
+		{
+			workerId: input.workerId,
+			...(input.workerQueue ? { workerQueue: input.workerQueue } : {}),
+			...(typeof input.leaseSeconds === "number"
+				? { leaseSeconds: input.leaseSeconds }
+				: {}),
+		},
+		options,
+	);
+	return {
+		run: normalizeRequiredRun(payload),
+		lease: normalizeLease(payload.lease),
+		events: normalizeEvents(payload),
+	};
+}
+
+export async function recordAgentRuntimeRunStep(
+	input: PlatformAgentRuntimeRecordRunStepInput,
+	options?: {
+		config?: PlatformServiceConfig;
+		signal?: AbortSignal;
+	},
+): Promise<PlatformAgentRuntimeRecordRunStepResult> {
+	const payload = await postAgentRuntimeOperation(
+		RECORD_RUN_STEP_PATH,
+		{
+			runId: input.runId,
+			leaseToken: input.leaseToken,
+			step: input.step,
+		},
+		options,
+	);
+	return {
+		run: normalizeRequiredRun(payload),
+		step: normalizeStep(payload.step),
+		event: normalizeEvent(payload.event),
+	};
+}
+
+export async function waitAgentRuntimeRun(
+	input: PlatformAgentRuntimeWaitRunInput,
+	options?: {
+		config?: PlatformServiceConfig;
+		signal?: AbortSignal;
+	},
+): Promise<PlatformAgentRuntimeWaitRunResult> {
+	const payload = await postAgentRuntimeOperation(
+		WAIT_RUN_PATH,
+		{
+			runId: input.runId,
+			leaseToken: input.leaseToken,
+			wait: input.wait,
+			...(input.checkpoint ? { checkpoint: input.checkpoint } : {}),
+		},
+		options,
+	);
+	return {
+		run: normalizeRequiredRun(payload),
+		wait: normalizeWait(payload.wait),
+		checkpoint: normalizeCheckpoint(payload.checkpoint),
+		event: normalizeEvent(payload.event),
+	};
+}
+
+export async function resumeAgentRuntimeRun(
+	input: PlatformAgentRuntimeResumeRunInput,
+	options?: {
+		config?: PlatformServiceConfig;
+		signal?: AbortSignal;
+	},
+): Promise<PlatformAgentRuntimeRunEventResult> {
+	const payload = await postAgentRuntimeOperation(
+		RESUME_RUN_PATH,
+		{
+			runId: input.runId,
+			waitId: input.waitId,
+			...(input.resumeEventId ? { resumeEventId: input.resumeEventId } : {}),
+			...(input.payload ? { payload: input.payload } : {}),
+		},
+		options,
+	);
+	return {
+		run: normalizeRequiredRun(payload),
+		event: normalizeEvent(payload.event),
+	};
+}
+
+export async function completeAgentRuntimeRun(
+	input: PlatformAgentRuntimeCompleteRunInput,
+	options?: {
+		config?: PlatformServiceConfig;
+		signal?: AbortSignal;
+	},
+): Promise<PlatformAgentRuntimeCompleteRunResult> {
+	const payload = await postAgentRuntimeOperation(
+		COMPLETE_RUN_PATH,
+		{
+			runId: input.runId,
+			leaseToken: input.leaseToken,
+			...(input.result ? { result: input.result } : {}),
+			...(input.checkpoint ? { checkpoint: input.checkpoint } : {}),
+		},
+		options,
+	);
+	return {
+		run: normalizeRequiredRun(payload),
+		checkpoint: normalizeCheckpoint(payload.checkpoint),
+		event: normalizeEvent(payload.event),
+	};
+}
+
+export async function failAgentRuntimeRun(
+	input: PlatformAgentRuntimeFailRunInput,
+	options?: {
+		config?: PlatformServiceConfig;
+		signal?: AbortSignal;
+	},
+): Promise<PlatformAgentRuntimeRunEventResult> {
+	const payload = await postAgentRuntimeOperation(
+		FAIL_RUN_PATH,
+		{
+			runId: input.runId,
+			leaseToken: input.leaseToken,
+			errorMessage: input.errorMessage,
+			...(typeof input.retryable === "boolean"
+				? { retryable: input.retryable }
+				: {}),
+			...(typeof input.retryDelaySeconds === "number"
+				? { retryDelaySeconds: input.retryDelaySeconds }
+				: {}),
+		},
+		options,
+	);
+	return {
+		run: normalizeRequiredRun(payload),
+		event: normalizeEvent(payload.event),
+	};
+}
+
+export async function getAgentRuntimeRun(
+	input: PlatformAgentRuntimeGetRunInput,
+	options?: {
+		config?: PlatformServiceConfig;
+		signal?: AbortSignal;
+	},
+): Promise<PlatformAgentRuntimeRunEventResult> {
+	const payload = await postAgentRuntimeOperation(
+		GET_RUN_PATH,
+		{ id: input.runId },
+		options,
+	);
+	return { run: normalizeRequiredRun(payload) };
+}
+
+export async function listAgentRuntimeRunEvents(
+	input: PlatformAgentRuntimeListRunEventsInput,
+	options?: {
+		config?: PlatformServiceConfig;
+		signal?: AbortSignal;
+	},
+): Promise<PlatformAgentRuntimeListRunEventsResult> {
+	const payload = await postAgentRuntimeOperation(
+		LIST_RUN_EVENTS_PATH,
+		{ runId: input.runId },
+		options,
+	);
+	return { events: normalizeEvents(payload) };
 }
 
 export async function recordMaestroSessionRuntimeTrigger(

--- a/src/platform/core-services.ts
+++ b/src/platform/core-services.ts
@@ -18,6 +18,10 @@ export const PLATFORM_CONNECT_SERVICES = {
 
 export const PLATFORM_CONNECT_METHODS = {
 	agentRuntime: {
+		claimNextRun: {
+			service: PLATFORM_CONNECT_SERVICES.agentRuntime,
+			method: "ClaimNextRun",
+		},
 		completeRun: {
 			service: PLATFORM_CONNECT_SERVICES.agentRuntime,
 			method: "CompleteRun",

--- a/test/platform/agent-runtime-client.test.ts
+++ b/test/platform/agent-runtime-client.test.ts
@@ -2,12 +2,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	MaestroAgentRuntimeSourceEventType,
 	PlatformAgentRunStateValue,
+	PlatformAgentRunStepKindValue,
+	PlatformAgentRunStepStateValue,
+	PlatformAgentRunWaitTypeValue,
 	PlatformRuntimeChannelKindValue,
 	PlatformRuntimeEventTypeValue,
 	PlatformRuntimeTriggerKindValue,
 	PlatformSurfaceValue,
 	buildMaestroSessionRuntimeTrigger,
+	claimNextAgentRuntimeRun,
+	completeAgentRuntimeRun,
+	failAgentRuntimeRun,
+	getAgentRuntimeRun,
+	listAgentRuntimeRunEvents,
+	recordAgentRuntimeRunStep,
 	recordMaestroSessionRuntimeTrigger,
+	resumeAgentRuntimeRun,
+	waitAgentRuntimeRun,
 } from "../../src/platform/agent-runtime-client.js";
 import { resolveCerebroFactsServiceConfig } from "../../src/platform/cerebro-facts-client.js";
 
@@ -211,6 +222,428 @@ describe("agent runtime service client", () => {
 			],
 			idempotentReplay: false,
 		});
+	});
+
+	it("drives the Platform AgentRuntime lease, step, wait, resume, and complete lifecycle", async () => {
+		const config = {
+			baseUrl: "https://runtime.test",
+			token: "runtime-token",
+			organizationId: "org_1",
+			workspaceId: "ws_1",
+			timeoutMs: 2_000,
+			maxAttempts: 1,
+		};
+		const requests: Array<{
+			url: string;
+			body: Record<string, unknown> | undefined;
+		}> = [];
+		const fetchMock = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input);
+				const body = parseRequestBody(init?.body);
+				requests.push({ url, body });
+				expect(init?.method).toBe("POST");
+				expect(headersToRecord(init?.headers)).toMatchObject({
+					authorization: "Bearer runtime-token",
+					"connect-protocol-version": "1",
+					"content-type": "application/json",
+					"x-organization-id": "org_1",
+				});
+
+				if (url.endsWith("/ClaimNextRun")) {
+					expect(body).toMatchObject({
+						workerId: "maestro-worker",
+						workerQueue: "runs.default",
+						leaseSeconds: 30,
+					});
+					return Response.json({
+						run: {
+							id: "run_1",
+							state: PlatformAgentRunStateValue.Running,
+							lease: {
+								id: "lease_1",
+								token: "lease-token-1",
+								workerId: "maestro-worker",
+							},
+						},
+						lease: {
+							id: "lease_1",
+							token: "lease-token-1",
+							workerId: "maestro-worker",
+						},
+						events: [
+							{
+								id: "event_claimed",
+								runId: "run_1",
+								type: PlatformRuntimeEventTypeValue.RunClaimed,
+							},
+						],
+					});
+				}
+
+				if (url.endsWith("/RecordRunStep")) {
+					expect(body).toMatchObject({
+						runId: "run_1",
+						leaseToken: "lease-token-1",
+						step: {
+							id: "step_tool_1",
+							name: "governed shell",
+							stepKind: PlatformAgentRunStepKindValue.ToolCallIntent,
+							state: PlatformAgentRunStepStateValue.Running,
+						},
+					});
+					return Response.json({
+						run: {
+							id: "run_1",
+							state: PlatformAgentRunStateValue.Running,
+							steps: [
+								{
+									id: "step_tool_1",
+									name: "governed shell",
+									stepKind: PlatformAgentRunStepKindValue.ToolCallIntent,
+									state: PlatformAgentRunStepStateValue.Running,
+								},
+							],
+						},
+						step: {
+							id: "step_tool_1",
+							name: "governed shell",
+							stepKind: PlatformAgentRunStepKindValue.ToolCallIntent,
+							state: PlatformAgentRunStepStateValue.Running,
+						},
+						event: {
+							id: "event_step",
+							stepId: "step_tool_1",
+							type: PlatformRuntimeEventTypeValue.StepRecorded,
+						},
+					});
+				}
+
+				if (url.endsWith("/WaitRun")) {
+					expect(body).toMatchObject({
+						runId: "run_1",
+						leaseToken: "lease-token-1",
+						wait: {
+							id: "wait_approval_1",
+							stepId: "step_tool_1",
+							type: PlatformAgentRunWaitTypeValue.Approval,
+							externalRef: "approval_1",
+						},
+						checkpoint: {
+							id: "checkpoint_approval_1",
+							stepId: "step_tool_1",
+							resumeToken: "resume-after-approval",
+						},
+					});
+					return Response.json({
+						run: {
+							id: "run_1",
+							state: PlatformAgentRunStateValue.Waiting,
+							waits: [
+								{
+									id: "wait_approval_1",
+									stepId: "step_tool_1",
+									type: PlatformAgentRunWaitTypeValue.Approval,
+									externalRef: "approval_1",
+								},
+							],
+							latestCheckpoint: {
+								id: "checkpoint_approval_1",
+								stepId: "step_tool_1",
+								sequence: 1,
+							},
+						},
+						wait: {
+							id: "wait_approval_1",
+							stepId: "step_tool_1",
+							type: PlatformAgentRunWaitTypeValue.Approval,
+						},
+						checkpoint: {
+							id: "checkpoint_approval_1",
+							stepId: "step_tool_1",
+							sequence: 1,
+						},
+						event: {
+							id: "event_wait",
+							waitId: "wait_approval_1",
+							checkpointId: "checkpoint_approval_1",
+							type: PlatformRuntimeEventTypeValue.RunWaiting,
+						},
+					});
+				}
+
+				if (url.endsWith("/ResumeRun")) {
+					expect(body).toMatchObject({
+						runId: "run_1",
+						waitId: "wait_approval_1",
+						resumeEventId: "approval_event_1",
+					});
+					return Response.json({
+						run: {
+							id: "run_1",
+							state: PlatformAgentRunStateValue.Queued,
+						},
+						event: {
+							id: "event_resume",
+							waitId: "wait_approval_1",
+							type: PlatformRuntimeEventTypeValue.RunResumed,
+						},
+					});
+				}
+
+				if (url.endsWith("/CompleteRun")) {
+					expect(body).toMatchObject({
+						runId: "run_1",
+						leaseToken: "lease-token-2",
+						result: { status: "ok" },
+					});
+					return Response.json({
+						run: {
+							id: "run_1",
+							state: PlatformAgentRunStateValue.Succeeded,
+						},
+						event: {
+							id: "event_complete",
+							type: PlatformRuntimeEventTypeValue.RunSucceeded,
+						},
+					});
+				}
+
+				if (url.endsWith("/GetRun")) {
+					expect(body).toMatchObject({ id: "run_1" });
+					return Response.json({
+						run: {
+							id: "run_1",
+							state: PlatformAgentRunStateValue.Succeeded,
+						},
+					});
+				}
+
+				if (url.endsWith("/ListRunEvents")) {
+					expect(body).toMatchObject({ runId: "run_1" });
+					return Response.json({
+						events: [
+							{
+								id: "event_complete",
+								runId: "run_1",
+								type: PlatformRuntimeEventTypeValue.RunSucceeded,
+							},
+						],
+					});
+				}
+
+				return new Response("unexpected endpoint", { status: 404 });
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const claim = await claimNextAgentRuntimeRun(
+			{
+				workerId: "maestro-worker",
+				workerQueue: "runs.default",
+				leaseSeconds: 30,
+			},
+			{ config },
+		);
+		expect(claim.run.lease?.token).toBe("lease-token-1");
+		expect(claim.lease?.workerId).toBe("maestro-worker");
+
+		await expect(
+			recordAgentRuntimeRunStep(
+				{
+					runId: "run_1",
+					leaseToken: "lease-token-1",
+					step: {
+						id: "step_tool_1",
+						name: "governed shell",
+						stepKind: PlatformAgentRunStepKindValue.ToolCallIntent,
+						state: PlatformAgentRunStepStateValue.Running,
+					},
+				},
+				{ config },
+			),
+		).resolves.toMatchObject({
+			step: { id: "step_tool_1" },
+			event: { stepId: "step_tool_1" },
+		});
+
+		await expect(
+			waitAgentRuntimeRun(
+				{
+					runId: "run_1",
+					leaseToken: "lease-token-1",
+					wait: {
+						id: "wait_approval_1",
+						stepId: "step_tool_1",
+						type: PlatformAgentRunWaitTypeValue.Approval,
+						externalRef: "approval_1",
+						reason: "needs approval",
+					},
+					checkpoint: {
+						id: "checkpoint_approval_1",
+						stepId: "step_tool_1",
+						resumeToken: "resume-after-approval",
+					},
+				},
+				{ config },
+			),
+		).resolves.toMatchObject({
+			run: {
+				state: PlatformAgentRunStateValue.Waiting,
+				latestCheckpoint: { id: "checkpoint_approval_1" },
+			},
+			wait: { id: "wait_approval_1" },
+		});
+
+		await expect(
+			resumeAgentRuntimeRun(
+				{
+					runId: "run_1",
+					waitId: "wait_approval_1",
+					resumeEventId: "approval_event_1",
+				},
+				{ config },
+			),
+		).resolves.toMatchObject({
+			run: { state: PlatformAgentRunStateValue.Queued },
+			event: { waitId: "wait_approval_1" },
+		});
+
+		await expect(
+			completeAgentRuntimeRun(
+				{
+					runId: "run_1",
+					leaseToken: "lease-token-2",
+					result: { status: "ok" },
+				},
+				{ config },
+			),
+		).resolves.toMatchObject({
+			run: { state: PlatformAgentRunStateValue.Succeeded },
+		});
+
+		await expect(
+			getAgentRuntimeRun({ runId: "run_1" }, { config }),
+		).resolves.toMatchObject({
+			run: { state: PlatformAgentRunStateValue.Succeeded },
+		});
+		await expect(
+			listAgentRuntimeRunEvents({ runId: "run_1" }, { config }),
+		).resolves.toMatchObject({
+			events: [{ type: PlatformRuntimeEventTypeValue.RunSucceeded }],
+		});
+
+		expect(requests.map((request) => request.url)).toEqual([
+			"https://runtime.test/agentruntime.v1.AgentRuntimeService/ClaimNextRun",
+			"https://runtime.test/agentruntime.v1.AgentRuntimeService/RecordRunStep",
+			"https://runtime.test/agentruntime.v1.AgentRuntimeService/WaitRun",
+			"https://runtime.test/agentruntime.v1.AgentRuntimeService/ResumeRun",
+			"https://runtime.test/agentruntime.v1.AgentRuntimeService/CompleteRun",
+			"https://runtime.test/agentruntime.v1.AgentRuntimeService/GetRun",
+			"https://runtime.test/agentruntime.v1.AgentRuntimeService/ListRunEvents",
+		]);
+	});
+
+	it("preserves zero lease seconds when claiming a Platform AgentRuntime run", async () => {
+		const config = {
+			baseUrl: "https://runtime.test",
+			token: "runtime-token",
+			organizationId: "org_1",
+			workspaceId: "ws_1",
+			timeoutMs: 2_000,
+			maxAttempts: 1,
+		};
+		const fetchMock = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				expect(String(input)).toBe(
+					"https://runtime.test/agentruntime.v1.AgentRuntimeService/ClaimNextRun",
+				);
+				expect(parseRequestBody(init?.body)).toMatchObject({
+					workerId: "maestro-worker",
+					workerQueue: "runs.default",
+					leaseSeconds: 0,
+				});
+				return Response.json({
+					run: {
+						id: "run_1",
+						state: PlatformAgentRunStateValue.Running,
+					},
+					lease: {
+						id: "lease_1",
+						token: "lease-token-1",
+					},
+				});
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			claimNextAgentRuntimeRun(
+				{
+					workerId: "maestro-worker",
+					workerQueue: "runs.default",
+					leaseSeconds: 0,
+				},
+				{ config },
+			),
+		).resolves.toMatchObject({
+			run: { state: PlatformAgentRunStateValue.Running },
+			lease: { token: "lease-token-1" },
+		});
+	});
+
+	it("preserves zero retry delay when failing a Platform AgentRuntime run", async () => {
+		const config = {
+			baseUrl: "https://runtime.test",
+			token: "runtime-token",
+			organizationId: "org_1",
+			workspaceId: "ws_1",
+			timeoutMs: 2_000,
+			maxAttempts: 1,
+		};
+		const fetchMock = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				expect(String(input)).toBe(
+					"https://runtime.test/agentruntime.v1.AgentRuntimeService/FailRun",
+				);
+				expect(parseRequestBody(init?.body)).toMatchObject({
+					runId: "run_1",
+					leaseToken: "lease-token-1",
+					errorMessage: "tool failed",
+					retryable: true,
+					retryDelaySeconds: 0,
+				});
+				return Response.json({
+					run: {
+						id: "run_1",
+						state: PlatformAgentRunStateValue.Failed,
+					},
+					event: {
+						id: "event_failed",
+						runId: "run_1",
+						type: PlatformRuntimeEventTypeValue.RunFailed,
+					},
+				});
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			failAgentRuntimeRun(
+				{
+					runId: "run_1",
+					leaseToken: "lease-token-1",
+					errorMessage: "tool failed",
+					retryable: true,
+					retryDelaySeconds: 0,
+				},
+				{ config },
+			),
+		).resolves.toMatchObject({
+			run: { state: PlatformAgentRunStateValue.Failed },
+			event: { type: PlatformRuntimeEventTypeValue.RunFailed },
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("enriches Maestro session triggers with Cerebro facts when configured", async () => {

--- a/test/platform/core-services.test.ts
+++ b/test/platform/core-services.test.ts
@@ -16,6 +16,11 @@ describe("Platform core service contract names", () => {
 		).toBe("/agentruntime.v1.AgentRuntimeService/HandleTrigger");
 		expect(
 			platformConnectMethodPath(
+				PLATFORM_CONNECT_METHODS.agentRuntime.claimNextRun,
+			),
+		).toBe("/agentruntime.v1.AgentRuntimeService/ClaimNextRun");
+		expect(
+			platformConnectMethodPath(
 				PLATFORM_CONNECT_METHODS.agentRuntime.recordRunStep,
 			),
 		).toBe("/agentruntime.v1.AgentRuntimeService/RecordRunStep");


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `06aada7f76409a56e879a92f8f91d77b03cf982c`
- last generated public sync base: `5a898a83ec456bf7eeaec4b08bdf67f978ddcb38`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (06aada7f7640)`
- public projection: `https://github.com/evalops/maestro@main (5a898a83ec45)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update package.json
- copy/update scripts/smoke-platform-agentruntime-lifecycle.ts
- copy/update src/platform/agent-runtime-client.ts
- copy/update src/platform/core-services.ts
- copy/update test/platform/agent-runtime-client.test.ts
- copy/update test/platform/core-services.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update package.json
- copy/update scripts/smoke-platform-agentruntime-lifecycle.ts
- copy/update src/platform/agent-runtime-client.ts
- copy/update src/platform/core-services.ts
- copy/update test/platform/agent-runtime-client.test.ts
- copy/update test/platform/core-services.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #255 to internal source `06aada7f76409a56e879a92f8f91d77b03cf982c`