### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/platform/agent-runtime-client.ts
+++ b/src/platform/agent-runtime-client.ts
@@ -417,11 +417,15 @@ function pickNumber(
 ): number | undefined {
 	for (const name of names) {
 		const value = record?.[name];
-		if (typeof value === "number" && Number.isFinite(value)) {
+		if (isFiniteNumber(value)) {
 			return value;
 		}
 	}
 	return undefined;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
 }
 
 function normalizeLinkage(
@@ -728,7 +732,7 @@ export async function claimNextAgentRuntimeRun(
 		{
 			workerId: input.workerId,
 			...(input.workerQueue ? { workerQueue: input.workerQueue } : {}),
-			...(typeof input.leaseSeconds === "number"
+			...(isFiniteNumber(input.leaseSeconds)
 				? { leaseSeconds: input.leaseSeconds }
 				: {}),
 		},
@@ -852,7 +856,7 @@ export async function failAgentRuntimeRun(
 			...(typeof input.retryable === "boolean"
 				? { retryable: input.retryable }
 				: {}),
-			...(typeof input.retryDelaySeconds === "number"
+			...(isFiniteNumber(input.retryDelaySeconds)
 				? { retryDelaySeconds: input.retryDelaySeconds }
 				: {}),
 		},

--- a/test/platform/agent-runtime-client.test.ts
+++ b/test/platform/agent-runtime-client.test.ts
@@ -646,6 +646,56 @@ describe("agent runtime service client", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
+	it("omits non-finite lease duration when claiming a Platform AgentRuntime run", async () => {
+		const config = {
+			baseUrl: "https://runtime.test",
+			token: "runtime-token",
+			organizationId: "org_1",
+			workspaceId: "ws_1",
+			timeoutMs: 2_000,
+			maxAttempts: 1,
+		};
+		const fetchMock = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				expect(String(input)).toBe(
+					"https://runtime.test/agentruntime.v1.AgentRuntimeService/ClaimNextRun",
+				);
+				expect(parseRequestBody(init?.body)).toEqual({
+					workerId: "maestro-worker",
+					workerQueue: "runs.default",
+				});
+				return Response.json({
+					run: {
+						id: "run_1",
+						state: PlatformAgentRunStateValue.Running,
+					},
+					lease: {
+						token: "lease-token-1",
+						workerId: "maestro-worker",
+						workerQueue: "runs.default",
+					},
+					events: [],
+				});
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			claimNextAgentRuntimeRun(
+				{
+					workerId: "maestro-worker",
+					workerQueue: "runs.default",
+					leaseSeconds: Number.NaN,
+				},
+				{ config },
+			),
+		).resolves.toMatchObject({
+			run: { state: PlatformAgentRunStateValue.Running },
+			lease: { token: "lease-token-1" },
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("enriches Maestro session triggers with Cerebro facts when configured", async () => {
 		vi.stubEnv("MAESTRO_AGENT_RUNTIME_SERVICE_URL", "https://runtime.test/");
 		vi.stubEnv("MAESTRO_AGENT_RUNTIME_SERVICE_TOKEN", "runtime-token");


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `f510805b0fd7639c2c049eaeb23d893dd5061227`
- last generated public sync base: `e623987b954d7ef559418e5f32239284d4e60531`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (f510805b0fd7)`
- public projection: `https://github.com/evalops/maestro@main (e623987b954d)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/platform/agent-runtime-client.ts
- copy/update test/platform/agent-runtime-client.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/platform/agent-runtime-client.ts
- copy/update test/platform/agent-runtime-client.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode