### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/test/agent/mcp-platform-plugin.test.ts
+++ b/test/agent/mcp-platform-plugin.test.ts
@@ -84,6 +84,19 @@ describe("platform MCP plugin servers", () => {
 		]);
 	});
 
+	it("keeps transport session evidence for existing MCP clients", () => {
+		process.env.MAESTRO_PLATFORM_MCP_URL =
+			"https://agent-mcp.evalops.example/mcp/";
+		process.env.EVALOPS_ORGANIZATION_ID = "workspace-123";
+		process.env.MAESTRO_SESSION_ID = "session-123";
+
+		const [server] = getPlatformMcpPluginServers();
+		expect(server?.headers).toMatchObject({
+			"Mcp-Session-Id": "session-123",
+			"X-EvalOps-Session-Id": "session-123",
+		});
+	});
+
 	it("merges the Platform MCP plugin server into the runtime MCP config", () => {
 		process.env.MAESTRO_PLATFORM_MCP_URL =
 			"https://agent-mcp.evalops.example/mcp";


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `d1bb89ceadd28ac8dca0ea109b625a7158fddf41`
- last generated public sync base: `3ad35781ba5b05337403a65cd212d706a24e22da`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (d1bb89ceadd2)`
- public projection: `https://github.com/evalops/maestro@main (3ad35781ba5b)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update test/agent/mcp-platform-plugin.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update test/agent/mcp-platform-plugin.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode