### PR TITLE
fix: address missed OpenAI provider review feedback

### DIFF
--- a/src/agent/providers/openai-responses-sdk.ts
+++ b/src/agent/providers/openai-responses-sdk.ts
@@ -105,13 +105,22 @@ export async function* streamResponsesApiSdk(
 	}
 
 	if (options.toolChoice && validTools.length > 0) {
-		params.tool_choice =
-			typeof options.toolChoice === "string"
-				? options.toolChoice
-				: {
-						type: "function",
-						name: options.toolChoice.function.name,
-					};
+		if (typeof options.toolChoice === "string") {
+			params.tool_choice = options.toolChoice;
+		} else {
+			const toolName = options.toolChoice.function.name;
+			if (validTools.some((tool) => tool.name === toolName)) {
+				params.tool_choice = {
+					type: "function",
+					name: toolName,
+				};
+			} else {
+				logger.warn("Dropping tool_choice for filtered Responses API tool", {
+					toolName,
+					model: model.id,
+				});
+			}
+		}
 	}
 
 	if (options.maxTokens) {

--- a/src/agent/providers/openai-shared.ts
+++ b/src/agent/providers/openai-shared.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ReasoningEffort, StreamOptions } from "../types.js";
+import { isRecord } from "./tool-arguments.js";
 
 // =============================================================================
 // OpenAI API Types
@@ -105,10 +106,6 @@ const EMPTY_TOOL_PARAMETERS_SCHEMA = {
 } as const;
 
 const TOP_LEVEL_UNION_KEYS = ["anyOf", "oneOf", "allOf"] as const;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return !!value && typeof value === "object" && !Array.isArray(value);
-}
 
 function canonicalizeSchema(value: unknown): unknown {
 	if (Array.isArray(value)) {
@@ -231,8 +228,18 @@ function mergeObjectVariants(
 					const {
 						const: _const,
 						enum: _enum,
-						...schemaWithoutDiscriminator
+						...currentWithoutDiscriminator
 					} = current;
+					const {
+						const: _incomingConst,
+						enum: _incomingEnum,
+						...incomingWithoutDiscriminator
+					} = propertySchema;
+					const mergedSchema =
+						mergeCompatibleObjectSchemas(
+							currentWithoutDiscriminator,
+							incomingWithoutDiscriminator,
+						) ?? currentWithoutDiscriminator;
 					const enumValues =
 						requiredMode === "union"
 							? currentValues.filter((value) => incomingValues.includes(value))
@@ -241,7 +248,7 @@ function mergeObjectVariants(
 						return undefined;
 					}
 					mergedProperties[propertyName] = {
-						...schemaWithoutDiscriminator,
+						...mergedSchema,
 						...(enumValues.length > 0 ? { enum: enumValues } : {}),
 					};
 					continue;

--- a/test/agent/openai-responses-sdk.test.ts
+++ b/test/agent/openai-responses-sdk.test.ts
@@ -424,6 +424,42 @@ describe("OpenAI Responses SDK streaming", () => {
 		expect(params.tool_choice).toBe("none");
 	});
 
+	it("drops forced tool_choice when that tool is filtered out", async () => {
+		const context: Context = {
+			...baseContext,
+			tools: [
+				{
+					name: "read",
+					description: "read file",
+					parameters: {
+						type: "object",
+						properties: { path: { type: "string" } },
+						required: ["path"],
+					},
+				},
+				{
+					name: "unsupported",
+					description: "unsupported schema",
+					parameters: { enum: ["a", "b"] },
+				},
+			],
+		};
+
+		for await (const _ of streamResponsesApiSdk(responsesModel, context, {
+			apiKey: "k",
+			toolChoice: { type: "function", function: { name: "unsupported" } },
+		})) {
+			// drain
+		}
+
+		const params = openaiMock.getLastParams() as {
+			tools?: Array<{ name: string }>;
+			tool_choice?: unknown;
+		};
+		expect(params.tools?.map((tool) => tool.name)).toEqual(["read"]);
+		expect(params.tool_choice).toBeUndefined();
+	});
+
 	it("normalizes top-level union tool schemas before Responses filtering", async () => {
 		const context: Context = {
 			...baseContext,
@@ -441,7 +477,7 @@ describe("OpenAI Responses SDK streaming", () => {
 							{
 								type: "object",
 								properties: {
-									action: { const: "stop" },
+									action: { const: "stop", type: "string" },
 									taskId: { type: "string" },
 								},
 								required: ["action"],
@@ -470,7 +506,7 @@ describe("OpenAI Responses SDK streaming", () => {
 			parameters: {
 				type: "object",
 				properties: {
-					action: { enum: ["list", "stop"] },
+					action: { type: "string", enum: ["list", "stop"] },
 					taskId: { type: "string" },
 				},
 				required: ["action"],

--- a/test/agent/openai-streaming.test.ts
+++ b/test/agent/openai-streaming.test.ts
@@ -416,7 +416,7 @@ describe("filterResponsesApiTools", () => {
 						},
 						{
 							type: "object",
-							properties: { action: { const: "stop" } },
+							properties: { action: { const: "stop", type: "string" } },
 							required: ["action"],
 						},
 					],
@@ -429,7 +429,7 @@ describe("filterResponsesApiTools", () => {
 		expect(result[0]!.parameters).toMatchObject({
 			type: "object",
 			properties: {
-				action: { enum: ["list", "stop"] },
+				action: { type: "string", enum: ["list", "stop"] },
 			},
 			required: ["action"],
 		});


### PR DESCRIPTION
## Summary
- preserve compatible schema metadata when merging const/enum object variants for Responses tools
- drop forced Responses tool_choice when the selected tool was filtered out
- share the existing tool argument isRecord helper

Source-of-truth private PR: evalops/maestro-internal#1625

## Tests
- node ./scripts/run-vitest.js --run test/agent/openai-streaming.test.ts test/agent/openai-responses-sdk.test.ts
- pre-commit hook: guardian, biome/lint, build, compile
