### PR TITLE
fix: preserve shared OpenAI enum constraints

### DIFF
--- a/src/agent/providers/openai-shared.ts
+++ b/src/agent/providers/openai-shared.ts
@@ -198,6 +198,31 @@ function mergeCompatibleObjectSchemas(
 	return merged;
 }
 
+function mergeSharedObjectSchemaConstraints(
+	left: Record<string, unknown>,
+	right: Record<string, unknown>,
+	enumValues: unknown[],
+): Record<string, unknown> {
+	const merged: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(left)) {
+		if (right[key] !== undefined && schemasAreEqual(value, right[key])) {
+			merged[key] = value;
+		}
+	}
+	const primitiveTypes = new Set(
+		enumValues
+			.map((value) => (value === null ? "null" : typeof value))
+			.filter((value) => ["boolean", "number", "string"].includes(value)),
+	);
+	if (primitiveTypes.size === 1) {
+		const [primitiveType] = [...primitiveTypes];
+		if (left.type === primitiveType || right.type === primitiveType) {
+			merged.type = primitiveType;
+		}
+	}
+	return merged;
+}
+
 function mergeObjectVariants(
 	variants: unknown[],
 	requiredMode: "intersection" | "union",
@@ -235,11 +260,6 @@ function mergeObjectVariants(
 						enum: _incomingEnum,
 						...incomingWithoutDiscriminator
 					} = propertySchema;
-					const mergedSchema =
-						mergeCompatibleObjectSchemas(
-							currentWithoutDiscriminator,
-							incomingWithoutDiscriminator,
-						) ?? currentWithoutDiscriminator;
 					const enumValues =
 						requiredMode === "union"
 							? currentValues.filter((value) => incomingValues.includes(value))
@@ -247,6 +267,17 @@ function mergeObjectVariants(
 					if (requiredMode === "union" && enumValues.length === 0) {
 						return undefined;
 					}
+					const mergedSchema =
+						requiredMode === "union"
+							? (mergeCompatibleObjectSchemas(
+									currentWithoutDiscriminator,
+									incomingWithoutDiscriminator,
+								) ?? currentWithoutDiscriminator)
+							: mergeSharedObjectSchemaConstraints(
+									currentWithoutDiscriminator,
+									incomingWithoutDiscriminator,
+									enumValues,
+								);
 					mergedProperties[propertyName] = {
 						...mergedSchema,
 						...(enumValues.length > 0 ? { enum: enumValues } : {}),

--- a/test/agent/openai-streaming.test.ts
+++ b/test/agent/openai-streaming.test.ts
@@ -619,6 +619,45 @@ describe("normalizeOpenAIToolParameters", () => {
 		});
 	});
 
+	it("drops branch-only constraints when merging enum-like anyOf branches", () => {
+		const schema = {
+			anyOf: [
+				{
+					type: "object",
+					properties: {
+						action: {
+							const: "list",
+							type: "string",
+							minLength: 4,
+							description: "List background tasks",
+						},
+					},
+					required: ["action"],
+				},
+				{
+					type: "object",
+					properties: {
+						action: {
+							const: "stop",
+							type: "string",
+							minLength: 1,
+							description: "Stop a background task",
+						},
+					},
+					required: ["action"],
+				},
+			],
+		};
+
+		expect(normalizeOpenAIToolParameters(schema)).toMatchObject({
+			type: "object",
+			properties: {
+				action: { type: "string", enum: ["list", "stop"] },
+			},
+			required: ["action"],
+		});
+	});
+
 	it("filters lossy Responses unions with branch-only required fields", () => {
 		const result = filterResponsesApiTools([
 			{


### PR DESCRIPTION
Addresses missed review feedback from #260. Keeps shared discriminator structure while dropping branch-only constraints when normalizing OpenAI tool schemas.

Source-of-truth: https://github.com/evalops/maestro-internal/pull/1626

Tested:
- node ./scripts/run-vitest.js --run test/agent/openai-streaming.test.ts