### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/governance/tsconfig.build.json
+++ b/packages/governance/tsconfig.build.json
@@ -3,10 +3,9 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"rootDir": "../../",
-		"composite": true,
 		"tsBuildInfoFile": "../../tmp/tsbuildinfo/governance.tsbuildinfo"
 	},
-	"include": ["src/**/*.ts", "../../src/**/*.ts"],
+	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules", "dist"],
 	"references": [
 		{ "path": "../contracts/tsconfig.build.json" },

--- a/scripts/ci-nx-tests.sh
+++ b/scripts/ci-nx-tests.sh
@@ -22,7 +22,7 @@ run_shared_memory_tests() {
 	fi
 }
 
-node scripts/ensure-deps.js --no-install --workspace @evalops/contracts
+node scripts/ensure-deps.js --no-install --workspace @evalops/contracts --workspace @evalops/tui
 
 if git diff --name-only "$NX_BASE" "$NX_HEAD" | grep -qE '^(nx\.json|project\.json|tsconfig\.base\.json|package\.json|bun\.lockb|package-lock\.json|packages/.*/project\.json)$'; then
 	cmd=(npx nx run-many -t test --all --parallel=3)


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `9b3e503f2503570de70089093fee7a0ae83dd57d`
- last generated public sync base: `45545f097837434a370fae28b9311b934245f47d`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (9b3e503f2503)`
- public projection: `https://github.com/evalops/maestro@main (45545f097837)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/governance/tsconfig.build.json
- copy/update scripts/ci-nx-tests.sh

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/governance/tsconfig.build.json
- copy/update scripts/ci-nx-tests.sh

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #266 to internal source `9b3e503f2503570de70089093fee7a0ae83dd57d`