### PR TITLE
chore: sync release mirror from internal

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Commit release branch
         env:
           RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
+          HUSKY: "0"
         run: |
           set -euo pipefail
           if git diff --quiet; then


### PR DESCRIPTION
## Summary

- sync shared release automation files from `evalops/maestro-internal`
- keep public release tooling aligned while public source parity is being migrated
- internal source SHA: `a05640fee4d83c6fa43ea46d85a82498c25edcd7`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (a05640fee4d8)`
- public projection: `https://github.com/evalops/maestro@main (926f2026c55b)`
- files to copy or update: `0`
- stale files to delete: `0`
- result: in sync
- invariant: `public_is_verified_projection`

### Guidance

Public main matches the sanitized private source tree for mirrored paths.

## Drift sample

- no changed mirrored paths sampled

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `manifest` mode