### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -22,6 +22,7 @@ import { getHomeDir } from "../../utils/path-expansion.js";
 import type { Api } from "../../agent/types.js";
 import { getEnvVarsForProvider } from "../../providers/api-keys.js";
 import {
+	DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL,
 	getEvalOpsManagedProviderDefinitions,
 	isEvalOpsManagedProvider,
 } from "../../providers/evalops-managed.js";
@@ -41,7 +42,8 @@ type ProviderPreset = {
 
 function getManagedGatewayBaseUrl(): string {
 	return (
-		process.env.MAESTRO_LLM_GATEWAY_URL?.trim() || "http://127.0.0.1:8081/v1"
+		process.env.MAESTRO_LLM_GATEWAY_URL?.trim() ||
+		DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL
 	);
 }
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -125,6 +125,10 @@ export async function handleInitCommand(args: string[] = []): Promise<void> {
 	const result = await bootstrapEvalOpsAgent(options, {
 		onAuthUrl: (url) => {
 			if (options.json) {
+				console.error(
+					"Open this URL in your browser to authenticate with EvalOps:",
+				);
+				console.error(url);
 				return;
 			}
 			console.log(
@@ -135,9 +139,11 @@ export async function handleInitCommand(args: string[] = []): Promise<void> {
 			console.log(chalk.underline(url));
 		},
 		onStatus: (status) => {
-			if (!options.json) {
-				console.log(chalk.dim(status.message));
+			if (options.json) {
+				console.error(status.message);
+				return;
 			}
+			console.log(chalk.dim(status.message));
 		},
 	});
 

--- a/src/models/builtin.ts
+++ b/src/models/builtin.ts
@@ -1,16 +1,15 @@
 import type { Api, Model } from "../agent/types.js";
 import {
+	DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL,
 	getEvalOpsManagedProviderDefinitions,
 	isEvalOpsManagedGatewayEnabled,
 } from "../providers/evalops-managed.js";
 import { MODELS as GENERATED_MODELS } from "./models.generated.js";
 import { normalizeModelBaseUrl } from "./url-normalize.js";
 
-const DEFAULT_MANAGED_GATEWAY_BASE_URL = "http://127.0.0.1:8081/v1";
-
 function getManagedGatewayBaseUrl(): string {
 	const configured = process.env.MAESTRO_LLM_GATEWAY_URL?.trim();
-	return configured || DEFAULT_MANAGED_GATEWAY_BASE_URL;
+	return configured || DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL;
 }
 
 function getManagedGatewayBaseUrlForApi(api: Api): string {

--- a/src/oauth/evalops.ts
+++ b/src/oauth/evalops.ts
@@ -619,10 +619,11 @@ export async function loginEvalOps(
 		const result = await Promise.race([
 			getResult(),
 			new Promise<EvalOpsCallbackResult>((_, reject) => {
-				setTimeout(
+				const timeout = setTimeout(
 					() => reject(new Error("EvalOps login timed out after 5 minutes")),
 					5 * 60 * 1000,
 				);
+				timeout.unref?.();
 			}),
 		]);
 

--- a/src/providers/evalops-managed.ts
+++ b/src/providers/evalops-managed.ts
@@ -4,6 +4,9 @@ import {
 	isFeatureFlagEnabled,
 } from "../config/feature-flags.js";
 
+export const DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL =
+	"https://llm-gateway.evalops.dev/v1";
+
 export type EvalOpsManagedProviderDefinition = {
 	allowedModelApis?: readonly Api[];
 	api: Api;

--- a/test/cli/config-presets.test.ts
+++ b/test/cli/config-presets.test.ts
@@ -3,8 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetFeatureFlagCacheForTests } from "../../src/config/feature-flags.js";
-
-const DEFAULT_MANAGED_GATEWAY_BASE_URL = "http://127.0.0.1:8081/v1";
+import { DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL } from "../../src/providers/evalops-managed.js";
 
 describe("config provider presets", () => {
 	const originalGatewayUrl = process.env.MAESTRO_LLM_GATEWAY_URL;
@@ -53,7 +52,7 @@ describe("config provider presets", () => {
 				name: definition.name,
 				api: definition.api,
 				defaultModel: definition.defaultModel,
-				baseUrl: DEFAULT_MANAGED_GATEWAY_BASE_URL,
+				baseUrl: DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL,
 				requiresApiKey: false,
 				note: definition.note,
 			});

--- a/test/testing/evalops-managed.ts
+++ b/test/testing/evalops-managed.ts
@@ -1,5 +1,6 @@
 import {
 	ALL_EVALOPS_MANAGED_PROVIDER_DEFINITIONS,
+	DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL,
 	type EvalOpsManagedProviderDefinition,
 } from "../../src/providers/evalops-managed.js";
 
@@ -27,10 +28,10 @@ export function expectedManagedGatewayModelBaseURL(
 ): string {
 	const api = expectedManagedGatewayModelAPI(definition);
 	if (api === "anthropic-messages") {
-		return "http://127.0.0.1:8081/v1/messages";
+		return `${DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL}/messages`;
 	}
 	if (api === "openai-responses") {
-		return "http://127.0.0.1:8081/v1/responses";
+		return `${DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL}/responses`;
 	}
-	return "http://127.0.0.1:8081/v1/chat/completions";
+	return `${DEFAULT_EVALOPS_MANAGED_GATEWAY_BASE_URL}/chat/completions`;
 }


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `127e5659dbf13302c56c9368c8016301da3f6264`
- last generated public sync base: `926f2026c55b130c25f8d29aff43d87b126dfc66`
- previewed public-tree drift: `7` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (127e5659dbf1)`
- public projection: `https://github.com/evalops/maestro@main (be771fe69cec)`
- files to copy or update: `7`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli/commands/config.ts
- copy/update src/cli/commands/init.ts
- copy/update src/models/builtin.ts
- copy/update src/oauth/evalops.ts
- copy/update src/providers/evalops-managed.ts
- copy/update test/cli/config-presets.test.ts
- copy/update test/testing/evalops-managed.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli/commands/config.ts
- copy/update src/cli/commands/init.ts
- copy/update src/models/builtin.ts
- copy/update src/oauth/evalops.ts
- copy/update src/providers/evalops-managed.ts
- copy/update test/cli/config-presets.test.ts
- copy/update test/testing/evalops-managed.ts

## Public-only commits since last generated sync

- be771fe6 chore: sync release mirror from internal (#269)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode