### PR TITLE
Release v0.10.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ versioning when releases are cut.
 
 
 
+
+## [0.10.12] - 2026-05-05
+
+### Added
+
+### Changed
+
+### Fixed
+
+
 ## [0.10.11] - 2026-05-04
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Maestro Web API",
-    "version": "0.10.11",
+    "version": "0.10.12",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evalops/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": false,
   "type": "module",
   "workspaces": [
@@ -127,8 +127,8 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1020.0",
     "@crosscopy/clipboard": "^0.2.8",
     "@daytonaio/sdk": "^0.155.0",
-    "@evalops/contracts": "^0.10.11",
-    "@evalops/tui": "^0.10.11",
+    "@evalops/contracts": "^0.10.12",
+    "@evalops/tui": "^0.10.12",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.74.0",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/ai",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Shared Maestro AI SDK (models, transport, and agent event stream facade).",
 	"type": "module",
 	"main": "./dist/packages/ai/src/index.js",
@@ -124,8 +124,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.11",
-		"@evalops/tui": "^0.10.11",
+		"@evalops/contracts": "^0.10.12",
+		"@evalops/tui": "^0.10.12",
 		"@google/genai": "^1.29.1",
 		"@sinclair/typebox": "^0.34.0",
 		"nats": "^2.29.3"

--- a/packages/consumer-sdk/package.json
+++ b/packages/consumer-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/consumer",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Unified EvalOps consumer SDK for Maestro service integrations",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -28,7 +28,7 @@
 		"directory": "packages/consumer-sdk"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.11"
+		"@evalops/contracts": "^0.10.12"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/contracts",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Shared Maestro contracts for frontend/backend integration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-core",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Maestro agent loop, transport, types, and sandbox primitives — the engine behind all Maestro interfaces",
 	"type": "module",
 	"main": "./dist/packages/core/src/index.js",
@@ -57,7 +57,7 @@
 		"vscode-jsonrpc": "^8.2.0"
 	},
 	"peerDependencies": {
-		"@evalops/tui": "^0.10.11"
+		"@evalops/tui": "^0.10.12"
 	},
 	"peerDependenciesMeta": {
 		"@evalops/tui": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-desktop",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Maestro Desktop - Beautiful Electron app for AI-assisted development",
 	"type": "module",
 	"main": "dist-electron/main/index.js",
@@ -37,7 +37,7 @@
 		"directory": "packages/desktop"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.11",
+		"@evalops/contracts": "^0.10.12",
 		"electron-store": "^10.0.1",
 		"electron-updater": "^6.3.9"
 	},

--- a/packages/github-agent/package.json
+++ b/packages/github-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/github-agent",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Autonomous GitHub agent - Maestro building Maestro",
 	"type": "module",
 	"bin": {
@@ -36,7 +36,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/ai": "^0.10.11",
+		"@evalops/ai": "^0.10.12",
 		"@octokit/rest": "^21.0.0",
 		"@octokit/webhooks": "^13.0.0",
 		"@sinclair/typebox": "^0.34.0",

--- a/packages/governance-mcp-server/package.json
+++ b/packages/governance-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance-mcp-server",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "MCP server exposing Platform governance proxy tools to any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -43,7 +43,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/governance": "^0.10.11",
+		"@evalops/governance": "^0.10.12",
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"zod": "^4.3.5"
 	},

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Thin Platform governance proxy for MCP-compatible agents.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/memory",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"private": true,
 	"type": "module",
 	"sideEffects": false,

--- a/packages/slack-agent-ui/package.json
+++ b/packages/slack-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent-ui",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Web UI for Slack Agent - Dashboard gallery, connector management, OAuth flows",
 	"type": "module",
 	"private": true,

--- a/packages/slack-agent/package.json
+++ b/packages/slack-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Slack bot agent with Docker sandbox support for Maestro",
 	"type": "module",
 	"bin": {
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@daytonaio/sdk": "^0.139.0",
-		"@evalops/ai": "^0.10.11",
+		"@evalops/ai": "^0.10.12",
 		"@sinclair/typebox": "^0.34.0",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/tui",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Terminal UI library with differential rendering for Maestro",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Maestro",
 	"description": "Use Maestro's deterministic AI assistant inside VS Code.",
 	"publisher": "evalops",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"license": "MIT",
 	"type": "commonjs",
 	"main": "./dist/extension.js",
@@ -139,7 +139,7 @@
 		"test": "vitest --run"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.11"
+		"@evalops/contracts": "^0.10.12"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-web",
-	"version": "0.10.11",
+	"version": "0.10.12",
 	"description": "Web UI for Maestro - Browser-based AI coding assistant interface",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,7 +24,7 @@
 		"directory": "packages/web"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.11",
+		"@evalops/contracts": "^0.10.12",
 		"docx-preview": "^0.3.7",
 		"dompurify": "^3.3.0",
 		"exceljs": "^4.4.0",

--- a/test/agent/mcp-merge.test.ts
+++ b/test/agent/mcp-merge.test.ts
@@ -9,8 +9,30 @@ describe("MCP multi-scope precedence and env expansion", () => {
 	const ENV_KEYS = [
 		"HOME",
 		"MAESTRO_HOME",
+		"MAESTRO_AGENT_DIR",
 		"MAESTRO_ENTERPRISE_MCP_PATH",
 		"MAESTRO_USER_MCP_PATH",
+		"MAESTRO_PLATFORM_MCP_ENABLED",
+		"MAESTRO_AGENT_MCP_ENABLED",
+		"MAESTRO_PLATFORM_MCP_URL",
+		"MAESTRO_AGENT_MCP_URL",
+		"MAESTRO_EVALOPS_AGENT_MCP_URL",
+		"MAESTRO_PLATFORM_MCP_TOKEN",
+		"MAESTRO_AGENT_MCP_TOKEN",
+		"MAESTRO_EVALOPS_ACCESS_TOKEN",
+		"EVALOPS_TOKEN",
+		"MAESTRO_WORKSPACE_ID",
+		"MAESTRO_EVALOPS_WORKSPACE_ID",
+		"MAESTRO_EVALOPS_ORG_ID",
+		"EVALOPS_ORGANIZATION_ID",
+		"MAESTRO_ENTERPRISE_ORG_ID",
+		"MAESTRO_AGENT_ID",
+		"MAESTRO_EVALOPS_AGENT_ID",
+		"MAESTRO_AGENT_RUN_ID",
+		"MAESTRO_SESSION_ID",
+		"MAESTRO_REQUEST_ID",
+		"TRACE_ID",
+		"OTEL_TRACE_ID",
 		"TEST_FOO",
 	] as const;
 
@@ -28,6 +50,10 @@ describe("MCP multi-scope precedence and env expansion", () => {
 		for (const key of ENV_KEYS) {
 			Reflect.deleteProperty(process.env, key);
 		}
+		process.env.MAESTRO_PLATFORM_MCP_ENABLED = "false";
+		process.env.MAESTRO_AGENT_MCP_ENABLED = "false";
+		process.env.MAESTRO_HOME = join(baseDir, "home");
+		process.env.MAESTRO_AGENT_DIR = join(baseDir, "agent");
 	});
 
 	afterEach(() => {

--- a/test/agent/mcp.test.ts
+++ b/test/agent/mcp.test.ts
@@ -6,15 +6,62 @@ import type { ToolAnnotations } from "../../src/agent/types.js";
 import { loadMcpConfig } from "../../src/mcp/config.js";
 import { McpClientManager } from "../../src/mcp/manager.js";
 
+const PLATFORM_MCP_ENV_KEYS = [
+	"MAESTRO_PLATFORM_MCP_ENABLED",
+	"MAESTRO_AGENT_MCP_ENABLED",
+	"MAESTRO_HOME",
+	"MAESTRO_AGENT_DIR",
+	"MAESTRO_PLATFORM_MCP_URL",
+	"MAESTRO_AGENT_MCP_URL",
+	"MAESTRO_EVALOPS_AGENT_MCP_URL",
+	"MAESTRO_PLATFORM_MCP_TOKEN",
+	"MAESTRO_AGENT_MCP_TOKEN",
+	"MAESTRO_EVALOPS_ACCESS_TOKEN",
+	"EVALOPS_TOKEN",
+	"MAESTRO_WORKSPACE_ID",
+	"MAESTRO_EVALOPS_WORKSPACE_ID",
+	"MAESTRO_EVALOPS_ORG_ID",
+	"EVALOPS_ORGANIZATION_ID",
+	"MAESTRO_ENTERPRISE_ORG_ID",
+	"MAESTRO_AGENT_ID",
+	"MAESTRO_EVALOPS_AGENT_ID",
+	"MAESTRO_AGENT_RUN_ID",
+	"MAESTRO_SESSION_ID",
+	"MAESTRO_REQUEST_ID",
+	"TRACE_ID",
+	"OTEL_TRACE_ID",
+] as const;
+
 describe("MCP config loader", () => {
 	let testDir: string;
+	let previousEnv: Partial<
+		Record<(typeof PLATFORM_MCP_ENV_KEYS)[number], string>
+	>;
 
 	beforeEach(() => {
+		previousEnv = Object.fromEntries(
+			PLATFORM_MCP_ENV_KEYS.map((key) => [key, process.env[key]]),
+		);
 		testDir = join(tmpdir(), `mcp-test-${Date.now()}`);
 		mkdirSync(testDir, { recursive: true });
+		for (const key of PLATFORM_MCP_ENV_KEYS) {
+			Reflect.deleteProperty(process.env, key);
+		}
+		process.env.MAESTRO_PLATFORM_MCP_ENABLED = "false";
+		process.env.MAESTRO_AGENT_MCP_ENABLED = "false";
+		process.env.MAESTRO_HOME = join(testDir, "home");
+		process.env.MAESTRO_AGENT_DIR = join(testDir, "agent");
 	});
 
 	afterEach(() => {
+		for (const key of PLATFORM_MCP_ENV_KEYS) {
+			const value = previousEnv[key];
+			if (value === undefined) {
+				Reflect.deleteProperty(process.env, key);
+			} else {
+				process.env[key] = value;
+			}
+		}
 		rmSync(testDir, { recursive: true, force: true });
 	});
 

--- a/test/prompts/service-client.test.ts
+++ b/test/prompts/service-client.test.ts
@@ -2,8 +2,37 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resolvePromptTemplate } from "../../src/prompts/service-client.js";
 
+const PROMPTS_ENV_KEYS = [
+	"PROMPTS_SERVICE_URL",
+	"PROMPTS_SERVICE_TOKEN",
+	"PROMPTS_SERVICE_ORGANIZATION_ID",
+	"PROMPTS_SERVICE_TIMEOUT_MS",
+	"PROMPTS_SERVICE_TRANSPORT",
+	"MAESTRO_PLATFORM_BASE_URL",
+	"MAESTRO_EVALOPS_BASE_URL",
+	"EVALOPS_BASE_URL",
+	"MAESTRO_PROMPTS_SERVICE_URL",
+	"MAESTRO_PROMPTS_SERVICE_TOKEN",
+	"MAESTRO_PROMPTS_ORGANIZATION_ID",
+	"MAESTRO_EVALOPS_ACCESS_TOKEN",
+	"EVALOPS_TOKEN",
+	"MAESTRO_EVALOPS_ORG_ID",
+	"EVALOPS_ORGANIZATION_ID",
+	"MAESTRO_ENTERPRISE_ORG_ID",
+	"MAESTRO_HOME",
+] as const;
+
 describe("prompts service client", () => {
+	let previousEnv: Partial<Record<(typeof PROMPTS_ENV_KEYS)[number], string>>;
+
 	beforeEach(() => {
+		previousEnv = Object.fromEntries(
+			PROMPTS_ENV_KEYS.map((key) => [key, process.env[key]]),
+		);
+		for (const key of PROMPTS_ENV_KEYS) {
+			Reflect.deleteProperty(process.env, key);
+		}
+		process.env.MAESTRO_HOME = `/tmp/maestro-prompts-test-${Date.now()}`;
 		process.env.PROMPTS_SERVICE_URL = "http://prompts.test/";
 		process.env.PROMPTS_SERVICE_TOKEN = "prompts-token";
 		process.env.PROMPTS_SERVICE_ORGANIZATION_ID = "org_123";
@@ -12,19 +41,14 @@ describe("prompts service client", () => {
 	});
 
 	afterEach(() => {
-		delete process.env.PROMPTS_SERVICE_URL;
-		delete process.env.PROMPTS_SERVICE_TOKEN;
-		delete process.env.PROMPTS_SERVICE_ORGANIZATION_ID;
-		delete process.env.PROMPTS_SERVICE_TIMEOUT_MS;
-		delete process.env.PROMPTS_SERVICE_TRANSPORT;
-		delete process.env.MAESTRO_PLATFORM_BASE_URL;
-		delete process.env.MAESTRO_PROMPTS_SERVICE_URL;
-		delete process.env.MAESTRO_PROMPTS_SERVICE_TOKEN;
-		delete process.env.MAESTRO_PROMPTS_ORGANIZATION_ID;
-		delete process.env.MAESTRO_EVALOPS_ACCESS_TOKEN;
-		delete process.env.MAESTRO_EVALOPS_ORG_ID;
-		delete process.env.MAESTRO_HOME;
-		delete process.env.EVALOPS_TOKEN;
+		for (const key of PROMPTS_ENV_KEYS) {
+			const value = previousEnv[key];
+			if (value === undefined) {
+				Reflect.deleteProperty(process.env, key);
+			} else {
+				process.env[key] = value;
+			}
+		}
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
 	});

--- a/test/telemetry/meter-service-client.test.ts
+++ b/test/telemetry/meter-service-client.test.ts
@@ -46,6 +46,14 @@ function createCanonicalTurnEvent() {
 
 describe("meter telemetry client", () => {
 	beforeEach(() => {
+		vi.stubEnv("MAESTRO_HOME", `/tmp/maestro-meter-test-${Date.now()}`);
+		vi.stubEnv("MAESTRO_PLATFORM_BASE_URL", "");
+		vi.stubEnv("MAESTRO_EVALOPS_BASE_URL", "");
+		vi.stubEnv("EVALOPS_BASE_URL", "");
+		vi.stubEnv("MAESTRO_EVALOPS_ACCESS_TOKEN", "");
+		vi.stubEnv("EVALOPS_TOKEN", "");
+		vi.stubEnv("EVALOPS_ORGANIZATION_ID", "");
+		vi.stubEnv("MAESTRO_ENTERPRISE_ORG_ID", "");
 		vi.stubEnv("MAESTRO_METER_BASE", "http://meter.test/");
 		vi.stubEnv("MAESTRO_METER_ACCESS_TOKEN", "meter-token");
 		vi.stubEnv("MAESTRO_EVALOPS_ORG_ID", "org_evalops");
@@ -217,7 +225,10 @@ describe("meter telemetry client", () => {
 	});
 
 	it("skips remote mirroring when required meter config is missing", async () => {
+		vi.stubEnv("MAESTRO_METER_ORGANIZATION_ID", "");
 		vi.stubEnv("MAESTRO_EVALOPS_ORG_ID", "");
+		vi.stubEnv("EVALOPS_ORGANIZATION_ID", "");
+		vi.stubEnv("MAESTRO_ENTERPRISE_ORG_ID", "");
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 


### PR DESCRIPTION
## Summary
- bump Maestro and workspace packages to v0.10.12
- refresh generated OpenAPI metadata for the release
- isolate MCP, prompts, and meter tests from ambient EvalOps auth/env so release checks pass on production-authenticated machines

Source-of-truth PR: evalops/maestro-internal#1647

## Test plan
- bun run vitest --run test/agent/mcp.test.ts test/agent/mcp-merge.test.ts test/prompts/service-client.test.ts test/telemetry/meter-service-client.test.ts
- npm run release:check