### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/memory/auto-extraction.ts
+++ b/src/memory/auto-extraction.ts
@@ -2,10 +2,12 @@ import { createHash } from "node:crypto";
 import { getLastAssistantMessage } from "../agent/index.js";
 import type { Agent, Api, Model, TextContent } from "../agent/index.js";
 import { buildSessionMemoryContent } from "../session/session-memory.js";
+import { recordMaestroLearnedContext } from "../telemetry/maestro-event-bus.js";
 import { safeJsonParse } from "../utils/json.js";
 import { createLogger } from "../utils/logger.js";
 import { getDurableMemoryBackend } from "./backend.js";
 import { upsertDurableMemory } from "./store.js";
+import { getMemoryProjectScope } from "./team-memory.js";
 
 const logger = createLogger("memory:auto-extraction");
 
@@ -98,6 +100,75 @@ function hashSessionMemory(content: string): string {
 		.filter((line) => !line.startsWith("- Updated: "))
 		.join("\n");
 	return createHash("sha256").update(stableContent).digest("hex");
+}
+
+function learnedContextID(
+	sessionId: string,
+	topic: string,
+	content: string,
+): string {
+	const hash = createHash("sha256")
+		.update(`${sessionId}\u0000${topic}\u0000${content}`)
+		.digest("hex")
+		.slice(0, 16);
+	const topicPart =
+		topic
+			.trim()
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-+|-+$/g, "") || "memory";
+	return `${sessionId}-${topicPart}-${hash}`;
+}
+
+function learnedContextDimension(topic: string): string {
+	const topicPart =
+		topic
+			.trim()
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "_")
+			.replace(/^_+|_+$/g, "") || "memory";
+	return `memory.${topicPart}`;
+}
+
+function learnedContextSubjectKey(cwd: string | undefined): string | undefined {
+	if (!cwd) {
+		return undefined;
+	}
+	const scope = getMemoryProjectScope(cwd);
+	return scope?.projectId ? `repo:${scope.projectId}` : undefined;
+}
+
+function publishLearnedContext(params: {
+	content: string;
+	cwd?: string;
+	sessionId: string;
+	topic: string;
+}): void {
+	recordMaestroLearnedContext({
+		learning_id: learnedContextID(
+			params.sessionId,
+			params.topic,
+			params.content,
+		),
+		subject_key: learnedContextSubjectKey(params.cwd),
+		statement: params.content,
+		dimension: learnedContextDimension(params.topic),
+		confidence_score: 0.78,
+		confidence_reason:
+			"Automatic durable memory extraction from a Maestro session summary.",
+		evidence: [
+			{
+				source: "maestro-session",
+				source_id: params.sessionId,
+				uri: `maestro://sessions/${params.sessionId}`,
+				excerpt: params.content,
+			},
+		],
+		correlation: {
+			session_id: params.sessionId,
+			agent_id: "maestro",
+		},
+	});
 }
 
 function stripCodeFence(text: string): string {
@@ -276,6 +347,7 @@ export function createAutomaticMemoryExtractionCoordinator(
 									{
 										tags: ["auto", "durable", ...(memory.tags ?? [])],
 										cwd: snapshot.cwd,
+										sessionId: snapshot.sessionId,
 									},
 								);
 							if (remoteResult?.created) {
@@ -299,6 +371,12 @@ export function createAutomaticMemoryExtractionCoordinator(
 						} else if (result.updated) {
 							updated += 1;
 						}
+						publishLearnedContext({
+							content: memory.content,
+							cwd: snapshot.cwd,
+							sessionId: snapshot.sessionId,
+							topic: memory.topic,
+						});
 					}
 					options.sessionManager.saveSessionMemoryExtractionHash(
 						extractionHash,

--- a/src/memory/backend.ts
+++ b/src/memory/backend.ts
@@ -39,6 +39,7 @@ export interface DurableMemoryBackend {
 			cwd?: string;
 			projectId?: string;
 			projectName?: string;
+			sessionId?: string;
 			tags?: string[];
 		},
 	): Promise<DurableMemoryUpsertResult | null>;
@@ -62,6 +63,7 @@ class ServiceClientDurableMemoryBackend implements DurableMemoryBackend {
 			cwd?: string;
 			projectId?: string;
 			projectName?: string;
+			sessionId?: string;
 			tags?: string[];
 		},
 	): Promise<DurableMemoryUpsertResult | null> {

--- a/src/memory/service-client.ts
+++ b/src/memory/service-client.ts
@@ -16,6 +16,7 @@ const DURABLE_MEMORY_TAG = "maestro-kind:durable-memory";
 const SOURCE_TAG = "source:maestro";
 const TOPIC_TAG_PREFIX = "maestro-topic:";
 const PROJECT_NAME_TAG_PREFIX = "maestro-project-name:";
+const SESSION_TAG_PREFIX = "maestro-session:";
 
 type RemoteMemoryConfig = {
 	agentId: string;
@@ -189,6 +190,7 @@ function buildRemoteMemoryTags(
 	topic: string,
 	tags?: readonly string[],
 	projectName?: string,
+	sessionId?: string,
 ): string[] {
 	return (
 		mergeTags(
@@ -199,6 +201,7 @@ function buildRemoteMemoryTags(
 				...(projectName
 					? [`${PROJECT_NAME_TAG_PREFIX}${projectName.trim().toLowerCase()}`]
 					: []),
+				...(sessionId ? [`${SESSION_TAG_PREFIX}${sessionId.trim()}`] : []),
 			],
 			tags,
 		) ?? []
@@ -208,8 +211,11 @@ function buildRemoteMemoryTags(
 function buildSourceReferences(
 	topic: string,
 	scope: RemoteMemoryScope,
+	options?: {
+		sessionId?: string;
+	},
 ): MemorySourceReference[] {
-	return [
+	const references: MemorySourceReference[] = [
 		{
 			uri: scope.repository
 				? `repo:${scope.repository}`
@@ -225,6 +231,23 @@ function buildSourceReferences(
 			},
 		},
 	];
+	const sessionId = options?.sessionId?.trim();
+	if (sessionId) {
+		references.push({
+			uri: `maestro://sessions/${sessionId}`,
+			title: `Maestro session ${sessionId}`,
+			type: "maestro-session",
+			metadata: {
+				source: "maestro",
+				sessionId,
+				topic: normalizeTopic(topic),
+				...(scope.projectId ? { projectId: scope.projectId } : {}),
+				...(scope.projectName ? { projectName: scope.projectName } : {}),
+				...(scope.repository ? { repository: scope.repository } : {}),
+			},
+		});
+	}
+	return references;
 }
 
 function extractTopicFromTags(tags?: readonly string[]): string | undefined {
@@ -280,7 +303,8 @@ function toLocalMemoryEntry(
 				tag !== SOURCE_TAG &&
 				tag !== DURABLE_MEMORY_TAG &&
 				!tag.startsWith(TOPIC_TAG_PREFIX) &&
-				!tag.startsWith(PROJECT_NAME_TAG_PREFIX),
+				!tag.startsWith(PROJECT_NAME_TAG_PREFIX) &&
+				!tag.startsWith(SESSION_TAG_PREFIX),
 		);
 
 	return {
@@ -349,6 +373,7 @@ async function upsertRemoteDurableMemoryWithConfig(
 	content: string,
 	options?: {
 		existingRecords?: ClientMemory[];
+		sessionId?: string;
 		tags?: string[];
 	},
 ): Promise<{ entry: MemoryEntry; created: boolean; updated: boolean }> {
@@ -357,6 +382,7 @@ async function upsertRemoteDurableMemoryWithConfig(
 		topic,
 		options?.tags,
 		scope.projectName,
+		options?.sessionId,
 	);
 	const existingRecords =
 		options?.existingRecords ??
@@ -377,7 +403,9 @@ async function upsertRemoteDurableMemoryWithConfig(
 			agentId: config.agentId,
 			tags: nextTags,
 			reviewStatus: "approved",
-			sourceReferences: buildSourceReferences(topic, scope),
+			sourceReferences: buildSourceReferences(topic, scope, {
+				sessionId: options?.sessionId,
+			}),
 		};
 		const created = requireMemory(
 			(await config.client.store(request)).memory,
@@ -410,7 +438,9 @@ async function upsertRemoteDurableMemoryWithConfig(
 				id: existing.id,
 				content: nextContent,
 				reviewStatus: "approved",
-				sourceReferences: buildSourceReferences(topic, scope),
+				sourceReferences: buildSourceReferences(topic, scope, {
+					sessionId: options?.sessionId,
+				}),
 				tags: mergedTags ?? [],
 			})
 		).memory,
@@ -430,6 +460,7 @@ export async function upsertRemoteDurableMemory(
 		cwd?: string;
 		projectId?: string;
 		projectName?: string;
+		sessionId?: string;
 		tags?: string[];
 	},
 ): Promise<{ entry: MemoryEntry; created: boolean; updated: boolean } | null> {
@@ -443,7 +474,7 @@ export async function upsertRemoteDurableMemory(
 		resolveRemoteScope(options),
 		topic,
 		content,
-		{ tags: options?.tags },
+		{ sessionId: options?.sessionId, tags: options?.tags },
 	);
 }
 

--- a/test/memory/auto-extraction.test.ts
+++ b/test/memory/auto-extraction.test.ts
@@ -297,6 +297,16 @@ describe("automatic memory extraction", () => {
 				applyAutoMemoryConsolidation: vi.fn(),
 			}),
 		}));
+		const recordMaestroLearnedContext = vi.fn();
+		vi.doMock("../../src/telemetry/maestro-event-bus.js", async () => {
+			const actual = await vi.importActual<
+				typeof import("../../src/telemetry/maestro-event-bus.js")
+			>("../../src/telemetry/maestro-event-bus.js");
+			return {
+				...actual,
+				recordMaestroLearnedContext,
+			};
+		});
 
 		const { createAutomaticMemoryExtractionCoordinator } = await import(
 			"../../src/memory/auto-extraction.js"
@@ -353,7 +363,33 @@ describe("automatic memory extraction", () => {
 			{
 				tags: ["auto", "durable", "workflow"],
 				cwd: repoRoot,
+				sessionId: "session-123",
 			},
+		);
+		expect(recordMaestroLearnedContext).toHaveBeenCalledWith(
+			expect.objectContaining({
+				learning_id: expect.stringMatching(
+					/^session-123-team-preferences-[a-f0-9]+$/,
+				),
+				statement: "Keep PRs focused.",
+				subject_key: expect.stringMatching(/^repo:/),
+				dimension: "memory.team_preferences",
+				confidence_score: 0.78,
+				confidence_reason:
+					"Automatic durable memory extraction from a Maestro session summary.",
+				correlation: expect.objectContaining({
+					session_id: "session-123",
+					agent_id: "maestro",
+				}),
+				evidence: [
+					expect.objectContaining({
+						source: "maestro-session",
+						source_id: "session-123",
+						uri: "maestro://sessions/session-123",
+						excerpt: "Keep PRs focused.",
+					}),
+				],
+			}),
 		);
 	});
 

--- a/test/memory/service-client.test.ts
+++ b/test/memory/service-client.test.ts
@@ -118,6 +118,74 @@ describe("memory service client", () => {
 		});
 	});
 
+	it("attaches session provenance to remote durable memories", async () => {
+		const requests: Array<{ body?: string; method?: string; url: string }> = [];
+		const fetchMock = vi.fn(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				requests.push({
+					url,
+					method: init?.method,
+					body: typeof init?.body === "string" ? init.body : undefined,
+				});
+				if (url.includes("/v1/memories?")) {
+					return new Response(JSON.stringify({ memories: [] }), {
+						status: 200,
+					});
+				}
+				if (url.endsWith("/v1/memories")) {
+					const body = JSON.parse(String(init?.body));
+					return new Response(
+						JSON.stringify({
+							id: "mem_remote_session",
+							organization_id: "org_123",
+							type: "project",
+							content: body.content,
+							repository: body.repository,
+							agent: body.agent,
+							tags: body.tags,
+							created_at: "2026-04-09T00:00:00.000Z",
+							updated_at: "2026-04-09T00:00:00.000Z",
+						}),
+						{ status: 201 },
+					);
+				}
+				throw new Error(`Unexpected request: ${url}`);
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { upsertRemoteDurableMemory } = await import(
+			"../../src/memory/service-client.js"
+		);
+		await upsertRemoteDurableMemory(
+			"team-preferences",
+			"Keep pull requests focused.",
+			{
+				cwd: repoRoot,
+				sessionId: "session-123",
+				tags: ["auto", "durable", "workflow"],
+			},
+		);
+
+		const createBody = JSON.parse(String(requests[1]?.body));
+		expect(createBody.tags).toEqual(
+			expect.arrayContaining(["maestro-session:session-123"]),
+		);
+		expect(createBody.source_references).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: "maestro-session",
+					uri: "maestro://sessions/session-123",
+					metadata: expect.objectContaining({
+						sessionId: "session-123",
+						source: "maestro",
+					}),
+				}),
+			]),
+		);
+	});
+
 	it("updates matching remote durable memories when metadata changes", async () => {
 		const requests: Array<{ body?: string; method?: string; url: string }> = [];
 		const fetchMock = vi.fn(


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `39a118b8f176278911c51894da2bd3742e63de6d`
- last generated public sync base: `7fde126c644764365716db37a00b9082179d83fd`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (39a118b8f176)`
- public projection: `https://github.com/evalops/maestro@main (2ecbe9877562)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/memory/auto-extraction.ts
- copy/update src/memory/backend.ts
- copy/update src/memory/service-client.ts
- copy/update test/memory/auto-extraction.test.ts
- copy/update test/memory/service-client.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/memory/auto-extraction.ts
- copy/update src/memory/backend.ts
- copy/update src/memory/service-client.ts
- copy/update test/memory/auto-extraction.test.ts
- copy/update test/memory/service-client.test.ts

## Public-only commits since last generated sync

- 2ecbe987 Release v0.10.12

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode