### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/tui-rs/src/agent/native.rs
+++ b/packages/tui-rs/src/agent/native.rs
@@ -107,8 +107,8 @@ use super::{
     TokenUsage, ToolResult,
 };
 use crate::ai::{
-    AiProvider, ContentBlock, ImageSource, Message, MessageContent, RequestConfig, Role,
-    StreamEvent, ThinkingConfig, Tool, UnifiedClient,
+    provider_model_name, AiProvider, ContentBlock, ImageSource, Message, MessageContent,
+    RequestConfig, Role, StreamEvent, ThinkingConfig, Tool, UnifiedClient,
 };
 use crate::hooks::{HookResult, IntegratedHookSystem};
 use crate::safety::{
@@ -1710,7 +1710,7 @@ impl NativeAgentRunner {
         };
 
         RequestConfig {
-            model: self.config.model.clone(),
+            model: provider_model_name(&self.config.model),
             max_tokens: self.config.max_tokens,
             temperature: if self.config.thinking_enabled {
                 None // Temperature must be 1 or omitted for thinking

--- a/packages/tui-rs/src/ai/anthropic.rs
+++ b/packages/tui-rs/src/ai/anthropic.rs
@@ -82,7 +82,7 @@ use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use serde::Deserialize;
 use tokio::sync::mpsc;
 
-use super::client::{AiClient, AiProvider};
+use super::client::{provider_model_name, AiClient, AiProvider};
 use super::types::{ContentBlock, Message, RequestConfig, StopReason, StreamEvent};
 
 /// Parser state for accumulating data across SSE events within a single stream.
@@ -122,11 +122,9 @@ impl AnthropicClient {
             .timeout(std::time::Duration::from_mins(5))
             .build()
             .context("Failed to create HTTP client")?;
+        let api_key = api_key.into().trim().to_string();
 
-        Ok(Self {
-            client,
-            api_key: api_key.into(),
-        })
+        Ok(Self { client, api_key })
     }
 
     /// Create a new client from environment variable
@@ -289,8 +287,9 @@ impl AnthropicClient {
         messages: &[Message],
         config: &RequestConfig,
     ) -> Result<serde_json::Value> {
+        let model = provider_model_name(&config.model);
         let mut body = serde_json::json!({
-            "model": config.model,
+            "model": model,
             "max_tokens": config.max_tokens,
             "messages": messages,
             "stream": true,
@@ -702,7 +701,7 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
     fn test_build_request_body_basic() {
         let client = AnthropicClient::new("test-key").unwrap();
         let config = RequestConfig {
-            model: "claude-3-opus-20240229".to_string(),
+            model: "anthropic/claude-3-opus-20240229".to_string(),
             max_tokens: 4096,
             system: Some("You are a helpful assistant.".to_string()),
             cache_system_prompt: false,
@@ -716,6 +715,14 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
         assert_eq!(body["stream"], true);
         // Without caching, system is a simple string
         assert_eq!(body["system"], "You are a helpful assistant.");
+    }
+
+    #[test]
+    fn trims_api_key_before_building_headers() {
+        let client = AnthropicClient::new("  test-key\n").unwrap();
+        let headers = client.headers();
+
+        assert_eq!(headers.get("x-api-key").unwrap(), "test-key");
     }
 
     #[test]

--- a/packages/tui-rs/src/ai/client.rs
+++ b/packages/tui-rs/src/ai/client.rs
@@ -31,6 +31,17 @@ impl AiProvider {
     #[must_use]
     pub fn from_model(model: &str) -> Self {
         let model_lower = model.to_lowercase();
+        let provider_prefix = model_lower.split_once('/').map(|(provider, _)| provider);
+        match provider_prefix {
+            Some("anthropic") => return AiProvider::Anthropic,
+            Some("openai" | "azure-openai" | "azure") => return AiProvider::OpenAI,
+            Some("google" | "gemini") => return AiProvider::Google,
+            Some("mistral") => return AiProvider::Mistral,
+            Some("groq") => return AiProvider::Groq,
+            Some("vertex-ai" | "vertex") => return AiProvider::VertexAi,
+            _ => {}
+        }
+
         if model_lower.starts_with("claude") || model_lower.starts_with("anthropic") {
             AiProvider::Anthropic
         } else if model_lower.starts_with("gpt")
@@ -59,6 +70,25 @@ impl AiProvider {
             // Default to Anthropic for unknown models
             AiProvider::Anthropic
         }
+    }
+}
+
+/// Return the provider-native model id to send to upstream model APIs.
+#[must_use]
+pub fn provider_model_name(model: &str) -> String {
+    let trimmed = model.trim();
+    let Some((provider, model_id)) = trimmed.split_once('/') else {
+        return trimmed.to_string();
+    };
+    let model_id = model_id.trim();
+    if model_id.is_empty() {
+        return trimmed.to_string();
+    }
+
+    match provider.to_ascii_lowercase().as_str() {
+        "anthropic" | "openai" | "azure-openai" | "azure" | "google" | "gemini" | "mistral"
+        | "groq" | "vertex-ai" | "vertex" => model_id.to_string(),
+        _ => trimmed.to_string(),
     }
 }
 
@@ -208,6 +238,14 @@ mod tests {
             AiProvider::from_model("gpt-5.1-codex-max"),
             AiProvider::OpenAI
         );
+        assert_eq!(
+            AiProvider::from_model("openai/gpt-5.1-codex-max"),
+            AiProvider::OpenAI
+        );
+        assert_eq!(
+            AiProvider::from_model("azure-openai/gpt-4o"),
+            AiProvider::OpenAI
+        );
         assert_eq!(AiProvider::from_model("gpt-4o"), AiProvider::OpenAI);
         assert_eq!(AiProvider::from_model("gpt-4-turbo"), AiProvider::OpenAI);
         assert_eq!(AiProvider::from_model("o1-preview"), AiProvider::OpenAI);
@@ -230,6 +268,10 @@ mod tests {
     fn test_provider_from_model_google() {
         assert_eq!(
             AiProvider::from_model("gemini-2.0-flash"),
+            AiProvider::Google
+        );
+        assert_eq!(
+            AiProvider::from_model("google/gemini-2.5-pro"),
             AiProvider::Google
         );
         assert_eq!(AiProvider::from_model("gemini-2.5-pro"), AiProvider::Google);
@@ -277,6 +319,26 @@ mod tests {
             AiProvider::Anthropic
         );
         assert_eq!(AiProvider::from_model(""), AiProvider::Anthropic);
+    }
+
+    #[test]
+    fn test_provider_model_name_strips_known_provider_prefixes() {
+        assert_eq!(
+            provider_model_name("openai/gpt-5.1-codex-max"),
+            "gpt-5.1-codex-max"
+        );
+        assert_eq!(
+            provider_model_name("anthropic/claude-sonnet-4-5-20250514"),
+            "claude-sonnet-4-5-20250514"
+        );
+        assert_eq!(
+            provider_model_name(" google/gemini-2.5-pro\n"),
+            "gemini-2.5-pro"
+        );
+        assert_eq!(
+            provider_model_name("unknown-provider/model/name"),
+            "unknown-provider/model/name"
+        );
     }
 
     #[test]

--- a/packages/tui-rs/src/ai/google.rs
+++ b/packages/tui-rs/src/ai/google.rs
@@ -34,7 +34,7 @@ use tokio::sync::mpsc;
 use super::types::{
     ContentBlock, Message, MessageContent, RequestConfig, Role, StopReason, StreamEvent,
 };
-use super::AiProvider;
+use super::{provider_model_name, AiProvider};
 
 /// Google Gemini API base URL
 const GOOGLE_API_BASE: &str = "https://generativelanguage.googleapis.com/v1beta";
@@ -50,7 +50,7 @@ impl GoogleClient {
     /// Create a new Google client with the given API key
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            api_key: api_key.into(),
+            api_key: api_key.into().trim().to_string(),
             client: Client::new(),
         }
     }
@@ -77,7 +77,7 @@ impl GoogleClient {
         // Clone for the spawned task
         let client = self.client.clone();
         let api_key = self.api_key.clone();
-        let model = config.model.clone();
+        let model = provider_model_name(&config.model);
 
         tokio::spawn(async move {
             if let Err(e) =

--- a/packages/tui-rs/src/ai/mod.rs
+++ b/packages/tui-rs/src/ai/mod.rs
@@ -87,7 +87,10 @@ mod vertex;
 
 pub use anthropic::AnthropicClient;
 pub use app_message::{from_api_messages, transform_to_api_messages, AppMessage, BashExecution};
-pub use client::{create_client, create_client_for_model, AiClient, AiProvider, UnifiedClient};
+pub use client::{
+    create_client, create_client_for_model, provider_model_name, AiClient, AiProvider,
+    UnifiedClient,
+};
 pub use google::GoogleClient;
 pub use openai::OpenAiClient;
 pub use sanitize::{sanitize_control_chars, sanitize_for_api, sanitize_surrogates};

--- a/packages/tui-rs/src/ai/openai.rs
+++ b/packages/tui-rs/src/ai/openai.rs
@@ -108,7 +108,7 @@ use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
-use super::client::{AiClient, AiProvider};
+use super::client::{provider_model_name, AiClient, AiProvider};
 use super::types::{
     ContentBlock, ImageSource, Message, MessageContent, RequestConfig, Role, StreamEvent, Tool,
 };
@@ -481,6 +481,7 @@ fn extract_text_from_item(item: &serde_json::Value) -> Option<String> {
 
 /// Returns true if the model uses the Responses API (vs Chat Completions)
 fn uses_responses_api(model: &str) -> bool {
+    let model = provider_model_name(model);
     // Codex models and gpt-5.x models use the Responses API
     model.contains("codex") || model.starts_with("gpt-5") || model.starts_with("o3")
 }
@@ -593,10 +594,11 @@ impl OpenAiClient {
             .timeout(std::time::Duration::from_mins(5))
             .build()
             .context("Failed to create HTTP client")?;
+        let api_key = api_key.into().trim().to_string();
 
         Ok(Self {
             client,
-            api_key: api_key.into(),
+            api_key,
             base_url: None,
         })
     }
@@ -607,10 +609,11 @@ impl OpenAiClient {
             .timeout(std::time::Duration::from_mins(5))
             .build()
             .context("Failed to create HTTP client")?;
+        let api_key = api_key.into().trim().to_string();
 
         Ok(Self {
             client,
-            api_key: api_key.into(),
+            api_key,
             base_url: Some(base_url.into()),
         })
     }
@@ -822,10 +825,11 @@ impl OpenAiClient {
         messages: &[Message],
         config: &RequestConfig,
     ) -> serde_json::Value {
+        let model = provider_model_name(&config.model);
         // Check if this is a Mistral model (needs special tool handling)
-        let is_mistral = is_mistral_model(&config.model, self.base_url.as_deref());
+        let is_mistral = is_mistral_model(&model, self.base_url.as_deref());
         // Check if this is a Groq model (may need parameter adjustments)
-        let is_groq = is_groq_model(&config.model, self.base_url.as_deref());
+        let is_groq = is_groq_model(&model, self.base_url.as_deref());
 
         // Build tool ID to name mapping for Mistral
         let tool_id_to_name = if is_mistral {
@@ -837,7 +841,7 @@ impl OpenAiClient {
         let openai_messages = self.convert_messages(messages, is_mistral, &tool_id_to_name);
 
         let mut body = serde_json::json!({
-            "model": config.model,
+            "model": model,
             "max_tokens": config.max_tokens,
             "messages": openai_messages,
             "stream": true,
@@ -898,6 +902,7 @@ impl OpenAiClient {
         messages: &[Message],
         config: &RequestConfig,
     ) -> serde_json::Value {
+        let model = provider_model_name(&config.model);
         // Convert messages to Responses API format
         // The input array contains ResponseItems, which can be messages, function calls, or function outputs
         let mut input: Vec<serde_json::Value> = Vec::new();
@@ -1021,7 +1026,7 @@ impl OpenAiClient {
         }
 
         let mut body = serde_json::json!({
-            "model": config.model,
+            "model": model,
             "input": input,
             "stream": true,
             "parallel_tool_calls": true,
@@ -1784,6 +1789,7 @@ mod tests {
     fn test_uses_responses_api() {
         // gpt-5.1-codex-* should use Responses API
         assert!(uses_responses_api("gpt-5.1-codex-max"));
+        assert!(uses_responses_api("openai/gpt-5.1-codex-max"));
         assert!(uses_responses_api("gpt-5.1-codex-lite"));
         // o3 models use Responses API
         assert!(uses_responses_api("o3"));
@@ -1799,6 +1805,10 @@ mod tests {
         // Responses API models go to /v1/responses
         assert_eq!(
             api_url_for_model("gpt-5.1-codex-max"),
+            "https://api.openai.com/v1/responses"
+        );
+        assert_eq!(
+            api_url_for_model("openai/gpt-5.1-codex-max"),
             "https://api.openai.com/v1/responses"
         );
         // Chat Completions models go to /v1/chat/completions
@@ -1872,6 +1882,41 @@ mod tests {
         let filtered = filter_responses_api_tools(&tools);
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].name, "read");
+    }
+
+    #[test]
+    fn trims_api_key_before_building_headers() {
+        let client = OpenAiClient::new("  test-key\n").unwrap();
+        let headers = client.headers();
+
+        assert_eq!(headers.get(AUTHORIZATION).unwrap(), "Bearer test-key");
+    }
+
+    #[test]
+    fn strips_provider_prefix_from_request_body_model() {
+        let client = OpenAiClient::new("test-key").unwrap();
+        let messages = vec![Message {
+            role: Role::User,
+            content: MessageContent::Text("Hello".to_string()),
+        }];
+
+        let responses_body = client.build_request_body(
+            &messages,
+            &RequestConfig {
+                model: "openai/gpt-5.1-codex-max".to_string(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(responses_body["model"], "gpt-5.1-codex-max");
+
+        let chat_body = client.build_request_body(
+            &messages,
+            &RequestConfig {
+                model: "openai/gpt-4o".to_string(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(chat_body["model"], "gpt-4o");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `4796a553a54228b8387bcce327e3f8f8148da12a`
- last generated public sync base: `269fdb41d5db82a6fa86b537ff4d6066e43f5ed7`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (4796a553a542)`
- public projection: `https://github.com/evalops/maestro@main (269fdb41d5db)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/tui-rs/src/agent/native.rs
- copy/update packages/tui-rs/src/ai/anthropic.rs
- copy/update packages/tui-rs/src/ai/client.rs
- copy/update packages/tui-rs/src/ai/google.rs
- copy/update packages/tui-rs/src/ai/mod.rs
- copy/update packages/tui-rs/src/ai/openai.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/tui-rs/src/agent/native.rs
- copy/update packages/tui-rs/src/ai/anthropic.rs
- copy/update packages/tui-rs/src/ai/client.rs
- copy/update packages/tui-rs/src/ai/google.rs
- copy/update packages/tui-rs/src/ai/mod.rs
- copy/update packages/tui-rs/src/ai/openai.rs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode