### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/tui-rs/src/tools/registry.rs
+++ b/packages/tui-rs/src/tools/registry.rs
@@ -3625,9 +3625,34 @@ impl ToolRegistry {
                     serde_json::json!({
                         "type": "object",
                         "properties": {
-                            "questions": {"type": "array"}
+                            "questions": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "question": {"type": "string"},
+                                        "header": {"type": "string"},
+                                        "options": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "label": {"type": "string"},
+                                                    "description": {"type": "string"}
+                                                },
+                                                "required": ["label", "description"],
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "multiSelect": {"type": "boolean"}
+                                    },
+                                    "required": ["question", "header", "options"],
+                                    "additionalProperties": false
+                                }
+                            }
                         },
-                        "required": ["questions"]
+                        "required": ["questions"],
+                        "additionalProperties": false
                     }),
                 ),
                 requires_approval: false,
@@ -4501,6 +4526,36 @@ mod tests {
         let registry = ToolRegistry::new();
         let count = registry.tools().count();
         assert_eq!(count, 38); // includes parity tools + IDE stubs
+    }
+
+    #[test]
+    fn test_ask_user_schema_declares_nested_array_items() {
+        let registry = ToolRegistry::new();
+        let schema = &registry
+            .get("ask_user")
+            .expect("ask_user tool")
+            .tool
+            .input_schema;
+
+        let questions = &schema["properties"]["questions"];
+        assert_eq!(questions["type"], "array");
+        assert!(questions.get("items").is_some());
+        assert!(questions.get("minItems").is_none());
+        assert!(questions.get("maxItems").is_none());
+        assert_eq!(questions["items"]["properties"]["options"]["type"], "array");
+        assert!(questions["items"]["properties"]["options"]
+            .get("items")
+            .is_some());
+        assert!(questions["items"]["properties"]
+            .get("multi_select")
+            .is_none());
+        assert!(questions["items"]["properties"]
+            .get("multiSelect")
+            .is_some());
+        assert_eq!(
+            questions["items"]["properties"]["options"]["items"]["required"],
+            serde_json::json!(["label", "description"])
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `3c25f3c79df6712614ffd25643b998a90f6f33d7`
- last generated public sync base: `943da55063dc6b5b503d002e8ba6b7e7bc564470`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (3c25f3c79df6)`
- public projection: `https://github.com/evalops/maestro@main (943da55063dc)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/tui-rs/src/tools/registry.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/tui-rs/src/tools/registry.rs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode