### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/tui-rs/src/tools/registry.rs
+++ b/packages/tui-rs/src/tools/registry.rs
@@ -3473,7 +3473,7 @@ impl ToolRegistry {
                 .with_schema(serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "patterns": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+                        "patterns": {"type": "array", "items": {"type": "string"}},
                         "paths": {
                             "anyOf": [
                                 {"type": "string"},
@@ -3606,8 +3606,47 @@ impl ToolRegistry {
                         "type": "object",
                         "properties": {
                             "goal": {"type": "string"},
-                            "items": {},
-                            "updates": {"type": "array"},
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {"type": "string"},
+                                        "content": {"type": "string"},
+                                        "status": {"type": "string"},
+                                        "priority": {"type": "string"},
+                                        "notes": {"type": "string"},
+                                        "due": {"type": "string"},
+                                        "blockedBy": {
+                                            "type": "array",
+                                            "items": {"type": "string"}
+                                        }
+                                    },
+                                    "required": ["content"],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "updates": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {"type": "string"},
+                                        "status": {"type": "string"},
+                                        "priority": {"type": "string"},
+                                        "notes": {"type": "string"},
+                                        "due": {"type": "string"},
+                                        "blockedBy": {
+                                            "type": "array",
+                                            "items": {"type": "string"}
+                                        },
+                                        "content": {"type": "string"},
+                                        "remove": {"type": "boolean"}
+                                    },
+                                    "required": ["id"],
+                                    "additionalProperties": false
+                                }
+                            },
                             "includeSummary": {"type": "boolean"}
                         },
                         "required": ["goal"]
@@ -4313,6 +4352,40 @@ mod tests {
         )
     }
 
+    fn collect_openai_schema_issues(
+        value: &serde_json::Value,
+        path: &str,
+        issues: &mut Vec<String>,
+    ) {
+        let Some(object) = value.as_object() else {
+            return;
+        };
+
+        if object.get("type").and_then(serde_json::Value::as_str) == Some("array")
+            && !object.contains_key("items")
+        {
+            issues.push(format!("{path}: array schema missing items"));
+        }
+
+        for keyword in ["minItems", "maxItems"] {
+            if object.contains_key(keyword) {
+                issues.push(format!(
+                    "{path}: unsupported OpenAI schema keyword {keyword}"
+                ));
+            }
+        }
+
+        for (key, child) in object {
+            let child_path = format!("{path}.{key}");
+            collect_openai_schema_issues(child, &child_path, issues);
+            if let Some(values) = child.as_array() {
+                for (idx, nested) in values.iter().enumerate() {
+                    collect_openai_schema_issues(nested, &format!("{child_path}[{idx}]"), issues);
+                }
+            }
+        }
+    }
+
     #[cfg(not(windows))]
     fn failing_counter_server(server_name: &str, counter_path: &Path) -> serde_json::Value {
         serde_json::json!({
@@ -4556,6 +4629,22 @@ mod tests {
             questions["items"]["properties"]["options"]["items"]["required"],
             serde_json::json!(["label", "description"])
         );
+    }
+
+    #[test]
+    fn test_registered_tool_schemas_are_openai_safe() {
+        let registry = ToolRegistry::new();
+        let mut issues = Vec::new();
+
+        for (name, definition) in &registry.tools {
+            collect_openai_schema_issues(
+                &definition.tool.input_schema,
+                &format!("tool.{name}.parameters"),
+                &mut issues,
+            );
+        }
+
+        assert!(issues.is_empty(), "{}", issues.join("\n"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `45d14ae38d484222e286391f23c817c46d66f6dd`
- last generated public sync base: `943da55063dc6b5b503d002e8ba6b7e7bc564470`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (45d14ae38d48)`
- public projection: `https://github.com/evalops/maestro@main (304e03f31c25)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/tui-rs/src/tools/registry.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/tui-rs/src/tools/registry.rs

## Public-only commits since last generated sync

- 304e03f3 Sync public mirror from internal

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode