### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,10 @@ COPY --from=web-builder /app/src/db/migrations ./dist/db/migrations
 COPY --from=web-builder /app/node_modules ./node_modules
 COPY --from=web-builder /app/package.json ./
 COPY --from=web-builder /app/skills ./skills
+COPY --from=web-builder /app/packages/contracts/package.json ./packages/contracts/package.json
+COPY --from=web-builder /app/packages/contracts/dist ./packages/contracts/dist
+COPY --from=web-builder /app/packages/tui/package.json ./packages/tui/package.json
+COPY --from=web-builder /app/packages/tui/dist ./packages/tui/dist
 COPY --from=web-builder /app/packages/web/dist ./packages/web/dist
 COPY --from=rust-builder /app/target-bin/maestro-control-plane ./bin/maestro-control-plane
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "verify-build:packages": "VERIFY_PACKAGES=1 bun scripts/verify-build.ts",
     "release:check": "node scripts/release-readiness.js release",
     "release:check:ci": "node scripts/release-readiness.js ci",
-    "verify:runtime-deps": "node scripts/check-runtime-deps.js",
+    "verify:runtime-deps": "node scripts/check-runtime-deps.js && node scripts/check-docker-runtime-workspaces.mjs",
     "tui": "npm run cli",
     "verify": "npm run format && npm run lint && npm run test && npm run build && npm run smoke && npm run telemetry:report",
     "smoke": "node scripts/smoke-cli.js",

--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -3430,6 +3430,10 @@ mod tests {
             "workspace_1".to_string(),
         );
         env.insert(
+            "MAESTRO_AGENT_RUN_ID".to_string(),
+            "agent_run_1".to_string(),
+        );
+        env.insert(
             "MAESTRO_REMOTE_RUNNER_SNAPSHOT_ROOT".to_string(),
             ".snapshots".to_string(),
         );
@@ -3458,6 +3462,7 @@ mod tests {
             )
         );
         assert_eq!(config.workspace_id.as_deref(), Some("workspace_1"));
+        assert_eq!(config.agent_run_id.as_deref(), Some("agent_run_1"));
         assert_eq!(
             config.restore_manifest_path.as_deref(),
             Some(
@@ -3572,6 +3577,21 @@ mod tests {
         assert_eq!(identity.owner_instance_id.as_deref(), Some("owner_test"));
         assert!(identity.ready);
         assert!(!identity.draining);
+
+        let identity_json: serde_json::Value = client
+            .get(format!(
+                "{}/.well-known/evalops/remote-runner/identity",
+                handle.base_url()
+            ))
+            .send()
+            .await
+            .expect("identity response")
+            .json()
+            .await
+            .expect("identity json");
+        assert!(identity_json.get("workspace_id").is_none());
+        assert!(identity_json.get("agent_run_id").is_none());
+        assert!(identity_json.get("maestro_session_id").is_none());
 
         let drain: serde_json::Value = client
             .post(format!(

--- a/scripts/check-docker-runtime-workspaces.mjs
+++ b/scripts/check-docker-runtime-workspaces.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// @ts-check
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import { loadRootPackage } from "./workspace-utils.js";
+
+const rootDir = process.cwd();
+const dockerfilePath = join(rootDir, "Dockerfile");
+
+if (!existsSync(dockerfilePath)) {
+	console.error("Dockerfile not found.");
+	process.exit(1);
+}
+
+/**
+ * @param {string} path
+ * @returns {Record<string, unknown>}
+ */
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+function asStringArray(value) {
+	return Array.isArray(value)
+		? value.filter((item) => typeof item === "string")
+		: [];
+}
+
+/**
+ * @param {Record<string, unknown>} pkg
+ */
+function runtimeWorkspaceNames(pkg) {
+	return new Set([
+		...Object.keys(
+			/** @type {Record<string, unknown>} */ (pkg.dependencies ?? {}),
+		),
+		...asStringArray(pkg.bundleDependencies),
+	]);
+}
+
+const rootPackage = loadRootPackage();
+const runtimeNames = runtimeWorkspaceNames(rootPackage);
+const packagesDir = join(rootDir, "packages");
+const workspacePackages = new Map();
+
+for (const dirName of readdirSync(packagesDir)) {
+	const packagePath = join(packagesDir, dirName, "package.json");
+	if (!existsSync(packagePath)) {
+		continue;
+	}
+	const pkg = readJson(packagePath);
+	if (typeof pkg.name === "string") {
+		workspacePackages.set(pkg.name, { dirName, packagePath });
+	}
+}
+
+const requiredRuntimeWorkspaces = [...runtimeNames]
+	.filter((name) => workspacePackages.has(name))
+	.sort();
+const dockerfile = readFileSync(dockerfilePath, "utf8");
+const runnerStage = dockerfile.match(/FROM\s+\$\{BUN_IMAGE\}\s+AS\s+runner[\s\S]*$/);
+
+if (!runnerStage) {
+	console.error("Dockerfile runner stage not found.");
+	process.exit(1);
+}
+
+const missing = [];
+const runnerCopyPairs = new Set();
+
+for (const line of runnerStage[0].split(/\r?\n/)) {
+	const trimmed = line.trim();
+	const match = trimmed.match(
+		/^COPY\s+(?:--from=\S+\s+)?(?<source>\S+)\s+(?<target>\S+)$/,
+	);
+	if (match?.groups) {
+		runnerCopyPairs.add(`${match.groups.source}\0${match.groups.target}`);
+	}
+}
+
+for (const name of requiredRuntimeWorkspaces) {
+	const workspace = workspacePackages.get(name);
+	if (!workspace) {
+		continue;
+	}
+
+	for (const file of ["package.json", "dist"]) {
+		const source = `/app/packages/${workspace.dirName}/${file}`;
+		const target = `./packages/${workspace.dirName}/${file}`;
+		if (!runnerCopyPairs.has(`${source}\0${target}`)) {
+			missing.push(`${name}: missing runner COPY ${source} -> ${target}`);
+		}
+	}
+}
+
+if (missing.length > 0) {
+	console.error(
+		"Runtime workspace packages required by the Maestro CLI are not copied into the Docker runner image:",
+	);
+	for (const item of missing) {
+		console.error(`- ${item}`);
+	}
+	console.error(
+		"Add explicit runner-stage COPY lines so node_modules workspace symlinks resolve in production.",
+	);
+	process.exit(1);
+}
+
+console.log(
+	`Verified Docker runner workspace copies for ${requiredRuntimeWorkspaces.length} runtime package(s): ${requiredRuntimeWorkspaces.join(", ")}`,
+);
+console.log(`Checked ${relative(rootDir, dockerfilePath)} runner stage.`);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -8,7 +8,11 @@ import {
 	initOpenTelemetry,
 	isOpenTelemetryEnabled,
 } from "./opentelemetry.js";
-import { mirrorTelemetryToMaestroEventBus } from "./telemetry/maestro-event-bus.js";
+import {
+	type MaestroCorrelation,
+	mirrorTelemetryToMaestroEventBus,
+	resolveMaestroEventBusConfig,
+} from "./telemetry/maestro-event-bus.js";
 import {
 	hasRemoteMeterDestination,
 	mirrorCanonicalTurnEventToMeter,
@@ -320,9 +324,11 @@ async function postToEndpoint(payload: string) {
 
 function recordOpenTelemetrySpan(event: TelemetryEvent): void {
 	try {
+		const correlationAttributes = maestroCorrelationSpanAttributes(event);
 		const tracer = getTelemetryTracer();
 		tracer.startActiveSpan(`telemetry.${event.type}`, (span: Span) => {
 			span.setAttributes({
+				...correlationAttributes,
 				"maestro.telemetry.type": event.type,
 				"maestro.telemetry.timestamp": event.timestamp,
 			});
@@ -423,11 +429,26 @@ function recordOpenTelemetrySpan(event: TelemetryEvent): void {
 								: SpanStatusCode.OK,
 					});
 					break;
-				case "canonical-turn":
+				case "canonical-turn": {
+					const canonicalTurn = isCanonicalTurnTelemetryEvent(event)
+						? event
+						: undefined;
 					span.setAttributes({
 						"maestro.turn.id": event.turnId,
 						"maestro.turn.number": event.turnNumber,
 						"maestro.turn.session_id": event.sessionId,
+						"agent.session.id": event.sessionId,
+						...(canonicalTurn
+							? {
+									"llm.model.id": canonicalTurn.model.id,
+									"llm.model.provider": canonicalTurn.model.provider,
+									"llm.usage.input_tokens": canonicalTurn.tokens.input,
+									"llm.usage.output_tokens": canonicalTurn.tokens.output,
+									"llm.usage.cache_read_tokens": canonicalTurn.tokens.cacheRead,
+									"llm.usage.cache_write_tokens":
+										canonicalTurn.tokens.cacheWrite,
+								}
+							: {}),
 						"maestro.turn.status": String(
 							"status" in event ? event.status : "unknown",
 						),
@@ -451,6 +472,7 @@ function recordOpenTelemetrySpan(event: TelemetryEvent): void {
 								: SpanStatusCode.OK,
 					});
 					break;
+				}
 				default:
 					span.setStatus({ code: SpanStatusCode.UNSET });
 			}
@@ -464,6 +486,111 @@ function recordOpenTelemetrySpan(event: TelemetryEvent): void {
 	} catch {
 		// Never let tracing failures affect runtime
 	}
+}
+
+function stringRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function metadataString(
+	record: Record<string, unknown> | undefined,
+	keys: string[],
+): string | undefined {
+	for (const key of keys) {
+		const value = record?.[key];
+		if (typeof value === "string" && value.trim().length > 0) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function eventCorrelationOverrides(
+	event: TelemetryEvent,
+): Partial<MaestroCorrelation> {
+	const metadata = stringRecord(
+		"metadata" in event ? event.metadata : undefined,
+	);
+	const topLevelTraceId =
+		"traceId" in event &&
+		typeof event.traceId === "string" &&
+		event.traceId.trim().length > 0
+			? event.traceId
+			: undefined;
+	return {
+		organization_id: metadataString(metadata, [
+			"organizationId",
+			"organization_id",
+			"orgId",
+			"org_id",
+		]),
+		user_id: metadataString(metadata, ["userId", "user_id"]),
+		workspace_id: metadataString(metadata, ["workspaceId", "workspace_id"]),
+		session_id:
+			("sessionId" in event && typeof event.sessionId === "string"
+				? event.sessionId
+				: undefined) ??
+			metadataString(metadata, [
+				"sessionId",
+				"session_id",
+				"maestroSessionId",
+				"maestro_session_id",
+			]),
+		agent_run_id: metadataString(metadata, ["agentRunId", "agent_run_id"]),
+		agent_run_step_id: metadataString(metadata, [
+			"agentRunStepId",
+			"agent_run_step_id",
+			"toolCallId",
+			"tool_call_id",
+		]),
+		agent_id: metadataString(metadata, ["agentId", "agent_id"]),
+		trace_id:
+			topLevelTraceId ?? metadataString(metadata, ["traceId", "trace_id"]),
+		request_id: metadataString(metadata, ["requestId", "request_id"]),
+	};
+}
+
+function maestroCorrelationSpanAttributes(
+	event: TelemetryEvent,
+): Record<string, string> {
+	const config = resolveMaestroEventBusConfig();
+	const overrides = eventCorrelationOverrides(event);
+	const correlation = {
+		...config.defaultCorrelation,
+		...Object.fromEntries(
+			Object.entries(overrides).filter(([, value]) => value !== undefined),
+		),
+	};
+	const principal = config.defaultPrincipal;
+	const attributes: Record<string, string | undefined> = {
+		"enduser.id": correlation.user_id ?? principal?.user_id,
+		"user.id": correlation.user_id ?? principal?.user_id,
+		"agent.user.id": correlation.user_id ?? principal?.user_id,
+		"organization.id":
+			correlation.organization_id ?? principal?.organization_id,
+		"evalops.organization_id":
+			correlation.organization_id ?? principal?.organization_id,
+		"workspace.id": correlation.workspace_id ?? principal?.workspace_id,
+		"evalops.workspace_id": correlation.workspace_id ?? principal?.workspace_id,
+		"maestro.session_id": correlation.session_id,
+		"agent.id": correlation.agent_id,
+		"maestro.agent_run_id": correlation.agent_run_id,
+		"maestro.agent_run_step_id": correlation.agent_run_step_id,
+		"trace.id": correlation.trace_id,
+		"request.id": correlation.request_id,
+		"maestro.surface": config.defaultSurface,
+	};
+
+	return Object.fromEntries(
+		Object.entries(attributes).filter(
+			(entry): entry is [string, string] =>
+				typeof entry[1] === "string" &&
+				entry[1].trim().length > 0 &&
+				entry[1] !== "unknown",
+		),
+	);
 }
 
 async function persistTelemetry(event: TelemetryEvent) {

--- a/test/telemetry/opentelemetry-correlation.test.ts
+++ b/test/telemetry/opentelemetry-correlation.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spanAttributes: Record<string, unknown>[] = [];
+
+vi.mock("../../src/opentelemetry.js", () => ({
+	getTelemetryTracer: () => ({
+		startActiveSpan: (
+			_name: string,
+			callback: (span: {
+				setAttributes(attributes: Record<string, unknown>): void;
+				setStatus(status: Record<string, unknown>): void;
+				end(): void;
+			}) => void,
+		) => {
+			const attributes: Record<string, unknown> = {};
+			callback({
+				setAttributes(next) {
+					Object.assign(attributes, next);
+				},
+				setStatus() {},
+				end() {
+					spanAttributes.push(attributes);
+				},
+			});
+		},
+	}),
+	initOpenTelemetry: vi.fn(),
+	isOpenTelemetryEnabled: () => true,
+}));
+
+const ENV_KEYS = [
+	"MAESTRO_EVALOPS_WORKSPACE_ID",
+	"MAESTRO_SESSION_ID",
+	"MAESTRO_AGENT_RUN_ID",
+];
+
+const originalEnv = new Map(
+	ENV_KEYS.map((key) => [key, process.env[key] as string | undefined]),
+);
+
+describe("OpenTelemetry correlation", () => {
+	beforeEach(() => {
+		spanAttributes.length = 0;
+		process.env.MAESTRO_EVALOPS_WORKSPACE_ID = "workspace_process";
+		process.env.MAESTRO_SESSION_ID = "session_process";
+		process.env.MAESTRO_AGENT_RUN_ID = "run_process";
+	});
+
+	afterEach(() => {
+		for (const key of ENV_KEYS) {
+			const value = originalEnv.get(key);
+			if (value === undefined) {
+				Reflect.deleteProperty(process.env, key);
+			} else {
+				process.env[key] = value;
+			}
+		}
+	});
+
+	it("lets per-event metadata override process defaults on spans", async () => {
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+
+		await recordTelemetry({
+			type: "api-request",
+			timestamp: "2026-05-05T19:00:00.000Z",
+			method: "POST",
+			path: "/api/chat",
+			statusCode: 200,
+			durationMs: 42,
+			metadata: {
+				workspaceId: "workspace_event",
+				sessionId: "session_event",
+				agentRunId: "run_event",
+			},
+		});
+
+		expect(spanAttributes).toHaveLength(1);
+		expect(spanAttributes[0]).toMatchObject({
+			"workspace.id": "workspace_event",
+			"evalops.workspace_id": "workspace_event",
+			"maestro.session_id": "session_event",
+			"maestro.agent_run_id": "run_event",
+			"maestro.telemetry.type": "api-request",
+		});
+	});
+
+	it("omits undefined llm attributes for base canonical turn events", async () => {
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+
+		await recordTelemetry({
+			type: "canonical-turn",
+			timestamp: "2026-05-05T19:00:00.000Z",
+			sessionId: "session_event",
+			turnId: "turn_event",
+			turnNumber: 3,
+		});
+
+		expect(spanAttributes).toHaveLength(1);
+		expect(spanAttributes[0]).toMatchObject({
+			"maestro.turn.id": "turn_event",
+			"maestro.turn.number": 3,
+			"maestro.turn.session_id": "session_event",
+			"agent.session.id": "session_event",
+		});
+		expect(spanAttributes[0]).not.toHaveProperty("llm.model.id");
+		expect(spanAttributes[0]).not.toHaveProperty("llm.model.provider");
+		expect(Object.values(spanAttributes[0])).not.toContain(undefined);
+	});
+
+	it("uses top-level canonical turn trace ids for span correlation", async () => {
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+
+		await recordTelemetry({
+			type: "canonical-turn",
+			timestamp: "2026-05-05T19:00:00.000Z",
+			sessionId: "session_event",
+			turnId: "turn_event",
+			turnNumber: 4,
+			traceId: "trace_top_level",
+		});
+
+		expect(spanAttributes).toHaveLength(1);
+		expect(spanAttributes[0]).toMatchObject({
+			"trace.id": "trace_top_level",
+			"maestro.turn.id": "turn_event",
+			"maestro.telemetry.type": "canonical-turn",
+		});
+	});
+
+	it("falls back to metadata trace ids when canonical turn trace ids are blank", async () => {
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+
+		await recordTelemetry({
+			type: "canonical-turn",
+			timestamp: "2026-05-05T19:00:00.000Z",
+			sessionId: "session_event",
+			turnId: "turn_event",
+			turnNumber: 5,
+			traceId: "  ",
+			metadata: {
+				traceId: "trace_metadata",
+			},
+		});
+
+		expect(spanAttributes).toHaveLength(1);
+		expect(spanAttributes[0]).toMatchObject({
+			"trace.id": "trace_metadata",
+			"maestro.turn.id": "turn_event",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `959a243d39c963ce90b1d76539b8882935a7d1d7`
- last generated public sync base: `6a1af6010d2b307ceb9d763109eaf3e62a8d3915`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (959a243d39c9)`
- public projection: `https://github.com/evalops/maestro@main (6a1af6010d2b)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update Dockerfile
- copy/update package.json
- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update scripts/check-docker-runtime-workspaces.mjs
- copy/update src/telemetry.ts
- copy/update test/telemetry/opentelemetry-correlation.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update Dockerfile
- copy/update package.json
- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update scripts/check-docker-runtime-workspaces.mjs
- copy/update src/telemetry.ts
- copy/update test/telemetry/opentelemetry-correlation.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #277 to internal source `959a243d39c963ce90b1d76539b8882935a7d1d7`