### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli-tui/tui-renderer/attachment-controller.ts
+++ b/src/cli-tui/tui-renderer/attachment-controller.ts
@@ -6,9 +6,13 @@
  */
 
 import { randomUUID } from "node:crypto";
-import Clipboard from "@crosscopy/clipboard";
 import type { Attachment } from "../../agent/types.js";
 import type { PromptPayload, QueuedPrompt } from "../prompt-queue.js";
+
+type ClipboardApi = {
+	hasImage: () => boolean;
+	getImageBinary: () => Promise<Array<number>>;
+};
 
 // ─── Callback & Dependency Interfaces ────────────────────────────────────────
 
@@ -84,6 +88,10 @@ export class AttachmentController {
 	 */
 	async handleClipboardImagePaste(): Promise<void> {
 		try {
+			const Clipboard = await loadClipboardApi();
+			if (!Clipboard) {
+				return;
+			}
 			if (!Clipboard.hasImage()) {
 				return;
 			}
@@ -187,4 +195,20 @@ export function createAttachmentController(
 	options: AttachmentControllerOptions,
 ): AttachmentController {
 	return new AttachmentController(options);
+}
+
+async function loadClipboardApi(): Promise<ClipboardApi | undefined> {
+	try {
+		const module = await import("@crosscopy/clipboard");
+		const api = module.default ?? module;
+		if (
+			typeof api.hasImage !== "function" ||
+			typeof api.getImageBinary !== "function"
+		) {
+			return undefined;
+		}
+		return api;
+	} catch {
+		return undefined;
+	}
 }

--- a/test/cli-tui/attachment-controller.test.ts
+++ b/test/cli-tui/attachment-controller.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@crosscopy/clipboard", () => {
+	throw new Error("clipboard native package should load lazily");
+});
+
+import { createAttachmentController } from "../../src/cli-tui/tui-renderer/attachment-controller.js";
+
+function createController() {
+	return createAttachmentController({
+		deps: {
+			insertEditorText: vi.fn(),
+			setEditorText: vi.fn(),
+		},
+		callbacks: {
+			requestRender: vi.fn(),
+		},
+	});
+}
+
+describe("AttachmentController", () => {
+	it("does not require the native clipboard package at module import time", () => {
+		const controller = createController();
+
+		expect(controller.snapshotAttachments("hello")).toEqual({ text: "hello" });
+	});
+
+	it("ignores unavailable native clipboard bindings during image paste", async () => {
+		const controller = createController();
+
+		await expect(
+			controller.handleClipboardImagePaste(),
+		).resolves.toBeUndefined();
+		expect(controller.hasPendingAttachments()).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `7e9bf9beb65c0afff050badef49637b65e9adad1`
- last generated public sync base: `5e057901f2c28974f935a1e195ce9968f729ae8f`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (7e9bf9beb65c)`
- public projection: `https://github.com/evalops/maestro@main (5e057901f2c2)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli-tui/tui-renderer/attachment-controller.ts
- copy/update test/cli-tui/attachment-controller.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli-tui/tui-renderer/attachment-controller.ts
- copy/update test/cli-tui/attachment-controller.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode