### PR TITLE
chore: sync release mirror from internal

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:
@@ -37,3 +38,12 @@ jobs:
           else
             echo "Created semver tag ${{ steps.release.outputs.release_tag }}."
           fi
+
+      - name: Dispatch public release workflow
+        if: ${{ github.repository == 'evalops/maestro' && steps.release.outputs.tag_exists != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          gh workflow run release --field "version=${RELEASE_VERSION}"


### PR DESCRIPTION
## Summary

- sync shared release automation files from `evalops/maestro-internal`
- keep public release tooling aligned while public source parity is being migrated
- internal source SHA: `ea5ab0df160a27bd6ec0f11d84f832de25dfb495`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (ea5ab0df160a)`
- public projection: `https://github.com/evalops/maestro@main (b2b4b80db1f8)`
- files to copy or update: `0`
- stale files to delete: `0`
- result: in sync
- invariant: `public_is_verified_projection`

### Guidance

Public main matches the sanitized private source tree for mirrored paths.

## Drift sample

- no changed mirrored paths sampled

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `manifest` mode