### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -43,7 +43,8 @@ jobs:
         if: ${{ github.repository == 'evalops/maestro' && steps.release.outputs.tag_exists != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
           RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
         run: |
           set -euo pipefail
-          gh workflow run release --field "version=${RELEASE_VERSION}"
+          gh workflow run release --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"

--- a/scripts/check-public-mirror-drift.mjs
+++ b/scripts/check-public-mirror-drift.mjs
@@ -58,6 +58,61 @@ function readReport(reportPath) {
 	return JSON.parse(readFileSync(reportPath, "utf8"));
 }
 
+function readReleaseManifestDrift(sourceRoot, targetRoot) {
+	const manifestPath = resolve(
+		sourceRoot,
+		".github/release-mirror-manifest.json",
+	);
+	if (!existsSync(manifestPath)) {
+		return [];
+	}
+
+	const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+	const files = Array.isArray(manifest.files) ? manifest.files : [];
+	const changedPaths = [];
+	for (const relativePath of files) {
+		if (typeof relativePath !== "string" || !relativePath.trim()) {
+			continue;
+		}
+		const sourcePath = resolve(sourceRoot, relativePath);
+		if (!existsSync(sourcePath)) {
+			throw new Error(`Missing source file for mirror sync: ${sourcePath}`);
+		}
+		const targetPath = resolve(targetRoot, relativePath);
+		const sourceContent = readFileSync(sourcePath);
+		const targetContent = existsSync(targetPath) ? readFileSync(targetPath) : null;
+		if (!targetContent || !sourceContent.equals(targetContent)) {
+			changedPaths.push(relativePath);
+		}
+	}
+	return changedPaths.sort();
+}
+
+function mergeReleaseManifestDrift(report, releaseManifestChangedPaths) {
+	if (releaseManifestChangedPaths.length === 0) {
+		return {
+			...report,
+			releaseManifestChangedCount: 0,
+			releaseManifestChangedPaths: [],
+		};
+	}
+
+	const copiedPaths = Array.isArray(report.copiedPaths)
+		? [...report.copiedPaths]
+		: [];
+	const copiedPathSet = new Set(copiedPaths);
+	const addedPaths = releaseManifestChangedPaths.filter(
+		(path) => !copiedPathSet.has(path),
+	);
+	return {
+		...report,
+		copiedCount: copiedPaths.length + addedPaths.length,
+		copiedPaths: [...copiedPaths, ...addedPaths],
+		releaseManifestChangedCount: releaseManifestChangedPaths.length,
+		releaseManifestChangedPaths,
+	};
+}
+
 function samplePaths(report, limit) {
 	const copied = Array.isArray(report.copiedPaths) ? report.copiedPaths : [];
 	const deleted = Array.isArray(report.deletedPaths) ? report.deletedPaths : [];
@@ -204,7 +259,17 @@ if (result.error) {
 }
 
 const report = readReport(reportPath);
-const status = buildStatus(report, options.summaryLimit, sourceRoot, targetRoot);
+const mergedReport = mergeReleaseManifestDrift(
+	report,
+	readReleaseManifestDrift(sourceRoot, targetRoot),
+);
+writeFileSync(reportPath, `${JSON.stringify(mergedReport, null, 2)}\n`);
+const status = buildStatus(
+	mergedReport,
+	options.summaryLimit,
+	sourceRoot,
+	targetRoot,
+);
 const markdown = buildMarkdown(status);
 process.stdout.write(markdown);
 
@@ -218,8 +283,8 @@ if (process.env.GITHUB_STEP_SUMMARY) {
 	appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n${markdown}`);
 }
 
-const copiedCount = Number(report.copiedCount ?? 0);
-const deletedCount = Number(report.deletedCount ?? 0);
+const copiedCount = Number(mergedReport.copiedCount ?? 0);
+const deletedCount = Number(mergedReport.deletedCount ?? 0);
 if (copiedCount + deletedCount > 0) {
 	console.error(
 		"Public mirror drift detected. Let internal main generate and merge the public sync PR before relying on public main.",

--- a/src/evalops/managed-context.ts
+++ b/src/evalops/managed-context.ts
@@ -88,6 +88,26 @@ const USER_ENV = [
 ] as const;
 
 const TOKEN_ENV = ["MAESTRO_EVALOPS_ACCESS_TOKEN", "EVALOPS_TOKEN"] as const;
+const INTEGRATION_PROFILE_ENV = [
+	"MAESTRO_EVALOPS_INTEGRATION_PROFILE",
+	"MAESTRO_INTEGRATION_PROFILE",
+] as const;
+const MEMORY_MODE_ENV = [
+	"MAESTRO_EVALOPS_MEMORY_MODE",
+	"MAESTRO_MEMORY_MODE",
+] as const;
+const RUNTIME_OWNER_ENV = [
+	"MAESTRO_EVALOPS_RUNTIME_OWNER",
+	"MAESTRO_RUNTIME_OWNER",
+] as const;
+const SHIM_TYPE_ENV = [
+	"MAESTRO_EVALOPS_SHIM_TYPE",
+	"MAESTRO_SHIM_TYPE",
+] as const;
+const TRACE_MODE_ENV = [
+	"MAESTRO_EVALOPS_TRACE_MODE",
+	"MAESTRO_TRACE_MODE",
+] as const;
 
 function nonEmptyString(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim().length > 0
@@ -217,20 +237,21 @@ export function resolveManagedEvalOpsContext(
 		evidencePublisher: managed ? "EvalOps" : "none",
 		expiresAt: credentials?.expires,
 		inference: managed ? "managed" : "local",
-		integrationProfile: agentMcp?.integrationProfile,
+		integrationProfile:
+			readEnv(env, INTEGRATION_PROFILE_ENV) ?? agentMcp?.integrationProfile,
 		keyPrefix: agentMcp?.keyPrefix,
 		managed,
-		memoryMode: agentMcp?.memoryMode,
+		memoryMode: readEnv(env, MEMORY_MODE_ENV) ?? agentMcp?.memoryMode,
 		mode,
 		organizationId,
 		providerRef,
 		runId,
-		runtimeOwner: agentMcp?.runtimeOwner,
+		runtimeOwner: readEnv(env, RUNTIME_OWNER_ENV) ?? agentMcp?.runtimeOwner,
 		sessionExpiresAt: agentMcp?.sessionExpiresAt,
 		sessionId: readEnv(env, ["MAESTRO_SESSION_ID"]),
-		shimType: agentMcp?.shimType,
+		shimType: readEnv(env, SHIM_TYPE_ENV) ?? agentMcp?.shimType,
 		traceIngestion: managed && runId ? "live" : "not configured",
-		traceMode: agentMcp?.traceMode,
+		traceMode: readEnv(env, TRACE_MODE_ENV) ?? agentMcp?.traceMode,
 		userEmail: nonEmptyString(metadata?.email),
 		userId: readEnv(env, USER_ENV) ?? nonEmptyString(metadata?.userId),
 		workspaceId,
@@ -265,6 +286,8 @@ export function formatManagedEvalOpsStatus(
 	if (context.integrationProfile) {
 		lines.push(`${dim("Integration profile")}: ${context.integrationProfile}`);
 	}
+	if (context.runtimeOwner)
+		lines.push(`${dim("Runtime owner")}: ${context.runtimeOwner}`);
 	if (context.shimType) lines.push(`${dim("Shim")}: ${context.shimType}`);
 	if (context.traceMode)
 		lines.push(`${dim("Trace mode")}: ${context.traceMode}`);

--- a/src/mcp/platform-plugin.ts
+++ b/src/mcp/platform-plugin.ts
@@ -49,6 +49,26 @@ const PLATFORM_MCP_SCOPES_ENV_VARS = [
 	"MAESTRO_EVALOPS_AGENT_MCP_SCOPES",
 	"MAESTRO_CEREBRO_MCP_SCOPES",
 ] as const;
+const PLATFORM_MCP_INTEGRATION_PROFILE_ENV_VARS = [
+	"MAESTRO_EVALOPS_INTEGRATION_PROFILE",
+	"MAESTRO_INTEGRATION_PROFILE",
+] as const;
+const PLATFORM_MCP_MEMORY_MODE_ENV_VARS = [
+	"MAESTRO_EVALOPS_MEMORY_MODE",
+	"MAESTRO_MEMORY_MODE",
+] as const;
+const PLATFORM_MCP_RUNTIME_OWNER_ENV_VARS = [
+	"MAESTRO_EVALOPS_RUNTIME_OWNER",
+	"MAESTRO_RUNTIME_OWNER",
+] as const;
+const PLATFORM_MCP_SHIM_TYPE_ENV_VARS = [
+	"MAESTRO_EVALOPS_SHIM_TYPE",
+	"MAESTRO_SHIM_TYPE",
+] as const;
+const PLATFORM_MCP_TRACE_MODE_ENV_VARS = [
+	"MAESTRO_EVALOPS_TRACE_MODE",
+	"MAESTRO_TRACE_MODE",
+] as const;
 const DEFAULT_PLATFORM_MCP_SERVER_NAME = "evalops";
 const AGENT_MCP_MANIFEST_PATH = "/.well-known/evalops/agent-mcp.json";
 const AGENT_MCP_PATH = "/mcp";
@@ -79,14 +99,21 @@ function buildPlatformMcpHeaders(): Record<string, string> | undefined {
 				getEnvValue(PLATFORM_MCP_AGENT_ID_ENV_VARS) ?? stored?.agentId,
 			"X-EvalOps-Agent-Run-Id":
 				getEnvValue(["MAESTRO_AGENT_RUN_ID"]) ?? stored?.runId,
-			"X-EvalOps-Integration-Profile": stored?.integrationProfile,
-			"X-EvalOps-Memory-Mode": stored?.memoryMode,
-			"X-EvalOps-Runtime-Owner": stored?.runtimeOwner,
+			"X-EvalOps-Integration-Profile":
+				getEnvValue(PLATFORM_MCP_INTEGRATION_PROFILE_ENV_VARS) ??
+				stored?.integrationProfile,
+			"X-EvalOps-Memory-Mode":
+				getEnvValue(PLATFORM_MCP_MEMORY_MODE_ENV_VARS) ?? stored?.memoryMode,
+			"X-EvalOps-Runtime-Owner":
+				getEnvValue(PLATFORM_MCP_RUNTIME_OWNER_ENV_VARS) ??
+				stored?.runtimeOwner,
 			"X-EvalOps-Scopes": getEnvValue(PLATFORM_MCP_SCOPES_ENV_VARS),
-			"X-EvalOps-Shim-Type": stored?.shimType,
+			"X-EvalOps-Shim-Type":
+				getEnvValue(PLATFORM_MCP_SHIM_TYPE_ENV_VARS) ?? stored?.shimType,
 			"X-EvalOps-Request-Id": getEnvValue(["MAESTRO_REQUEST_ID"]),
 			"X-EvalOps-Trace-Id": getEnvValue(["TRACE_ID", "OTEL_TRACE_ID"]),
-			"X-EvalOps-Trace-Mode": stored?.traceMode,
+			"X-EvalOps-Trace-Mode":
+				getEnvValue(PLATFORM_MCP_TRACE_MODE_ENV_VARS) ?? stored?.traceMode,
 			"X-EvalOps-Maestro-Surface":
 				getEnvValue(["MAESTRO_SURFACE"]) ?? "maestro",
 		}).filter(

--- a/test/agent/mcp-platform-plugin.test.ts
+++ b/test/agent/mcp-platform-plugin.test.ts
@@ -42,6 +42,16 @@ describe("platform MCP plugin servers", () => {
 			"MAESTRO_AGENT_MCP_SCOPES",
 			"MAESTRO_EVALOPS_AGENT_MCP_SCOPES",
 			"MAESTRO_CEREBRO_MCP_SCOPES",
+			"MAESTRO_EVALOPS_INTEGRATION_PROFILE",
+			"MAESTRO_INTEGRATION_PROFILE",
+			"MAESTRO_EVALOPS_MEMORY_MODE",
+			"MAESTRO_MEMORY_MODE",
+			"MAESTRO_EVALOPS_RUNTIME_OWNER",
+			"MAESTRO_RUNTIME_OWNER",
+			"MAESTRO_EVALOPS_SHIM_TYPE",
+			"MAESTRO_SHIM_TYPE",
+			"MAESTRO_EVALOPS_TRACE_MODE",
+			"MAESTRO_TRACE_MODE",
 			"MAESTRO_REQUEST_ID",
 			"TRACE_ID",
 			"OTEL_TRACE_ID",
@@ -90,6 +100,42 @@ describe("platform MCP plugin servers", () => {
 				},
 			},
 		]);
+	});
+
+	it("prefers env-driven profile headers over stored managed metadata", () => {
+		process.env.MAESTRO_PLATFORM_MCP_URL =
+			"https://agent-mcp.evalops.example/mcp";
+		process.env.EVALOPS_ORGANIZATION_ID = "workspace-123";
+		process.env.MAESTRO_EVALOPS_INTEGRATION_PROFILE = "mcp_only";
+		process.env.MAESTRO_EVALOPS_MEMORY_MODE = "cerebro";
+		process.env.MAESTRO_EVALOPS_RUNTIME_OWNER = "customer";
+		process.env.MAESTRO_EVALOPS_SHIM_TYPE = "shim";
+		process.env.MAESTRO_EVALOPS_TRACE_MODE = "mcp_events";
+		saveOAuthCredentials("evalops", {
+			type: "oauth",
+			access: "oauth-access",
+			refresh: "oauth-refresh",
+			expires: Date.now() + 60_000,
+			metadata: {
+				agentMcp: {
+					apiKey: "eoak_stored",
+					endpoint: "https://app.evalops.dev/mcp",
+					integrationProfile: "managed_runtime",
+					memoryMode: "durable",
+					runtimeOwner: "evalops",
+					shimType: "sdk",
+					traceMode: "otlp",
+				},
+			},
+		});
+
+		expect(getPlatformMcpPluginServers()[0]?.headers).toMatchObject({
+			"X-EvalOps-Integration-Profile": "mcp_only",
+			"X-EvalOps-Memory-Mode": "cerebro",
+			"X-EvalOps-Runtime-Owner": "customer",
+			"X-EvalOps-Shim-Type": "shim",
+			"X-EvalOps-Trace-Mode": "mcp_events",
+		});
 	});
 
 	it("keeps transport session evidence for existing MCP clients", () => {

--- a/test/evalops/managed-context.test.ts
+++ b/test/evalops/managed-context.test.ts
@@ -84,6 +84,11 @@ describe("managed EvalOps context", () => {
 				EVALOPS_WORKSPACE_ID: "workspace_env",
 				MAESTRO_AGENT_ID: "agent_env",
 				MAESTRO_AGENT_RUN_ID: "run_env",
+				MAESTRO_EVALOPS_INTEGRATION_PROFILE: "mcp_only",
+				MAESTRO_EVALOPS_MEMORY_MODE: "cerebro",
+				MAESTRO_EVALOPS_RUNTIME_OWNER: "customer",
+				MAESTRO_EVALOPS_SHIM_TYPE: "shim",
+				MAESTRO_EVALOPS_TRACE_MODE: "mcp_events",
 			},
 			() => baseCredentials,
 		);
@@ -92,6 +97,11 @@ describe("managed EvalOps context", () => {
 		expect(context.workspaceId).toBe("workspace_env");
 		expect(context.agentId).toBe("agent_env");
 		expect(context.runId).toBe("run_env");
+		expect(context.integrationProfile).toBe("mcp_only");
+		expect(context.memoryMode).toBe("cerebro");
+		expect(context.runtimeOwner).toBe("customer");
+		expect(context.shimType).toBe("shim");
+		expect(context.traceMode).toBe("mcp_events");
 	});
 
 	it("does not report managed mode without an organization identity", () => {
@@ -205,6 +215,7 @@ describe("managed EvalOps context", () => {
 		expect(output).toContain("Organization: org_evalops");
 		expect(output).toContain("Workspace: workspace_evalops");
 		expect(output).toContain("Agent runtime: registered");
+		expect(output).toContain("Runtime owner: evalops");
 		expect(output).toContain("Trace ingestion: live");
 		expect(output).toContain("Evidence publisher: EvalOps");
 		expect(output).toContain("Inference: managed");

--- a/test/scripts/check-public-mirror-drift.test.ts
+++ b/test/scripts/check-public-mirror-drift.test.ts
@@ -145,4 +145,47 @@ describe("check-public-mirror-drift", () => {
 		});
 		expect(readFileSync(markdownPath, "utf8")).toContain("drift detected");
 	});
+
+	it("includes release manifest overlay drift in preview status", () => {
+		const { root, source, target } = makeFixture();
+		write(join(source, "README.md"), "hello\n");
+		write(join(target, "README.md"), "hello\n");
+		write(
+			join(source, ".github/release-mirror-manifest.json"),
+			`${JSON.stringify(
+				{ files: [".github/workflows/tag-release.yml"] },
+				null,
+				2,
+			)}\n`,
+		);
+		write(join(source, ".github/workflows/tag-release.yml"), "new\n");
+		write(join(target, ".github/workflows/tag-release.yml"), "old\n");
+		const reportPath = join(root, "drift.json");
+		const statusPath = join(root, "status.json");
+		const markdownPath = join(root, "status.md");
+
+		const result = runCheck(
+			source,
+			target,
+			reportPath,
+			statusPath,
+			markdownPath,
+		);
+
+		expect(result.status).toBe(1);
+		const report = readJson(reportPath);
+		expect(report).toMatchObject({
+			copiedCount: 1,
+			releaseManifestChangedCount: 1,
+			releaseManifestChangedPaths: [".github/workflows/tag-release.yml"],
+		});
+		const status = readJson(statusPath);
+		expect(status).toMatchObject({
+			mirror: {
+				filesToCopyOrUpdate: 1,
+				sampledChangedPaths: ["copy/update .github/workflows/tag-release.yml"],
+			},
+			result: "drift_detected",
+		});
+	});
 });

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+describe("tag-release workflow", () => {
+	it("dispatches the release workflow from the tag it just created", () => {
+		const workflow = YAML.parse(
+			readFileSync(
+				join(process.cwd(), ".github/workflows/tag-release.yml"),
+				"utf8",
+			),
+		) as {
+			jobs: {
+				"tag-current-version": {
+					steps: Array<{
+						env?: Record<string, string>;
+						name?: string;
+						run?: string;
+					}>;
+				};
+			};
+		};
+		const dispatchStep = workflow.jobs["tag-current-version"].steps.find(
+			(step) => step.name === "Dispatch public release workflow",
+		);
+
+		expect(dispatchStep?.env?.RELEASE_TAG).toBe(
+			"${{ steps.release.outputs.release_tag }}",
+		);
+		expect(dispatchStep?.run).toContain(
+			'gh workflow run release --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `482861a816fdf21974a2455b374973a8193501bc`
- last generated public sync base: `b2b4b80db1f83031ea4d030a17d8259edd6b78c5`
- previewed public-tree drift: `8` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (482861a816fd)`
- public projection: `https://github.com/evalops/maestro@main (aa7cf5b0e50d)`
- files to copy or update: `8`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update scripts/check-public-mirror-drift.mjs
- copy/update src/evalops/managed-context.ts
- copy/update src/mcp/platform-plugin.ts
- copy/update test/agent/mcp-platform-plugin.test.ts
- copy/update test/evalops/managed-context.test.ts
- copy/update test/scripts/check-public-mirror-drift.test.ts
- copy/update test/workflows/tag-release.test.ts
- copy/update .github/workflows/tag-release.yml

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update scripts/check-public-mirror-drift.mjs
- copy/update src/evalops/managed-context.ts
- copy/update src/mcp/platform-plugin.ts
- copy/update test/agent/mcp-platform-plugin.test.ts
- copy/update test/evalops/managed-context.test.ts
- copy/update test/scripts/check-public-mirror-drift.test.ts
- copy/update test/workflows/tag-release.test.ts
- copy/update .github/workflows/tag-release.yml

## Public-only commits since last generated sync

- aa7cf5b0 chore: sync release mirror from internal (#287)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode