### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -452,6 +452,12 @@ export async function main(args: string[]) {
 		process.exit(1);
 	}
 
+	const exitWithEarlyStartupError = (error: unknown): never => {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(chalk.red(message));
+		process.exit(1);
+	};
+
 	// Handle `maestro hosted-runner` before importing web-server so hosted
 	// defaults are visible to its module-level runtime profile.
 	if (parsed.command === "hosted-runner") {
@@ -481,6 +487,34 @@ export async function main(args: string[]) {
 			parsed.port ?? (Number.parseInt(process.env.PORT || "8080", 10) || 8080);
 		await migrate();
 		await startWebServer(port, { skipStartupMigration: true });
+		return;
+	}
+
+	// Bootstrap/status commands need stdout to stay under their direct control.
+	// In particular, `maestro init --json` must be parseable JSON with any
+	// progress or diagnostic output on stderr, so route it before config loading
+	// can emit normal CLI startup logs.
+	if (parsed.command === "init") {
+		try {
+			validateCodexFlags(args, parsed.command);
+		} catch (error) {
+			exitWithEarlyStartupError(error);
+		}
+
+		const { handleInitCommand } = await import("./cli/commands/init.js");
+		await handleInitCommand(parsed.commandArgs ?? []);
+		return;
+	}
+
+	if (parsed.command === "status") {
+		try {
+			validateCodexFlags(args, parsed.command);
+		} catch (error) {
+			exitWithEarlyStartupError(error);
+		}
+
+		const { handleStatusCommand } = await import("./cli/commands/status.js");
+		await handleStatusCommand();
 		return;
 	}
 
@@ -745,18 +779,6 @@ export async function main(args: string[]) {
 	if (parsed.command === "evalops") {
 		const { handleEvalOpsCommand } = await import("./cli/commands/evalops.js");
 		await handleEvalOpsCommand(parsed.subcommand, parsed.commandArgs ?? []);
-		return;
-	}
-
-	if (parsed.command === "status") {
-		const { handleStatusCommand } = await import("./cli/commands/status.js");
-		await handleStatusCommand();
-		return;
-	}
-
-	if (parsed.command === "init") {
-		const { handleInitCommand } = await import("./cli/commands/init.js");
-		await handleInitCommand(parsed.commandArgs ?? []);
 		return;
 	}
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -35,7 +35,7 @@ interface LoggerConfig {
 	jsonFormat: boolean;
 	/** Whether to include timestamps */
 	timestamps: boolean;
-	/** Custom output function (defaults to console) */
+	/** Custom output function (defaults to stderr) */
 	output?: (entry: LogEntry) => void;
 }
 
@@ -114,15 +114,13 @@ class Logger {
 	 * Output as JSON (for log aggregation systems)
 	 */
 	private outputJson(entry: LogEntry): void {
-		const output = entry.level === "error" ? console.error : console.log;
-		output(JSON.stringify(entry));
+		console.error(JSON.stringify(entry));
 	}
 
 	/**
 	 * Output as human-readable format
 	 */
 	private outputPretty(entry: LogEntry): void {
-		const output = entry.level === "error" ? console.error : console.log;
 		const parts: string[] = [];
 
 		if (this.config.timestamps) {
@@ -136,10 +134,10 @@ class Logger {
 			parts.push(JSON.stringify(entry.context));
 		}
 
-		output(parts.join(" "));
+		console.error(parts.join(" "));
 
 		if (entry.error?.stack) {
-			output(entry.error.stack);
+			console.error(entry.error.stack);
 		}
 	}
 

--- a/test/agent/workflow-state-integration.test.ts
+++ b/test/agent/workflow-state-integration.test.ts
@@ -144,7 +144,7 @@ describe("ProviderTransport workflow-state integration", () => {
 			timestamp: Date.now(),
 		};
 
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		const handoffResults: ToolResultMessage[] = [];
 
 		for await (const event of transport.run([], userMessage, cfg)) {

--- a/test/cli/cli.integration.test.ts
+++ b/test/cli/cli.integration.test.ts
@@ -248,6 +248,50 @@ vi.mock("../../src/models/registry.js", () => ({
 		) ?? null,
 }));
 
+vi.mock("../../src/evalops/agent-bootstrap.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import("../../src/evalops/agent-bootstrap.js")
+		>();
+	return {
+		...actual,
+		bootstrapEvalOpsAgent: async (
+			_options: unknown,
+			deps?: { onStatus?: (status: { message: string }) => void },
+		) => {
+			deps?.onStatus?.({
+				message: "Registering Maestro with EvalOps agent MCP",
+			});
+			return {
+				agentId: "agent_json",
+				apiKeyCreated: true,
+				approvalPolicyAttached: true,
+				authenticatedAs: "json@example.com",
+				consoleUrl: "https://app.evalops.dev/overview?env=production",
+				endpoint: "https://app.evalops.dev/mcp",
+				evidenceEventPublished: true,
+				evidenceEvents: 1,
+				governedActionsLoaded: 17,
+				governedInferenceCheckRan: true,
+				integrationProfile: "managed_runtime",
+				keyPrefix: "pk_live_json",
+				memoryMode: "durable",
+				organizationId: "org_json",
+				registryVisible: true,
+				riskFindings: 0,
+				runId: "run_json",
+				runtimeOwner: "evalops",
+				scopesGranted: ["agent:register"],
+				sessionExpiresAt: "2026-05-06T13:00:00Z",
+				shimType: "sdk",
+				stored: true,
+				traceIngestionStarted: true,
+				traceMode: "otlp",
+			};
+		},
+	};
+});
+
 describe("CLI integration", () => {
 	const originalEnv = process.env.ANTHROPIC_API_KEY;
 	const originalAgentDir = process.env.MAESTRO_AGENT_DIR;
@@ -362,6 +406,37 @@ describe("CLI integration", () => {
 		expect(exitCodes).toEqual([0]);
 		expect(output.some((line) => line.includes("anthropic"))).toBe(true);
 		exitSpy.mockRestore();
+	});
+
+	it("keeps maestro init --json stdout parseable", async () => {
+		const stdoutLines: string[] = [];
+		const stderrLines: string[] = [];
+		console.log = (...args: unknown[]) => {
+			stdoutLines.push(args.map((arg) => String(arg)).join(" "));
+		};
+		console.error = (...args: unknown[]) => {
+			stderrLines.push(args.map((arg) => String(arg)).join(" "));
+		};
+
+		await main(["init", "--json"]);
+
+		expect(stderrLines.join("\n")).toContain(
+			"Registering Maestro with EvalOps agent MCP",
+		);
+		expect(stdoutLines).toHaveLength(1);
+		const parsed = JSON.parse(stdoutLines[0] ?? "{}") as Record<
+			string,
+			unknown
+		>;
+		expect(parsed).toMatchObject({
+			agentId: "agent_json",
+			integrationProfile: "managed_runtime",
+			memoryMode: "durable",
+			organizationId: "org_json",
+			runtimeOwner: "evalops",
+			traceMode: "otlp",
+		});
+		expect(stdoutLines.join("\n")).not.toContain("Loaded configuration");
 	});
 
 	it("exports a saved session as portable jsonl", async () => {
@@ -709,6 +784,22 @@ describe("CLI integration", () => {
 		});
 		await expect(
 			main(["--codex-api-key", "codex-token", "hello"]),
+		).rejects.toThrow("exit");
+		expect(exitCodes).toEqual([1]);
+		expect(output.join("\n")).toContain(
+			"Legacy Codex/ChatGPT auth flags are no longer supported",
+		);
+		exitSpy.mockRestore();
+	});
+
+	it("rejects legacy auth flags before status early exit", async () => {
+		const exitCodes: number[] = [];
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+			exitCodes.push(Number(code ?? 0));
+			throw new Error("exit");
+		});
+		await expect(
+			main(["--codex-api-key", "codex-token", "status"]),
 		).rejects.toThrow("exit");
 		expect(exitCodes).toEqual([1]);
 		expect(output.join("\n")).toContain(

--- a/test/prompts/service-client.test.ts
+++ b/test/prompts/service-client.test.ts
@@ -190,7 +190,7 @@ describe("prompts service client", () => {
 
 	it("warns when configured prompt service is missing an organization id", async () => {
 		delete process.env.PROMPTS_SERVICE_ORGANIZATION_ID;
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 
@@ -213,7 +213,7 @@ describe("prompts service client", () => {
 	it("warns when configured prompt service is missing an access token", async () => {
 		delete process.env.PROMPTS_SERVICE_TOKEN;
 		process.env.MAESTRO_HOME = "/tmp/maestro-prompts-test-no-oauth";
-		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `ccf3ff591bbb590ee642252b3eabc40fb9e5a4e8`
- last generated public sync base: `f9b895834bc7012fe6dee18e658b2a2dd888bd48`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (ccf3ff591bbb)`
- public projection: `https://github.com/evalops/maestro@main (f9b895834bc7)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/main.ts
- copy/update src/utils/logger.ts
- copy/update test/agent/workflow-state-integration.test.ts
- copy/update test/cli/cli.integration.test.ts
- copy/update test/prompts/service-client.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/main.ts
- copy/update src/utils/logger.ts
- copy/update test/agent/workflow-state-integration.test.ts
- copy/update test/cli/cli.integration.test.ts
- copy/update test/prompts/service-client.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #291 to internal source `ccf3ff591bbb590ee642252b3eabc40fb9e5a4e8`