### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ versioning when releases are cut.
 
 
 
+
+## [0.10.18] - 2026-05-06
+
+### Added
+
+### Changed
+
+### Fixed
+
+
 ## [0.10.17] - 2026-05-06
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Maestro Web API",
-    "version": "0.10.17",
+    "version": "0.10.18",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evalops/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "private": false,
   "type": "module",
   "workspaces": [
@@ -127,8 +127,8 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1020.0",
     "@crosscopy/clipboard": "^0.2.8",
     "@daytonaio/sdk": "^0.155.0",
-    "@evalops/contracts": "^0.10.17",
-    "@evalops/tui": "^0.10.17",
+    "@evalops/contracts": "^0.10.18",
+    "@evalops/tui": "^0.10.18",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.74.0",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/ai",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Shared Maestro AI SDK (models, transport, and agent event stream facade).",
 	"type": "module",
 	"main": "./dist/packages/ai/src/index.js",
@@ -124,8 +124,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.17",
-		"@evalops/tui": "^0.10.17",
+		"@evalops/contracts": "^0.10.18",
+		"@evalops/tui": "^0.10.18",
 		"@google/genai": "^1.29.1",
 		"@sinclair/typebox": "^0.34.0",
 		"nats": "^2.29.3"

--- a/packages/consumer-sdk/package.json
+++ b/packages/consumer-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/consumer",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Unified EvalOps consumer SDK for Maestro service integrations",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -28,7 +28,7 @@
 		"directory": "packages/consumer-sdk"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.17"
+		"@evalops/contracts": "^0.10.18"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/contracts",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Shared Maestro contracts for frontend/backend integration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-core",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Maestro agent loop, transport, types, and sandbox primitives — the engine behind all Maestro interfaces",
 	"type": "module",
 	"main": "./dist/packages/core/src/index.js",
@@ -57,7 +57,7 @@
 		"vscode-jsonrpc": "^8.2.0"
 	},
 	"peerDependencies": {
-		"@evalops/tui": "^0.10.17"
+		"@evalops/tui": "^0.10.18"
 	},
 	"peerDependenciesMeta": {
 		"@evalops/tui": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-desktop",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Maestro Desktop - Beautiful Electron app for AI-assisted development",
 	"type": "module",
 	"main": "dist-electron/main/index.js",
@@ -37,7 +37,7 @@
 		"directory": "packages/desktop"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.17",
+		"@evalops/contracts": "^0.10.18",
 		"electron-store": "^10.0.1",
 		"electron-updater": "^6.3.9"
 	},

--- a/packages/github-agent/package.json
+++ b/packages/github-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/github-agent",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Autonomous GitHub agent - Maestro building Maestro",
 	"type": "module",
 	"bin": {
@@ -36,7 +36,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/ai": "^0.10.17",
+		"@evalops/ai": "^0.10.18",
 		"@octokit/rest": "^21.0.0",
 		"@octokit/webhooks": "^13.0.0",
 		"@sinclair/typebox": "^0.34.0",

--- a/packages/governance-mcp-server/package.json
+++ b/packages/governance-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance-mcp-server",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "MCP server exposing Platform governance proxy tools to any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -43,7 +43,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/governance": "^0.10.17",
+		"@evalops/governance": "^0.10.18",
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"zod": "^4.3.5"
 	},

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Thin Platform governance proxy for MCP-compatible agents.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/memory",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"private": true,
 	"type": "module",
 	"sideEffects": false,

--- a/packages/slack-agent-ui/package.json
+++ b/packages/slack-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent-ui",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Web UI for Slack Agent - Dashboard gallery, connector management, OAuth flows",
 	"type": "module",
 	"private": true,

--- a/packages/slack-agent/package.json
+++ b/packages/slack-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Slack bot agent with Docker sandbox support for Maestro",
 	"type": "module",
 	"bin": {
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@daytonaio/sdk": "^0.139.0",
-		"@evalops/ai": "^0.10.17",
+		"@evalops/ai": "^0.10.18",
 		"@sinclair/typebox": "^0.34.0",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/tui",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Terminal UI library with differential rendering for Maestro",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Maestro",
 	"description": "Use Maestro's deterministic AI assistant inside VS Code.",
 	"publisher": "evalops",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"license": "MIT",
 	"type": "commonjs",
 	"main": "./dist/extension.js",
@@ -139,7 +139,7 @@
 		"test": "vitest --run"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.17"
+		"@evalops/contracts": "^0.10.18"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-web",
-	"version": "0.10.17",
+	"version": "0.10.18",
 	"description": "Web UI for Maestro - Browser-based AI coding assistant interface",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,7 +24,7 @@
 		"directory": "packages/web"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.17",
+		"@evalops/contracts": "^0.10.18",
 		"docx-preview": "^0.3.7",
 		"dompurify": "^3.3.0",
 		"exceljs": "^4.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
 
 // SDK tool types for external consumers
 export * from "./sdk-tools.js";
+export * from "./platform/a2a-client.js";
 
 // Distributed lock manager for concurrent operations
 export {

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -1,0 +1,354 @@
+import { fetchDownstream } from "../utils/downstream-http.js";
+import {
+	type PlatformServiceConfig,
+	buildPlatformJsonHeaders,
+	getEnvValue,
+	resolvePlatformServiceConfig,
+	trimString,
+} from "./client.js";
+
+const DEFAULT_TIMEOUT_MS = 2_500;
+const DEFAULT_MAX_ATTEMPTS = 2;
+
+const A2A_BASE_URL_ENV_VARS = [
+	"MAESTRO_PLATFORM_A2A_URL",
+	"MAESTRO_A2A_URL",
+	"MAESTRO_AGENT_RUNTIME_SERVICE_URL",
+	"PLATFORM_AGENT_RUNTIME_URL",
+	"AGENT_RUNTIME_SERVICE_URL",
+	"MAESTRO_PLATFORM_BASE_URL",
+	"MAESTRO_EVALOPS_BASE_URL",
+	"EVALOPS_BASE_URL",
+] as const;
+
+const A2A_TOKEN_ENV_VARS = [
+	"MAESTRO_PLATFORM_A2A_TOKEN",
+	"MAESTRO_A2A_TOKEN",
+	"MAESTRO_AGENT_RUNTIME_SERVICE_TOKEN",
+	"AGENT_RUNTIME_SERVICE_TOKEN",
+] as const;
+
+const A2A_ORGANIZATION_ENV_VARS = [
+	"MAESTRO_PLATFORM_A2A_ORG_ID",
+	"MAESTRO_A2A_ORG_ID",
+	"MAESTRO_AGENT_RUNTIME_ORG_ID",
+	"AGENT_RUNTIME_ORGANIZATION_ID",
+	"MAESTRO_EVALOPS_ORG_ID",
+	"EVALOPS_ORGANIZATION_ID",
+	"EVALOPS_ORG_ID",
+	"MAESTRO_ENTERPRISE_ORG_ID",
+] as const;
+
+const A2A_WORKSPACE_ENV_VARS = [
+	"MAESTRO_PLATFORM_A2A_WORKSPACE_ID",
+	"MAESTRO_A2A_WORKSPACE_ID",
+	"MAESTRO_AGENT_RUNTIME_WORKSPACE_ID",
+	"AGENT_RUNTIME_WORKSPACE_ID",
+	"MAESTRO_EVALOPS_WORKSPACE_ID",
+	"MAESTRO_WORKSPACE_ID",
+	"EVALOPS_WORKSPACE_ID",
+] as const;
+
+const A2A_TIMEOUT_ENV_VARS = [
+	"MAESTRO_PLATFORM_A2A_TIMEOUT_MS",
+	"MAESTRO_A2A_TIMEOUT_MS",
+	"MAESTRO_AGENT_RUNTIME_TIMEOUT_MS",
+	"AGENT_RUNTIME_SERVICE_TIMEOUT_MS",
+] as const;
+
+const A2A_MAX_ATTEMPTS_ENV_VARS = [
+	"MAESTRO_PLATFORM_A2A_MAX_ATTEMPTS",
+	"MAESTRO_A2A_MAX_ATTEMPTS",
+	"MAESTRO_AGENT_RUNTIME_MAX_ATTEMPTS",
+	"AGENT_RUNTIME_SERVICE_MAX_ATTEMPTS",
+] as const;
+
+const A2A_BASE_URL_SUFFIXES = [
+	"/.well-known/agent-card.json",
+	"/message:send",
+	"/message:stream",
+] as const;
+
+export interface A2AServiceConfig extends PlatformServiceConfig {
+	agentId?: string;
+	sessionId?: string;
+	actorId?: string;
+}
+
+export interface A2AAgentCard {
+	name: string;
+	description: string;
+	supportedInterfaces: A2AAgentInterface[];
+	provider?: {
+		url: string;
+		organization: string;
+	};
+	version: string;
+	capabilities: {
+		streaming?: boolean;
+		pushNotifications?: boolean;
+		extendedAgentCard?: boolean;
+	};
+	defaultInputModes: string[];
+	defaultOutputModes: string[];
+	skills: A2AAgentSkill[];
+}
+
+export interface A2AAgentInterface {
+	url: string;
+	protocolBinding: string;
+	tenant?: string;
+	protocolVersion: string;
+}
+
+export interface A2AAgentSkill {
+	id: string;
+	name: string;
+	description: string;
+	tags: string[];
+	examples?: string[];
+	inputModes?: string[];
+	outputModes?: string[];
+}
+
+export interface A2APart {
+	text?: string;
+	url?: string;
+	data?: unknown;
+	metadata?: Record<string, unknown>;
+	filename?: string;
+	mediaType?: string;
+}
+
+export interface A2AMessage {
+	messageId: string;
+	contextId?: string;
+	taskId?: string;
+	role: "ROLE_USER" | "ROLE_AGENT" | "user" | "agent";
+	parts: A2APart[];
+	metadata?: Record<string, unknown>;
+	extensions?: string[];
+	referenceTaskIds?: string[];
+}
+
+export interface A2ATaskStatus {
+	state: string;
+	message?: A2AMessage;
+	timestamp?: string;
+}
+
+export interface A2ATask {
+	id: string;
+	contextId?: string;
+	status: A2ATaskStatus;
+	history?: A2AMessage[];
+	metadata?: Record<string, unknown>;
+}
+
+export interface SendA2AMessageInput {
+	message: A2AMessage;
+	configuration?: {
+		acceptedOutputModes?: string[];
+		returnImmediately?: boolean;
+	};
+	metadata?: Record<string, unknown>;
+}
+
+export interface SendA2AMessageResult {
+	task: A2ATask;
+}
+
+function normalizeA2ABaseUrl(baseUrl: string): string {
+	let normalized = baseUrl.trim().replace(/\/+$/u, "");
+	for (const suffix of A2A_BASE_URL_SUFFIXES) {
+		if (normalized.endsWith(suffix)) {
+			normalized = normalized.slice(0, -suffix.length).replace(/\/+$/u, "");
+		}
+	}
+	return normalized;
+}
+
+export async function resolveA2AServiceConfig(
+	overrides: Partial<A2AServiceConfig> = {},
+): Promise<A2AServiceConfig | null> {
+	const config = await resolvePlatformServiceConfig({
+		baseUrlEnvVars: A2A_BASE_URL_ENV_VARS,
+		tokenEnvVars: A2A_TOKEN_ENV_VARS,
+		organizationEnvVars: A2A_ORGANIZATION_ENV_VARS,
+		workspaceEnvVars: A2A_WORKSPACE_ENV_VARS,
+		timeoutEnvVars: A2A_TIMEOUT_ENV_VARS,
+		maxAttemptsEnvVars: A2A_MAX_ATTEMPTS_ENV_VARS,
+		baseUrlSuffixes: A2A_BASE_URL_SUFFIXES,
+		defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+		defaultMaxAttempts: DEFAULT_MAX_ATTEMPTS,
+		requireBaseUrl: false,
+		requireOrganizationId: false,
+		requireToken: false,
+		allowOAuthTokenFallback: false,
+	});
+	const baseUrl = trimString(overrides.baseUrl ?? config?.baseUrl);
+	const workspaceId = trimString(overrides.workspaceId ?? config?.workspaceId);
+	if (!baseUrl || !workspaceId) {
+		return null;
+	}
+	return {
+		...(config ?? {
+			baseUrl,
+			timeoutMs: DEFAULT_TIMEOUT_MS,
+			maxAttempts: DEFAULT_MAX_ATTEMPTS,
+		}),
+		baseUrl: normalizeA2ABaseUrl(baseUrl),
+		organizationId:
+			trimString(overrides.organizationId ?? config?.organizationId) ??
+			config?.organizationId,
+		workspaceId,
+		token: trimString(overrides.token ?? config?.token) ?? config?.token,
+		timeoutMs: overrides.timeoutMs ?? config?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+		maxAttempts:
+			overrides.maxAttempts ?? config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+		agentId:
+			trimString(overrides.agentId) ??
+			getEnvValue(["MAESTRO_AGENT_ID", "MAESTRO_EVALOPS_AGENT_ID"]) ??
+			"maestro",
+		sessionId:
+			trimString(overrides.sessionId) ?? getEnvValue(["MAESTRO_SESSION_ID"]),
+		actorId:
+			trimString(overrides.actorId) ??
+			getEnvValue(["MAESTRO_USER_ID", "MAESTRO_ACTOR_ID"]),
+	};
+}
+
+export function buildA2AUserMessage(input: {
+	text: string;
+	messageId: string;
+	contextId?: string;
+	taskId?: string;
+	metadata?: Record<string, unknown>;
+}): A2AMessage {
+	return {
+		messageId: input.messageId,
+		contextId: input.contextId,
+		taskId: input.taskId,
+		role: "ROLE_USER",
+		parts: [{ text: input.text, mediaType: "text/plain" }],
+		metadata: input.metadata,
+	};
+}
+
+export async function discoverA2AAgentCard(
+	config: A2AServiceConfig,
+	options: { signal?: AbortSignal } = {},
+): Promise<A2AAgentCard> {
+	const response = await fetchDownstream(
+		`${config.baseUrl}/.well-known/agent-card.json`,
+		{
+			method: "GET",
+			headers: buildA2AHeaders(config),
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "discover agent card");
+	return (await response.json()) as A2AAgentCard;
+}
+
+export async function sendA2AMessage(
+	config: A2AServiceConfig,
+	input: SendA2AMessageInput,
+	options: { signal?: AbortSignal } = {},
+): Promise<SendA2AMessageResult> {
+	const body = {
+		...input,
+		message: {
+			...input.message,
+			metadata: {
+				...(input.message.metadata ?? {}),
+				workspaceId: config.workspaceId,
+				agentId: config.agentId,
+				sessionId: config.sessionId,
+				actorId: config.actorId,
+			},
+		},
+	};
+	const response = await fetchDownstream(
+		`${config.baseUrl}/message:send`,
+		{
+			method: "POST",
+			headers: buildA2AHeaders(config),
+			body: JSON.stringify(body),
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "send message");
+	return (await response.json()) as SendA2AMessageResult;
+}
+
+export async function getA2ATask(
+	config: A2AServiceConfig,
+	taskId: string,
+	options: { signal?: AbortSignal } = {},
+): Promise<A2ATask> {
+	const trimmedTaskId = trimString(taskId);
+	if (!trimmedTaskId) {
+		throw new Error("A2A task id is required");
+	}
+	const response = await fetchDownstream(
+		`${config.baseUrl}/tasks/${encodeURIComponent(trimmedTaskId)}`,
+		{
+			method: "GET",
+			headers: buildA2AHeaders(config),
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "get task");
+	return (await response.json()) as A2ATask;
+}
+
+function buildA2AHeaders(config: A2AServiceConfig): Record<string, string> {
+	return buildPlatformJsonHeaders(config, {
+		"X-EvalOps-Workspace-Id": config.workspaceId,
+		"X-EvalOps-Agent-Id": config.agentId,
+		"X-EvalOps-Session-Id": config.sessionId,
+		"X-EvalOps-Actor-Id": config.actorId,
+	});
+}
+
+async function throwForA2AError(
+	response: Response,
+	operation: string,
+): Promise<void> {
+	if (response.ok) {
+		return;
+	}
+	let detail = "";
+	try {
+		const payload = (await response.json()) as {
+			error?: { code?: string; message?: string };
+		};
+		detail = payload.error?.message ?? payload.error?.code ?? "";
+	} catch {
+		detail = await response.text().catch(() => "");
+	}
+	throw new Error(
+		`Platform A2A ${operation} failed with ${response.status}${
+			detail ? `: ${detail}` : ""
+		}`,
+	);
+}

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -33,6 +33,7 @@ export interface ResolvePlatformServiceConfigOptions {
 	requireBaseUrl?: boolean;
 	requireOrganizationId?: boolean;
 	requireToken?: boolean;
+	allowOAuthTokenFallback?: boolean;
 }
 
 export interface PlatformRequestOptions {
@@ -160,7 +161,10 @@ export async function resolvePlatformServiceConfig(
 		return null;
 	}
 
-	const token = await resolvePlatformToken(options.tokenEnvVars);
+	const token =
+		options.allowOAuthTokenFallback === false
+			? getEnvValue(options.tokenEnvVars ?? [])
+			: await resolvePlatformToken(options.tokenEnvVars);
 	if (!token && options.requireToken !== false) {
 		return null;
 	}
@@ -186,7 +190,7 @@ export async function resolvePlatformServiceConfig(
 	};
 }
 
-function buildPlatformJsonHeaders(
+export function buildPlatformJsonHeaders(
 	config: Pick<PlatformServiceConfig, "organizationId" | "token">,
 	extraHeaders?: Record<string, string | undefined>,
 ): Record<string, string> {

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	buildA2AUserMessage,
+	discoverA2AAgentCard,
+	getA2ATask,
+	resolveA2AServiceConfig,
+	sendA2AMessage,
+} from "../../src/platform/a2a-client.js";
+
+type CapturedRequest = {
+	body?: Record<string, unknown>;
+	headers: Record<string, string>;
+	method?: string;
+	pathname: string;
+	url: string;
+};
+
+function headersToRecord(
+	headers: HeadersInit | undefined,
+): Record<string, string> {
+	return Object.fromEntries(new Headers(headers).entries());
+}
+
+function parseRequestBody(
+	body: BodyInit | null | undefined,
+): Record<string, unknown> | undefined {
+	return typeof body === "string"
+		? (JSON.parse(body) as Record<string, unknown>)
+		: undefined;
+}
+
+describe("platform A2A client", () => {
+	let requests: CapturedRequest[];
+
+	beforeEach(() => {
+		requests = [];
+		for (const name of [
+			"MAESTRO_PLATFORM_A2A_URL",
+			"MAESTRO_A2A_URL",
+			"MAESTRO_AGENT_RUNTIME_SERVICE_URL",
+			"PLATFORM_AGENT_RUNTIME_URL",
+			"AGENT_RUNTIME_SERVICE_URL",
+			"MAESTRO_PLATFORM_BASE_URL",
+			"MAESTRO_EVALOPS_BASE_URL",
+			"EVALOPS_BASE_URL",
+			"MAESTRO_PLATFORM_A2A_TOKEN",
+			"MAESTRO_A2A_TOKEN",
+			"MAESTRO_AGENT_RUNTIME_SERVICE_TOKEN",
+			"AGENT_RUNTIME_SERVICE_TOKEN",
+			"MAESTRO_EVALOPS_ACCESS_TOKEN",
+			"EVALOPS_TOKEN",
+			"MAESTRO_PLATFORM_A2A_ORG_ID",
+			"MAESTRO_A2A_ORG_ID",
+			"MAESTRO_AGENT_RUNTIME_ORG_ID",
+			"AGENT_RUNTIME_ORGANIZATION_ID",
+			"MAESTRO_EVALOPS_ORG_ID",
+			"EVALOPS_ORGANIZATION_ID",
+			"MAESTRO_PLATFORM_A2A_WORKSPACE_ID",
+			"MAESTRO_A2A_WORKSPACE_ID",
+			"MAESTRO_AGENT_RUNTIME_WORKSPACE_ID",
+			"AGENT_RUNTIME_WORKSPACE_ID",
+			"MAESTRO_EVALOPS_WORKSPACE_ID",
+			"MAESTRO_WORKSPACE_ID",
+			"EVALOPS_WORKSPACE_ID",
+			"MAESTRO_AGENT_ID",
+			"MAESTRO_SESSION_ID",
+			"MAESTRO_USER_ID",
+		]) {
+			vi.stubEnv(name, "");
+		}
+		vi.stubEnv(
+			"MAESTRO_PLATFORM_A2A_URL",
+			"https://platform.test/message:send",
+		);
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_TOKEN", "a2a-token");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_ORG_ID", "org_1");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_WORKSPACE_ID", "ws_1");
+		vi.stubEnv("MAESTRO_AGENT_ID", "agent_maestro");
+		vi.stubEnv("MAESTRO_SESSION_ID", "session_1");
+		vi.stubEnv("MAESTRO_USER_ID", "user_1");
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+
+				if (parsed.pathname === "/.well-known/agent-card.json") {
+					return Response.json({
+						name: "EvalOps Platform Agent Runtime",
+						description: "A2A facade",
+						supportedInterfaces: [
+							{
+								url: "https://platform.test",
+								protocolBinding: "HTTP+JSON",
+								protocolVersion: "1.0",
+							},
+						],
+						version: "test",
+						capabilities: { streaming: false, pushNotifications: false },
+						defaultInputModes: ["text/plain"],
+						defaultOutputModes: ["application/json"],
+						skills: [
+							{
+								id: "platform-agent-runtime",
+								name: "Platform AgentRuntime",
+								description: "Submit work",
+								tags: ["evalops"],
+							},
+						],
+					});
+				}
+
+				if (parsed.pathname === "/message:send") {
+					return Response.json({
+						task: {
+							id: "run_1",
+							contextId: "session_1",
+							status: { state: "TASK_STATE_SUBMITTED" },
+							metadata: { agentRunId: "run_1" },
+						},
+					});
+				}
+
+				if (parsed.pathname === "/tasks/run_1") {
+					return Response.json({
+						id: "run_1",
+						contextId: "session_1",
+						status: { state: "TASK_STATE_COMPLETED" },
+					});
+				}
+
+				return Response.json(
+					{ error: { code: "not_found", message: `unexpected ${url}` } },
+					{ status: 404 },
+				);
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.unstubAllGlobals();
+	});
+
+	it("resolves A2A config from shared EvalOps environment", async () => {
+		await expect(resolveA2AServiceConfig()).resolves.toMatchObject({
+			baseUrl: "https://platform.test",
+			token: "a2a-token",
+			organizationId: "org_1",
+			workspaceId: "ws_1",
+			agentId: "agent_maestro",
+			sessionId: "session_1",
+			actorId: "user_1",
+		});
+	});
+
+	it("resolves explicit overrides without requiring A2A environment", async () => {
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_URL", "");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_TOKEN", "");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_WORKSPACE_ID", "");
+
+		await expect(
+			resolveA2AServiceConfig({
+				baseUrl: "https://override.test/message:send",
+				token: "override-token",
+				workspaceId: "ws_override",
+				timeoutMs: 123,
+				maxAttempts: 1,
+			}),
+		).resolves.toMatchObject({
+			baseUrl: "https://override.test",
+			token: "override-token",
+			workspaceId: "ws_override",
+			timeoutMs: 123,
+			maxAttempts: 1,
+		});
+	});
+
+	it("does not forward generic EvalOps tokens to arbitrary A2A URLs", async () => {
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_URL", "");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_TOKEN", "");
+		vi.stubEnv("MAESTRO_A2A_URL", "https://third-party-a2a.test");
+		vi.stubEnv("MAESTRO_A2A_WORKSPACE_ID", "ws_external");
+		vi.stubEnv("MAESTRO_EVALOPS_ACCESS_TOKEN", "evalops-access-token");
+		vi.stubEnv("EVALOPS_TOKEN", "evalops-token");
+
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+
+		expect(config.token).toBeUndefined();
+		await discoverA2AAgentCard(config);
+
+		expect(requests[0]?.headers).not.toHaveProperty("authorization");
+	});
+
+	it("discovers the Platform A2A agent card", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+
+		await expect(discoverA2AAgentCard(config)).resolves.toMatchObject({
+			name: "EvalOps Platform Agent Runtime",
+			supportedInterfaces: [
+				{
+					protocolBinding: "HTTP+JSON",
+					protocolVersion: "1.0",
+				},
+			],
+		});
+
+		expect(requests[0]).toMatchObject({
+			method: "GET",
+			url: "https://platform.test/.well-known/agent-card.json",
+			headers: expect.objectContaining({
+				authorization: "Bearer a2a-token",
+				"x-evalops-workspace-id": "ws_1",
+				"x-evalops-agent-id": "agent_maestro",
+				"x-evalops-session-id": "session_1",
+			}),
+		});
+	});
+
+	it("sends A2A messages with Platform correlation metadata", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+
+		await expect(
+			sendA2AMessage(config, {
+				message: buildA2AUserMessage({
+					messageId: "msg_1",
+					contextId: "session_1",
+					text: "Run the release smoke test",
+					metadata: {
+						workspaceId: "caller_ws",
+						agentId: "caller_agent",
+						sessionId: "caller_session",
+						actorId: "caller_actor",
+						requestKind: "smoke",
+					},
+				}),
+				configuration: { returnImmediately: true },
+			}),
+		).resolves.toMatchObject({
+			task: {
+				id: "run_1",
+				status: { state: "TASK_STATE_SUBMITTED" },
+			},
+		});
+
+		expect(requests[0]).toMatchObject({
+			method: "POST",
+			url: "https://platform.test/message:send",
+			body: expect.objectContaining({
+				message: expect.objectContaining({
+					messageId: "msg_1",
+					metadata: expect.objectContaining({
+						workspaceId: "ws_1",
+						agentId: "agent_maestro",
+						sessionId: "session_1",
+						actorId: "user_1",
+						requestKind: "smoke",
+					}),
+				}),
+				configuration: { returnImmediately: true },
+			}),
+		});
+	});
+
+	it("gets an A2A task by run id", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+
+		await expect(getA2ATask(config, "run_1")).resolves.toMatchObject({
+			id: "run_1",
+			status: { state: "TASK_STATE_COMPLETED" },
+		});
+		expect(requests[0]?.url).toBe("https://platform.test/tasks/run_1");
+	});
+
+	it("reuses the existing AgentRuntime service environment", async () => {
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_URL", "");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_TOKEN", "");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_ORG_ID", "");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_WORKSPACE_ID", "");
+		vi.stubEnv(
+			"AGENT_RUNTIME_SERVICE_URL",
+			"http://agent-runtime-service.staging.svc.cluster.local:8080",
+		);
+		vi.stubEnv("AGENT_RUNTIME_SERVICE_TOKEN", "agent-runtime-token");
+		vi.stubEnv("AGENT_RUNTIME_ORGANIZATION_ID", "org_runtime");
+		vi.stubEnv("AGENT_RUNTIME_WORKSPACE_ID", "ws_runtime");
+
+		await expect(resolveA2AServiceConfig()).resolves.toMatchObject({
+			baseUrl: "http://agent-runtime-service.staging.svc.cluster.local:8080",
+			token: "agent-runtime-token",
+			organizationId: "org_runtime",
+			workspaceId: "ws_runtime",
+		});
+	});
+
+	it("resolves from deploy's current Maestro AgentRuntime wiring", async () => {
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_URL", "");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_TOKEN", "");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_ORG_ID", "");
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_WORKSPACE_ID", "");
+		vi.stubEnv(
+			"MAESTRO_AGENT_RUNTIME_SERVICE_URL",
+			"http://agent-runtime-service.evalops.svc.cluster.local:8080",
+		);
+		vi.stubEnv("MAESTRO_EVALOPS_WORKSPACE_ID", "evalops");
+
+		await expect(resolveA2AServiceConfig()).resolves.toMatchObject({
+			baseUrl: "http://agent-runtime-service.evalops.svc.cluster.local:8080",
+			workspaceId: "evalops",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `a5f0df2a5f7618f0fb9abdc341d16b130bf4ae18`
- last generated public sync base: `9daa72f0bf44430ef2c323c1860ef7988db4c48f`
- previewed public-tree drift: `21` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (a5f0df2a5f76)`
- public projection: `https://github.com/evalops/maestro@main (e5f9e8b230f6)`
- files to copy or update: `21`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update CHANGELOG.md
- copy/update openapi.json
- copy/update package.json
- copy/update packages/ai/package.json
- copy/update packages/consumer-sdk/package.json
- copy/update packages/contracts/package.json
- copy/update packages/core/package.json
- copy/update packages/desktop/package.json
- copy/update packages/github-agent/package.json
- copy/update packages/governance-mcp-server/package.json
- copy/update packages/governance/package.json
- copy/update packages/memory/package.json
- copy/update packages/slack-agent-ui/package.json
- copy/update packages/slack-agent/package.json
- copy/update packages/tui/package.json
- copy/update packages/vscode-extension/package.json
- copy/update packages/web/package.json
- copy/update src/index.ts
- copy/update src/platform/a2a-client.ts
- copy/update src/platform/client.ts
- copy/update test/platform/a2a-client.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update CHANGELOG.md
- copy/update openapi.json
- copy/update package.json
- copy/update packages/ai/package.json
- copy/update packages/consumer-sdk/package.json
- copy/update packages/contracts/package.json
- copy/update packages/core/package.json
- copy/update packages/desktop/package.json
- copy/update packages/github-agent/package.json
- copy/update packages/governance-mcp-server/package.json
- copy/update packages/governance/package.json
- copy/update packages/memory/package.json
- copy/update packages/slack-agent-ui/package.json
- copy/update packages/slack-agent/package.json
- copy/update packages/tui/package.json
- copy/update packages/vscode-extension/package.json
- copy/update packages/web/package.json
- copy/update src/index.ts
- copy/update src/platform/a2a-client.ts
- copy/update src/platform/client.ts

## Public-only commits since last generated sync

- e5f9e8b2 Declare managed agent capabilities during init

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #293 to internal source `a5f0df2a5f7618f0fb9abdc341d16b130bf4ae18`