### PR TITLE
Declare managed agent capabilities during init

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -20,6 +20,7 @@ Options
   --trace-mode <mode>                 none, mcp_events, or otlp
   --memory-mode <mode>                none, read_only, durable, or cerebro
   --runtime-owner <owner>             external or evalops
+  --capability <cap[,cap...]>         Agent capability to declare; repeatable
   --workspace, --workspace-id <id>    Workspace to associate with the registration
   --scope <scope[,scope...]>          Registration scopes to request
   --key-scope <scope[,scope...]>      API key scopes to request
@@ -74,6 +75,14 @@ export function parseInitArgs(args: string[]): EvalOpsInitOptions {
 			case "--key-scope":
 				options.apiKeyScopes = appendScopes(
 					options.apiKeyScopes,
+					readValue(args, i, arg),
+				);
+				i++;
+				break;
+			case "--capabilities":
+			case "--capability":
+				options.capabilities = appendScopes(
+					options.capabilities,
 					readValue(args, i, arg),
 				);
 				i++;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -194,6 +194,7 @@ export function printHelp(version: string) {
 		`  maestro init                         Login, create or reuse an API key, and register this agent
   maestro init --rotate-key           Replace the stored agent MCP API key
   maestro init --mcp-url <url>        Override the EvalOps agent MCP endpoint
+  maestro init --capability code:write Declare an agent-registry capability
   maestro init --json                 Emit machine-readable bootstrap output`,
 	)}`;
 	const hostedRunnerSection = `${sectionHeading("maestro hosted-runner")}${muted(

--- a/src/evalops/agent-bootstrap.ts
+++ b/src/evalops/agent-bootstrap.ts
@@ -18,6 +18,27 @@ const AGENT_MCP_MANIFEST_PATH = "/.well-known/evalops/agent-mcp.json";
 const AGENT_MCP_PATH = "/mcp";
 const DEFAULT_AGENT_TYPE = "maestro";
 const DEFAULT_SURFACE = "cli";
+const DEFAULT_AGENT_NEUTRAL_CAPABILITIES = [
+	"mcp",
+	"tool.use",
+	"responses:create",
+];
+const DEFAULT_MAESTRO_AGENT_CAPABILITIES = [
+	"maestro:init",
+	"maestro:cli",
+	"conversation:manage",
+	"workflow:orchestrate",
+	"code:write",
+	"code:review",
+	"code:test",
+	"shell",
+	"git",
+	"fs",
+	"mcp",
+	"tool.use",
+	"research",
+	"responses:create",
+];
 const DEFAULT_API_KEY_SCOPES = [
 	"agent:register",
 	"agent:heartbeat",
@@ -31,6 +52,7 @@ const DEFAULT_API_KEY_SCOPES = [
 export interface EvalOpsInitOptions {
 	agentType?: string;
 	apiKeyScopes?: string[];
+	capabilities?: string[];
 	expiresInDays?: number;
 	forceLogin?: boolean;
 	integrationProfile?: string;
@@ -596,6 +618,25 @@ function runtimeOwnerForOptions(options: EvalOpsInitOptions): string {
 	);
 }
 
+function capabilitiesForOptions(options: EvalOpsInitOptions): string[] {
+	const requested = stringArray(options.capabilities);
+	const defaults =
+		(options.agentType ?? DEFAULT_AGENT_TYPE) === DEFAULT_AGENT_TYPE
+			? DEFAULT_MAESTRO_AGENT_CAPABILITIES
+			: DEFAULT_AGENT_NEUTRAL_CAPABILITIES;
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const capability of requested ?? defaults) {
+		const normalized = nonEmptyString(capability);
+		if (!normalized) continue;
+		const key = normalized.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(normalized);
+	}
+	return out;
+}
+
 async function createAgentAPIKey(
 	options: EvalOpsInitOptions,
 	identityBaseUrl: string,
@@ -662,7 +703,7 @@ async function registerAgent(
 		"evalops_register",
 		{
 			agent_type: options.agentType ?? DEFAULT_AGENT_TYPE,
-			capabilities: ["maestro:init", "maestro:cli"],
+			capabilities: capabilitiesForOptions(options),
 			integration_profile: integrationProfileForOptions(options),
 			memory_mode: memoryModeForOptions(options),
 			runtime_owner: runtimeOwnerForOptions(options),

--- a/test/cli/init-command.test.ts
+++ b/test/cli/init-command.test.ts
@@ -33,7 +33,24 @@ describe("maestro init command", () => {
 		);
 		expect(help).toContain("--rotate-key");
 		expect(help).toContain("--mcp-url <url>");
+		expect(help).toContain("--capability <cap[,cap...]>");
 		expect(help).toContain("--json");
+	});
+
+	it("parses explicit agent capabilities for custom shims", () => {
+		expect(
+			parseInitArgs([
+				"--agent-type",
+				"codex",
+				"--capability",
+				"code:write,git",
+				"--capabilities",
+				"x-demo:plan",
+			]),
+		).toMatchObject({
+			agentType: "codex",
+			capabilities: ["code:write", "git", "x-demo:plan"],
+		});
 	});
 
 	it("still rejects unknown bootstrap options", () => {

--- a/test/evalops/agent-bootstrap.test.ts
+++ b/test/evalops/agent-bootstrap.test.ts
@@ -187,6 +187,20 @@ describe("bootstrapEvalOpsAgent", () => {
 		]);
 		expect(calls[0]?.args).toMatchObject({
 			agent_type: "maestro",
+			capabilities: expect.arrayContaining([
+				"maestro:init",
+				"maestro:cli",
+				"code:write",
+				"code:review",
+				"code:test",
+				"shell",
+				"git",
+				"fs",
+				"mcp",
+				"tool.use",
+				"research",
+				"responses:create",
+			]),
 			integration_profile: "managed_runtime",
 			memory_mode: "durable",
 			runtime_owner: "evalops",
@@ -296,6 +310,7 @@ describe("bootstrapEvalOpsAgent", () => {
 
 		expect(calls[0]?.args).toMatchObject({
 			agent_type: "codex",
+			capabilities: ["mcp", "tool.use", "responses:create"],
 			integration_profile: "mcp_otlp",
 			memory_mode: "durable",
 			runtime_owner: "external",
@@ -320,6 +335,77 @@ describe("bootstrapEvalOpsAgent", () => {
 			runtimeOwner: "external",
 			shimType: "command_wrapper",
 			traceMode: "otlp",
+		});
+	});
+
+	it("lets external shims declare explicit agent-registry capabilities", async () => {
+		const calls: Array<{ args: Record<string, unknown>; tool: string }> = [];
+		const createMcpClient = vi.fn(
+			(_endpoint: string, _token: string): EvalOpsMcpClient => ({
+				callTool: async (tool, args) => {
+					calls.push({ args, tool });
+					if (tool === "evalops_register") {
+						return {
+							content: [],
+							structuredContent: {
+								agent_id: "agent_custom",
+								registered: true,
+								run_id: "run_custom",
+							},
+						};
+					}
+					if (tool === "evalops_check_action") {
+						return { content: [], structuredContent: { decision: "allow" } };
+					}
+					if (tool === "evalops_control_plane_summary") {
+						return {
+							content: [],
+							structuredContent: {
+								evidence: [{ id: "proof", trace: "run_custom" }],
+								findings: [],
+								metrics: { total_tools: 1 },
+								policy_controls: [{ label: "Starter policy" }],
+								tools: [{ name: "evalops_check_action" }],
+							},
+						};
+					}
+					throw new Error(`unexpected tool ${tool}`);
+				},
+				close: async () => undefined,
+				connect: async () => undefined,
+			}),
+		);
+
+		await bootstrapEvalOpsAgent(
+			{
+				agentType: "external-agent",
+				capabilities: [" code:write ", "git", "code:write", "x-demo:plan"],
+				mcpUrl: "https://app.evalops.dev",
+			},
+			{
+				createMcpClient,
+				fetch: vi.fn(
+					async () =>
+						new Response(JSON.stringify({ api_key: "eoak_created" }), {
+							status: 201,
+						}),
+				),
+				getOAuthToken: vi.fn().mockResolvedValue("oauth-access"),
+				hasOAuthCredentials: vi.fn().mockReturnValue(true),
+				loadCredentials: vi.fn(() => ({
+					type: "oauth",
+					access: "oauth-access",
+					metadata: { organizationId: "org_evalops" },
+				})),
+				login: vi.fn(),
+				now: () => new Date("2026-05-06T06:00:00Z"),
+				saveCredentials: vi.fn(),
+			},
+		);
+
+		expect(calls[0]?.args).toMatchObject({
+			agent_type: "external-agent",
+			capabilities: ["code:write", "git", "x-demo:plan"],
 		});
 	});
 


### PR DESCRIPTION
## Summary
- expand managed Maestro registration from the old init/cli pair to the governed coding-agent capability set
- add explicit --capability/--capabilities init flags so non-Maestro shims can declare their real surface
- keep external agents on neutral defaults unless they opt into richer capabilities

Source-of-truth internal PR: https://github.com/evalops/maestro-internal/pull/1676
Companion Platform receiver guard: https://github.com/evalops/platform/pull/1530

## Test plan
- node ./scripts/run-vitest.js --run test/evalops/agent-bootstrap.test.ts test/cli/init-command.test.ts
- precommit hook: Guardian, biome/lint:evals, codegen/build, compiled dist/maestro-bun