### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/slack-agent/src/agent-runner.ts
+++ b/packages/slack-agent/src/agent-runner.ts
@@ -21,9 +21,12 @@ import { isRetryableError, retryAsync } from "./errors.js";
 import * as logger from "./logger.js";
 import {
 	type SlackRuntimeEventType,
-	recordSlackAgentRuntimeEvent,
 	recordSlackAgentRuntimeTrigger,
 } from "./platform-runtime.js";
+import {
+	type RuntimeEventRecorder,
+	createRuntimeEventRecorder,
+} from "./runtime-event-recorder.js";
 import {
 	type Executor,
 	type SandboxConfig,
@@ -173,17 +176,6 @@ interface LogMessage {
 	}>;
 	isBot?: boolean;
 }
-
-type RuntimeEventAttributes = Record<
-	string,
-	string | number | boolean | null | undefined
->;
-
-type RuntimeEventRecorder = (
-	type: SlackRuntimeEventType,
-	message: string,
-	attributes?: RuntimeEventAttributes,
-) => Promise<void>;
 
 interface Thread {
 	parentTs: string;
@@ -715,50 +707,6 @@ export interface AgentRunnerOptions {
 	) => void;
 }
 
-function compactRuntimeAttributes(
-	attributes: RuntimeEventAttributes | undefined,
-): Record<string, string | number | boolean> {
-	const result: Record<string, string | number | boolean> = {};
-	for (const [key, value] of Object.entries(attributes ?? {})) {
-		if (value === undefined || value === null) {
-			continue;
-		}
-		if (typeof value === "string") {
-			const trimmed = value.trim();
-			if (trimmed) {
-				result[key] = trimmed;
-			}
-			continue;
-		}
-		result[key] = value;
-	}
-	return result;
-}
-
-function createRuntimeEventRecorder(
-	ctx: SlackContext,
-	runId: string | undefined,
-): RuntimeEventRecorder {
-	if (!runId) {
-		return async () => undefined;
-	}
-	return async (type, message, attributes) => {
-		try {
-			await recordSlackAgentRuntimeEvent(ctx, {
-				runId,
-				type,
-				message,
-				attributes: compactRuntimeAttributes(attributes),
-			});
-		} catch (error) {
-			logger.logWarning(
-				"Platform AgentRuntime event recording skipped",
-				error instanceof Error ? error.message : String(error),
-			);
-		}
-	};
-}
-
 export function createAgentRunner(
 	sandboxConfig: SandboxConfig,
 	workingDir?: string,
@@ -803,7 +751,13 @@ export function createAgentRunner(
 			);
 			const memory = getMemory(channelDir);
 			let recentMessages = "";
-			let recordRuntimeEvent: RuntimeEventRecorder = async () => undefined;
+			let runtimeEventRecorder: RuntimeEventRecorder =
+				createRuntimeEventRecorder(ctx, undefined);
+			const recordRuntimeEvent = (
+				type: SlackRuntimeEventType,
+				message: string,
+				attributes?: Parameters<RuntimeEventRecorder["record"]>[2],
+			) => runtimeEventRecorder.record(type, message, attributes);
 
 			// Build file content section for code/text files attached to current message
 			let fileContentSection = "";
@@ -1306,7 +1260,7 @@ export function createAgentRunner(
 				});
 				if (runtimeResult?.runId) {
 					ctx.platformRunId = runtimeResult.runId;
-					recordRuntimeEvent = createRuntimeEventRecorder(
+					runtimeEventRecorder = createRuntimeEventRecorder(
 						ctx,
 						runtimeResult.runId,
 					);
@@ -1367,6 +1321,7 @@ export function createAgentRunner(
 				throw error;
 			}
 
+			await runtimeEventRecorder.flush();
 			await queue.flush();
 
 			// Get final assistant message and replace main message

--- a/packages/slack-agent/src/platform-runtime.ts
+++ b/packages/slack-agent/src/platform-runtime.ts
@@ -349,7 +349,11 @@ function buildRuntimeHeaders(
 
 function normalizeAgentRuntimeBaseUrl(value: string): string {
 	let normalized = value.trim().replace(/\/+$/, "");
-	for (const suffix of [HANDLE_TRIGGER_PATH, AGENT_RUNTIME_SERVICE_SUFFIX]) {
+	for (const suffix of [
+		HANDLE_TRIGGER_PATH,
+		RECORD_RUN_EVENT_PATH,
+		AGENT_RUNTIME_SERVICE_SUFFIX,
+	]) {
 		if (normalized.endsWith(suffix)) {
 			normalized = normalized.slice(0, -suffix.length).replace(/\/+$/, "");
 		}

--- a/packages/slack-agent/src/runtime-event-recorder.ts
+++ b/packages/slack-agent/src/runtime-event-recorder.ts
@@ -1,0 +1,98 @@
+import * as logger from "./logger.js";
+import {
+	type PlatformRuntimeEventResult,
+	type SlackRuntimeEventOptions,
+	type SlackRuntimeEventType,
+	recordSlackAgentRuntimeEvent,
+} from "./platform-runtime.js";
+import type { SlackContext } from "./slack/bot.js";
+
+type RuntimeEventAttributes = Record<
+	string,
+	string | number | boolean | null | undefined
+>;
+
+type RuntimeEventWriter = (
+	ctx: SlackContext,
+	options: SlackRuntimeEventOptions,
+) => Promise<PlatformRuntimeEventResult | null>;
+
+export interface RuntimeEventRecorder {
+	record: (
+		type: SlackRuntimeEventType,
+		message: string,
+		attributes?: RuntimeEventAttributes,
+	) => Promise<void>;
+	flush: () => Promise<void>;
+}
+
+export interface RuntimeEventRecorderOptions {
+	writeEvent?: RuntimeEventWriter;
+	logWarning?: (message: string, detail: string) => void;
+}
+
+export function createRuntimeEventRecorder(
+	ctx: SlackContext,
+	runId: string | undefined,
+	options: RuntimeEventRecorderOptions = {},
+): RuntimeEventRecorder {
+	if (!runId) {
+		return {
+			record: async () => undefined,
+			flush: async () => undefined,
+		};
+	}
+
+	const writeEvent = options.writeEvent ?? recordSlackAgentRuntimeEvent;
+	const logWarning = options.logWarning ?? logger.logWarning;
+	let tail: Promise<void> = Promise.resolve();
+
+	const record: RuntimeEventRecorder["record"] = (
+		type,
+		message,
+		attributes,
+	) => {
+		const task = tail.then(async () => {
+			try {
+				await writeEvent(ctx, {
+					runId,
+					type,
+					message,
+					attributes: compactRuntimeAttributes(attributes),
+				});
+			} catch (error) {
+				logWarning(
+					"Platform AgentRuntime event recording skipped",
+					error instanceof Error ? error.message : String(error),
+				);
+			}
+		});
+		tail = task.catch(() => undefined);
+		return task;
+	};
+
+	return {
+		record,
+		flush: () => tail,
+	};
+}
+
+function compactRuntimeAttributes(
+	attributes: RuntimeEventAttributes | undefined,
+): Record<string, string | number | boolean> {
+	const result: Record<string, string | number | boolean> = {};
+	for (const [key, value] of Object.entries(attributes ?? {})) {
+		if (value === undefined || value === null) {
+			continue;
+		}
+		if (typeof value === "string") {
+			const trimmed = value.trim();
+			if (trimmed) {
+				result[key] = trimmed;
+			}
+			continue;
+		}
+		result[key] = value;
+	}
+	return result;
+}

--- a/packages/slack-agent/test/platform-runtime.test.ts
+++ b/packages/slack-agent/test/platform-runtime.test.ts
@@ -68,6 +68,15 @@ describe("resolvePlatformRuntimeConfig", () => {
 		expect(resolved?.agentId).toBe("maestro-slack-agent");
 	});
 
+	it("normalizes RecordRunEvent endpoint URLs", () => {
+		const resolved = resolvePlatformRuntimeConfig({
+			SLACK_AGENT_PLATFORM_RUNTIME_URL:
+				"https://platform.example/agentruntime.v1.AgentRuntimeService/RecordRunEvent",
+		});
+
+		expect(resolved?.baseUrl).toBe("https://platform.example");
+	});
+
 	it("resolves organization scoping for Connect requests", () => {
 		const resolved = resolvePlatformRuntimeConfig({
 			SLACK_AGENT_PLATFORM_RUNTIME_URL: "https://platform.example",

--- a/packages/slack-agent/test/runtime-event-recorder.test.ts
+++ b/packages/slack-agent/test/runtime-event-recorder.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRuntimeEventRecorder } from "../src/runtime-event-recorder.js";
+import type { SlackContext } from "../src/slack/bot.js";
+
+function context(): SlackContext {
+	return {
+		teamId: "T123",
+		channelName: "eng-ops",
+		channels: [],
+		users: [],
+		threadKey: "1710000000.000100",
+		useThread: true,
+		runId: "run_test",
+		source: "channel",
+		message: {
+			text: "investigate",
+			rawText: "investigate",
+			user: "U123",
+			userName: "Ada",
+			teamId: "T123",
+			channel: "C123",
+			ts: "1710000000.000100",
+			threadTs: undefined,
+			attachments: [],
+		},
+		store: {} as SlackContext["store"],
+		respond: async () => undefined,
+		replaceMessage: async () => undefined,
+		respondInThread: async () => undefined,
+		setTyping: async () => undefined,
+		uploadFile: async () => undefined,
+		setWorking: async () => undefined,
+		updateStatus: async () => undefined,
+	};
+}
+
+describe("createRuntimeEventRecorder", () => {
+	it("serializes overlapping runtime event writes", async () => {
+		let releaseFirst: () => void = () => undefined;
+		const firstWrite = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		const calls: string[] = [];
+		const writeEvent = vi.fn(async (_ctx, options) => {
+			calls.push(`start:${options.message}`);
+			if (options.message === "first") {
+				await firstWrite;
+			}
+			calls.push(`end:${options.message}`);
+			return null;
+		});
+
+		const recorder = createRuntimeEventRecorder(context(), "run_platform", {
+			writeEvent,
+		});
+		const first = recorder.record(
+			"RUNTIME_EVENT_TYPE_TOOL_CALL_RECORDED",
+			"first",
+		);
+		const second = recorder.record(
+			"RUNTIME_EVENT_TYPE_TOOL_RESULT_RECORDED",
+			"second",
+		);
+
+		await Promise.resolve();
+		expect(calls).toEqual(["start:first"]);
+
+		releaseFirst();
+		await Promise.all([first, second, recorder.flush()]);
+
+		expect(calls).toEqual([
+			"start:first",
+			"end:first",
+			"start:second",
+			"end:second",
+		]);
+	});
+
+	it("keeps the queue alive after a failed event write", async () => {
+		const calls: string[] = [];
+		const logWarning = vi.fn();
+		const writeEvent = vi.fn(async (_ctx, options) => {
+			calls.push(options.message);
+			if (options.message === "first") {
+				throw new Error("temporary outage");
+			}
+			return null;
+		});
+		const recorder = createRuntimeEventRecorder(context(), "run_platform", {
+			writeEvent,
+			logWarning,
+		});
+
+		await recorder.record(
+			"RUNTIME_EVENT_TYPE_AGENT_PROGRESS_RECORDED",
+			"first",
+		);
+		await recorder.record(
+			"RUNTIME_EVENT_TYPE_AGENT_PROGRESS_RECORDED",
+			"second",
+		);
+
+		expect(calls).toEqual(["first", "second"]);
+		expect(logWarning).toHaveBeenCalledWith(
+			"Platform AgentRuntime event recording skipped",
+			"temporary outage",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `63f5399cd0832e6b10ea96650c29d69088c96c76`
- last generated public sync base: `e4a6b997c77d5a9b0a8476ac2970ff0421b1b423`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `2`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (63f5399cd083)`
- public projection: `https://github.com/evalops/maestro@main (30a542d1c9a9)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/slack-agent/src/agent-runner.ts
- copy/update packages/slack-agent/src/platform-runtime.ts
- copy/update packages/slack-agent/src/runtime-event-recorder.ts
- copy/update packages/slack-agent/test/platform-runtime.test.ts
- copy/update packages/slack-agent/test/runtime-event-recorder.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/slack-agent/src/agent-runner.ts
- copy/update packages/slack-agent/src/platform-runtime.ts
- copy/update packages/slack-agent/src/runtime-event-recorder.ts
- copy/update packages/slack-agent/test/platform-runtime.test.ts
- copy/update packages/slack-agent/test/runtime-event-recorder.test.ts

## Public-only commits since last generated sync

- 30a542d1 feat(slack-agent): record Platform runtime lifecycle events
- 565ca0d8 feat: record Slack runs in Platform AgentRuntime (#294)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #301 to internal source `63f5399cd0832e6b10ea96650c29d69088c96c76`