### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/design/PLATFORM_AGENT_RUNTIME_SESSION_BRIDGE.md
+++ b/docs/design/PLATFORM_AGENT_RUNTIME_SESSION_BRIDGE.md
@@ -9,15 +9,19 @@ runtime owner.
 Maestro remains the source of truth for the live headless runtime: session
 ownership, connection leases, prompt execution, approval mode, and local
 workspace state all stay in Maestro. Platform AgentRuntime receives a durable
-projection of that session start so Platform can correlate work across A2A
-tasks, AgentRuntime runs, traces, worker queues, and hosted-runner health.
+projection of that session start and, when Platform returns a leased run
+handle, a best-effort stream of hosted runtime progress. Platform can correlate
+work across A2A tasks, AgentRuntime runs, traces, worker queues, hosted-runner
+health, and timeline views without owning the live session.
 
-The bridge is intentionally one-way at session start:
+The bridge is intentionally anchored by session start:
 
 1. A headless session is created or attached.
 2. Maestro records a Platform AgentRuntime trigger.
 3. Platform returns an AgentRun, or an A2A task that maps back to an AgentRun.
-4. Maestro stores only correlation handles on the hosted-runner context.
+4. Maestro stores correlation handles on the hosted-runner context.
+5. If the AgentRun includes a lease token, Maestro records turn, tool, wait,
+   and resume progress back to Platform.
 
 Maestro does not let Platform mutate the live runtime in this path. If the
 Platform write fails or is not configured, the headless session still starts.
@@ -27,6 +31,7 @@ Platform write fails or is not configured, the headless session still starts.
 | File | Responsibility |
 |------|----------------|
 | `src/server/handlers/headless-sessions.ts` | Starts headless runtimes, chooses session ownership, captures HTTP trace context, and stores hosted-runner correlation fields. |
+| `src/server/hosted-agent-runtime-progress.ts` | Converts hosted runtime events into leased AgentRuntime step, wait, and resume writes. |
 | `src/platform/agent-runtime-client.ts` | Builds Platform AgentRuntime triggers, normalizes Connect responses, selects the Connect or A2A transport, and maps A2A task metadata back into AgentRuntime-shaped results. |
 | `src/platform/a2a-client.ts` | Implements the A2A HTTP/JSON facade: agent-card discovery, message send, task lookup, Platform headers, and trace propagation. |
 
@@ -106,22 +111,44 @@ Hosted-runner context stores only the Platform handles that operators and
 support tools need:
 
 - `agentRunId`
+- `agentRuntimeLeaseToken`
 - `a2aMessageId`
 - `a2aTaskId`
 - `agentRuntimeWorkerQueue`
 - `agentRuntimeCorrelationPath`
 
-These fields are surfaced by health and identity endpoints, but they are not a
-replacement for the headless runtime snapshot. They let Platform, deploy smoke
-tests, and support workflows join a Maestro session to the AgentRuntime run and
-A2A task without granting them ownership of the live session.
+The lease token is used only inside the hosted runtime process for progress
+writes. Health and identity endpoints surface the support-grade ids, not the
+lease token. These fields are not a replacement for the headless runtime
+snapshot. They let Platform, deploy smoke tests, and support workflows join a
+Maestro session to the AgentRuntime run and A2A task without granting them
+ownership of the live session.
+
+## Runtime Progress Projection
+
+`hosted-agent-runtime-progress.ts` listens to the local headless runtime event
+stream and records only structural progress metadata:
+
+- `turn_start` and `turn_end` become model-call steps.
+- Tool starts become tool-intent steps; tool ends become tool-result or error
+  steps.
+- Pending server requests become AgentRuntime waits with checkpoints.
+- Server-request resolutions resume the matching AgentRuntime wait.
+
+The recorder is deliberately inert unless the hosted-runner context has both
+`agentRunId` and `agentRuntimeLeaseToken`. Writes are queued in order and
+logged as warnings on failure; a Platform outage must not interrupt local
+prompt execution. Tool arguments are summarized as key names instead of copied
+into Platform progress payloads.
 
 ## Failure Behavior
 
-The bridge is best-effort for session-start recording:
+The bridge is best-effort for session-start and runtime-progress recording:
 
 - Missing Platform config returns `null`.
 - Platform/A2A failures return `null`.
+- Progress writes no-op without a run id and lease token.
+- Progress write failures are logged and later progress writes continue.
 - Abort errors are rethrown so shutdown and request cancellation still behave
   correctly.
 - The headless session continues even when the Platform record is unavailable.
@@ -136,9 +163,11 @@ When changing the bridge, verify the behavior at all three layers:
 
 1. Unit tests for request shape and normalization:
    `npm run test -- test/platform/agent-runtime-client.test.ts test/platform/a2a-client.test.ts`
-2. Headless-session tests for hosted-runner correlation:
+2. Runtime-progress tests for step, wait, resume, and failure-safe behavior:
+   `npm run test -- test/server/hosted-agent-runtime-progress.test.ts`
+3. Headless-session tests for hosted-runner correlation:
    `npm run test -- test/web/headless-sessions.test.ts`
-3. Managed deployment smoke tests for live A2A trace projection in `evalops/deploy`.
+4. Managed deployment smoke tests for live A2A trace projection in `evalops/deploy`.
 
 Keep new code behind this adapter boundary. Server handlers should pass
 session facts into the bridge and store returned correlation handles; they

--- a/src/server/app-context.ts
+++ b/src/server/app-context.ts
@@ -30,6 +30,7 @@ export interface HostedRunnerContext {
 	listenPort?: number;
 	workspaceId?: string;
 	agentRunId?: string;
+	agentRuntimeLeaseToken?: string;
 	a2aMessageId?: string;
 	a2aTaskId?: string;
 	agentRuntimeWorkerQueue?: string;

--- a/src/server/handlers/headless-sessions.ts
+++ b/src/server/handlers/headless-sessions.ts
@@ -653,6 +653,7 @@ async function recordPlatformAgentRuntimeSessionStart(options: {
 	if (result.run.id) {
 		hostedRunner.agentRunId = result.run.id;
 	}
+	hostedRunner.agentRuntimeLeaseToken = result.run.lease?.token;
 	// Store only support-grade handles on the hosted runner. The full run/task
 	// state stays in Platform; health and identity endpoints expose these ids
 	// for operators without making Platform a session-state dependency.

--- a/src/server/headless-runtime-service.ts
+++ b/src/server/headless-runtime-service.ts
@@ -63,6 +63,10 @@ import { WebActionApprovalService } from "./approval-service.js";
 import { getAgentCircuitBreaker } from "./circuit-breaker.js";
 import { clientToolService } from "./client-tools-service.js";
 import {
+	type HostedAgentRuntimeProgressRecorder,
+	createHostedAgentRuntimeProgressRecorder,
+} from "./hosted-agent-runtime-progress.js";
+import {
 	type ServerRequestLifecycleEvent,
 	serverRequestManager,
 } from "./server-request-manager.js";
@@ -607,7 +611,10 @@ type RuntimeOptions = {
 	approvalMode: ApprovalMode;
 	enableClientTools?: boolean;
 	client?: "vscode" | "jetbrains" | "conductor" | "generic";
-	context: Pick<WebServerContext, "createAgent" | "createBackgroundAgent">;
+	context: Pick<
+		WebServerContext,
+		"createAgent" | "createBackgroundAgent" | "hostedRunner"
+	>;
 	sessionManager: SessionManager;
 };
 
@@ -645,6 +652,7 @@ export class HeadlessSessionRuntime {
 	private readonly updateSessionSummary: (event: AgentEvent) => void;
 	private readonly automaticMemoryConsolidation: AutomaticMemoryConsolidationCoordinator;
 	private readonly automaticMemoryExtraction: AutomaticMemoryExtractionCoordinator;
+	private readonly agentRuntimeProgress?: HostedAgentRuntimeProgressRecorder;
 
 	private constructor(
 		options: RuntimeOptions,
@@ -747,6 +755,11 @@ export class HeadlessSessionRuntime {
 		this.updateSessionSummary = createRuntimeSessionSummaryUpdater(
 			this.sessionManager,
 		);
+		this.agentRuntimeProgress = createHostedAgentRuntimeProgressRecorder({
+			sessionId: this.sessionId,
+			hostedRunner: options.context.hostedRunner,
+			workspaceRoot: this.workspaceRoot,
+		});
 
 		this.agent.subscribe((event) => {
 			this.handleAgentEvent(event);
@@ -874,6 +887,7 @@ export class HeadlessSessionRuntime {
 			await this.utilityCommands.dispose();
 			this.fileWatches.dispose();
 			this.agent.abort();
+			await this.agentRuntimeProgress?.flush();
 			await this.automaticMemoryExtraction.flush();
 			await this.automaticMemoryConsolidation.flush();
 			await this.sessionManager.flush();
@@ -2159,6 +2173,7 @@ export class HeadlessSessionRuntime {
 		} catch (error) {
 			const message =
 				error instanceof Error ? error.message : "Unknown remote runtime error";
+			this.agentRuntimeProgress?.recordPromptFailure(message);
 			this.publish({
 				type: "error",
 				message,
@@ -2224,6 +2239,7 @@ export class HeadlessSessionRuntime {
 	private handleAgentEvent(event: AgentEvent): void {
 		this.recordFleetEvent(event);
 		this.updateSessionSummary(event);
+		this.agentRuntimeProgress?.recordAgentEvent(event);
 
 		if (
 			Array.from(this.connections.values()).some(
@@ -2348,6 +2364,7 @@ export class HeadlessSessionRuntime {
 		if (event.request.sessionId !== this.sessionId) {
 			return;
 		}
+		this.agentRuntimeProgress?.recordServerRequestEvent(event);
 
 		if (event.type === "registered") {
 			if (this.publishedServerRequestIds.has(event.request.id)) {
@@ -2493,7 +2510,10 @@ export type EnsureRuntimeOptions = {
 	enableClientTools?: boolean;
 	client?: "vscode" | "jetbrains" | "conductor" | "generic";
 	registerConnection?: boolean;
-	context: Pick<WebServerContext, "createAgent" | "createBackgroundAgent">;
+	context: Pick<
+		WebServerContext,
+		"createAgent" | "createBackgroundAgent" | "hostedRunner"
+	>;
 	sessionManager: SessionManager;
 };
 

--- a/src/server/hosted-agent-runtime-progress.ts
+++ b/src/server/hosted-agent-runtime-progress.ts
@@ -1,0 +1,443 @@
+import type { AgentEvent } from "../agent/types.js";
+import {
+	type PlatformAgentRunStep,
+	PlatformAgentRunStepKindValue,
+	PlatformAgentRunStepStateValue,
+	PlatformAgentRunWaitTypeValue,
+	recordAgentRuntimeRunStep,
+	resumeAgentRuntimeRun,
+	waitAgentRuntimeRun,
+} from "../platform/agent-runtime-client.js";
+import { createLogger } from "../utils/logger.js";
+import type { ServerRequestLifecycleEvent } from "./server-request-manager.js";
+
+const logger = createLogger("server:hosted-agent-runtime-progress");
+
+export interface HostedAgentRuntimeProgressContext {
+	enabled: true;
+	agentRunId?: string;
+	agentRuntimeLeaseToken?: string;
+	agentRuntimeWorkerQueue?: string;
+	agentRuntimeCorrelationPath?: string;
+	workspaceId?: string;
+	runnerSessionId?: string;
+	ownerInstanceId?: string;
+}
+
+type ProgressOperation = () => Promise<unknown>;
+
+export interface HostedAgentRuntimeProgressRecorderOperations {
+	recordStep?: typeof recordAgentRuntimeRunStep;
+	waitRun?: typeof waitAgentRuntimeRun;
+	resumeRun?: typeof resumeAgentRuntimeRun;
+}
+
+export interface HostedAgentRuntimeProgressRecorderOptions {
+	sessionId: string;
+	hostedRunner?: HostedAgentRuntimeProgressContext;
+	workspaceRoot?: string;
+	operations?: HostedAgentRuntimeProgressRecorderOperations;
+}
+
+function safeIdPart(value: string): string {
+	return value.replace(/[^A-Za-z0-9_.:-]+/g, "_").slice(0, 96) || "unknown";
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0
+		? value
+		: undefined;
+}
+
+function objectKeys(value: unknown): string[] | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const keys = Object.keys(value).sort();
+	return keys.length > 0 ? keys : undefined;
+}
+
+function toolDisplayName(event: {
+	displayName?: string;
+	summaryLabel?: string;
+	toolName: string;
+}): string {
+	return event.displayName ?? event.summaryLabel ?? event.toolName;
+}
+
+function waitTypeForRequest(
+	kind: ServerRequestLifecycleEvent["request"]["kind"],
+): PlatformAgentRunWaitTypeValue {
+	switch (kind) {
+		case "approval":
+		case "tool_retry":
+			return PlatformAgentRunWaitTypeValue.Approval;
+		case "client_tool":
+		case "mcp_elicitation":
+		case "user_input":
+			return PlatformAgentRunWaitTypeValue.Input;
+	}
+}
+
+export class HostedAgentRuntimeProgressRecorder {
+	private readonly sessionId: string;
+	private readonly hostedRunner?: HostedAgentRuntimeProgressContext;
+	private readonly workspaceRoot?: string;
+	private readonly operations: Required<HostedAgentRuntimeProgressRecorderOperations>;
+	private readonly pendingWaitIds = new Map<string, string>();
+	private readonly resumedWaitIds = new Set<string>();
+	private pending: Promise<void> = Promise.resolve();
+	private turnIndex = 0;
+
+	constructor(options: HostedAgentRuntimeProgressRecorderOptions) {
+		this.sessionId = options.sessionId;
+		this.hostedRunner = options.hostedRunner;
+		this.workspaceRoot = options.workspaceRoot;
+		this.operations = {
+			recordStep: options.operations?.recordStep ?? recordAgentRuntimeRunStep,
+			waitRun: options.operations?.waitRun ?? waitAgentRuntimeRun,
+			resumeRun: options.operations?.resumeRun ?? resumeAgentRuntimeRun,
+		};
+	}
+
+	recordAgentEvent(event: AgentEvent): void {
+		switch (event.type) {
+			case "agent_start":
+				this.recordStep({
+					id: this.stepId("agent", `start-${this.turnIndex + 1}`),
+					name: event.continuation ? "Agent continuation" : "Agent run",
+					stepKind: PlatformAgentRunStepKindValue.System,
+					state: PlatformAgentRunStepStateValue.Running,
+					input: this.basePayload({
+						event_type: event.type,
+						continuation: event.continuation ?? false,
+					}),
+				});
+				return;
+			case "agent_end":
+				this.recordStep({
+					id: this.stepId("agent", `end-${this.turnIndex}`),
+					name: "Agent run completed",
+					stepKind:
+						event.aborted || event.stopReason === "error"
+							? PlatformAgentRunStepKindValue.Error
+							: PlatformAgentRunStepKindValue.System,
+					state:
+						event.aborted || event.stopReason === "error"
+							? PlatformAgentRunStepStateValue.Failed
+							: PlatformAgentRunStepStateValue.Succeeded,
+					output: this.basePayload({
+						event_type: event.type,
+						aborted: event.aborted ?? false,
+						stop_reason: event.stopReason,
+					}),
+				});
+				return;
+			case "turn_start":
+				this.turnIndex += 1;
+				this.recordStep({
+					id: this.stepId("turn", String(this.turnIndex)),
+					name: `Turn ${this.turnIndex}`,
+					stepKind: PlatformAgentRunStepKindValue.ModelCall,
+					state: PlatformAgentRunStepStateValue.Running,
+					input: this.basePayload({ event_type: event.type }),
+				});
+				return;
+			case "turn_end":
+				this.recordStep({
+					id: this.stepId("turn", String(this.turnIndex)),
+					name: `Turn ${this.turnIndex}`,
+					stepKind: PlatformAgentRunStepKindValue.ModelCall,
+					state: PlatformAgentRunStepStateValue.Succeeded,
+					output: this.basePayload({
+						event_type: event.type,
+						tool_result_count: event.toolResults.length,
+					}),
+				});
+				return;
+			case "tool_execution_start":
+				this.recordStep({
+					id: this.toolStepId(event.toolCallId),
+					name: toolDisplayName(event),
+					stepKind: PlatformAgentRunStepKindValue.ToolCallIntent,
+					state: PlatformAgentRunStepStateValue.Running,
+					input: this.basePayload({
+						event_type: event.type,
+						tool_call_id: event.toolCallId,
+						tool_execution_id: event.toolExecutionId,
+						tool_name: event.toolName,
+						display_name: event.displayName,
+						summary_label: event.summaryLabel,
+						arg_keys: objectKeys(event.args),
+					}),
+				});
+				return;
+			case "tool_execution_end":
+				this.recordStep({
+					id: this.toolStepId(event.toolCallId),
+					name: toolDisplayName(event),
+					stepKind: event.isError
+						? PlatformAgentRunStepKindValue.Error
+						: PlatformAgentRunStepKindValue.ToolResult,
+					state: event.isError
+						? PlatformAgentRunStepStateValue.Failed
+						: PlatformAgentRunStepStateValue.Succeeded,
+					errorMessage: event.isError
+						? (event.errorCode ?? event.governedOutcome ?? "tool failed")
+						: undefined,
+					output: this.basePayload({
+						event_type: event.type,
+						tool_call_id: event.toolCallId,
+						tool_execution_id: event.toolExecutionId,
+						approval_request_id: event.approvalRequestId,
+						tool_name: event.toolName,
+						display_name: event.displayName,
+						summary_label: event.summaryLabel,
+						error_code: event.errorCode,
+						governed_outcome: event.governedOutcome,
+					}),
+				});
+				return;
+			case "action_approval_required":
+				this.recordApprovalWait({
+					id: event.request.id,
+					callId: event.request.id,
+					toolName: event.request.toolName,
+					reason: event.request.reason,
+					displayName: event.request.displayName,
+					summaryLabel: event.request.summaryLabel,
+				});
+				return;
+			case "action_approval_resolved":
+				this.resumeWait({
+					id: event.request.id,
+					kind: "approval",
+					resolution: event.decision.approved ? "approved" : "denied",
+					resolvedBy: event.decision.resolvedBy ?? "user",
+					reason: event.decision.reason,
+				});
+				return;
+			case "error":
+				this.recordPromptFailure(event.message);
+				return;
+			default:
+				return;
+		}
+	}
+
+	recordServerRequestEvent(event: ServerRequestLifecycleEvent): void {
+		if (event.type === "registered") {
+			this.recordApprovalWait({
+				id: event.request.id,
+				callId: event.request.callId,
+				toolName: event.request.toolName,
+				reason: event.request.reason,
+				displayName: event.request.displayName,
+				summaryLabel: event.request.summaryLabel,
+				kind: event.request.kind,
+			});
+			return;
+		}
+		this.resumeWait({
+			id: event.request.id,
+			kind: event.request.kind,
+			resolution: event.resolution,
+			resolvedBy: event.resolvedBy,
+			reason: event.reason,
+		});
+	}
+
+	recordPromptFailure(message: string): void {
+		this.recordStep({
+			id: this.stepId("error", `${Date.now()}`),
+			name: "Prompt failed",
+			stepKind: PlatformAgentRunStepKindValue.Error,
+			state: PlatformAgentRunStepStateValue.Failed,
+			errorMessage: message,
+			output: this.basePayload({
+				event_type: "prompt_failure",
+			}),
+		});
+	}
+
+	async flush(): Promise<void> {
+		await this.pending;
+	}
+
+	private recordApprovalWait(input: {
+		id: string;
+		callId: string;
+		toolName: string;
+		reason: string;
+		displayName?: string;
+		summaryLabel?: string;
+		kind?: ServerRequestLifecycleEvent["request"]["kind"];
+	}): void {
+		if (this.pendingWaitIds.has(input.id)) {
+			return;
+		}
+		const waitId = this.waitId(input.id);
+		this.pendingWaitIds.set(input.id, waitId);
+		this.enqueue(async () => {
+			const handles = this.handles();
+			if (!handles) {
+				return;
+			}
+			await this.operations.waitRun({
+				runId: handles.runId,
+				leaseToken: handles.leaseToken,
+				wait: {
+					id: waitId,
+					stepId: this.toolStepId(input.callId),
+					type: waitTypeForRequest(input.kind ?? "approval"),
+					externalRef: input.id,
+					reason: input.reason,
+					payload: this.basePayload({
+						request_id: input.id,
+						request_type: input.kind ?? "approval",
+						call_id: input.callId,
+						tool_name: input.toolName,
+						display_name: input.displayName,
+						summary_label: input.summaryLabel,
+					}),
+				},
+				checkpoint: {
+					id: this.checkpointId(input.id),
+					stepId: this.toolStepId(input.callId),
+					resumeToken: waitId,
+					payload: this.basePayload({
+						request_id: input.id,
+						request_type: input.kind ?? "approval",
+					}),
+				},
+			});
+		});
+	}
+
+	private resumeWait(input: {
+		id: string;
+		kind: string;
+		resolution: string;
+		resolvedBy: string;
+		reason?: string;
+	}): void {
+		if (this.resumedWaitIds.has(input.id)) {
+			return;
+		}
+		this.resumedWaitIds.add(input.id);
+		const waitId = this.pendingWaitIds.get(input.id) ?? this.waitId(input.id);
+		this.pendingWaitIds.delete(input.id);
+		this.enqueue(async () => {
+			const handles = this.handles();
+			if (!handles) {
+				return;
+			}
+			await this.operations.resumeRun({
+				runId: handles.runId,
+				waitId,
+				resumeEventId: this.resumeEventId(input.id),
+				payload: this.basePayload({
+					request_id: input.id,
+					request_type: input.kind,
+					resolution: input.resolution,
+					resolved_by: input.resolvedBy,
+					reason: input.reason,
+				}),
+			});
+		});
+	}
+
+	private recordStep(step: PlatformAgentRunStep): void {
+		this.enqueue(async () => {
+			const handles = this.handles();
+			if (!handles) {
+				return;
+			}
+			await this.operations.recordStep({
+				runId: handles.runId,
+				leaseToken: handles.leaseToken,
+				step,
+			});
+		});
+	}
+
+	private enqueue(operation: ProgressOperation): void {
+		this.pending = this.pending.then(operation, operation).then(
+			() => {},
+			(error) => {
+				logger.warn("Failed to record hosted AgentRuntime progress", {
+					error: error instanceof Error ? error.message : String(error),
+					session_id: this.sessionId,
+					agent_run_id: this.hostedRunner?.agentRunId,
+				});
+			},
+		);
+	}
+
+	private handles(): { runId: string; leaseToken: string } | null {
+		const runId = nonEmptyString(this.hostedRunner?.agentRunId);
+		const leaseToken = nonEmptyString(
+			this.hostedRunner?.agentRuntimeLeaseToken,
+		);
+		if (!this.hostedRunner?.enabled || !runId || !leaseToken) {
+			return null;
+		}
+		return { runId, leaseToken };
+	}
+
+	private basePayload(
+		values: Record<string, unknown>,
+	): Record<string, unknown> {
+		return {
+			maestro_session_id: this.sessionId,
+			...(this.workspaceRoot ? { workspace_root: this.workspaceRoot } : {}),
+			...(this.hostedRunner?.workspaceId
+				? { workspace_id: this.hostedRunner.workspaceId }
+				: {}),
+			...(this.hostedRunner?.runnerSessionId
+				? { runner_session_id: this.hostedRunner.runnerSessionId }
+				: {}),
+			...(this.hostedRunner?.ownerInstanceId
+				? { owner_instance_id: this.hostedRunner.ownerInstanceId }
+				: {}),
+			...(this.hostedRunner?.agentRuntimeWorkerQueue
+				? { worker_queue: this.hostedRunner.agentRuntimeWorkerQueue }
+				: {}),
+			...(this.hostedRunner?.agentRuntimeCorrelationPath
+				? { correlation_path: this.hostedRunner.agentRuntimeCorrelationPath }
+				: {}),
+			...Object.fromEntries(
+				Object.entries(values).filter(([, value]) => value !== undefined),
+			),
+		};
+	}
+
+	private stepId(kind: string, id: string): string {
+		return `maestro:${safeIdPart(this.sessionId)}:${kind}:${safeIdPart(id)}`;
+	}
+
+	private toolStepId(toolCallId: string): string {
+		return this.stepId("tool", toolCallId);
+	}
+
+	private waitId(requestId: string): string {
+		return this.stepId("wait", requestId);
+	}
+
+	private checkpointId(requestId: string): string {
+		return this.stepId("checkpoint", requestId);
+	}
+
+	private resumeEventId(requestId: string): string {
+		return this.stepId("resume", requestId);
+	}
+}
+
+export function createHostedAgentRuntimeProgressRecorder(
+	options: HostedAgentRuntimeProgressRecorderOptions,
+): HostedAgentRuntimeProgressRecorder | undefined {
+	if (!options.hostedRunner?.enabled) {
+		return undefined;
+	}
+	return new HostedAgentRuntimeProgressRecorder(options);
+}

--- a/test/server/hosted-agent-runtime-progress.test.ts
+++ b/test/server/hosted-agent-runtime-progress.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentEvent } from "../../src/agent/types.js";
+import {
+	PlatformAgentRunStepKindValue,
+	PlatformAgentRunStepStateValue,
+	PlatformAgentRunWaitTypeValue,
+} from "../../src/platform/agent-runtime-client.js";
+import { HostedAgentRuntimeProgressRecorder } from "../../src/server/hosted-agent-runtime-progress.js";
+import type { ServerRequestLifecycleEvent } from "../../src/server/server-request-manager.js";
+
+function createRecorder(overrides?: {
+	agentRunId?: string;
+	agentRuntimeLeaseToken?: string;
+	recordStep?: ReturnType<typeof vi.fn>;
+	waitRun?: ReturnType<typeof vi.fn>;
+	resumeRun?: ReturnType<typeof vi.fn>;
+}) {
+	const recordStep =
+		overrides?.recordStep ?? vi.fn(async () => ({ run: { id: "run_1" } }));
+	const waitRun =
+		overrides?.waitRun ?? vi.fn(async () => ({ run: { id: "run_1" } }));
+	const resumeRun =
+		overrides?.resumeRun ?? vi.fn(async () => ({ run: { id: "run_1" } }));
+	const recorder = new HostedAgentRuntimeProgressRecorder({
+		sessionId: "session_1",
+		workspaceRoot: "/workspace",
+		hostedRunner: {
+			enabled: true,
+			agentRunId: overrides?.agentRunId ?? "run_1",
+			agentRuntimeLeaseToken:
+				overrides?.agentRuntimeLeaseToken ?? "lease-token-1",
+			workspaceId: "ws_1",
+			runnerSessionId: "mrs_1",
+			ownerInstanceId: "pod-a",
+			agentRuntimeWorkerQueue: "agent-runtime.production",
+		},
+		operations: { recordStep, waitRun, resumeRun },
+	});
+	return { recorder, recordStep, waitRun, resumeRun };
+}
+
+describe("hosted AgentRuntime progress recorder", () => {
+	it("records turn and tool progress as leased AgentRuntime steps", async () => {
+		const { recorder, recordStep } = createRecorder();
+
+		recorder.recordAgentEvent({ type: "turn_start" });
+		recorder.recordAgentEvent({
+			type: "tool_execution_start",
+			toolCallId: "call_1",
+			toolName: "shell",
+			displayName: "Shell",
+			args: { command: "npm test", secret: "not copied" },
+		});
+		recorder.recordAgentEvent({
+			type: "tool_execution_end",
+			toolCallId: "call_1",
+			toolName: "shell",
+			displayName: "Shell",
+			result: { type: "text", text: "ok" },
+			isError: false,
+		} as AgentEvent);
+		recorder.recordAgentEvent({
+			type: "turn_end",
+			message: { role: "assistant", content: [] },
+			toolResults: [],
+		} as AgentEvent);
+
+		await recorder.flush();
+
+		expect(recordStep).toHaveBeenCalledTimes(4);
+		expect(recordStep).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				runId: "run_1",
+				leaseToken: "lease-token-1",
+				step: expect.objectContaining({
+					id: "maestro:session_1:turn:1",
+					stepKind: PlatformAgentRunStepKindValue.ModelCall,
+					state: PlatformAgentRunStepStateValue.Running,
+				}),
+			}),
+		);
+		expect(recordStep).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({
+				step: expect.objectContaining({
+					id: "maestro:session_1:tool:call_1",
+					name: "Shell",
+					stepKind: PlatformAgentRunStepKindValue.ToolCallIntent,
+					state: PlatformAgentRunStepStateValue.Running,
+					input: expect.objectContaining({
+						arg_keys: ["command", "secret"],
+						maestro_session_id: "session_1",
+					}),
+				}),
+			}),
+		);
+		expect(recordStep).toHaveBeenNthCalledWith(
+			3,
+			expect.objectContaining({
+				step: expect.objectContaining({
+					id: "maestro:session_1:tool:call_1",
+					stepKind: PlatformAgentRunStepKindValue.ToolResult,
+					state: PlatformAgentRunStepStateValue.Succeeded,
+				}),
+			}),
+		);
+	});
+
+	it("records pending server requests as waits and resumes them on resolution", async () => {
+		const { recorder, waitRun, resumeRun } = createRecorder();
+		const registered: ServerRequestLifecycleEvent = {
+			type: "registered",
+			request: {
+				id: "approval_1",
+				kind: "approval",
+				sessionId: "session_1",
+				callId: "call_1",
+				toolName: "shell",
+				args: { command: "git status" },
+				reason: "Confirm shell",
+				timestamp: Date.now(),
+				timeoutMs: 60_000,
+			},
+		};
+		const resolved: ServerRequestLifecycleEvent = {
+			type: "resolved",
+			request: registered.request,
+			resolution: "approved",
+			resolvedBy: "user",
+			reason: "looks good",
+		};
+
+		recorder.recordServerRequestEvent(registered);
+		recorder.recordServerRequestEvent(resolved);
+		await recorder.flush();
+
+		expect(waitRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				runId: "run_1",
+				leaseToken: "lease-token-1",
+				wait: expect.objectContaining({
+					id: "maestro:session_1:wait:approval_1",
+					stepId: "maestro:session_1:tool:call_1",
+					type: PlatformAgentRunWaitTypeValue.Approval,
+					externalRef: "approval_1",
+				}),
+				checkpoint: expect.objectContaining({
+					id: "maestro:session_1:checkpoint:approval_1",
+					resumeToken: "maestro:session_1:wait:approval_1",
+				}),
+			}),
+		);
+		expect(resumeRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				runId: "run_1",
+				waitId: "maestro:session_1:wait:approval_1",
+				resumeEventId: "maestro:session_1:resume:approval_1",
+				payload: expect.objectContaining({
+					resolution: "approved",
+					resolved_by: "user",
+				}),
+			}),
+		);
+	});
+
+	it("no-ops when hosted Platform lease handles are absent", async () => {
+		const { recorder, recordStep, waitRun, resumeRun } = createRecorder({
+			agentRuntimeLeaseToken: "",
+		});
+
+		recorder.recordAgentEvent({ type: "turn_start" });
+		recorder.recordServerRequestEvent({
+			type: "registered",
+			request: {
+				id: "request_1",
+				kind: "user_input",
+				sessionId: "session_1",
+				callId: "request_1",
+				toolName: "ask_user",
+				args: {},
+				reason: "Need input",
+				timestamp: Date.now(),
+				timeoutMs: 60_000,
+			},
+		});
+		recorder.recordServerRequestEvent({
+			type: "resolved",
+			request: {
+				id: "request_1",
+				kind: "user_input",
+				sessionId: "session_1",
+				callId: "request_1",
+				toolName: "ask_user",
+				args: {},
+				reason: "Need input",
+				timestamp: Date.now(),
+				timeoutMs: 60_000,
+			},
+			resolution: "answered",
+			resolvedBy: "client",
+		});
+		await recorder.flush();
+
+		expect(recordStep).not.toHaveBeenCalled();
+		expect(waitRun).not.toHaveBeenCalled();
+		expect(resumeRun).not.toHaveBeenCalled();
+	});
+
+	it("keeps later progress flowing after a Platform write failure", async () => {
+		const recordStep = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Platform unavailable"))
+			.mockResolvedValue({ run: { id: "run_1" } });
+		const { recorder } = createRecorder({ recordStep });
+
+		recorder.recordAgentEvent({ type: "turn_start" });
+		recorder.recordAgentEvent({ type: "agent_start" });
+		await recorder.flush();
+
+		expect(recordStep).toHaveBeenCalledTimes(2);
+		expect(recordStep).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				step: expect.objectContaining({
+					id: "maestro:session_1:agent:start-2",
+				}),
+			}),
+		);
+	});
+});

--- a/test/web/headless-sessions.test.ts
+++ b/test/web/headless-sessions.test.ts
@@ -2839,6 +2839,9 @@ describe("headless session handlers", () => {
 							run: {
 								id: "agent_run_123",
 								state: PlatformAgentRunStateValue.Accepted,
+								lease: {
+									token: "lease-token-123",
+								},
 								linkage: {
 									runId: "agent_run_123",
 									workspaceId: "ws_hosted",
@@ -2919,6 +2922,9 @@ describe("headless session handlers", () => {
 				},
 			});
 			expect(context.hostedRunner?.agentRunId).toBe("agent_run_123");
+			expect(context.hostedRunner?.agentRuntimeLeaseToken).toBe(
+				"lease-token-123",
+			);
 			expect(context.hostedRunner?.a2aMessageId).toBeUndefined();
 			expect(context.hostedRunner?.a2aTaskId).toBeUndefined();
 			expect(context.hostedRunner?.agentRuntimeWorkerQueue).toBeUndefined();


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `d35ae45cf746fe294d91917ecb1e001cabe9ea10`
- last generated public sync base: `a4f661a3fc87ba4e0ab10a1e80a349b6d949e165`
- previewed public-tree drift: `7` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (d35ae45cf746)`
- public projection: `https://github.com/evalops/maestro@main (a4f661a3fc87)`
- files to copy or update: `7`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/design/PLATFORM_AGENT_RUNTIME_SESSION_BRIDGE.md
- copy/update src/server/app-context.ts
- copy/update src/server/handlers/headless-sessions.ts
- copy/update src/server/headless-runtime-service.ts
- copy/update src/server/hosted-agent-runtime-progress.ts
- copy/update test/server/hosted-agent-runtime-progress.test.ts
- copy/update test/web/headless-sessions.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/design/PLATFORM_AGENT_RUNTIME_SESSION_BRIDGE.md
- copy/update src/server/app-context.ts
- copy/update src/server/handlers/headless-sessions.ts
- copy/update src/server/headless-runtime-service.ts
- copy/update src/server/hosted-agent-runtime-progress.ts
- copy/update test/server/hosted-agent-runtime-progress.test.ts
- copy/update test/web/headless-sessions.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode