### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/design/PLATFORM_AGENT_RUNTIME_SESSION_BRIDGE.md
+++ b/docs/design/PLATFORM_AGENT_RUNTIME_SESSION_BRIDGE.md
@@ -22,6 +22,8 @@ The bridge is intentionally anchored by session start:
 4. Maestro stores correlation handles on the hosted-runner context.
 5. If the AgentRun includes a lease token, Maestro records turn, tool, wait,
    and resume progress back to Platform.
+6. When a managed hosted-runner drain explicitly flushes the active runtime,
+   Maestro completes or fails the Platform run.
 
 Maestro does not let Platform mutate the live runtime in this path. If the
 Platform write fails or is not configured, the headless session still starts.
@@ -31,7 +33,8 @@ Platform write fails or is not configured, the headless session still starts.
 | File | Responsibility |
 |------|----------------|
 | `src/server/handlers/headless-sessions.ts` | Starts headless runtimes, chooses session ownership, captures HTTP trace context, and stores hosted-runner correlation fields. |
-| `src/server/hosted-agent-runtime-progress.ts` | Converts hosted runtime events into leased AgentRuntime step, wait, and resume writes. |
+| `src/server/hosted-agent-runtime-progress.ts` | Converts hosted runtime events into leased AgentRuntime step, wait, resume, complete, and fail writes. |
+| `src/server/handlers/hosted-runner-drain.ts` | Defines the explicit terminal lifecycle boundary for successful or interrupted hosted-runner drains. |
 | `src/platform/agent-runtime-client.ts` | Builds Platform AgentRuntime triggers, normalizes Connect responses, selects the Connect or A2A transport, and maps A2A task metadata back into AgentRuntime-shaped results. |
 | `src/platform/a2a-client.ts` | Implements the A2A HTTP/JSON facade: agent-card discovery, message send, task lookup, Platform headers, and trace propagation. |
 
@@ -134,12 +137,21 @@ stream and records only structural progress metadata:
   steps.
 - Pending server requests become AgentRuntime waits with checkpoints.
 - Server-request resolutions resume the matching AgentRuntime wait.
+- Successful hosted-runner drain completes the Platform run.
+- Interrupted hosted-runner drain records a terminal error step and fails the
+  Platform run.
 
 The recorder is deliberately inert unless the hosted-runner context has both
 `agentRunId` and `agentRuntimeLeaseToken`. Writes are queued in order and
 logged as warnings on failure; a Platform outage must not interrupt local
 prompt execution. Tool arguments are summarized as key names instead of copied
 into Platform progress payloads.
+
+Terminal `CompleteRun` / `FailRun` calls are tied to hosted-runner drain,
+including Kubernetes preStop and process shutdown. Generic idle disposal is not
+a terminal signal because headless sessions can be disconnected and later
+resumed. The current Platform client has no `CancelRun` helper, so interrupted
+drains are represented with `FailRun` and a non-retryable drain error.
 
 ## Failure Behavior
 
@@ -165,9 +177,11 @@ When changing the bridge, verify the behavior at all three layers:
    `npm run test -- test/platform/agent-runtime-client.test.ts test/platform/a2a-client.test.ts`
 2. Runtime-progress tests for step, wait, resume, and failure-safe behavior:
    `npm run test -- test/server/hosted-agent-runtime-progress.test.ts`
-3. Headless-session tests for hosted-runner correlation:
+3. Hosted-runner drain tests for terminal complete/fail semantics:
+   `npm run test -- test/server/hosted-runner-drain.test.ts`
+4. Headless-session tests for hosted-runner correlation:
    `npm run test -- test/web/headless-sessions.test.ts`
-4. Managed deployment smoke tests for live A2A trace projection in `evalops/deploy`.
+5. Managed deployment smoke tests for live A2A trace projection in `evalops/deploy`.
 
 Keep new code behind this adapter boundary. Server handlers should pass
 session facts into the bridge and store returned correlation handles; they

--- a/src/server/handlers/hosted-runner-drain.ts
+++ b/src/server/handlers/hosted-runner-drain.ts
@@ -156,6 +156,7 @@ export interface DrainHostedRunnerOptions {
 	hostedRunner?: HostedRunnerContext;
 	drainRuntime?: (
 		sessionId: string,
+		terminal: HostedRunnerRuntimeTerminalInput,
 	) => Promise<HostedRunnerRuntimeDrainResult | null>;
 	now?: () => Date;
 }
@@ -170,6 +171,11 @@ interface HostedRunnerDrainRuntimeContext {
 
 export interface DrainHostedRunnerForShutdownOptions {
 	now?: () => Date;
+	reason?: HostedRunnerDrainReason;
+	requestedBy?: HostedRunnerDrainRequestedBy;
+}
+
+interface HostedRunnerRuntimeTerminalInput {
 	reason?: HostedRunnerDrainReason;
 	requestedBy?: HostedRunnerDrainRequestedBy;
 }
@@ -440,7 +446,10 @@ export async function drainHostedRunner(
 
 	if (activeSessionId && options.drainRuntime) {
 		try {
-			const runtimeResult = await options.drainRuntime(activeSessionId);
+			const runtimeResult = await options.drainRuntime(activeSessionId, {
+				reason: input.reason,
+				requestedBy: input.requestedBy,
+			});
 			const runtimeProtocolVersion =
 				runtimeResult?.protocolVersion ??
 				runtimeResult?.snapshot?.protocolVersion;
@@ -532,6 +541,7 @@ export async function drainHostedRunner(
 async function drainActiveRuntime(
 	context: HostedRunnerDrainRuntimeContext,
 	sessionId: string,
+	terminal: HostedRunnerRuntimeTerminalInput,
 ): Promise<HostedRunnerRuntimeDrainResult | null> {
 	const runtime =
 		context.headlessRuntimeService.getRuntimeBySessionId(sessionId);
@@ -540,7 +550,24 @@ async function drainActiveRuntime(
 	}
 	const snapshot = runtime.getSnapshot();
 	const sessionFile = runtime.getSessionFile();
-	await runtime.dispose();
+	try {
+		await runtime.dispose();
+		await runtime.completeHostedAgentRuntimeRun({
+			reason: terminal.reason,
+			requestedBy: terminal.requestedBy,
+			flushStatus: HostedRunnerRuntimeFlushStatusValue.Completed,
+		});
+	} catch (error) {
+		await runtime.failHostedAgentRuntimeRun({
+			errorMessage: `Hosted runner drain failed: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+			reason: terminal.reason,
+			requestedBy: terminal.requestedBy,
+			retryable: false,
+		});
+		throw error;
+	}
 	return {
 		sessionId: snapshot.session_id,
 		sessionFile,
@@ -563,7 +590,8 @@ export async function drainHostedRunnerForShutdown(
 		},
 		{
 			hostedRunner: context.hostedRunner,
-			drainRuntime: (sessionId) => drainActiveRuntime(context, sessionId),
+			drainRuntime: (sessionId, terminal) =>
+				drainActiveRuntime(context, sessionId, terminal),
 			now: options.now,
 		},
 	);
@@ -579,7 +607,8 @@ export async function handleHostedRunnerDrain(
 	const input = parseHostedRunnerDrainInput(body);
 	const result = await drainHostedRunner(input, {
 		hostedRunner: context.hostedRunner,
-		drainRuntime: (sessionId) => drainActiveRuntime(context, sessionId),
+		drainRuntime: (sessionId, terminal) =>
+			drainActiveRuntime(context, sessionId, terminal),
 	});
 
 	if (!result) {

--- a/src/server/headless-runtime-service.ts
+++ b/src/server/headless-runtime-service.ts
@@ -63,6 +63,8 @@ import { WebActionApprovalService } from "./approval-service.js";
 import { getAgentCircuitBreaker } from "./circuit-breaker.js";
 import { clientToolService } from "./client-tools-service.js";
 import {
+	type HostedAgentRuntimeCompleteInput,
+	type HostedAgentRuntimeFailInput,
 	type HostedAgentRuntimeProgressRecorder,
 	createHostedAgentRuntimeProgressRecorder,
 } from "./hosted-agent-runtime-progress.js";
@@ -900,6 +902,18 @@ export class HeadlessSessionRuntime {
 			}
 		});
 		return disposePromise;
+	}
+
+	async completeHostedAgentRuntimeRun(
+		input: HostedAgentRuntimeCompleteInput = {},
+	): Promise<void> {
+		await this.agentRuntimeProgress?.completeRun(input);
+	}
+
+	async failHostedAgentRuntimeRun(
+		input: HostedAgentRuntimeFailInput,
+	): Promise<void> {
+		await this.agentRuntimeProgress?.failRun(input);
 	}
 
 	disposeBestEffort(reason: string): void {

--- a/src/server/hosted-agent-runtime-progress.ts
+++ b/src/server/hosted-agent-runtime-progress.ts
@@ -4,6 +4,8 @@ import {
 	PlatformAgentRunStepKindValue,
 	PlatformAgentRunStepStateValue,
 	PlatformAgentRunWaitTypeValue,
+	completeAgentRuntimeRun,
+	failAgentRuntimeRun,
 	recordAgentRuntimeRunStep,
 	resumeAgentRuntimeRun,
 	waitAgentRuntimeRun,
@@ -30,6 +32,8 @@ export interface HostedAgentRuntimeProgressRecorderOperations {
 	recordStep?: typeof recordAgentRuntimeRunStep;
 	waitRun?: typeof waitAgentRuntimeRun;
 	resumeRun?: typeof resumeAgentRuntimeRun;
+	completeRun?: typeof completeAgentRuntimeRun;
+	failRun?: typeof failAgentRuntimeRun;
 }
 
 export interface HostedAgentRuntimeProgressRecorderOptions {
@@ -37,6 +41,20 @@ export interface HostedAgentRuntimeProgressRecorderOptions {
 	hostedRunner?: HostedAgentRuntimeProgressContext;
 	workspaceRoot?: string;
 	operations?: HostedAgentRuntimeProgressRecorderOperations;
+}
+
+export interface HostedAgentRuntimeCompleteInput {
+	reason?: string;
+	requestedBy?: string;
+	flushStatus?: string;
+	manifestPath?: string;
+}
+
+export interface HostedAgentRuntimeFailInput {
+	errorMessage: string;
+	reason?: string;
+	requestedBy?: string;
+	retryable?: boolean;
 }
 
 function safeIdPart(value: string): string {
@@ -88,6 +106,7 @@ export class HostedAgentRuntimeProgressRecorder {
 	private readonly resumedWaitIds = new Set<string>();
 	private pending: Promise<void> = Promise.resolve();
 	private turnIndex = 0;
+	private terminalRecorded = false;
 
 	constructor(options: HostedAgentRuntimeProgressRecorderOptions) {
 		this.sessionId = options.sessionId;
@@ -97,6 +116,8 @@ export class HostedAgentRuntimeProgressRecorder {
 			recordStep: options.operations?.recordStep ?? recordAgentRuntimeRunStep,
 			waitRun: options.operations?.waitRun ?? waitAgentRuntimeRun,
 			resumeRun: options.operations?.resumeRun ?? resumeAgentRuntimeRun,
+			completeRun: options.operations?.completeRun ?? completeAgentRuntimeRun,
+			failRun: options.operations?.failRun ?? failAgentRuntimeRun,
 		};
 	}
 
@@ -262,6 +283,68 @@ export class HostedAgentRuntimeProgressRecorder {
 
 	async flush(): Promise<void> {
 		await this.pending;
+	}
+
+	async completeRun(
+		input: HostedAgentRuntimeCompleteInput = {},
+	): Promise<void> {
+		if (this.terminalRecorded) {
+			await this.flush();
+			return;
+		}
+		this.terminalRecorded = true;
+		this.enqueue(async () => {
+			const handles = this.handles();
+			if (!handles) {
+				return;
+			}
+			await this.operations.completeRun({
+				runId: handles.runId,
+				leaseToken: handles.leaseToken,
+				result: this.basePayload({
+					event_type: "hosted_runner_drained",
+					status: "drained",
+					flush_status: input.flushStatus,
+					reason: input.reason,
+					requested_by: input.requestedBy,
+					manifest_path: input.manifestPath,
+				}),
+			});
+		});
+		await this.flush();
+	}
+
+	async failRun(input: HostedAgentRuntimeFailInput): Promise<void> {
+		if (this.terminalRecorded) {
+			await this.flush();
+			return;
+		}
+		this.terminalRecorded = true;
+		this.recordStep({
+			id: this.stepId("terminal", "failed"),
+			name: "Hosted runner drain failed",
+			stepKind: PlatformAgentRunStepKindValue.Error,
+			state: PlatformAgentRunStepStateValue.Failed,
+			errorMessage: input.errorMessage,
+			output: this.basePayload({
+				event_type: "hosted_runner_drain_failed",
+				reason: input.reason,
+				requested_by: input.requestedBy,
+			}),
+		});
+		this.enqueue(async () => {
+			const handles = this.handles();
+			if (!handles) {
+				return;
+			}
+			await this.operations.failRun({
+				runId: handles.runId,
+				leaseToken: handles.leaseToken,
+				errorMessage: input.errorMessage,
+				retryable: input.retryable ?? false,
+			});
+		});
+		await this.flush();
 	}
 
 	private recordApprovalWait(input: {

--- a/test/server/hosted-agent-runtime-progress.test.ts
+++ b/test/server/hosted-agent-runtime-progress.test.ts
@@ -15,6 +15,8 @@ function createRecorder(overrides?: {
 	recordStep?: ReturnType<typeof vi.fn>;
 	waitRun?: ReturnType<typeof vi.fn>;
 	resumeRun?: ReturnType<typeof vi.fn>;
+	completeRun?: ReturnType<typeof vi.fn>;
+	failRun?: ReturnType<typeof vi.fn>;
 }) {
 	const recordStep =
 		overrides?.recordStep ?? vi.fn(async () => ({ run: { id: "run_1" } }));
@@ -22,6 +24,10 @@ function createRecorder(overrides?: {
 		overrides?.waitRun ?? vi.fn(async () => ({ run: { id: "run_1" } }));
 	const resumeRun =
 		overrides?.resumeRun ?? vi.fn(async () => ({ run: { id: "run_1" } }));
+	const completeRun =
+		overrides?.completeRun ?? vi.fn(async () => ({ run: { id: "run_1" } }));
+	const failRun =
+		overrides?.failRun ?? vi.fn(async () => ({ run: { id: "run_1" } }));
 	const recorder = new HostedAgentRuntimeProgressRecorder({
 		sessionId: "session_1",
 		workspaceRoot: "/workspace",
@@ -35,9 +41,9 @@ function createRecorder(overrides?: {
 			ownerInstanceId: "pod-a",
 			agentRuntimeWorkerQueue: "agent-runtime.production",
 		},
-		operations: { recordStep, waitRun, resumeRun },
+		operations: { recordStep, waitRun, resumeRun, completeRun, failRun },
 	});
-	return { recorder, recordStep, waitRun, resumeRun };
+	return { recorder, recordStep, waitRun, resumeRun, completeRun, failRun };
 }
 
 describe("hosted AgentRuntime progress recorder", () => {
@@ -166,9 +172,10 @@ describe("hosted AgentRuntime progress recorder", () => {
 	});
 
 	it("no-ops when hosted Platform lease handles are absent", async () => {
-		const { recorder, recordStep, waitRun, resumeRun } = createRecorder({
-			agentRuntimeLeaseToken: "",
-		});
+		const { recorder, recordStep, waitRun, resumeRun, completeRun, failRun } =
+			createRecorder({
+				agentRuntimeLeaseToken: "",
+			});
 
 		recorder.recordAgentEvent({ type: "turn_start" });
 		recorder.recordServerRequestEvent({
@@ -201,11 +208,81 @@ describe("hosted AgentRuntime progress recorder", () => {
 			resolution: "answered",
 			resolvedBy: "client",
 		});
+		await recorder.completeRun({ reason: "process_shutdown" });
+		await recorder.failRun({ errorMessage: "should stay local" });
 		await recorder.flush();
 
 		expect(recordStep).not.toHaveBeenCalled();
 		expect(waitRun).not.toHaveBeenCalled();
 		expect(resumeRun).not.toHaveBeenCalled();
+		expect(completeRun).not.toHaveBeenCalled();
+		expect(failRun).not.toHaveBeenCalled();
+	});
+
+	it("completes the Platform run after prior progress writes during hosted drain", async () => {
+		const { recorder, recordStep, completeRun } = createRecorder();
+
+		recorder.recordAgentEvent({ type: "turn_start" });
+		await recorder.completeRun({
+			reason: "process_shutdown",
+			requestedBy: "maestro_web_server",
+			flushStatus: "completed",
+			manifestPath: "/workspace/.maestro/runner-snapshots/mrs.json",
+		});
+		await recorder.completeRun({ reason: "duplicate" });
+
+		expect(recordStep).toHaveBeenCalledTimes(1);
+		expect(completeRun).toHaveBeenCalledTimes(1);
+		expect(completeRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				runId: "run_1",
+				leaseToken: "lease-token-1",
+				result: expect.objectContaining({
+					event_type: "hosted_runner_drained",
+					status: "drained",
+					flush_status: "completed",
+					reason: "process_shutdown",
+					requested_by: "maestro_web_server",
+					manifest_path: "/workspace/.maestro/runner-snapshots/mrs.json",
+				}),
+			}),
+		);
+	});
+
+	it("fails the Platform run once when hosted drain is interrupted", async () => {
+		const { recorder, recordStep, failRun } = createRecorder();
+
+		await recorder.failRun({
+			errorMessage: "Hosted runner drain failed: flush timed out",
+			reason: "kubernetes_prestop",
+			requestedBy: "kubernetes_prestop",
+		});
+		await recorder.failRun({ errorMessage: "duplicate failure" });
+
+		expect(recordStep).toHaveBeenCalledWith(
+			expect.objectContaining({
+				step: expect.objectContaining({
+					id: "maestro:session_1:terminal:failed",
+					stepKind: PlatformAgentRunStepKindValue.Error,
+					state: PlatformAgentRunStepStateValue.Failed,
+					errorMessage: "Hosted runner drain failed: flush timed out",
+					output: expect.objectContaining({
+						event_type: "hosted_runner_drain_failed",
+						reason: "kubernetes_prestop",
+						requested_by: "kubernetes_prestop",
+					}),
+				}),
+			}),
+		);
+		expect(failRun).toHaveBeenCalledTimes(1);
+		expect(failRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				runId: "run_1",
+				leaseToken: "lease-token-1",
+				errorMessage: "Hosted runner drain failed: flush timed out",
+				retryable: false,
+			}),
+		);
 	});
 
 	it("keeps later progress flowing after a Platform write failure", async () => {

--- a/test/server/hosted-runner-drain.test.ts
+++ b/test/server/hosted-runner-drain.test.ts
@@ -119,7 +119,10 @@ describe("hosted runner drain", () => {
 			reason: "ttl_expired",
 			requestedBy: "platform",
 		});
-		expect(drainRuntime).toHaveBeenCalledWith("session_123");
+		expect(drainRuntime).toHaveBeenCalledWith("session_123", {
+			reason: "ttl_expired",
+			requestedBy: "platform",
+		});
 		expect(result?.manifest).toMatchObject({
 			protocol_version: HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
 			runner_session_id: "mrs_123",
@@ -281,6 +284,8 @@ describe("hosted runner drain", () => {
 				join(workspaceRoot, ".maestro", "sessions", "session.jsonl"),
 			),
 			dispose: vi.fn().mockResolvedValue(undefined),
+			completeHostedAgentRuntimeRun: vi.fn().mockResolvedValue(undefined),
+			failHostedAgentRuntimeRun: vi.fn().mockResolvedValue(undefined),
 		};
 		const headlessRuntimeService = {
 			getRuntimeBySessionId: vi.fn(() => runtime),
@@ -306,6 +311,12 @@ describe("hosted runner drain", () => {
 			"session_123",
 		);
 		expect(runtime.dispose).toHaveBeenCalled();
+		expect(runtime.completeHostedAgentRuntimeRun).toHaveBeenCalledWith({
+			reason: HostedRunnerDrainReasonValue.ProcessShutdown,
+			requestedBy: HostedRunnerDrainRequestedByValue.MaestroWebServer,
+			flushStatus: HostedRunnerRuntimeFlushStatusValue.Completed,
+		});
+		expect(runtime.failHostedAgentRuntimeRun).not.toHaveBeenCalled();
 		expect(result?.manifest).toMatchObject({
 			maestro_session_id: "session_123",
 			reason: HostedRunnerDrainReasonValue.ProcessShutdown,
@@ -316,6 +327,49 @@ describe("hosted runner drain", () => {
 				cursor: 11,
 			},
 			snapshot,
+		});
+	});
+
+	it("fails the Platform AgentRuntime run when active runtime drain is interrupted", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const context = hostedRunnerContext(workspaceRoot);
+		const snapshot = runtimeSnapshot(workspaceRoot, 12);
+		const runtime = {
+			getSnapshot: vi.fn(() => snapshot),
+			getSessionFile: vi.fn(() =>
+				join(workspaceRoot, ".maestro", "sessions", "session.jsonl"),
+			),
+			dispose: vi.fn().mockRejectedValue(new Error("flush timed out")),
+			completeHostedAgentRuntimeRun: vi.fn().mockResolvedValue(undefined),
+			failHostedAgentRuntimeRun: vi.fn().mockResolvedValue(undefined),
+		};
+		const headlessRuntimeService = {
+			getRuntimeBySessionId: vi.fn(() => runtime),
+		};
+
+		const result = await drainHostedRunnerForShutdown(
+			{
+				hostedRunner: context,
+				headlessRuntimeService,
+			},
+			{
+				reason: HostedRunnerDrainReasonValue.KubernetesPreStop,
+				requestedBy: HostedRunnerDrainRequestedByValue.KubernetesPreStop,
+				now: () => new Date("2026-04-23T00:02:45.000Z"),
+			},
+		);
+
+		expect(result?.status).toBe(HostedRunnerDrainStatusValue.Interrupted);
+		expect(runtime.completeHostedAgentRuntimeRun).not.toHaveBeenCalled();
+		expect(runtime.failHostedAgentRuntimeRun).toHaveBeenCalledWith({
+			errorMessage: "Hosted runner drain failed: flush timed out",
+			reason: HostedRunnerDrainReasonValue.KubernetesPreStop,
+			requestedBy: HostedRunnerDrainRequestedByValue.KubernetesPreStop,
+			retryable: false,
+		});
+		expect(result?.manifest.runtime).toMatchObject({
+			flush_status: HostedRunnerRuntimeFlushStatusValue.Failed,
+			error: "flush timed out",
 		});
 	});
 


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `2648b2dcc4a024cbf2e69e44c35fc30f5f79f84a`
- last generated public sync base: `a4f661a3fc87ba4e0ab10a1e80a349b6d949e165`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (2648b2dcc4a0)`
- public projection: `https://github.com/evalops/maestro@main (1becf94f523d)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/design/PLATFORM_AGENT_RUNTIME_SESSION_BRIDGE.md
- copy/update src/server/handlers/hosted-runner-drain.ts
- copy/update src/server/headless-runtime-service.ts
- copy/update src/server/hosted-agent-runtime-progress.ts
- copy/update test/server/hosted-agent-runtime-progress.test.ts
- copy/update test/server/hosted-runner-drain.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/design/PLATFORM_AGENT_RUNTIME_SESSION_BRIDGE.md
- copy/update src/server/handlers/hosted-runner-drain.ts
- copy/update src/server/headless-runtime-service.ts
- copy/update src/server/hosted-agent-runtime-progress.ts
- copy/update test/server/hosted-agent-runtime-progress.test.ts
- copy/update test/server/hosted-runner-drain.test.ts

## Public-only commits since last generated sync

- 1becf94f Record hosted AgentRuntime progress

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode