### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/agent/tracing.ts
+++ b/src/agent/tracing.ts
@@ -207,13 +207,15 @@ export async function traceToolCall<T>(
 			"tool.input_size": context.inputSize,
 		},
 		async (span) => {
-			const result = await operation(span);
-
-			if (span) {
-				span.setAttribute("tool.duration_ms", performance.now() - startTime);
+			try {
+				const result = await operation(span);
+				return result;
+			} finally {
+				const durationMs = performance.now() - startTime;
+				if (span) {
+					span.setAttribute("tool.duration_ms", durationMs);
+				}
 			}
-
-			return result;
 		},
 	);
 }
@@ -254,19 +256,19 @@ export async function traceLlmRequest<T>(
 			"llm.thinking_tokens": context.thinkingTokens,
 		},
 		async (span) => {
-			const result = await operation(span);
-
-			if (span) {
-				span.setAttribute("llm.duration_ms", performance.now() - startTime);
+			try {
+				return await operation(span);
+			} finally {
+				if (span) {
+					span.setAttribute("llm.duration_ms", performance.now() - startTime);
+				}
 			}
-
-			return result;
 		},
 	);
 }
 
 /**
- * Records usage metrics on an existing span.
+ * Records usage attributes on an existing span.
  */
 export function recordUsageOnSpan(span: Span | null, usage: Usage): void {
 	if (!span) return;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -18,6 +18,10 @@ import {
 	mirrorCanonicalTurnEventToMeter,
 } from "./telemetry/meter-service-client.js";
 import {
+	recordCompactionMetric,
+	recordToolInvocationMetric,
+} from "./telemetry/metrics.js";
+import {
 	type CanonicalTurnEvent,
 	setDefaultTelemetryRecorder,
 } from "./telemetry/wide-events.js";
@@ -488,10 +492,52 @@ function recordOpenTelemetrySpan(event: TelemetryEvent): void {
 	}
 }
 
+function recordOpenTelemetryMetric(event: TelemetryEvent): void {
+	try {
+		switch (event.type) {
+			case "tool-execution":
+				recordToolInvocationMetric({
+					toolName: event.toolName,
+					durationMs: event.durationMs,
+					success: event.success,
+					agentRunId: metadataString(event.metadata, [
+						"agentRunId",
+						"agent_run_id",
+					]),
+					skillName: skillNameFromMetadata(event.metadata),
+				});
+				break;
+			case "business-metric":
+				if (event.metric === "compaction.triggered") {
+					recordCompactionMetric({
+						"maestro.session_id": event.metadata?.sessionId,
+						"llm.model.id": event.metadata?.model,
+						"llm.model.provider": event.metadata?.provider,
+					});
+				}
+				break;
+			default:
+				break;
+		}
+	} catch {
+		// Never let metric recording affect runtime behavior.
+	}
+}
+
 function stringRecord(value: unknown): Record<string, unknown> | undefined {
 	return value && typeof value === "object" && !Array.isArray(value)
 		? (value as Record<string, unknown>)
 		: undefined;
+}
+
+function skillNameFromMetadata(
+	metadata: Record<string, unknown> | undefined,
+): string | undefined {
+	return (
+		metadataString(metadata, ["skillName", "skill_name"]) ??
+		metadataString(stringRecord(metadata?.skillMetadata), ["name"]) ??
+		metadataString(stringRecord(metadata?.skill_metadata), ["name"])
+	);
 }
 
 function metadataString(
@@ -647,6 +693,7 @@ export async function recordTelemetry(event: TelemetryEvent): Promise<void> {
 	const openTelemetryEnabled = isOpenTelemetryEnabled();
 	if (openTelemetryEnabled) {
 		recordOpenTelemetrySpan(event);
+		recordOpenTelemetryMetric(event);
 	}
 	const eventBusTask = mirrorTelemetryToMaestroEventBus(event);
 

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -1,0 +1,241 @@
+import {
+	type Counter,
+	type Histogram,
+	metrics as otelMetrics,
+} from "@opentelemetry/api";
+
+export type MaestroMetricDefinition = {
+	key: string;
+	name: string;
+	kind: "counter" | "histogram";
+	description: string;
+	unit?: string;
+};
+
+export const MAESTRO_OTEL_METRIC_DEFINITIONS = [
+	{
+		key: "toolInvocationCount",
+		name: "tool_service.invocation_count",
+		kind: "counter",
+		description: "Number of tool invocations",
+	},
+	{
+		key: "toolInvocationLatency",
+		name: "tool_service.invocation_latency",
+		kind: "histogram",
+		description: "Latency of tool invocations",
+		unit: "ms",
+	},
+	{
+		key: "skillInvocationCount",
+		name: "tool_service.skill.invocation_count",
+		kind: "counter",
+		description: "Skill tool invocations by skill name",
+	},
+	{
+		key: "agentTurnCount",
+		name: "agent.turn_count",
+		kind: "counter",
+		description: "Agent turns by mode and outcome",
+	},
+	{
+		key: "agentTurnLatency",
+		name: "agent.turn_latency",
+		kind: "histogram",
+		description: "Wall-clock duration per agent turn",
+		unit: "ms",
+	},
+	{
+		key: "compactionTriggered",
+		name: "compaction.triggered",
+		kind: "counter",
+		description: "Auto-compaction triggers",
+	},
+	{
+		key: "llmRequestCount",
+		name: "llm.request_count",
+		kind: "counter",
+		description: "LLM requests by provider, model, mode",
+	},
+	{
+		key: "llmTokenUsage",
+		name: "llm.tokens_used",
+		kind: "counter",
+		description: "Tokens consumed by direction",
+	},
+] as const satisfies readonly MaestroMetricDefinition[];
+
+type MetricKey = (typeof MAESTRO_OTEL_METRIC_DEFINITIONS)[number]["key"];
+type MetricDefinitionByKey = Record<MetricKey, MaestroMetricDefinition>;
+
+const definitionsByKey = Object.fromEntries(
+	MAESTRO_OTEL_METRIC_DEFINITIONS.map((definition) => [
+		definition.key,
+		definition,
+	]),
+) as MetricDefinitionByKey;
+
+const meter = otelMetrics.getMeter(
+	"evalops.maestro",
+	process.env.MAESTRO_VERSION ?? "unknown",
+);
+
+function counter(key: MetricKey): Counter {
+	const definition = definitionsByKey[key];
+	return meter.createCounter(definition.name, {
+		description: definition.description,
+		unit: definition.unit,
+	});
+}
+
+function histogram(key: MetricKey): Histogram {
+	const definition = definitionsByKey[key];
+	return meter.createHistogram(definition.name, {
+		description: definition.description,
+		unit: definition.unit,
+	});
+}
+
+export const maestroOtelMetrics = {
+	toolInvocationCount: counter("toolInvocationCount"),
+	toolInvocationLatency: histogram("toolInvocationLatency"),
+	skillInvocationCount: counter("skillInvocationCount"),
+	agentTurnCount: counter("agentTurnCount"),
+	agentTurnLatency: histogram("agentTurnLatency"),
+	compactionTriggered: counter("compactionTriggered"),
+	llmRequestCount: counter("llmRequestCount"),
+	llmTokenUsage: counter("llmTokenUsage"),
+};
+
+function compactAttributes(
+	attributes: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+	return Object.fromEntries(
+		Object.entries(attributes).filter(
+			(entry): entry is [string, string | number | boolean] =>
+				entry[1] !== undefined,
+		),
+	);
+}
+
+export function recordToolInvocationMetric(input: {
+	toolName: string;
+	durationMs?: number;
+	success?: boolean;
+	surface?: string;
+	agentRunId?: string;
+	skillName?: string;
+}): void {
+	const attributes = compactAttributes({
+		"tool.name": input.toolName,
+		"tool.success": input.success,
+		"maestro.surface": input.surface,
+		"maestro.agent_run_id": input.agentRunId,
+	});
+	maestroOtelMetrics.toolInvocationCount.add(1, attributes);
+	if (
+		typeof input.durationMs === "number" &&
+		Number.isFinite(input.durationMs)
+	) {
+		maestroOtelMetrics.toolInvocationLatency.record(
+			input.durationMs,
+			attributes,
+		);
+	}
+	if (input.skillName) {
+		maestroOtelMetrics.skillInvocationCount.add(
+			1,
+			compactAttributes({
+				...attributes,
+				"skill.name": input.skillName,
+			}),
+		);
+	}
+}
+
+export function recordAgentTurnMetric(input: {
+	durationMs?: number;
+	status?: string;
+	mode?: string;
+	modelId?: string;
+	modelProvider?: string;
+	surface?: string;
+	agentRunId?: string;
+}): void {
+	const attributes = compactAttributes({
+		"agent.turn.status": input.status,
+		"agent.turn.mode": input.mode,
+		"llm.model.id": input.modelId,
+		"llm.model.provider": input.modelProvider,
+		"maestro.surface": input.surface,
+		"maestro.agent_run_id": input.agentRunId,
+	});
+	maestroOtelMetrics.agentTurnCount.add(1, attributes);
+	if (
+		typeof input.durationMs === "number" &&
+		Number.isFinite(input.durationMs)
+	) {
+		maestroOtelMetrics.agentTurnLatency.record(input.durationMs, attributes);
+	}
+}
+
+export function recordCompactionMetric(
+	attributes: Record<string, string | number | boolean | undefined> = {},
+): void {
+	maestroOtelMetrics.compactionTriggered.add(1, compactAttributes(attributes));
+}
+
+export function recordLlmTokenUsageMetric(
+	tokens: {
+		input?: number;
+		output?: number;
+		cacheRead?: number;
+		cacheWrite?: number;
+	},
+	attributes: Record<string, string | number | boolean | undefined> = {},
+): void {
+	const compactedAttributes = compactAttributes(attributes);
+	const tokenEntries = [
+		["input", tokens.input],
+		["output", tokens.output],
+		["cache_read", tokens.cacheRead],
+		["cache_write", tokens.cacheWrite],
+	] as const;
+	for (const [direction, value] of tokenEntries) {
+		if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+			maestroOtelMetrics.llmTokenUsage.add(
+				value,
+				compactAttributes({
+					...compactedAttributes,
+					"llm.token.direction": direction,
+				}),
+			);
+		}
+	}
+}
+
+export function recordLlmRequestMetric(input: {
+	provider?: string;
+	modelId?: string;
+	mode?: string;
+	surface?: string;
+	agentRunId?: string;
+	tokens?: {
+		input?: number;
+		output?: number;
+		cacheRead?: number;
+		cacheWrite?: number;
+	};
+}): void {
+	const attributes = compactAttributes({
+		"llm.model.provider": input.provider,
+		"llm.model.id": input.modelId,
+		"llm.request.mode": input.mode,
+		"maestro.surface": input.surface,
+		"maestro.agent_run_id": input.agentRunId,
+	});
+	maestroOtelMetrics.llmRequestCount.add(1, attributes);
+	if (input.tokens) {
+		recordLlmTokenUsageMetric(input.tokens, attributes);
+	}
+}

--- a/src/telemetry/turn-tracker.ts
+++ b/src/telemetry/turn-tracker.ts
@@ -10,6 +10,7 @@ import type { AgentEvent, ThinkingLevel, Usage } from "../agent/types.js";
 import {
 	type CanonicalTurnEvent,
 	type TailSamplingConfig,
+	type TokenUsage,
 	TurnCollector,
 	getSamplingConfigFromEnv,
 } from "./wide-events.js";
@@ -68,6 +69,7 @@ export class TurnTracker {
 	private unsubscribe: (() => void) | null = null;
 	private samplingConfig: Partial<TailSamplingConfig>;
 	private accumulatedUsage: Usage | null = null;
+	private lastMetricTokens: TokenUsage | null = null;
 
 	constructor(
 		private readonly agent: Agent,
@@ -192,6 +194,7 @@ export class TurnTracker {
 		if (!isContinuation || this.turnNumber === 0) {
 			this.turnNumber++;
 			this.accumulatedUsage = null;
+			this.lastMetricTokens = null;
 		}
 
 		this.currentTurn = new TurnCollector(
@@ -277,6 +280,7 @@ export class TurnTracker {
 		};
 
 		const costUsd = this.accumulatedUsage?.cost?.total ?? 0;
+		const metricTokens = diffTokenUsage(tokens, this.lastMetricTokens);
 
 		// Complete the turn
 		const canonicalEvent = this.currentTurn.complete(
@@ -285,7 +289,9 @@ export class TurnTracker {
 			costUsd,
 			errorDetails,
 			abortReason,
+			metricTokens,
 		);
+		this.lastMetricTokens = tokens;
 
 		// Call the callback if provided
 		if (this.config.onTurnComplete) {
@@ -304,4 +310,23 @@ export function createTurnTracker(
 	config: TurnTrackerConfig,
 ): TurnTracker {
 	return new TurnTracker(agent, config);
+}
+
+function diffTokenUsage(
+	current: TokenUsage,
+	previous: TokenUsage | null,
+): TokenUsage {
+	if (!previous) {
+		return current;
+	}
+	return {
+		input: Math.max(0, current.input - previous.input),
+		output: Math.max(0, current.output - previous.output),
+		cacheRead: Math.max(0, current.cacheRead - previous.cacheRead),
+		cacheWrite: Math.max(0, current.cacheWrite - previous.cacheWrite),
+		thinking:
+			current.thinking !== undefined || previous.thinking !== undefined
+				? Math.max(0, (current.thinking ?? 0) - (previous.thinking ?? 0))
+				: undefined,
+	};
 }

--- a/src/telemetry/wide-events.ts
+++ b/src/telemetry/wide-events.ts
@@ -13,8 +13,14 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { isOpenTelemetryEnabled } from "../opentelemetry.js";
 import type { PromptMetadata } from "../prompts/types.js";
 import type { SkillArtifactMetadata } from "../skills/artifact-metadata.js";
+import {
+	recordAgentTurnMetric,
+	recordLlmRequestMetric,
+	recordLlmTokenUsageMetric,
+} from "./metrics.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -179,6 +185,7 @@ export class TurnCollector {
 	private readonly startTime: number;
 	private llmStartTime?: number;
 	private accumulatedLlmDurationMs = 0;
+	private llmRequestCount = 0;
 	private queueStartTime?: number;
 
 	private model: ModelInfo = {
@@ -310,6 +317,7 @@ export class TurnCollector {
 	}
 
 	recordLlmStart(): this {
+		this.llmRequestCount += 1;
 		this.llmStartTime = performance.now();
 		return this;
 	}
@@ -371,6 +379,7 @@ export class TurnCollector {
 		costUsd: number,
 		errorDetails?: { category?: string; message?: string },
 		abortReason?: CanonicalTurnEvent["abortReason"],
+		metricTokens: TokenUsage = tokens,
 	): CanonicalTurnEvent {
 		const endTime = performance.now();
 		const totalDurationMs = endTime - this.startTime;
@@ -453,6 +462,37 @@ export class TurnCollector {
 			sampleReason,
 		};
 
+		if (isOpenTelemetryEnabled()) {
+			try {
+				recordAgentTurnMetric({
+					durationMs: event.totalDurationMs,
+					status: event.status,
+					modelId: event.model.id,
+					modelProvider: event.model.provider,
+				});
+				const llmRequestCount = Math.max(
+					this.llmRequestCount,
+					hasTokenUsage(metricTokens) ? 1 : 0,
+				);
+				for (
+					let requestIndex = 0;
+					requestIndex < llmRequestCount;
+					requestIndex++
+				) {
+					recordLlmRequestMetric({
+						provider: event.model.provider,
+						modelId: event.model.id,
+					});
+				}
+				recordLlmTokenUsageMetric(metricTokens, {
+					"llm.model.provider": event.model.provider,
+					"llm.model.id": event.model.id,
+				});
+			} catch {
+				// Metrics must never affect canonical event creation or sampling.
+			}
+		}
+
 		// Only persist if sampled
 		if (sampled) {
 			const recorder = this.recorder ?? defaultRecorder;
@@ -492,6 +532,15 @@ export class TurnCollector {
 
 		return { sampled: false, sampleReason: "random" };
 	}
+}
+
+function hasTokenUsage(tokens: TokenUsage): boolean {
+	return (
+		tokens.input > 0 ||
+		tokens.output > 0 ||
+		tokens.cacheRead > 0 ||
+		tokens.cacheWrite > 0
+	);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/tools/typebox-tool.ts
+++ b/src/tools/typebox-tool.ts
@@ -6,6 +6,7 @@ import type {
 	AgentToolResult,
 	ToolAnnotations,
 } from "../agent/types.js";
+import { getSkillArtifactMetadataFromDetails } from "../skills/artifact-metadata.js";
 import { logToolFailure, recordToolExecution } from "../telemetry.js";
 import { compileTypeboxSchema } from "../utils/typebox-ajv.js";
 
@@ -90,10 +91,14 @@ export function createTypeboxTool<Schema extends TSchema, Details = undefined>(
 						parsedParams,
 						signal,
 					);
+					const skillMetadata = getSkillArtifactMetadataFromDetails(
+						result.details,
+					);
 					recordToolExecution(options.name, true, performance.now() - start, {
 						toolCallId,
 						attempt,
 						maxAttempts,
+						...(skillMetadata ? { skillMetadata } : {}),
 					});
 					return result;
 				} catch (error: unknown) {

--- a/test/agent/tracing-metrics.test.ts
+++ b/test/agent/tracing-metrics.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const metricRecorders = vi.hoisted(() => ({
+	recordAgentTurnMetric: vi.fn(),
+	recordLlmRequestMetric: vi.fn(),
+	recordLlmTokenUsageMetric: vi.fn(),
+	recordToolInvocationMetric: vi.fn(),
+}));
+
+vi.mock("../../src/telemetry/metrics.js", () => metricRecorders);
+
+describe("agent tracing metric isolation", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("does not emit agent turn metrics from tracing spans", async () => {
+		const { traceAgentTurn } = await import("../../src/agent/tracing.js");
+
+		await expect(
+			traceAgentTurn(
+				{
+					modelId: "claude-sonnet-4-5",
+					modelProvider: "anthropic",
+					thinkingLevel: "medium",
+					toolCount: 2,
+					messageCount: 4,
+					surface: "cli",
+					agentRunId: "run_123",
+				},
+				async () => "ok",
+			),
+		).resolves.toBe("ok");
+
+		expect(metricRecorders.recordAgentTurnMetric).not.toHaveBeenCalled();
+	});
+
+	it("does not emit tool metrics from tracing spans", async () => {
+		const { traceToolCall } = await import("../../src/agent/tracing.js");
+
+		await expect(
+			traceToolCall(
+				{
+					toolName: "read_file",
+					toolCallId: "tool_123",
+					inputSize: 20,
+					surface: "cli",
+					agentRunId: "run_123",
+				},
+				async () => "ok",
+			),
+		).resolves.toBe("ok");
+
+		expect(metricRecorders.recordToolInvocationMetric).not.toHaveBeenCalled();
+	});
+
+	it("does not emit llm request metrics when the request fails", async () => {
+		const { traceLlmRequest } = await import("../../src/agent/tracing.js");
+		const error = new Error("request failed");
+		metricRecorders.recordLlmRequestMetric.mockImplementation(() => {
+			throw new Error("metric failure");
+		});
+
+		await expect(
+			traceLlmRequest(
+				{
+					modelId: "claude-sonnet-4-5",
+					provider: "anthropic",
+					inputTokens: 10,
+					outputTokens: 20,
+					surface: "cli",
+					agentRunId: "run_123",
+				},
+				async () => {
+					throw error;
+				},
+			),
+		).rejects.toBe(error);
+
+		expect(metricRecorders.recordLlmRequestMetric).not.toHaveBeenCalled();
+	});
+
+	it("does not emit llm request metrics when the request succeeds", async () => {
+		const { traceLlmRequest } = await import("../../src/agent/tracing.js");
+
+		await expect(
+			traceLlmRequest(
+				{
+					modelId: "claude-sonnet-4-5",
+					provider: "anthropic",
+					inputTokens: 10,
+					outputTokens: 20,
+				},
+				async () => "ok",
+			),
+		).resolves.toBe("ok");
+
+		expect(metricRecorders.recordLlmRequestMetric).not.toHaveBeenCalled();
+	});
+
+	it("does not emit token usage metrics when no span is available", async () => {
+		const { recordUsageOnSpan } = await import("../../src/agent/tracing.js");
+
+		recordUsageOnSpan(null, {
+			input: 10,
+			output: 20,
+			cacheRead: 3,
+			cacheWrite: 4,
+			cost: { input: 0.01, output: 0.02, total: 0.03 },
+		});
+
+		expect(metricRecorders.recordLlmTokenUsageMetric).not.toHaveBeenCalled();
+	});
+});

--- a/test/agent/tracing-usage.test.ts
+++ b/test/agent/tracing-usage.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("recordUsageOnSpan", () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.resetModules();
+		vi.restoreAllMocks();
+	});
+
+	it("adds usage attributes to an existing span without emitting metrics", async () => {
+		const recordLlmTokenUsageMetric = vi.fn();
+		const setAttributes = vi.fn();
+
+		vi.doMock("../../src/telemetry/metrics.js", async (importOriginal) => {
+			const actual =
+				await importOriginal<typeof import("../../src/telemetry/metrics.js")>();
+			return {
+				...actual,
+				recordLlmTokenUsageMetric,
+			};
+		});
+
+		const { recordUsageOnSpan } = await import("../../src/agent/tracing.js");
+		const span = { setAttributes } as Parameters<typeof recordUsageOnSpan>[0];
+
+		recordUsageOnSpan(span, {
+			input: 10,
+			output: 5,
+			cacheRead: 2,
+			cacheWrite: 1,
+			cost: {
+				input: 0.01,
+				output: 0.02,
+				cacheRead: 0,
+				cacheWrite: 0,
+				total: 0.03,
+			},
+		});
+
+		expect(recordLlmTokenUsageMetric).not.toHaveBeenCalled();
+		expect(setAttributes).toHaveBeenCalledWith({
+			"llm.usage.input_tokens": 10,
+			"llm.usage.output_tokens": 5,
+			"llm.usage.cache_read_tokens": 2,
+			"llm.usage.cache_write_tokens": 1,
+			"llm.usage.cost_total": 0.03,
+		});
+	});
+});

--- a/test/telemetry/otel-metrics.test.ts
+++ b/test/telemetry/otel-metrics.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Maestro OTel metrics catalog", () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		vi.resetModules();
+		vi.restoreAllMocks();
+	});
+
+	it("defines the canonical agent-domain metric instruments", async () => {
+		const createCounter = vi.fn(() => ({ add: vi.fn() }));
+		const createHistogram = vi.fn(() => ({ record: vi.fn() }));
+		const createUpDownCounter = vi.fn(() => ({ add: vi.fn() }));
+		const getMeter = vi.fn(() => ({
+			createCounter,
+			createHistogram,
+			createUpDownCounter,
+		}));
+		vi.doMock("@opentelemetry/api", async (importOriginal) => {
+			const actual =
+				await importOriginal<typeof import("@opentelemetry/api")>();
+			return {
+				...actual,
+				metrics: {
+					...actual.metrics,
+					getMeter,
+				},
+			};
+		});
+
+		const { MAESTRO_OTEL_METRIC_DEFINITIONS } = await import(
+			"../../src/telemetry/metrics.js"
+		);
+
+		expect(
+			MAESTRO_OTEL_METRIC_DEFINITIONS.map((metric) => metric.name),
+		).toEqual([
+			"tool_service.invocation_count",
+			"tool_service.invocation_latency",
+			"tool_service.skill.invocation_count",
+			"agent.turn_count",
+			"agent.turn_latency",
+			"compaction.triggered",
+			"llm.request_count",
+			"llm.tokens_used",
+		]);
+		expect(createUpDownCounter).not.toHaveBeenCalled();
+		expect(createCounter).toHaveBeenCalledWith(
+			"tool_service.invocation_count",
+			{
+				description: "Number of tool invocations",
+				unit: undefined,
+			},
+		);
+		expect(createHistogram).toHaveBeenCalledWith(
+			"tool_service.invocation_latency",
+			{
+				description: "Latency of tool invocations",
+				unit: "ms",
+			},
+		);
+		expect(createCounter).toHaveBeenCalledWith("llm.tokens_used", {
+			description: "Tokens consumed by direction",
+			unit: undefined,
+		});
+	});
+
+	it("records tool, turn, compaction, and token observations", async () => {
+		const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
+		const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
+		const upDownCounters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
+		const createCounter = vi.fn((name: string) => {
+			const instrument = { add: vi.fn() };
+			counters.set(name, instrument);
+			return instrument;
+		});
+		const createHistogram = vi.fn((name: string) => {
+			const instrument = { record: vi.fn() };
+			histograms.set(name, instrument);
+			return instrument;
+		});
+		const createUpDownCounter = vi.fn((name: string) => {
+			const instrument = { add: vi.fn() };
+			upDownCounters.set(name, instrument);
+			return instrument;
+		});
+		vi.doMock("@opentelemetry/api", async (importOriginal) => {
+			const actual =
+				await importOriginal<typeof import("@opentelemetry/api")>();
+			return {
+				...actual,
+				metrics: {
+					...actual.metrics,
+					getMeter: vi.fn(() => ({
+						createCounter,
+						createHistogram,
+						createUpDownCounter,
+					})),
+				},
+			};
+		});
+
+		const metrics = await import("../../src/telemetry/metrics.js");
+		metrics.recordToolInvocationMetric({
+			toolName: "bash",
+			durationMs: 42,
+			success: true,
+			skillName: "fix-tests",
+		});
+		metrics.recordAgentTurnMetric({
+			durationMs: 100,
+			status: "success",
+			modelId: "claude-opus-4-6",
+			modelProvider: "anthropic",
+		});
+		metrics.recordCompactionMetric({ "maestro.session_id": "session_1" });
+		metrics.recordLlmRequestMetric({
+			provider: "anthropic",
+			modelId: "claude-opus-4-6",
+			tokens: {
+				input: 10,
+				output: 20,
+				cacheRead: 5,
+				cacheWrite: 2,
+			},
+		});
+
+		expect(
+			counters.get("tool_service.invocation_count")?.add,
+		).toHaveBeenCalledWith(
+			1,
+			expect.objectContaining({ "tool.name": "bash", "tool.success": true }),
+		);
+		expect(
+			histograms.get("tool_service.invocation_latency")?.record,
+		).toHaveBeenCalledWith(
+			42,
+			expect.objectContaining({ "tool.name": "bash" }),
+		);
+		expect(
+			counters.get("tool_service.skill.invocation_count")?.add,
+		).toHaveBeenCalledWith(
+			1,
+			expect.objectContaining({ "skill.name": "fix-tests" }),
+		);
+		expect(counters.get("agent.turn_count")?.add).toHaveBeenCalledWith(
+			1,
+			expect.objectContaining({ "agent.turn.status": "success" }),
+		);
+		expect(histograms.get("agent.turn_latency")?.record).toHaveBeenCalledWith(
+			100,
+			expect.objectContaining({ "llm.model.id": "claude-opus-4-6" }),
+		);
+		expect(counters.get("compaction.triggered")?.add).toHaveBeenCalledWith(
+			1,
+			expect.objectContaining({ "maestro.session_id": "session_1" }),
+		);
+		expect(counters.get("llm.request_count")?.add).toHaveBeenCalledWith(
+			1,
+			expect.objectContaining({ "llm.model.provider": "anthropic" }),
+		);
+		expect(counters.get("llm.tokens_used")?.add).toHaveBeenCalledTimes(4);
+		expect(counters.get("llm.tokens_used")?.add).toHaveBeenCalledWith(
+			10,
+			expect.objectContaining({ "llm.token.direction": "input" }),
+		);
+	});
+});

--- a/test/telemetry/telemetry-otel-routing.test.ts
+++ b/test/telemetry/telemetry-otel-routing.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function createCanonicalTurnEvent() {
+	return {
+		type: "canonical-turn" as const,
+		timestamp: "2026-05-07T07:00:00.000Z",
+		sessionId: "session-123",
+		turnId: "turn-456",
+		turnNumber: 3,
+		model: {
+			id: "claude-opus-4-6",
+			provider: "anthropic",
+		},
+		tokens: {
+			input: 120,
+			output: 48,
+			cacheRead: 4,
+			cacheWrite: 2,
+		},
+		totalDurationMs: 620,
+		status: "success" as const,
+		toolCount: 0,
+	};
+}
+
+describe("telemetry OTel metric routing", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.unstubAllEnvs();
+	});
+
+	afterEach(() => {
+		vi.resetModules();
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+	});
+
+	it("does not duplicate turn or token metrics from telemetry replay paths", async () => {
+		const recordAgentTurnMetric = vi.fn();
+		const recordCompactionMetric = vi.fn();
+		const recordLlmRequestMetric = vi.fn();
+		const recordLlmTokenUsageMetric = vi.fn();
+		const recordToolInvocationMetric = vi.fn();
+
+		vi.doMock("../../src/opentelemetry.js", () => ({
+			getTelemetryTracer: () => ({
+				startActiveSpan: (
+					_name: string,
+					callback: (span: {
+						setAttributes(attributes: Record<string, unknown>): void;
+						setAttribute(name: string, value: unknown): void;
+						setStatus(status: Record<string, unknown>): void;
+						end(): void;
+					}) => void,
+				) => {
+					callback({
+						setAttributes() {},
+						setAttribute() {},
+						setStatus() {},
+						end() {},
+					});
+				},
+			}),
+			initOpenTelemetry: vi.fn(),
+			isOpenTelemetryEnabled: () => true,
+		}));
+		vi.doMock("../../src/telemetry/metrics.js", () => ({
+			recordAgentTurnMetric,
+			recordCompactionMetric,
+			recordLlmRequestMetric,
+			recordLlmTokenUsageMetric,
+			recordToolInvocationMetric,
+		}));
+		vi.doMock("../../src/telemetry/maestro-event-bus.js", () => ({
+			mirrorTelemetryToMaestroEventBus: vi.fn(() => Promise.resolve()),
+			resolveMaestroEventBusConfig: () => ({
+				defaultCorrelation: {},
+				defaultPrincipal: undefined,
+				defaultSurface: "cli",
+			}),
+		}));
+		vi.doMock("../../src/telemetry/meter-service-client.js", () => ({
+			hasRemoteMeterDestination: () => false,
+			mirrorCanonicalTurnEventToMeter: vi.fn(() => Promise.resolve()),
+		}));
+
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+		const event = createCanonicalTurnEvent();
+
+		await recordTelemetry(event);
+		await recordTelemetry({
+			type: "business-metric",
+			timestamp: "2026-05-07T07:00:01.000Z",
+			metric: "tokens.input",
+			value: event.tokens.input,
+			metadata: {
+				sessionId: event.sessionId,
+				model: event.model.id,
+				provider: event.model.provider,
+			},
+		});
+
+		expect(recordAgentTurnMetric).not.toHaveBeenCalled();
+		expect(recordLlmRequestMetric).not.toHaveBeenCalled();
+		expect(recordLlmTokenUsageMetric).not.toHaveBeenCalled();
+		expect(recordCompactionMetric).not.toHaveBeenCalled();
+		expect(recordToolInvocationMetric).not.toHaveBeenCalled();
+	});
+
+	it("populates skill metrics from tool skill metadata", async () => {
+		const recordAgentTurnMetric = vi.fn();
+		const recordCompactionMetric = vi.fn();
+		const recordLlmRequestMetric = vi.fn();
+		const recordLlmTokenUsageMetric = vi.fn();
+		const recordToolInvocationMetric = vi.fn();
+
+		vi.doMock("../../src/opentelemetry.js", () => ({
+			getTelemetryTracer: () => ({
+				startActiveSpan: (
+					_name: string,
+					callback: (span: {
+						setAttributes(attributes: Record<string, unknown>): void;
+						setAttribute(name: string, value: unknown): void;
+						setStatus(status: Record<string, unknown>): void;
+						end(): void;
+					}) => void,
+				) => {
+					callback({
+						setAttributes() {},
+						setAttribute() {},
+						setStatus() {},
+						end() {},
+					});
+				},
+			}),
+			initOpenTelemetry: vi.fn(),
+			isOpenTelemetryEnabled: () => true,
+		}));
+		vi.doMock("../../src/telemetry/metrics.js", () => ({
+			recordAgentTurnMetric,
+			recordCompactionMetric,
+			recordLlmRequestMetric,
+			recordLlmTokenUsageMetric,
+			recordToolInvocationMetric,
+		}));
+		vi.doMock("../../src/telemetry/maestro-event-bus.js", () => ({
+			mirrorTelemetryToMaestroEventBus: vi.fn(() => Promise.resolve()),
+			resolveMaestroEventBusConfig: () => ({
+				defaultCorrelation: {},
+				defaultPrincipal: undefined,
+				defaultSurface: "cli",
+			}),
+		}));
+		vi.doMock("../../src/telemetry/meter-service-client.js", () => ({
+			hasRemoteMeterDestination: () => false,
+			mirrorCanonicalTurnEventToMeter: vi.fn(() => Promise.resolve()),
+		}));
+
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+
+		await recordTelemetry({
+			type: "tool-execution",
+			timestamp: "2026-05-07T07:00:02.000Z",
+			toolName: "Skill",
+			success: true,
+			durationMs: 125,
+			metadata: {
+				toolCallId: "call-123",
+				skillMetadata: {
+					name: "incident-review",
+					hash: "hash_skill_123",
+					source: "service",
+				},
+			},
+		});
+
+		expect(recordToolInvocationMetric).toHaveBeenCalledWith({
+			toolName: "Skill",
+			durationMs: 125,
+			success: true,
+			agentRunId: undefined,
+			skillName: "incident-review",
+		});
+		expect(recordAgentTurnMetric).not.toHaveBeenCalled();
+		expect(recordLlmRequestMetric).not.toHaveBeenCalled();
+		expect(recordLlmTokenUsageMetric).not.toHaveBeenCalled();
+		expect(recordCompactionMetric).not.toHaveBeenCalled();
+	});
+});

--- a/test/telemetry/turn-tracker.test.ts
+++ b/test/telemetry/turn-tracker.test.ts
@@ -1,9 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Agent } from "../../src/agent/agent.js";
 import type { AgentEvent, AssistantMessage } from "../../src/agent/types.js";
 import { TurnTracker } from "../../src/telemetry/turn-tracker.js";
 
+const metricRecorders = vi.hoisted(() => ({
+	recordAgentTurnMetric: vi.fn(),
+	recordLlmRequestMetric: vi.fn(),
+	recordLlmTokenUsageMetric: vi.fn(),
+}));
+
+vi.mock("../../src/telemetry/metrics.js", () => metricRecorders);
+
 describe("TurnTracker", () => {
+	beforeEach(() => {
+		vi.stubEnv("MAESTRO_OTEL", "1");
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
 	it("does not start LLM timing on user message boundaries", () => {
 		let listener: ((event: AgentEvent) => void) | undefined;
 		const agent = {
@@ -303,6 +320,16 @@ describe("TurnTracker", () => {
 			},
 			costUsd: 1.1,
 		});
+		expect(metricRecorders.recordLlmTokenUsageMetric).toHaveBeenNthCalledWith(
+			1,
+			{ input: 10, output: 20, cacheRead: 1, cacheWrite: 2 },
+			expect.any(Object),
+		);
+		expect(metricRecorders.recordLlmTokenUsageMetric).toHaveBeenNthCalledWith(
+			2,
+			{ input: 30, output: 40, cacheRead: 3, cacheWrite: 4 },
+			expect.any(Object),
+		);
 	});
 
 	it("records governed tool failure codes on completed turns", () => {

--- a/test/telemetry/wide-events-metrics.test.ts
+++ b/test/telemetry/wide-events-metrics.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const metricRecorders = vi.hoisted(() => ({
+	recordAgentTurnMetric: vi.fn(),
+	recordLlmRequestMetric: vi.fn(),
+	recordLlmTokenUsageMetric: vi.fn(),
+}));
+
+vi.mock("../../src/telemetry/metrics.js", () => metricRecorders);
+
+describe("TurnCollector metrics", () => {
+	beforeEach(() => {
+		vi.stubEnv("MAESTRO_OTEL", "1");
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("records turn and token metrics before canonical-event sampling", async () => {
+		const { TurnCollector } = await import(
+			"../../src/telemetry/wide-events.js"
+		);
+		const recorder = vi.fn();
+		const collector = new TurnCollector(
+			"session-unsampled",
+			100,
+			{
+				alwaysSampleFirstN: 0,
+				slowThresholdMs: 999999,
+				successSampleRate: 0,
+			},
+			recorder,
+		);
+		collector.setModel({
+			id: "claude-opus-4-6",
+			provider: "anthropic",
+			thinkingLevel: "high",
+		});
+
+		const event = collector.complete(
+			"success",
+			{ input: 11, output: 22, cacheRead: 3, cacheWrite: 4 },
+			0.01,
+		);
+
+		expect(event.sampled).toBe(false);
+		expect(recorder).not.toHaveBeenCalled();
+		expect(metricRecorders.recordAgentTurnMetric).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: "success",
+				modelId: "claude-opus-4-6",
+				modelProvider: "anthropic",
+			}),
+		);
+		expect(metricRecorders.recordLlmRequestMetric).toHaveBeenCalledWith({
+			provider: "anthropic",
+			modelId: "claude-opus-4-6",
+		});
+		expect(metricRecorders.recordLlmTokenUsageMetric).toHaveBeenCalledWith(
+			{
+				input: 11,
+				output: 22,
+				cacheRead: 3,
+				cacheWrite: 4,
+			},
+			{
+				"llm.model.provider": "anthropic",
+				"llm.model.id": "claude-opus-4-6",
+			},
+		);
+	});
+
+	it("counts each LLM request while recording aggregate turn tokens once", async () => {
+		const { TurnCollector } = await import(
+			"../../src/telemetry/wide-events.js"
+		);
+		const collector = new TurnCollector("session-tools", 1);
+		collector.setModel({
+			id: "claude-opus-4-6",
+			provider: "anthropic",
+			thinkingLevel: "high",
+		});
+
+		collector.recordLlmStart();
+		collector.recordLlmEnd();
+		collector.recordLlmStart();
+		collector.recordLlmEnd();
+		collector.complete(
+			"success",
+			{ input: 30, output: 40, cacheRead: 5, cacheWrite: 6 },
+			0.02,
+		);
+
+		expect(metricRecorders.recordLlmRequestMetric).toHaveBeenCalledTimes(2);
+		expect(metricRecorders.recordLlmRequestMetric).toHaveBeenNthCalledWith(1, {
+			provider: "anthropic",
+			modelId: "claude-opus-4-6",
+		});
+		expect(metricRecorders.recordLlmRequestMetric).toHaveBeenNthCalledWith(2, {
+			provider: "anthropic",
+			modelId: "claude-opus-4-6",
+		});
+		expect(metricRecorders.recordLlmTokenUsageMetric).toHaveBeenCalledTimes(1);
+		expect(metricRecorders.recordLlmTokenUsageMetric).toHaveBeenCalledWith(
+			{ input: 30, output: 40, cacheRead: 5, cacheWrite: 6 },
+			{
+				"llm.model.provider": "anthropic",
+				"llm.model.id": "claude-opus-4-6",
+			},
+		);
+	});
+
+	it("counts failed LLM attempts even when no usage is produced", async () => {
+		const { TurnCollector } = await import(
+			"../../src/telemetry/wide-events.js"
+		);
+		const collector = new TurnCollector("session-provider-error", 1);
+		collector.setModel({
+			id: "claude-opus-4-6",
+			provider: "anthropic",
+			thinkingLevel: "high",
+		});
+
+		collector.recordLlmStart();
+		collector.complete(
+			"error",
+			{ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			0,
+		);
+
+		expect(metricRecorders.recordLlmRequestMetric).toHaveBeenCalledTimes(1);
+		expect(metricRecorders.recordLlmRequestMetric).toHaveBeenCalledWith({
+			provider: "anthropic",
+			modelId: "claude-opus-4-6",
+		});
+	});
+
+	it("does not count pre-provider turn errors as LLM requests", async () => {
+		const { TurnCollector } = await import(
+			"../../src/telemetry/wide-events.js"
+		);
+		const collector = new TurnCollector("session-early-error", 1);
+		collector.setModel({
+			id: "claude-opus-4-6",
+			provider: "anthropic",
+			thinkingLevel: "high",
+		});
+
+		collector.complete(
+			"error",
+			{ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			0,
+		);
+
+		expect(metricRecorders.recordLlmRequestMetric).not.toHaveBeenCalled();
+	});
+
+	it("honors the explicit OTel opt-out for turn metrics", async () => {
+		vi.stubEnv("MAESTRO_OTEL", "0");
+		const { TurnCollector } = await import(
+			"../../src/telemetry/wide-events.js"
+		);
+		const collector = new TurnCollector("session-otel-disabled", 1);
+		collector.setModel({
+			id: "claude-opus-4-6",
+			provider: "anthropic",
+			thinkingLevel: "high",
+		});
+
+		collector.complete(
+			"success",
+			{ input: 10, output: 5, cacheRead: 0, cacheWrite: 0 },
+			0.01,
+		);
+
+		expect(metricRecorders.recordAgentTurnMetric).not.toHaveBeenCalled();
+		expect(metricRecorders.recordLlmRequestMetric).not.toHaveBeenCalled();
+		expect(metricRecorders.recordLlmTokenUsageMetric).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `5e045dc982f6e3b7aee4b39e0312ffd2b168319a`
- last generated public sync base: `9fef67f2a83b590d92a04bb7a49a0a23fad3576c`
- previewed public-tree drift: `12` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (5e045dc982f6)`
- public projection: `https://github.com/evalops/maestro@main (9fef67f2a83b)`
- files to copy or update: `12`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/agent/tracing.ts
- copy/update src/telemetry.ts
- copy/update src/telemetry/metrics.ts
- copy/update src/telemetry/turn-tracker.ts
- copy/update src/telemetry/wide-events.ts
- copy/update src/tools/typebox-tool.ts
- copy/update test/agent/tracing-metrics.test.ts
- copy/update test/agent/tracing-usage.test.ts
- copy/update test/telemetry/otel-metrics.test.ts
- copy/update test/telemetry/telemetry-otel-routing.test.ts
- copy/update test/telemetry/turn-tracker.test.ts
- copy/update test/telemetry/wide-events-metrics.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/agent/tracing.ts
- copy/update src/telemetry.ts
- copy/update src/telemetry/metrics.ts
- copy/update src/telemetry/turn-tracker.ts
- copy/update src/telemetry/wide-events.ts
- copy/update src/tools/typebox-tool.ts
- copy/update test/agent/tracing-metrics.test.ts
- copy/update test/agent/tracing-usage.test.ts
- copy/update test/telemetry/otel-metrics.test.ts
- copy/update test/telemetry/telemetry-otel-routing.test.ts
- copy/update test/telemetry/turn-tracker.test.ts
- copy/update test/telemetry/wide-events-metrics.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #305 to internal source `5e045dc982f6e3b7aee4b39e0312ffd2b168319a`