### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -42,6 +42,7 @@ type BaseTelemetryEvent = {
 		| "business-metric"
 		| "sandbox-violation";
 	timestamp: string;
+	sensitiveMetadata?: Record<string, unknown>;
 };
 
 export interface ApiRequestTelemetry extends BaseTelemetryEvent {
@@ -237,6 +238,8 @@ const defaultTelemetryFile = PATHS.TELEMETRY_LOG;
 const toolFailureLogFile = PATHS.TOOL_FAILURE_LOG;
 const BACKGROUND_TASK_HISTORY_LIMIT = 50;
 const backgroundTaskHistory: BackgroundTaskTelemetry[] = [];
+const SENSITIVE_METADATA_KEY_PATTERN =
+	/^(api[_-]?key|authorization|auth|bearer|client[_-]?secret|cookie|credential|credentials|key|password|passwd|private[_-]?key|refresh[_-]?token|secret|session[_-]?token|set[_-]?cookie|token)$/i;
 
 export interface TelemetryStatus {
 	enabled: boolean;
@@ -289,6 +292,246 @@ export function setTelemetryRuntimeOverride(
 	telemetryOverride = enabled;
 	telemetryOverrideReason = reason;
 	telemetryEnabled = enabled === null ? initialTelemetryEnabled : enabled;
+}
+
+export function splitTelemetryMetadata(metadata?: Record<string, unknown>): {
+	metadata?: Record<string, unknown>;
+	sensitiveMetadata?: Record<string, unknown>;
+} {
+	return splitTelemetryMetadataRecord(metadata, new WeakSet<object>());
+}
+
+function splitTelemetryMetadataRecord(
+	metadata: Record<string, unknown> | undefined,
+	seen: WeakSet<object>,
+): {
+	metadata?: Record<string, unknown>;
+	sensitiveMetadata?: Record<string, unknown>;
+} {
+	if (!metadata) {
+		return {};
+	}
+	if (seen.has(metadata)) {
+		return {
+			metadata: {
+				value: "[circular]",
+			},
+		};
+	}
+	seen.add(metadata);
+	const safe: Record<string, unknown> = {};
+	const sensitive: Record<string, unknown> = {};
+
+	for (const [key, value] of Object.entries(metadata)) {
+		if (isSensitiveMetadataKey(key)) {
+			sensitive[key] = maskSensitiveMetadataValue(value, seen);
+			continue;
+		}
+		const splitValue = splitTelemetryMetadataValue(value, seen);
+		if (splitValue.safe !== undefined) {
+			safe[key] = splitValue.safe;
+		}
+		if (splitValue.sensitive !== undefined) {
+			sensitive[key] = splitValue.sensitive;
+		}
+	}
+	seen.delete(metadata);
+
+	return {
+		metadata: hasEntries(safe) ? safe : undefined,
+		sensitiveMetadata: hasEntries(sensitive) ? sensitive : undefined,
+	};
+}
+
+function normalizeTelemetryEventMetadata(
+	event: TelemetryEvent,
+): TelemetryEvent {
+	if (!("metadata" in event) && !("sensitiveMetadata" in event)) {
+		return event;
+	}
+	const existingMetadata =
+		"metadata" in event ? stringRecord(event.metadata) : undefined;
+	const { metadata, sensitiveMetadata } =
+		splitTelemetryMetadata(existingMetadata);
+	const sanitizedSensitiveMetadata = stringRecord(
+		maskSensitiveMetadataValue(event.sensitiveMetadata),
+	);
+	const mergedSensitiveMetadata = mergeRecords(
+		sensitiveMetadata,
+		sanitizedSensitiveMetadata,
+	);
+	const normalized = { ...event };
+	if ("metadata" in normalized) {
+		if (metadata) {
+			normalized.metadata = metadata;
+		} else {
+			delete normalized.metadata;
+		}
+	}
+	if (mergedSensitiveMetadata) {
+		normalized.sensitiveMetadata = mergedSensitiveMetadata;
+	} else {
+		delete normalized.sensitiveMetadata;
+	}
+	return normalized;
+}
+
+function splitTelemetryMetadataValue(
+	value: unknown,
+	seen: WeakSet<object>,
+): {
+	safe?: unknown;
+	sensitive?: unknown;
+} {
+	if (Array.isArray(value)) {
+		if (seen.has(value)) {
+			return {
+				safe: "[circular]",
+			};
+		}
+		seen.add(value);
+		const safeItems: unknown[] = [];
+		const sensitiveItems: unknown[] = [];
+		let hasSensitive = false;
+		for (const item of value) {
+			const splitItem = splitTelemetryMetadataValue(item, seen);
+			safeItems.push(splitItem.safe ?? null);
+			sensitiveItems.push(splitItem.sensitive ?? null);
+			hasSensitive = hasSensitive || splitItem.sensitive !== undefined;
+		}
+		seen.delete(value);
+		return {
+			safe: safeItems,
+			sensitive: hasSensitive ? sensitiveItems : undefined,
+		};
+	}
+	if (value && typeof value === "object") {
+		const record = plainRecord(value);
+		if (!record) {
+			return {
+				safe: sanitizeTelemetryMetadataValue(value),
+			};
+		}
+		if (seen.has(value)) {
+			return {
+				safe: "[circular]",
+			};
+		}
+		const nested = splitTelemetryMetadataRecord(record, seen);
+		return {
+			safe: nested.metadata,
+			sensitive: nested.sensitiveMetadata,
+		};
+	}
+	return {
+		safe: sanitizeTelemetryMetadataValue(value),
+	};
+}
+
+function sanitizeTelemetryMetadataValue(value: unknown): unknown {
+	return typeof value === "string" ? sanitizeWithStaticMask(value) : value;
+}
+
+function maskSensitiveMetadataValue(
+	value: unknown,
+	seen = new WeakSet<object>(),
+): unknown {
+	if (typeof value === "string") {
+		return "[sensitive]";
+	}
+	if (Array.isArray(value)) {
+		if (seen.has(value)) {
+			return "[sensitive]";
+		}
+		seen.add(value);
+		const masked = value.map((item) => maskSensitiveMetadataValue(item, seen));
+		seen.delete(value);
+		return masked;
+	}
+	if (value && typeof value === "object") {
+		const record = plainRecord(value);
+		if (!record) {
+			return "[sensitive]";
+		}
+		if (seen.has(value)) {
+			return "[sensitive]";
+		}
+		seen.add(value);
+		const masked = Object.fromEntries(
+			Object.entries(record).map(([key, nested]) => [
+				key,
+				maskSensitiveMetadataValue(nested, seen),
+			]),
+		);
+		seen.delete(value);
+		return masked;
+	}
+	if (value === undefined) {
+		return undefined;
+	}
+	if (value === null) {
+		return null;
+	}
+	return "[sensitive]";
+}
+
+function isSensitiveMetadataKey(key: string): boolean {
+	return SENSITIVE_METADATA_KEY_PATTERN.test(key);
+}
+
+function hasEntries(record: Record<string, unknown>): boolean {
+	return Object.keys(record).length > 0;
+}
+
+function mergeRecords(
+	first?: Record<string, unknown>,
+	second?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+	if (!first && !second) {
+		return undefined;
+	}
+	const merged: Record<string, unknown> = { ...(first ?? {}) };
+	for (const [key, value] of Object.entries(second ?? {})) {
+		merged[key] = mergeMetadataValues(merged[key], value);
+	}
+	return hasEntries(merged) ? merged : undefined;
+}
+
+function mergeMetadataValues(first: unknown, second: unknown): unknown {
+	if (second === null || second === undefined) {
+		return first;
+	}
+	if (first === null || first === undefined) {
+		return second;
+	}
+	if (Array.isArray(first) && Array.isArray(second)) {
+		return mergeMetadataArrays(first, second);
+	}
+	const firstRecord = plainRecord(first);
+	const secondRecord = plainRecord(second);
+	if (firstRecord && secondRecord) {
+		return mergeRecords(firstRecord, secondRecord);
+	}
+	return second;
+}
+
+function mergeMetadataArrays(first: unknown[], second: unknown[]): unknown[] {
+	const merged: unknown[] = [];
+	const length = Math.max(first.length, second.length);
+	for (let index = 0; index < length; index += 1) {
+		merged[index] = mergeMetadataValues(first[index], second[index]);
+	}
+	return merged;
+}
+
+function plainRecord(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null
+		? (value as Record<string, unknown>)
+		: undefined;
 }
 
 function isCanonicalTurnTelemetryEvent(
@@ -690,12 +933,13 @@ export function getBackgroundTaskHistory(
 }
 
 export async function recordTelemetry(event: TelemetryEvent): Promise<void> {
+	const normalizedEvent = normalizeTelemetryEventMetadata(event);
 	const openTelemetryEnabled = isOpenTelemetryEnabled();
 	if (openTelemetryEnabled) {
-		recordOpenTelemetrySpan(event);
-		recordOpenTelemetryMetric(event);
+		recordOpenTelemetrySpan(normalizedEvent);
+		recordOpenTelemetryMetric(normalizedEvent);
 	}
-	const eventBusTask = mirrorTelemetryToMaestroEventBus(event);
+	const eventBusTask = mirrorTelemetryToMaestroEventBus(normalizedEvent);
 
 	const legacyEnabled = telemetryEnabled && samplingRate > 0;
 	if (!legacyEnabled) {
@@ -709,7 +953,7 @@ export async function recordTelemetry(event: TelemetryEvent): Promise<void> {
 	}
 
 	try {
-		await Promise.all([persistTelemetry(event), eventBusTask]);
+		await Promise.all([persistTelemetry(normalizedEvent), eventBusTask]);
 	} catch (_error) {
 		// Ignore telemetry persistence failures
 	}

--- a/test/telemetry/telemetry-metadata-split.test.ts
+++ b/test/telemetry/telemetry-metadata-split.test.ts
@@ -1,0 +1,252 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("telemetry metadata split", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		vi.resetModules();
+		tempDir = await mkdtemp(join(tmpdir(), "maestro-telemetry-"));
+		vi.stubEnv("MAESTRO_TELEMETRY", "1");
+		vi.stubEnv("MAESTRO_TELEMETRY_FILE", join(tempDir, "telemetry.jsonl"));
+		vi.stubEnv("MAESTRO_OTEL", "0");
+	});
+
+	afterEach(async () => {
+		vi.resetModules();
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("routes sensitive metadata keys out of queryable metadata", async () => {
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+
+		await recordTelemetry({
+			type: "tool-execution",
+			timestamp: "2026-05-07T09:00:00.000Z",
+			toolName: "bash",
+			success: true,
+			durationMs: 25,
+			metadata: {
+				sessionId: "session-123",
+				agentRunId: "run-456",
+				commandSummary: "npm test -- token=sk-test1234567890abcd",
+				apiKey: "sk-test1234567890abcd",
+				password: "correct-horse-battery-staple",
+				headers: {
+					authorization: "Bearer secret-token",
+					route: "/v1/runs",
+				},
+			},
+		});
+
+		const payload = JSON.parse(
+			(await readFile(join(tempDir, "telemetry.jsonl"), "utf8")).trim(),
+		) as {
+			metadata?: Record<string, unknown>;
+			sensitiveMetadata?: Record<string, unknown>;
+		};
+
+		expect(payload.metadata).toEqual({
+			sessionId: "session-123",
+			agentRunId: "run-456",
+			commandSummary: "npm test -- token=[secret]",
+			headers: {
+				route: "/v1/runs",
+			},
+		});
+		expect(payload.sensitiveMetadata).toEqual({
+			apiKey: "[sensitive]",
+			password: "[sensitive]",
+			headers: {
+				authorization: "[sensitive]",
+			},
+		});
+		expect(JSON.stringify(payload.metadata)).not.toContain("correct-horse");
+		expect(JSON.stringify(payload.metadata)).not.toContain("sk-test");
+	});
+
+	it("mirrors normalized metadata to the Maestro event bus", async () => {
+		const mirrorTelemetryToMaestroEventBus = vi.fn(() => Promise.resolve());
+		vi.doMock("../../src/telemetry/maestro-event-bus.js", () => ({
+			mirrorTelemetryToMaestroEventBus,
+			resolveMaestroEventBusConfig: () => ({
+				defaultCorrelation: {},
+				defaultPrincipal: undefined,
+				defaultSurface: "cli",
+			}),
+		}));
+
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+
+		await recordTelemetry({
+			type: "tool-execution",
+			timestamp: "2026-05-07T09:00:01.000Z",
+			toolName: "bash",
+			success: false,
+			durationMs: 40,
+			metadata: {
+				agentRunId: "run-789",
+				error: "request failed with Authorization: Bearer secret-token",
+				headers: {
+					authorization: "Bearer secret-token",
+					route: "/v1/runs",
+				},
+			},
+			sensitiveMetadata: {
+				headers: {
+					cookie: "session=secret-cookie",
+				},
+			},
+		});
+
+		expect(mirrorTelemetryToMaestroEventBus).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadata: {
+					agentRunId: "run-789",
+					error: "request failed with Authorization: Bearer [secret]",
+					headers: {
+						route: "/v1/runs",
+					},
+				},
+				sensitiveMetadata: {
+					headers: {
+						authorization: "[sensitive]",
+						cookie: "[sensitive]",
+					},
+				},
+			}),
+		);
+	});
+
+	it("preserves sensitive fields when overlapping arrays are merged", async () => {
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+
+		await recordTelemetry({
+			type: "tool-execution",
+			timestamp: "2026-05-07T09:00:02.000Z",
+			toolName: "bash",
+			success: true,
+			durationMs: 18,
+			metadata: {
+				events: [
+					{ name: "first", token: "secret-token" },
+					{ apiKey: "sk-test1234567890abcd" },
+				],
+			},
+			sensitiveMetadata: {
+				events: [{ cookie: "session=secret-cookie" }, null, { password: "pw" }],
+			},
+		});
+
+		const payload = JSON.parse(
+			(await readFile(join(tempDir, "telemetry.jsonl"), "utf8")).trim(),
+		) as {
+			metadata?: Record<string, unknown>;
+			sensitiveMetadata?: Record<string, unknown>;
+		};
+
+		expect(payload.metadata).toEqual({
+			events: [{ name: "first" }, null],
+		});
+		expect(payload.sensitiveMetadata).toEqual({
+			events: [
+				{ token: "[sensitive]", cookie: "[sensitive]" },
+				{ apiKey: "[sensitive]" },
+				{ password: "[sensitive]" },
+			],
+		});
+	});
+
+	it("keeps telemetry recording safe when metadata contains cycles", async () => {
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+		const metadata: Record<string, unknown> = {
+			sessionId: "session-cycle",
+		};
+		metadata.self = metadata;
+
+		await expect(
+			recordTelemetry({
+				type: "tool-execution",
+				timestamp: "2026-05-07T09:00:03.000Z",
+				toolName: "bash",
+				success: true,
+				durationMs: 10,
+				metadata,
+			}),
+		).resolves.toBeUndefined();
+
+		const payload = JSON.parse(
+			(await readFile(join(tempDir, "telemetry.jsonl"), "utf8")).trim(),
+		) as {
+			metadata?: Record<string, unknown>;
+		};
+
+		expect(payload.metadata).toEqual({
+			sessionId: "session-cycle",
+			self: "[circular]",
+		});
+	});
+
+	it("preserves non-plain metadata objects with their JSON representation", async () => {
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+
+		await recordTelemetry({
+			type: "tool-execution",
+			timestamp: "2026-05-07T09:00:04.000Z",
+			toolName: "bash",
+			success: true,
+			durationMs: 12,
+			metadata: {
+				generatedAt: new Date("2026-05-07T09:00:04.000Z"),
+				dashboardUrl: new URL("https://example.test/runs/run-123"),
+			},
+		});
+
+		const payload = JSON.parse(
+			(await readFile(join(tempDir, "telemetry.jsonl"), "utf8")).trim(),
+		) as {
+			metadata?: Record<string, unknown>;
+		};
+
+		expect(payload.metadata).toEqual({
+			generatedAt: "2026-05-07T09:00:04.000Z",
+			dashboardUrl: "https://example.test/runs/run-123",
+		});
+	});
+
+	it("classifies nested metadata without losing safe sibling fields", async () => {
+		const { splitTelemetryMetadata } = await import("../../src/telemetry.js");
+
+		expect(
+			splitTelemetryMetadata({
+				workspaceId: "workspace-1",
+				nested: {
+					token: "secret-token",
+					count: 2,
+				},
+				events: [
+					{ name: "safe", token: "secret-token" },
+					{ name: "also-safe" },
+				],
+			}),
+		).toEqual({
+			metadata: {
+				workspaceId: "workspace-1",
+				nested: {
+					count: 2,
+				},
+				events: [{ name: "safe" }, { name: "also-safe" }],
+			},
+			sensitiveMetadata: {
+				nested: {
+					token: "[sensitive]",
+				},
+				events: [{ token: "[sensitive]" }, null],
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `37b1a3085c625b0338ca46b3a5dad1aa5c61c1f0`
- last generated public sync base: `2bcc74f4dca23f9f8a120f87c7cea2927c41e86b`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (37b1a3085c62)`
- public projection: `https://github.com/evalops/maestro@main (2bcc74f4dca2)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/telemetry.ts
- copy/update test/telemetry/telemetry-metadata-split.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/telemetry.ts
- copy/update test/telemetry/telemetry-metadata-split.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode