### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -53,6 +53,11 @@ import {
 	ResourceListChangedNotificationSchema,
 	ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { getPackageVersion } from "../package-metadata.js";
+import {
+	emitMcpConnectionBeacon,
+	emitMcpToolUsageBeacon,
+} from "../telemetry/mcp-beacon.js";
 import { parseCommandArguments } from "../tools/shell-utils.js";
 import { createLogger } from "../utils/logger.js";
 import { getHomeDir } from "../utils/path-expansion.js";
@@ -695,6 +700,16 @@ export class McpClientManager extends EventEmitter {
 			this.setupNotificationHandlers(client, name);
 
 			this.emit("connected", { name, tools: tools.length, isReconnect });
+			void emitMcpConnectionBeacon({
+				serverName: name,
+				transport: transportType,
+				remoteHost: config.url ? getMcpRemoteHost(config.url) : undefined,
+				toolCount: tools.length,
+				resourceCount: resources.length,
+				promptCount: prompts.length,
+				isReconnect,
+				clientVersion: getPackageVersion(),
+			}).catch(() => undefined);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			this.lastErrors.set(name, message);
@@ -956,6 +971,16 @@ export class McpClientManager extends EventEmitter {
 		if (!server) {
 			throw new Error(`MCP server '${serverName}' not connected`);
 		}
+
+		void emitMcpToolUsageBeacon({
+			serverName,
+			transport: server.config.transport,
+			remoteHost: server.config.url
+				? getMcpRemoteHost(server.config.url)
+				: undefined,
+			toolName,
+			clientVersion: getPackageVersion(),
+		}).catch(() => undefined);
 
 		const result = await server.client.callTool({
 			name: toolName,

--- a/src/telemetry/mcp-beacon.ts
+++ b/src/telemetry/mcp-beacon.ts
@@ -1,0 +1,89 @@
+import { emitBeacon } from "./beacon.js";
+
+type McpBeaconTransport = "stdio" | "http" | "sse";
+
+interface McpBeaconBase {
+	serverName: string;
+	transport: McpBeaconTransport;
+	remoteHost?: string;
+	clientVersion?: string;
+}
+
+export interface McpConnectionBeacon extends McpBeaconBase {
+	toolCount: number;
+	resourceCount: number;
+	promptCount: number;
+	isReconnect?: boolean;
+}
+
+export interface McpToolUsageBeacon extends McpBeaconBase {
+	toolName: string;
+}
+
+export function emitMcpConnectionBeacon(
+	beacon: McpConnectionBeacon,
+): Promise<boolean> {
+	return emitBeacon({
+		feature: "mcp.connection",
+		action: mcpTransportAction(beacon.transport, "Connected"),
+		timestamp: Date.now() * 1000,
+		source: {
+			client: "cli",
+			clientVersion: clientVersion(beacon.clientVersion),
+			surface: "mcp",
+		},
+		parameters: {
+			metadata: compactMetadata({
+				serverName: beacon.serverName,
+				transport: beacon.transport,
+				remoteHost: beacon.remoteHost,
+				toolCount: beacon.toolCount,
+				resourceCount: beacon.resourceCount,
+				promptCount: beacon.promptCount,
+				reconnect: beacon.isReconnect === true,
+			}),
+		},
+	});
+}
+
+export function emitMcpToolUsageBeacon(
+	beacon: McpToolUsageBeacon,
+): Promise<boolean> {
+	return emitBeacon({
+		feature: "mcp.toolUsage",
+		action: mcpTransportAction(beacon.transport, "ToolCalled"),
+		timestamp: Date.now() * 1000,
+		source: {
+			client: "cli",
+			clientVersion: clientVersion(beacon.clientVersion),
+			surface: "mcp",
+		},
+		parameters: {
+			metadata: compactMetadata({
+				serverName: beacon.serverName,
+				transport: beacon.transport,
+				remoteHost: beacon.remoteHost,
+				toolName: beacon.toolName,
+			}),
+		},
+	});
+}
+
+function mcpTransportAction(
+	transport: McpBeaconTransport,
+	suffix: "Connected" | "ToolCalled",
+): string {
+	return `${transport === "stdio" ? "local" : "remote"}${suffix}`;
+}
+
+function clientVersion(value: string | undefined): string {
+	return value ?? process.env.MAESTRO_VERSION ?? "unknown";
+}
+
+function compactMetadata(
+	metadata: Record<string, unknown>,
+): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(metadata).filter(([, value]) => value !== undefined),
+	);
+}

--- a/test/agent/mcp-manager-transports.test.ts
+++ b/test/agent/mcp-manager-transports.test.ts
@@ -1,4 +1,11 @@
-import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,6 +13,7 @@ import { runWithMcpClientToolService } from "../../src/mcp/elicitation.js";
 
 const mockClientConnect = vi.fn();
 const mockClientClose = vi.fn();
+const mockCallTool = vi.fn();
 const mockSetNotificationHandler = vi.fn();
 const mockSetRequestHandler = vi.fn();
 const mockListPrompts = vi.fn().mockResolvedValue({ prompts: [] });
@@ -28,6 +36,10 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
 		listTools = vi.fn().mockResolvedValue({ tools: [] });
 		listResources = vi.fn().mockResolvedValue({ resources: [] });
 		listPrompts = mockListPrompts;
+		callTool = mockCallTool.mockResolvedValue({
+			content: [{ type: "text", text: "ok" }],
+			isError: false,
+		});
 		setNotificationHandler = mockSetNotificationHandler;
 		setRequestHandler = mockSetRequestHandler;
 		close = mockClientClose.mockResolvedValue(undefined);
@@ -66,6 +78,7 @@ describe("MCP manager remote transports", () => {
 		mkdirSync(tempDir, { recursive: true });
 		mockClientConnect.mockClear();
 		mockClientClose.mockClear();
+		mockCallTool.mockClear();
 		mockSetNotificationHandler.mockClear();
 		mockSetRequestHandler.mockClear();
 		mockListPrompts.mockReset().mockResolvedValue({ prompts: [] });
@@ -76,6 +89,7 @@ describe("MCP manager remote transports", () => {
 
 	afterEach(async () => {
 		await manager.disconnectAll();
+		vi.unstubAllEnvs();
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
@@ -96,6 +110,68 @@ describe("MCP manager remote transports", () => {
 			"https://example.com/mcp",
 		);
 		expect(manager.isConnected("remote-http")).toBe(true);
+	});
+
+	it("emits sparse MCP connection and tool usage beacons", async () => {
+		vi.stubEnv("MAESTRO_TELEMETRY", "1");
+		vi.stubEnv("MAESTRO_BEACON_FILE", join(tempDir, "beacon.jsonl"));
+		vi.stubEnv("MAESTRO_VERSION", "0.10.18-test");
+
+		await manager.configure({
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp?token=secret",
+				},
+			],
+		});
+		await waitForBeaconEvents(1, process.env.MAESTRO_BEACON_FILE!);
+
+		await manager.callTool("remote-http", "search", {
+			query: "do not collect this",
+		});
+		const events = await waitForBeaconEvents(
+			2,
+			process.env.MAESTRO_BEACON_FILE!,
+		);
+
+		expect(events).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					feature: "mcp.connection",
+					action: "remoteConnected",
+					parameters: {
+						metadata: expect.objectContaining({
+							serverName: "remote-http",
+							transport: "http",
+							remoteHost: "example.com",
+							toolCount: 0,
+							resourceCount: 0,
+							promptCount: 0,
+						}),
+					},
+				}),
+				expect.objectContaining({
+					feature: "mcp.toolUsage",
+					action: "remoteToolCalled",
+					parameters: {
+						metadata: {
+							serverName: "remote-http",
+							transport: "http",
+							remoteHost: "example.com",
+							toolName: "search",
+						},
+					},
+				}),
+			]),
+		);
+		for (const event of events) {
+			expect(event.parameters.metadata).not.toHaveProperty("url");
+			expect(event.parameters.metadata).not.toHaveProperty("args");
+			expect(event.parameters.metadata).not.toHaveProperty("query");
+			expect(event.parameters.metadata).not.toHaveProperty("content");
+		}
 	});
 
 	it("uses SSE transport for sse servers", async () => {
@@ -363,3 +439,36 @@ describe("MCP manager remote transports", () => {
 		).resolves.toEqual({ action: "cancel" });
 	});
 });
+
+async function waitForBeaconEvents(
+	count: number,
+	file: string,
+): Promise<
+	Array<{
+		feature: string;
+		action: string;
+		parameters: { metadata: Record<string, unknown> };
+	}>
+> {
+	const deadline = Date.now() + 1000;
+	while (Date.now() < deadline) {
+		if (existsSync(file)) {
+			const events = readFileSync(file, "utf8")
+				.trim()
+				.split("\n")
+				.filter(Boolean)
+				.flatMap((line) => JSON.parse(line));
+			if (events.length >= count) {
+				return events;
+			}
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	return existsSync(file)
+		? readFileSync(file, "utf8")
+				.trim()
+				.split("\n")
+				.filter(Boolean)
+				.flatMap((line) => JSON.parse(line))
+		: [];
+}

--- a/test/telemetry/mcp-beacon.test.ts
+++ b/test/telemetry/mcp-beacon.test.ts
@@ -1,0 +1,127 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("MCP telemetry beacons", () => {
+	let tempDir: string;
+	let beaconFile: string;
+
+	beforeEach(async () => {
+		vi.resetModules();
+		tempDir = await mkdtemp(join(tmpdir(), "maestro-mcp-beacon-"));
+		beaconFile = join(tempDir, "beacon.jsonl");
+		vi.stubEnv("MAESTRO_TELEMETRY", "1");
+		vi.stubEnv("MAESTRO_BEACON_FILE", beaconFile);
+		vi.stubEnv("MAESTRO_VERSION", "0.10.18-test");
+	});
+
+	afterEach(async () => {
+		vi.resetModules();
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("writes sparse local connection metadata without process details", async () => {
+		const { emitMcpConnectionBeacon } = await import(
+			"../../src/telemetry/mcp-beacon.js"
+		);
+
+		await emitMcpConnectionBeacon({
+			serverName: "local-tools",
+			transport: "stdio",
+			toolCount: 2,
+			resourceCount: 1,
+			promptCount: 0,
+		});
+
+		const [event] = await readBeaconEvents(beaconFile);
+
+		expect(event).toMatchObject({
+			feature: "mcp.connection",
+			action: "localConnected",
+			source: {
+				client: "cli",
+				clientVersion: "0.10.18-test",
+				surface: "mcp",
+			},
+			parameters: {
+				metadata: {
+					serverName: "local-tools",
+					transport: "stdio",
+					toolCount: 2,
+					resourceCount: 1,
+					promptCount: 0,
+					reconnect: false,
+				},
+			},
+		});
+		expect(event.parameters.metadata).not.toHaveProperty("command");
+		expect(event.parameters.metadata).not.toHaveProperty("args");
+		expect(event.parameters.metadata).not.toHaveProperty("env");
+	});
+
+	it("writes remote tool usage metadata without URL, args, or output", async () => {
+		const { emitMcpToolUsageBeacon } = await import(
+			"../../src/telemetry/mcp-beacon.js"
+		);
+
+		await emitMcpToolUsageBeacon({
+			serverName: "remote-tools",
+			transport: "http",
+			remoteHost: "mcp.example.test",
+			toolName: "search",
+		});
+
+		const [event] = await readBeaconEvents(beaconFile);
+
+		expect(event).toMatchObject({
+			feature: "mcp.toolUsage",
+			action: "remoteToolCalled",
+			parameters: {
+				metadata: {
+					serverName: "remote-tools",
+					transport: "http",
+					remoteHost: "mcp.example.test",
+					toolName: "search",
+				},
+			},
+		});
+		expect(event.parameters.metadata).not.toHaveProperty("url");
+		expect(event.parameters.metadata).not.toHaveProperty("args");
+		expect(event.parameters.metadata).not.toHaveProperty("content");
+		expect(event.parameters.metadata).not.toHaveProperty("structuredContent");
+	});
+
+	it("respects telemetry opt-out", async () => {
+		vi.stubEnv("MAESTRO_TELEMETRY", "0");
+		const { emitMcpToolUsageBeacon } = await import(
+			"../../src/telemetry/mcp-beacon.js"
+		);
+
+		const emitted = await emitMcpToolUsageBeacon({
+			serverName: "remote-tools",
+			transport: "sse",
+			remoteHost: "mcp.example.test",
+			toolName: "search",
+		});
+
+		expect(emitted).toBe(false);
+		await expect(readFile(beaconFile, "utf8")).rejects.toMatchObject({
+			code: "ENOENT",
+		});
+	});
+});
+
+async function readBeaconEvents(file: string): Promise<
+	Array<{
+		feature: string;
+		action: string;
+		source: Record<string, unknown>;
+		parameters: { metadata: Record<string, unknown> };
+	}>
+> {
+	const lines = (await readFile(file, "utf8")).trim().split("\n");
+	return lines.flatMap((line) => JSON.parse(line));
+}


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `6a7e60fe7e1b18317db12f528b9b22c6fa42caca`
- last generated public sync base: `421d67202da6bb36777e0dedf581bb8f61f027c7`
- previewed public-tree drift: `4` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (6a7e60fe7e1b)`
- public projection: `https://github.com/evalops/maestro@main (421d67202da6)`
- files to copy or update: `4`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/mcp/manager.ts
- copy/update src/telemetry/mcp-beacon.ts
- copy/update test/agent/mcp-manager-transports.test.ts
- copy/update test/telemetry/mcp-beacon.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/mcp/manager.ts
- copy/update src/telemetry/mcp-beacon.ts
- copy/update test/agent/mcp-manager-transports.test.ts
- copy/update test/telemetry/mcp-beacon.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode