### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/web/src/components/admin-security-tab.test.ts
+++ b/packages/web/src/components/admin-security-tab.test.ts
@@ -12,11 +12,13 @@ class TestAdminSecurityHost extends LitElement {
 		piiPatterns: string;
 		auditRetention: number;
 		webhookUrls: string;
+		telemetryDisabled: boolean;
 	} = {
 		orgSettings: null,
 		piiPatterns: "",
 		auditRetention: 90,
 		webhookUrls: "",
+		telemetryDisabled: false,
 	};
 
 	readonly getOrgSettings = vi.fn(async () => ({
@@ -24,6 +26,7 @@ class TestAdminSecurityHost extends LitElement {
 		piiPatterns: ["EMP-\\d{6}"],
 		auditRetentionDays: 30,
 		alertWebhooks: ["https://hooks.slack.com/services/a"],
+		internal: { telemetryDisabled: true },
 	}));
 
 	readonly updateOrgSettings = vi.fn(async () => undefined);
@@ -72,10 +75,14 @@ describe("AdminSecurityTab", () => {
 		const retentionInput = element.shadowRoot?.querySelector(
 			'input[type="number"]',
 		) as HTMLInputElement | null;
+		const checkboxes = Array.from(
+			element.shadowRoot?.querySelectorAll('input[type="checkbox"]') ?? [],
+		) as HTMLInputElement[];
 
 		assert.equal(textareas[0]?.value, "EMP-\\d{6}");
 		assert.equal(textareas[1]?.value, "https://hooks.slack.com/services/a");
 		assert.equal(retentionInput?.value, "30");
+		assert.equal(checkboxes[1]?.checked, true);
 	});
 
 	it("keeps PII save handler context when persisting settings", async () => {
@@ -158,6 +165,48 @@ describe("AdminSecurityTab", () => {
 		]);
 		assert.deepEqual(element.toastCalls, [
 			{ message: "Webhooks saved", type: "success" },
+		]);
+	});
+
+	it("persists the internal telemetry disablement control", async () => {
+		const element = await fixture<TestAdminSecurityHost>(
+			html`<test-admin-security-host></test-admin-security-host>`,
+		);
+		await element.updateComplete;
+
+		const checkboxes = Array.from(
+			element.shadowRoot?.querySelectorAll('input[type="checkbox"]') ?? [],
+		) as HTMLInputElement[];
+		const buttons = Array.from(
+			element.shadowRoot?.querySelectorAll("button.btn-primary") ?? [],
+		) as HTMLButtonElement[];
+		const telemetryCheckbox = checkboxes[1];
+		const telemetryButton = buttons[3];
+
+		assert.ok(telemetryCheckbox);
+		assert.ok(telemetryButton);
+
+		telemetryCheckbox.checked = true;
+		telemetryCheckbox.dispatchEvent(
+			new Event("change", { bubbles: true, composed: true }),
+		);
+		await element.updateComplete;
+
+		telemetryButton.click();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await element.updateComplete;
+
+		assert.deepEqual(element.updateOrgSettings.mock.calls, [
+			[
+				{
+					internal: {
+						telemetryDisabled: true,
+					},
+				},
+			],
+		]);
+		assert.deepEqual(element.toastCalls, [
+			{ message: "Telemetry controls saved", type: "success" },
 		]);
 	});
 });

--- a/packages/web/src/components/admin-security-tab.ts
+++ b/packages/web/src/components/admin-security-tab.ts
@@ -16,6 +16,7 @@ type SecurityState = {
 	piiPatterns: string;
 	auditRetention: number;
 	webhookUrls: string;
+	telemetryDisabled: boolean;
 };
 
 export class AdminSecurityTab {
@@ -36,6 +37,7 @@ export class AdminSecurityTab {
 			piiPatterns: settings?.piiPatterns?.join("\n") || "",
 			auditRetention: settings?.auditRetentionDays || 90,
 			webhookUrls: settings?.alertWebhooks?.join("\n") || "",
+			telemetryDisabled: settings?.internal?.telemetryDisabled ?? false,
 		});
 	}
 
@@ -111,6 +113,25 @@ INTERNAL-[A-Z]{3}-\\d{4}"
 					<button class="btn btn-primary" @click=${this.handleSaveWebhooks}>Save Webhooks</button>
 				</div>
 			</div>
+
+			<div class="section">
+				<div class="section-header">
+					<h3>Internal Telemetry</h3>
+				</div>
+				<div class="section-content">
+					<div class="form-group">
+						<label style="display: flex; align-items: center; gap: 0.5rem; cursor: pointer;">
+							<input
+								type="checkbox"
+								?checked=${state.telemetryDisabled}
+								@change=${this.handleTelemetryDisabledInput}
+							/>
+							<span>Disable internal telemetry for hosted runtimes</span>
+						</label>
+					</div>
+					<button class="btn btn-primary" @click=${this.handleSaveTelemetryControls}>Save Controls</button>
+				</div>
+			</div>
 		`;
 	}
 
@@ -130,6 +151,12 @@ INTERNAL-[A-Z]{3}-\\d{4}"
 	private readonly handleWebhookUrlsInput = (event: Event) => {
 		this.setState({
 			webhookUrls: (event.target as HTMLTextAreaElement).value,
+		});
+	};
+
+	private readonly handleTelemetryDisabledInput = (event: Event) => {
+		this.setState({
+			telemetryDisabled: (event.target as HTMLInputElement).checked,
 		});
 	};
 
@@ -181,6 +208,26 @@ INTERNAL-[A-Z]{3}-\\d{4}"
 		} catch (error) {
 			this.showToast(
 				error instanceof Error ? error.message : "Failed to save webhooks",
+				"error",
+			);
+		}
+	};
+
+	private readonly handleSaveTelemetryControls = async () => {
+		try {
+			const current = this.getState().orgSettings;
+			await this.getApi().updateOrgSettings({
+				internal: {
+					...current?.internal,
+					telemetryDisabled: this.getState().telemetryDisabled,
+				},
+			});
+			this.showToast("Telemetry controls saved", "success");
+		} catch (error) {
+			this.showToast(
+				error instanceof Error
+					? error.message
+					: "Failed to save telemetry controls",
 				"error",
 			);
 		}

--- a/packages/web/src/components/admin-settings.ts
+++ b/packages/web/src/components/admin-settings.ts
@@ -953,6 +953,7 @@ export class AdminSettings extends LitElement {
 	@state() private piiPatterns = "";
 	@state() private auditRetention = 90;
 	@state() private webhookUrls = "";
+	@state() private telemetryDisabled = false;
 
 	private api: EnterpriseApiClient;
 	private readonly auditTab: AdminAuditTab;
@@ -1024,6 +1025,7 @@ export class AdminSettings extends LitElement {
 				piiPatterns: this.piiPatterns,
 				auditRetention: this.auditRetention,
 				webhookUrls: this.webhookUrls,
+				telemetryDisabled: this.telemetryDisabled,
 			}),
 			(state) => {
 				if (state.orgSettings !== undefined) {
@@ -1037,6 +1039,9 @@ export class AdminSettings extends LitElement {
 				}
 				if (state.webhookUrls !== undefined) {
 					this.webhookUrls = state.webhookUrls;
+				}
+				if (state.telemetryDisabled !== undefined) {
+					this.telemetryDisabled = state.telemetryDisabled;
 				}
 				this.requestUpdate();
 			},
@@ -1157,6 +1162,8 @@ export class AdminSettings extends LitElement {
 						this.piiPatterns = settingsRes.piiPatterns?.join("\n") ?? "";
 						this.auditRetention = settingsRes.auditRetentionDays ?? 90;
 						this.webhookUrls = settingsRes.alertWebhooks?.join("\n") ?? "";
+						this.telemetryDisabled =
+							settingsRes.internal?.telemetryDisabled ?? false;
 					}
 					if (logsRes?.logs) {
 						this.auditLogs = logsRes.logs;

--- a/packages/web/src/services/enterprise-api.ts
+++ b/packages/web/src/services/enterprise-api.ts
@@ -28,6 +28,9 @@ export interface OrganizationSettings {
 	piiPatterns?: string[];
 	auditRetentionDays?: number;
 	alertWebhooks?: string[];
+	internal?: {
+		telemetryDisabled?: boolean;
+	};
 }
 
 export interface Role {

--- a/src/api/enterprise-routes.ts
+++ b/src/api/enterprise-routes.ts
@@ -5,7 +5,7 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { and, eq } from "drizzle-orm";
-import { AuditLogger } from "../audit/logger.js";
+import { AUDIT_ACTIONS, AuditLogger } from "../audit/logger.js";
 import { TokenTracker } from "../billing/token-tracker.js";
 import { getDb } from "../db/client.js";
 import {
@@ -26,6 +26,7 @@ import {
 } from "../rbac/permissions.js";
 import type { Route } from "../server/router.js";
 import { readJsonBody, sendJson } from "../server/server-utils.js";
+import { resolveInternalTelemetryDisabledSetting } from "../telemetry/disablement.js";
 import { createLogger } from "../utils/logger.js";
 import {
 	handleLogin,
@@ -262,14 +263,50 @@ async function handleUpdateOrgSettings(
 		return;
 	}
 
-	// Encrypt sensitive fields (webhookSigningSecret) before storing
-	const encryptedSettings = encryptOrgSettings(body);
-
 	const db = getDb();
+	const org = await db.query.organizations.findFirst({
+		where: eq(organizations.id, auth.orgId),
+	});
+	if (!org) {
+		sendJson(res, 404, { error: "Organization not found" }, cors, req);
+		return;
+	}
+
+	const previousSettings = decryptOrgSettings(org.settings) || {};
+	const mergedSettings: OrganizationSettings = {
+		...previousSettings,
+		...body,
+		internal:
+			body.internal || previousSettings.internal
+				? { ...previousSettings.internal, ...body.internal }
+				: undefined,
+	};
+	const previousTelemetryDisabled =
+		resolveInternalTelemetryDisabledSetting(previousSettings);
+	const nextTelemetryDisabled =
+		resolveInternalTelemetryDisabledSetting(mergedSettings);
+
+	// Encrypt sensitive fields (webhookSigningSecret) before storing
+	const encryptedSettings = encryptOrgSettings(mergedSettings);
+
 	await db
 		.update(organizations)
 		.set({ settings: encryptedSettings })
 		.where(eq(organizations.id, auth.orgId));
+
+	if (previousTelemetryDisabled !== nextTelemetryDisabled) {
+		await AuditLogger.log({
+			orgId: auth.orgId,
+			userId: auth.userId,
+			action: AUDIT_ACTIONS.CONFIG_WRITE,
+			resourceType: "organization_settings",
+			status: "success",
+			metadata: {
+				originalValue: String(previousTelemetryDisabled),
+				newValue: String(nextTelemetryDisabled),
+			},
+		});
+	}
 
 	sendJson(res, 200, { success: true }, cors, req);
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -108,6 +108,10 @@ export type OrganizationSettings = {
 		maxContextWindow?: number;
 		requireApproval?: boolean;
 	};
+	/** Internal EvalOps controls projected into hosted runtime environments */
+	internal?: {
+		telemetryDisabled?: boolean;
+	};
 };
 
 // ============================================================================

--- a/src/opentelemetry.ts
+++ b/src/opentelemetry.ts
@@ -13,6 +13,7 @@ import {
 	SEMRESATTRS_SERVICE_NAME,
 	SEMRESATTRS_SERVICE_VERSION,
 } from "@opentelemetry/semantic-conventions";
+import { isInternalTelemetryDisabled } from "./telemetry/disablement.js";
 
 let sdkStartPromise: Promise<void> | null = null;
 let sdkStarted = false;
@@ -41,6 +42,10 @@ const packageVersion = (() => {
 })();
 
 export const isOpenTelemetryEnabled = (): boolean => {
+	if (isInternalTelemetryDisabled()) {
+		return false;
+	}
+
 	if (process.env.MAESTRO_OTEL === "0") {
 		return false;
 	}
@@ -77,6 +82,7 @@ export interface OpenTelemetryStatus {
 }
 
 export function getOpenTelemetryStatus(): OpenTelemetryStatus {
+	const internalTelemetryDisabled = isInternalTelemetryDisabled();
 	const enabled = isOpenTelemetryEnabled();
 	const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
 	const tracesExporter =
@@ -95,9 +101,11 @@ export function getOpenTelemetryStatus(): OpenTelemetryStatus {
 		? process.env.MAESTRO_OTEL === "1"
 			? "MAESTRO_OTEL=1"
 			: "OTEL exporter detected"
-		: process.env.MAESTRO_OTEL === "0"
-			? "MAESTRO_OTEL=0"
-			: "no OTEL exporter configured";
+		: internalTelemetryDisabled
+			? "internal telemetry disabled"
+			: process.env.MAESTRO_OTEL === "0"
+				? "MAESTRO_OTEL=0"
+				: "no OTEL exporter configured";
 
 	return {
 		enabled,

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -8,6 +8,7 @@ import {
 	initOpenTelemetry,
 	isOpenTelemetryEnabled,
 } from "./opentelemetry.js";
+import { isInternalTelemetryDisabled } from "./telemetry/disablement.js";
 import {
 	type MaestroCorrelation,
 	mirrorTelemetryToMaestroEventBus,
@@ -933,6 +934,10 @@ export function getBackgroundTaskHistory(
 }
 
 export async function recordTelemetry(event: TelemetryEvent): Promise<void> {
+	if (isInternalTelemetryDisabled()) {
+		return;
+	}
+
 	const normalizedEvent = normalizeTelemetryEventMetadata(event);
 	const openTelemetryEnabled = isOpenTelemetryEnabled();
 	if (openTelemetryEnabled) {

--- a/src/telemetry/beacon.ts
+++ b/src/telemetry/beacon.ts
@@ -2,6 +2,7 @@ import { appendFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import { resolveEnvPath } from "../utils/path-expansion.js";
 import { sanitizeWithStaticMask } from "../utils/secret-redactor.js";
+import { isInternalTelemetryDisabled } from "./disablement.js";
 
 export interface BeaconEvent {
 	feature: string;
@@ -56,10 +57,7 @@ export function beaconTimeoutMs(env: NodeJS.ProcessEnv): number {
 }
 
 export function isBeaconEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-	if (
-		env.MAESTRO_INTERNAL_TELEMETRY_DISABLED === "1" ||
-		env.MAESTRO_INTERNAL_TELEMETRY_DISABLED === "true"
-	) {
+	if (isInternalTelemetryDisabled(env)) {
 		return false;
 	}
 	const flag = telemetryFlag(env)?.toLowerCase();

--- a/src/telemetry/disablement.ts
+++ b/src/telemetry/disablement.ts
@@ -1,0 +1,37 @@
+type TelemetryDisablementEnv = {
+	MAESTRO_INTERNAL_TELEMETRY_DISABLED?: string;
+	EVALOPS_INTERNAL_TELEMETRY_DISABLED?: string;
+};
+
+export type TelemetryDisablementSettings = {
+	internal?: {
+		telemetryDisabled?: boolean;
+	};
+};
+
+function readBooleanFlag(value: string | undefined): boolean {
+	switch (value?.trim().toLowerCase()) {
+		case "1":
+		case "true":
+		case "yes":
+		case "on":
+			return true;
+		default:
+			return false;
+	}
+}
+
+export function isInternalTelemetryDisabled(
+	env: TelemetryDisablementEnv = process.env,
+): boolean {
+	return (
+		readBooleanFlag(env.MAESTRO_INTERNAL_TELEMETRY_DISABLED) ||
+		readBooleanFlag(env.EVALOPS_INTERNAL_TELEMETRY_DISABLED)
+	);
+}
+
+export function resolveInternalTelemetryDisabledSetting(
+	settings: TelemetryDisablementSettings | null | undefined,
+): boolean {
+	return settings?.internal?.telemetryDisabled === true;
+}

--- a/src/telemetry/maestro-event-bus.ts
+++ b/src/telemetry/maestro-event-bus.ts
@@ -12,6 +12,7 @@ import {
 } from "../evalops/managed-context.js";
 import type { PromptMetadata } from "../prompts/types.js";
 import type { SkillArtifactMetadata } from "../skills/artifact-metadata.js";
+import { isInternalTelemetryDisabled } from "./disablement.js";
 import {
 	MaestroBusEventType,
 	getMaestroBusEventCatalogEntry,
@@ -676,6 +677,7 @@ export function resolveMaestroEventBusConfig(
 	env: Env = process.env,
 ): MaestroEventBusConfig {
 	const managedContext = resolveManagedEvalOpsContext(env);
+	const internalTelemetryDisabled = isInternalTelemetryDisabled(env);
 	const flag = readBoolean(
 		readEnv(env, ["MAESTRO_EVENT_BUS", "MAESTRO_AUDIT_BUS"]),
 	);
@@ -688,9 +690,11 @@ export function resolveMaestroEventBusConfig(
 	const baseEnabled =
 		flag === false ? false : (flag ?? Boolean(natsUrl || managedRouting));
 	const featureGate = resolveEventBusFeatureGate(env, managedContext);
-	const enabled = baseEnabled && featureGate.allowed;
+	const enabled =
+		!internalTelemetryDisabled && baseEnabled && featureGate.allowed;
 	let reason = "disabled";
-	if (flag === false) reason = "flag disabled";
+	if (internalTelemetryDisabled) reason = "internal telemetry disabled";
+	else if (flag === false) reason = "flag disabled";
 	else if (baseEnabled && !featureGate.allowed)
 		reason = featureGate.reason ?? "feature flag disabled";
 	else if (natsUrl) reason = "nats";

--- a/test/telemetry/beacon-disablement.test.ts
+++ b/test/telemetry/beacon-disablement.test.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("telemetry beacon disablement", () => {
+	let tempDir: string;
+	let beaconFile: string;
+
+	beforeEach(async () => {
+		vi.resetModules();
+		tempDir = await mkdtemp(join(tmpdir(), "maestro-beacon-disablement-"));
+		beaconFile = join(tempDir, "beacon.jsonl");
+		vi.stubEnv("MAESTRO_TELEMETRY", "1");
+		vi.stubEnv("MAESTRO_BEACON_FILE", beaconFile);
+		vi.stubEnv("MAESTRO_OTEL", "0");
+	});
+
+	afterEach(async () => {
+		vi.resetModules();
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	it("respects the internal telemetry kill switch for beacon files", async () => {
+		vi.stubEnv("MAESTRO_INTERNAL_TELEMETRY_DISABLED", "1");
+		const { emitBeacon } = await import("../../src/telemetry/beacon.js");
+
+		await emitBeacon({
+			feature: "cli.startup",
+			action: "interactive",
+			timestamp: 1,
+			source: {
+				client: "cli",
+				clientVersion: "0.10.18",
+			},
+		});
+
+		await expect(readFile(beaconFile, "utf8")).rejects.toMatchObject({
+			code: "ENOENT",
+		});
+	});
+});

--- a/test/telemetry/maestro-event-bus.test.ts
+++ b/test/telemetry/maestro-event-bus.test.ts
@@ -72,6 +72,19 @@ describe("maestro event bus", () => {
 		});
 	});
 
+	it("honors the internal telemetry kill switch before audit-bus routing", () => {
+		const config = resolveMaestroEventBusConfig({
+			MAESTRO_INTERNAL_TELEMETRY_DISABLED: "1",
+			MAESTRO_TELEMETRY: "1",
+			MAESTRO_EVENT_BUS_URL: "nats://bus.example:4222",
+			MAESTRO_EVALOPS_ORG_ID: "org_123",
+		});
+
+		expect(config.enabled).toBe(false);
+		expect(config.reason).toBe("internal telemetry disabled");
+		expect(config.natsUrl).toBe("nats://bus.example:4222");
+	});
+
 	it("requires the managed rollout flag when a feature flag snapshot is mounted", () => {
 		const snapshot = writeFlagSnapshot([
 			{ key: "platform.kill_switches.maestro.platform_events", enabled: false },

--- a/test/telemetry/opentelemetry-status.test.ts
+++ b/test/telemetry/opentelemetry-status.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("OpenTelemetry status", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.unstubAllEnvs();
+	});
+
+	afterEach(() => {
+		vi.resetModules();
+		vi.unstubAllEnvs();
+	});
+
+	it("reports policy disablement as the status reason", async () => {
+		vi.stubEnv("MAESTRO_INTERNAL_TELEMETRY_DISABLED", "1");
+		vi.stubEnv("MAESTRO_OTEL", "1");
+		vi.stubEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel.example.test");
+
+		const { getOpenTelemetryStatus, isOpenTelemetryEnabled } = await import(
+			"../../src/opentelemetry.js"
+		);
+
+		expect(isOpenTelemetryEnabled()).toBe(false);
+		expect(getOpenTelemetryStatus()).toMatchObject({
+			enabled: false,
+			reason: "internal telemetry disabled",
+			otlpEndpoint: "http://otel.example.test",
+		});
+	});
+});

--- a/test/telemetry/telemetry-otel-routing.test.ts
+++ b/test/telemetry/telemetry-otel-routing.test.ts
@@ -107,6 +107,53 @@ describe("telemetry OTel metric routing", () => {
 		expect(recordToolInvocationMetric).not.toHaveBeenCalled();
 	});
 
+	it("skips OTel and event-bus routing when internal telemetry is disabled", async () => {
+		vi.stubEnv("MAESTRO_INTERNAL_TELEMETRY_DISABLED", "1");
+		vi.stubEnv("MAESTRO_TELEMETRY", "1");
+
+		const recordCompactionMetric = vi.fn();
+		const recordToolInvocationMetric = vi.fn();
+		const mirrorTelemetryToMaestroEventBus = vi.fn(() => Promise.resolve());
+
+		vi.doMock("../../src/opentelemetry.js", () => ({
+			getTelemetryTracer: () => ({
+				startActiveSpan: vi.fn(),
+			}),
+			initOpenTelemetry: vi.fn(),
+			isOpenTelemetryEnabled: () => true,
+		}));
+		vi.doMock("../../src/telemetry/metrics.js", () => ({
+			recordCompactionMetric,
+			recordToolInvocationMetric,
+		}));
+		vi.doMock("../../src/telemetry/maestro-event-bus.js", () => ({
+			mirrorTelemetryToMaestroEventBus,
+			resolveMaestroEventBusConfig: () => ({
+				defaultCorrelation: {},
+				defaultPrincipal: undefined,
+				defaultSurface: "cli",
+			}),
+		}));
+		vi.doMock("../../src/telemetry/meter-service-client.js", () => ({
+			hasRemoteMeterDestination: () => false,
+			mirrorCanonicalTurnEventToMeter: vi.fn(() => Promise.resolve()),
+		}));
+
+		const { recordTelemetry } = await import("../../src/telemetry.js");
+
+		await recordTelemetry({
+			type: "tool-execution",
+			timestamp: "2026-05-07T07:00:02.000Z",
+			toolName: "bash",
+			success: true,
+			durationMs: 125,
+		});
+
+		expect(recordToolInvocationMetric).not.toHaveBeenCalled();
+		expect(recordCompactionMetric).not.toHaveBeenCalled();
+		expect(mirrorTelemetryToMaestroEventBus).not.toHaveBeenCalled();
+	});
+
 	it("populates skill metrics from tool skill metadata", async () => {
 		const recordAgentTurnMetric = vi.fn();
 		const recordCompactionMetric = vi.fn();


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `1f1dd6f96b55ff51cd610f91e1d968aa0616d6e8`
- last generated public sync base: `753df03a327ff3a7ffe5168abcb1aea3983d7ace`
- previewed public-tree drift: `15` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (1f1dd6f96b55)`
- public projection: `https://github.com/evalops/maestro@main (753df03a327f)`
- files to copy or update: `15`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/web/src/components/admin-security-tab.test.ts
- copy/update packages/web/src/components/admin-security-tab.ts
- copy/update packages/web/src/components/admin-settings.ts
- copy/update packages/web/src/services/enterprise-api.ts
- copy/update src/api/enterprise-routes.ts
- copy/update src/db/schema.ts
- copy/update src/opentelemetry.ts
- copy/update src/telemetry.ts
- copy/update src/telemetry/beacon.ts
- copy/update src/telemetry/disablement.ts
- copy/update src/telemetry/maestro-event-bus.ts
- copy/update test/telemetry/beacon-disablement.test.ts
- copy/update test/telemetry/maestro-event-bus.test.ts
- copy/update test/telemetry/opentelemetry-status.test.ts
- copy/update test/telemetry/telemetry-otel-routing.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/web/src/components/admin-security-tab.test.ts
- copy/update packages/web/src/components/admin-security-tab.ts
- copy/update packages/web/src/components/admin-settings.ts
- copy/update packages/web/src/services/enterprise-api.ts
- copy/update src/api/enterprise-routes.ts
- copy/update src/db/schema.ts
- copy/update src/opentelemetry.ts
- copy/update src/telemetry.ts
- copy/update src/telemetry/beacon.ts
- copy/update src/telemetry/disablement.ts
- copy/update src/telemetry/maestro-event-bus.ts
- copy/update test/telemetry/beacon-disablement.test.ts
- copy/update test/telemetry/maestro-event-bus.test.ts
- copy/update test/telemetry/opentelemetry-status.test.ts
- copy/update test/telemetry/telemetry-otel-routing.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode