### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/agent/transport/tool-safety-pipeline.ts
+++ b/src/agent/transport/tool-safety-pipeline.ts
@@ -12,6 +12,11 @@ import {
 } from "../../safety/action-firewall.js";
 import type { AdaptiveThresholds } from "../../safety/adaptive-thresholds.js";
 import { METRICS } from "../../safety/adaptive-thresholds.js";
+import {
+	DEFAULT_GUARDED_FILE_RULE_ID,
+	describeDefaultGuardedFileMatch,
+	findDefaultGuardedToolCallMatch,
+} from "../../safety/guarded-files.js";
 import type { SafetyMiddleware } from "../../safety/safety-middleware.js";
 import type { WorkflowStateTracker } from "../../safety/workflow-state.js";
 import {
@@ -521,6 +526,19 @@ export async function* evaluateToolSafety(
 		session: cfg.session,
 		userIntent: extractTextFromContent(userMessage.content),
 	});
+	const initialGuardedFileMatch = findDefaultGuardedToolCallMatch(
+		effectiveToolCall.name,
+		effectiveToolCall.arguments,
+	);
+	let guardedFileApprovalRequired =
+		Boolean(initialGuardedFileMatch) ||
+		(verdict.action === "require_approval" &&
+			verdict.ruleId === DEFAULT_GUARDED_FILE_RULE_ID);
+	let guardedFileApprovalReason = initialGuardedFileMatch
+		? describeDefaultGuardedFileMatch(initialGuardedFileMatch)
+		: guardedFileApprovalRequired && verdict.action === "require_approval"
+			? verdict.reason
+			: undefined;
 
 	if (verdict.action === "block") {
 		const blockedResult: ToolResultMessage = {
@@ -690,7 +708,11 @@ export async function* evaluateToolSafety(
 	}
 
 	// 6. Approval flow
-	if (verdict.action === "require_approval" || platformApprovalRequest) {
+	if (
+		verdict.action === "require_approval" ||
+		platformApprovalRequest ||
+		guardedFileApprovalRequired
+	) {
 		const localApprovalReason =
 			verdict.action === "require_approval" ? verdict.reason : undefined;
 		let permissionHookMadeDecision = false;
@@ -698,21 +720,33 @@ export async function* evaluateToolSafety(
 			const permissionHookResult = await hookService.runPermissionRequestHooks(
 				effectiveToolCall,
 				platformApprovalRequest?.reason ??
+					guardedFileApprovalReason ??
 					localApprovalReason ??
 					approvalReason ??
 					"Approval required",
 				signal,
 			);
-			if (permissionHookResult.updatedInput) {
+			if (permissionHookResult.updatedInput && !guardedFileApprovalRequired) {
 				effectiveToolCall = {
 					...effectiveToolCall,
 					arguments: permissionHookResult.updatedInput,
 				};
+				const guardedMatch = findDefaultGuardedToolCallMatch(
+					effectiveToolCall.name,
+					effectiveToolCall.arguments,
+				);
+				if (guardedMatch) {
+					guardedFileApprovalRequired = true;
+					guardedFileApprovalReason =
+						describeDefaultGuardedFileMatch(guardedMatch);
+				}
 			}
 			if (permissionHookResult.decision === "allow") {
-				permissionHookMadeDecision = true;
-				approvalAllowed = true;
-				approvalReason = permissionHookResult.decisionReason;
+				if (!guardedFileApprovalRequired) {
+					permissionHookMadeDecision = true;
+					approvalAllowed = true;
+					approvalReason = permissionHookResult.decisionReason;
+				}
 			} else if (permissionHookResult.decision === "deny") {
 				permissionHookMadeDecision = true;
 				approvalAllowed = false;
@@ -749,19 +783,31 @@ export async function* evaluateToolSafety(
 			}
 		}
 
-		if (approvalService && !permissionHookMadeDecision) {
+		if (
+			guardedFileApprovalRequired &&
+			approvalService?.requiresUserInteraction() !== true
+		) {
+			approvalAllowed = false;
+			if (!permissionHookMadeDecision) {
+				approvalReason = `${guardedFileApprovalReason ?? localApprovalReason ?? "Guarded file access requires explicit approval"} Approval mode must be prompt for guarded file access.`;
+			}
+		} else if (approvalService && !permissionHookMadeDecision) {
 			const sanitizedApprovalArgs = safetyMiddleware.sanitizeForLogging(
 				effectiveToolCall.arguments as Record<string, unknown>,
 			);
 			const request =
-				platformApprovalRequest ??
-				({
-					id: toolCall.id,
-					toolName: toolCall.name,
-					...describeArgs(sanitizedApprovalArgs),
-					args: sanitizedApprovalArgs,
-					reason: localApprovalReason ?? "Approval required",
-				} satisfies import("../action-approval.js").ActionApprovalRequest);
+				!guardedFileApprovalRequired && platformApprovalRequest
+					? platformApprovalRequest
+					: ({
+							id: toolCall.id,
+							toolName: toolCall.name,
+							...describeArgs(sanitizedApprovalArgs),
+							args: sanitizedApprovalArgs,
+							reason:
+								guardedFileApprovalReason ??
+								localApprovalReason ??
+								"Approval required",
+						} satisfies import("../action-approval.js").ActionApprovalRequest);
 			const shouldEmitEvents = approvalService.requiresUserInteraction();
 			const decisionPromise = approvalService.requestApproval(request, signal);
 			const registrationMetadata = await waitForPendingApprovalRegistration(

--- a/src/safety/action-firewall.ts
+++ b/src/safety/action-firewall.ts
@@ -71,6 +71,11 @@ import {
 	evaluateActionWithActionFirewallGovernanceService,
 	resolveActionFirewallGovernanceServiceConfig,
 } from "./governance-service-client.js";
+import {
+	DEFAULT_GUARDED_FILE_RULE_ID,
+	describeDefaultGuardedFileMatch,
+	findDefaultGuardedToolCallMatch,
+} from "./guarded-files.js";
 import { isContainedInWorkspace, isSystemPath } from "./path-containment.js";
 import { checkPolicy } from "./policy.js";
 import { RuleCache } from "./rule-cache.js";
@@ -412,22 +417,23 @@ function extractFilePaths(context: ActionApprovalContext): string[] {
 	const args = getArgsObject(context);
 	if (!args) return [];
 	const paths: string[] = [];
+	const toolName = context.toolName.toLowerCase();
 
 	// Simple extraction for standard file tools
 	// Note: deeper extraction is done in policy.ts, this is for quick system protection
-	if (context.toolName === "write" || context.toolName === "edit") {
+	if (toolName === "write" || toolName === "edit") {
 		const p =
 			getStringArg(context, "file_path") || getStringArg(context, "path");
 		if (p) paths.push(p);
 	}
-	if (context.toolName === "delete_file") {
+	if (toolName === "delete_file") {
 		const p =
 			getStringArg(context, "file_path") ||
 			getStringArg(context, "target_file");
 		if (p) paths.push(p);
 	}
 	// Handle move_file and copy_file - extract both source and destination
-	if (context.toolName === "move_file" || context.toolName === "copy_file") {
+	if (toolName === "move_file" || toolName === "copy_file") {
 		const source =
 			getStringArg(context, "source") ||
 			getStringArg(context, "source_path") ||
@@ -532,6 +538,22 @@ export const defaultFirewallRules: ActionFirewallRule[] = [
 		},
 		remediation: () =>
 			"Do not modify critical system paths. If you need to write a file, use the current workspace directory or a temporary folder.",
+	},
+	{
+		id: DEFAULT_GUARDED_FILE_RULE_ID,
+		description:
+			"Require explicit approval before reading or mutating guarded user and editor configuration files",
+		action: "require_approval",
+		evaluate: (ctx) => {
+			const match = findDefaultGuardedToolCallMatch(ctx.toolName, ctx.args);
+			if (match) {
+				return {
+					allowed: false,
+					reason: describeDefaultGuardedFileMatch(match),
+				};
+			}
+			return { allowed: true };
+		},
 	},
 	{
 		name: "workspace-containment",

--- a/src/safety/guarded-files.ts
+++ b/src/safety/guarded-files.ts
@@ -1,0 +1,445 @@
+import { resolve } from "node:path";
+import { minimatch } from "minimatch";
+import {
+	expandTildePathWithHomeDir,
+	getOsHomeDir,
+} from "../utils/path-expansion.js";
+import { tokenizeSimple, unwrapShellCommand } from "./bash-safety-analyzer.js";
+
+export const DEFAULT_GUARDED_FILE_RULE_ID = "default-guarded-file";
+
+export interface GuardedFileRule {
+	category: string;
+	patterns: string[];
+}
+
+export interface GuardedFileMatch {
+	ruleId: typeof DEFAULT_GUARDED_FILE_RULE_ID;
+	category: string;
+	pattern: string;
+	path: string;
+}
+
+export interface GuardedFileMatchOptions {
+	cwd?: string;
+	homeDir?: string;
+	env?: NodeJS.ProcessEnv;
+}
+
+export const DEFAULT_GUARDED_FILE_RULES: GuardedFileRule[] = [
+	{
+		category: "Cursor configuration",
+		patterns: [
+			"**/.cursor/**",
+			"~/.cursor/**",
+			"~/Library/Application Support/Cursor/**",
+			"~/.config/Cursor/**",
+			"%APPDATA%/Cursor/**",
+		],
+	},
+	{
+		category: "Windsurf configuration",
+		patterns: [
+			"**/.windsurf/**",
+			"~/.codeium/windsurf/**",
+			"~/Library/Application Support/Windsurf/**",
+			"~/.config/Windsurf/**",
+			"%APPDATA%/Windsurf/**",
+			"/Library/Application Support/Windsurf/**",
+			"/etc/windsurf/**",
+			"%ProgramData%/Windsurf/**",
+		],
+	},
+	{
+		category: "Antigravity configuration",
+		patterns: ["~/.gemini/**"],
+	},
+	{
+		category: "JetBrains application configuration",
+		patterns: [
+			"~/Library/Application Support/JetBrains/**",
+			"~/.config/JetBrains/**",
+			"~/.local/share/JetBrains/**",
+			"%APPDATA%/JetBrains/**",
+			"%LOCALAPPDATA%/JetBrains/**",
+		],
+	},
+	{
+		category: "JetBrains project configuration",
+		patterns: ["**/.idea/**"],
+	},
+	{
+		category: "Neovim configuration",
+		patterns: [
+			"~/.config/nvim/**",
+			"~/.local/share/nvim/**",
+			"~/.local/state/nvim/**",
+		],
+	},
+	{
+		category: "Amp settings",
+		patterns: ["**/amp.json", "**/.amp/**"],
+	},
+	{
+		category: "Shell configuration",
+		patterns: [
+			"~/.bashrc",
+			"~/.zshrc",
+			"~/.config/fish/config.fish",
+			"~/.config/fish/conf.d/**",
+			"~/.cshrc",
+			"~/.tcshrc",
+		],
+	},
+	{
+		category: "SSH and GPG keys",
+		patterns: ["**/.ssh/**", "~/.ssh/**", "**/.gnupg/**", "~/.gnupg/**"],
+	},
+];
+
+const ENV_TOKEN_PATTERN = /%([A-Z0-9_()]+)%/gi;
+const SHELL_ENV_TOKEN_PATTERN =
+	/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+
+function normalizeForGlob(value: string): string {
+	return value.replace(/\\/g, "/");
+}
+
+function hasGlob(pattern: string): boolean {
+	return /[*?{\[]/.test(pattern);
+}
+
+function expandEnvTokens(
+	pattern: string,
+	env: NodeJS.ProcessEnv,
+): string | null {
+	let missingToken = false;
+	const expanded = pattern.replace(
+		ENV_TOKEN_PATTERN,
+		(_token, name: string) => {
+			const value = env[name] ?? env[name.toUpperCase()];
+			if (!value?.trim()) {
+				missingToken = true;
+				return "";
+			}
+			return value;
+		},
+	);
+	return missingToken ? null : expanded;
+}
+
+function normalizePattern(
+	pattern: string,
+	options: Required<Pick<GuardedFileMatchOptions, "cwd" | "homeDir" | "env">>,
+): string | null {
+	const envExpanded = expandEnvTokens(pattern, options.env);
+	if (envExpanded === null) {
+		return null;
+	}
+	const homeExpanded = expandTildePathWithHomeDir(envExpanded, options.homeDir);
+	if (hasGlob(homeExpanded)) {
+		return normalizeForGlob(homeExpanded);
+	}
+	return normalizeForGlob(resolve(options.cwd, homeExpanded));
+}
+
+function normalizePatternVariants(
+	pattern: string,
+	options: Required<Pick<GuardedFileMatchOptions, "cwd" | "homeDir" | "env">>,
+): string[] {
+	const variants = [pattern];
+	if (pattern.endsWith("/**")) {
+		variants.push(pattern.slice(0, -3));
+	}
+	return variants.flatMap((variant) => {
+		const normalized = normalizePattern(variant, options);
+		return normalized ? [normalized] : [];
+	});
+}
+
+function buildCandidatePaths(
+	path: string,
+	options: Required<Pick<GuardedFileMatchOptions, "cwd" | "homeDir" | "env">>,
+): string[] {
+	const homeExpanded = expandTildePathWithHomeDir(path, options.homeDir);
+	const shellEnvExpanded = expandShellEnvTokens(path, options);
+	const profileEnvExpanded = expandEnvTokens(path, options.env);
+	const candidates = [path, homeExpanded];
+	if (shellEnvExpanded) {
+		candidates.push(shellEnvExpanded);
+	}
+	if (profileEnvExpanded) {
+		candidates.push(profileEnvExpanded);
+	}
+	for (const candidate of [...candidates]) {
+		candidates.push(resolve(options.cwd, candidate));
+	}
+	return Array.from(new Set(candidates.map(normalizeForGlob)));
+}
+
+function expandShellEnvTokens(
+	path: string,
+	options: Required<Pick<GuardedFileMatchOptions, "homeDir" | "env">>,
+): string | null {
+	let expandedAny = false;
+	let missingToken = false;
+	const expanded = path.replace(
+		SHELL_ENV_TOKEN_PATTERN,
+		(_token, bracedName: string | undefined, bareName: string | undefined) => {
+			const name = bracedName ?? bareName;
+			if (!name) {
+				return "";
+			}
+			const value =
+				name === "HOME"
+					? options.homeDir
+					: (options.env[name] ?? options.env[name.toUpperCase()]);
+			if (!value?.trim()) {
+				missingToken = true;
+				return "";
+			}
+			expandedAny = true;
+			return value;
+		},
+	);
+	return expandedAny && !missingToken ? expanded : null;
+}
+
+export function findDefaultGuardedFileMatch(
+	path: string,
+	options: GuardedFileMatchOptions = {},
+): GuardedFileMatch | null {
+	const trimmedPath = path.trim();
+	if (!trimmedPath) {
+		return null;
+	}
+	const requiredOptions = {
+		cwd: options.cwd ?? process.cwd(),
+		homeDir: options.homeDir ?? getOsHomeDir(),
+		env: options.env ?? process.env,
+	};
+	const candidates = buildCandidatePaths(trimmedPath, requiredOptions);
+
+	for (const rule of DEFAULT_GUARDED_FILE_RULES) {
+		for (const pattern of rule.patterns) {
+			const normalizedPatterns = normalizePatternVariants(
+				pattern,
+				requiredOptions,
+			);
+			const matches = candidates.some((candidate) =>
+				normalizedPatterns.some((normalizedPattern) =>
+					minimatch(candidate, normalizedPattern, {
+						dot: true,
+						nocase: process.platform === "win32",
+					}),
+				),
+			);
+			if (matches) {
+				return {
+					ruleId: DEFAULT_GUARDED_FILE_RULE_ID,
+					category: rule.category,
+					pattern,
+					path: trimmedPath,
+				};
+			}
+		}
+	}
+
+	return null;
+}
+
+function getArgsObject(args: unknown): Record<string, unknown> | null {
+	return args && typeof args === "object"
+		? (args as Record<string, unknown>)
+		: null;
+}
+
+function getStringArg(
+	args: Record<string, unknown>,
+	key: string,
+): string | null {
+	const value = args[key];
+	return typeof value === "string" ? value : null;
+}
+
+function getStringListArg(
+	args: Record<string, unknown>,
+	key: string,
+): string[] {
+	const value = args[key];
+	if (typeof value === "string") {
+		return [value];
+	}
+	if (Array.isArray(value)) {
+		return value.filter((item): item is string => typeof item === "string");
+	}
+	return [];
+}
+
+function addStringArgs(
+	paths: string[],
+	args: Record<string, unknown>,
+	keys: string[],
+) {
+	for (const key of keys) {
+		paths.push(...getStringListArg(args, key));
+	}
+}
+
+function isAnchoredPath(path: string): boolean {
+	const trimmed = path.trim();
+	return (
+		trimmed.startsWith("/") ||
+		trimmed.startsWith("~") ||
+		trimmed.startsWith("$") ||
+		/^[A-Za-z]:[\\/]/.test(trimmed) ||
+		/^%[^%]+%[\\/]/.test(trimmed)
+	);
+}
+
+function combineRelativePathWithCwd(cwd: string, path: string): string {
+	if (isAnchoredPath(path) || !cwd.trim()) {
+		return path;
+	}
+	const trimmedCwd = cwd.trim().replace(/[\\/]+$/, "");
+	const trimmedPath = path.trim().replace(/^[\\/]+/, "");
+	return `${trimmedCwd}/${trimmedPath}`;
+}
+
+function addStringArgsWithCwd(
+	paths: string[],
+	args: Record<string, unknown>,
+	keys: string[],
+	cwd: string | null,
+) {
+	const values = keys.flatMap((key) => getStringListArg(args, key));
+	paths.push(...values);
+	if (cwd) {
+		paths.push(...values.map((path) => combineRelativePathWithCwd(cwd, path)));
+	}
+}
+
+function stripShellTokenQuotes(token: string): string {
+	const trimmed = token.trim();
+	if (trimmed.length < 2) {
+		return trimmed;
+	}
+	const first = trimmed[0];
+	const last = trimmed[trimmed.length - 1];
+	if ((first === "'" && last === "'") || (first === '"' && last === '"')) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+function extractGuardedShellCommandPaths(command: string): string[] {
+	const unwrapped = unwrapShellCommand(command) ?? command;
+	return tokenizeSimple(unwrapped)
+		.map(stripShellTokenQuotes)
+		.filter((token) => token.length > 0 && !token.startsWith("-"));
+}
+
+function extractGuardedToolCallPaths(
+	toolName: string,
+	args: unknown,
+): string[] {
+	const argsObject = getArgsObject(args);
+	if (!argsObject) {
+		return [];
+	}
+	const paths: string[] = [];
+	const normalizedToolName = toolName.toLowerCase();
+	if (["read", "write", "edit"].includes(normalizedToolName)) {
+		const path =
+			getStringArg(argsObject, "file_path") || getStringArg(argsObject, "path");
+		if (path) {
+			paths.push(path);
+		}
+	}
+	if (normalizedToolName === "delete_file") {
+		const path =
+			getStringArg(argsObject, "file_path") ||
+			getStringArg(argsObject, "target_file");
+		if (path) {
+			paths.push(path);
+		}
+	}
+	if (
+		normalizedToolName === "move_file" ||
+		normalizedToolName === "copy_file"
+	) {
+		const source =
+			getStringArg(argsObject, "source") ||
+			getStringArg(argsObject, "source_path") ||
+			getStringArg(argsObject, "from");
+		const destination =
+			getStringArg(argsObject, "destination") ||
+			getStringArg(argsObject, "destination_path") ||
+			getStringArg(argsObject, "dest") ||
+			getStringArg(argsObject, "to");
+		if (source) {
+			paths.push(source);
+		}
+		if (destination) {
+			paths.push(destination);
+		}
+	}
+	if (["list", "find"].includes(normalizedToolName)) {
+		addStringArgs(paths, argsObject, ["path"]);
+	}
+	if (
+		["search", "parallel_ripgrep", "diff", "status"].includes(
+			normalizedToolName,
+		)
+	) {
+		addStringArgsWithCwd(
+			paths,
+			argsObject,
+			["paths"],
+			getStringArg(argsObject, "cwd"),
+		);
+	}
+	if (["search", "parallel_ripgrep", "diff"].includes(normalizedToolName)) {
+		addStringArgs(paths, argsObject, ["cwd"]);
+	}
+	if (
+		normalizedToolName === "bash" ||
+		normalizedToolName === "background_tasks"
+	) {
+		const command = getStringArg(argsObject, "command");
+		const cwd = getStringArg(argsObject, "cwd");
+		if (cwd) {
+			paths.push(cwd);
+		}
+		if (command) {
+			const shellPaths = extractGuardedShellCommandPaths(command);
+			paths.push(...shellPaths);
+			if (cwd) {
+				paths.push(
+					...shellPaths.map((path) => combineRelativePathWithCwd(cwd, path)),
+				);
+			}
+		}
+	}
+	return paths;
+}
+
+export function findDefaultGuardedToolCallMatch(
+	toolName: string,
+	args: unknown,
+	options: GuardedFileMatchOptions = {},
+): GuardedFileMatch | null {
+	for (const path of extractGuardedToolCallPaths(toolName, args)) {
+		const match = findDefaultGuardedFileMatch(path, options);
+		if (match) {
+			return match;
+		}
+	}
+	return null;
+}
+
+export function describeDefaultGuardedFileMatch(
+	match: GuardedFileMatch,
+): string {
+	return `Guarded file access requires explicit approval: ${match.category} (${match.pattern}) at ${match.path}.`;
+}

--- a/test/agent/tool-safety-pipeline.test.ts
+++ b/test/agent/tool-safety-pipeline.test.ts
@@ -1,8 +1,8 @@
 import { Type } from "@sinclair/typebox";
 import { describe, expect, it, vi } from "vitest";
 
-import type {
-	ActionApprovalRequest,
+import {
+	type ActionApprovalRequest,
 	ActionApprovalService,
 } from "../../src/agent/action-approval.js";
 import { evaluateToolSafety } from "../../src/agent/transport/tool-safety-pipeline.js";
@@ -36,6 +36,70 @@ async function collectSafetyResult(
 		}
 		events.push(step.value);
 	}
+}
+
+function createReadTool(): AgentTool {
+	return {
+		name: "read",
+		description: "Read a file",
+		parameters: Type.Object({
+			path: Type.String(),
+		}),
+		execute: async () => ({
+			content: [{ type: "text", text: "ok" }],
+		}),
+	};
+}
+
+function createBaseSafetyContext(options: {
+	tool: AgentTool;
+	path: string;
+	approvalService?: Parameters<typeof evaluateToolSafety>[0]["approvalService"];
+	hookService?: Parameters<typeof evaluateToolSafety>[0]["hookService"];
+	firewall?: ActionFirewall;
+}): Parameters<typeof evaluateToolSafety>[0] {
+	return {
+		toolCall: {
+			type: "toolCall",
+			id: "call-1",
+			name: options.tool.name,
+			arguments: { path: options.path },
+		},
+		tools: [options.tool],
+		userMessage: {
+			role: "user",
+			content: "Read the file",
+			timestamp: Date.now(),
+		} satisfies Message,
+		cfg: { tools: [options.tool] } as AgentRunConfig,
+		clock: { now: () => Date.now() },
+		safetyMiddleware: new SafetyMiddleware({
+			enableContextFirewall: false,
+			enableLoopDetection: false,
+			enableSequenceAnalysis: false,
+		}),
+		workflowState: new WorkflowStateTracker(),
+		adaptiveThresholds: new AdaptiveThresholds(),
+		approvalService: options.approvalService,
+		hookService: options.hookService,
+		firewall: options.firewall ?? new ActionFirewall(),
+		rateLimitState: {
+			recentToolTimestamps: new Map(),
+			toolCallsThisMinute: 0,
+			minuteWindowStart: 0,
+			rateWindowMs: 10_000,
+			rateLimit: 10,
+		},
+		emitToolResult: (message: ToolResultMessage, toolCall, isError) => [
+			{
+				type: "tool_execution_end",
+				toolCallId: toolCall.id,
+				toolName: toolCall.name,
+				result: message,
+				isError,
+			},
+		],
+	};
 }
 
 describe("evaluateToolSafety permission hooks", () => {
@@ -261,6 +325,255 @@ describe("evaluateToolSafety permission hooks", () => {
 					},
 				],
 			},
+		});
+	});
+});
+
+describe("evaluateToolSafety guarded files", () => {
+	it("blocks guarded files instead of auto approving them", async () => {
+		const readTool = createReadTool();
+		const approvalService = new ActionApprovalService("auto");
+		const requestApproval = vi.spyOn(approvalService, "requestApproval");
+
+		const { result } = await collectSafetyResult(
+			createBaseSafetyContext({
+				tool: readTool,
+				path: "~/.ssh/config",
+				approvalService,
+			}),
+		);
+
+		expect(result.verdict.outcome).toBe("blocked");
+		expect(requestApproval).not.toHaveBeenCalled();
+		const toolResultEvent = result.verdict.events.find(
+			(event) => event.type === "tool_execution_end",
+		);
+		expect(toolResultEvent).toMatchObject({
+			type: "tool_execution_end",
+			result: {
+				content: [
+					{
+						type: "text",
+						text: expect.stringContaining(
+							"Approval mode must be prompt for guarded file access",
+						),
+					},
+				],
+			},
+		});
+	});
+
+	it("does not let PermissionRequest hooks allow guarded files without user approval", async () => {
+		clearHookConfigCache();
+		clearRegisteredHooks();
+
+		registerHook("PermissionRequest", {
+			type: "callback",
+			callback: async () => ({
+				reason: "Trusted read policy",
+				hookSpecificOutput: {
+					hookEventName: "PermissionRequest",
+					decision: {
+						behavior: "allow",
+						updatedInput: { path: "/tmp/approved.txt" },
+					},
+				},
+			}),
+		});
+
+		const readTool = createReadTool();
+		const approvalService = {
+			requiresUserInteraction: () => true,
+			requestApproval: vi.fn(async (_request: ActionApprovalRequest) => ({
+				approved: true,
+				resolvedBy: "user" as const,
+			})),
+		};
+
+		const { result } = await collectSafetyResult(
+			createBaseSafetyContext({
+				tool: readTool,
+				path: "~/.ssh/config",
+				approvalService,
+				hookService: createToolHookService({
+					cwd: "/tmp/test",
+					resolveTool: (toolName) =>
+						toolName === "read" ? readTool : undefined,
+				}),
+			}),
+		);
+
+		expect(result.verdict.outcome).toBe("proceed");
+		if (result.verdict.outcome !== "proceed") {
+			throw new Error("Expected user-approved guarded file read to proceed");
+		}
+		expect(approvalService.requestApproval).toHaveBeenCalledTimes(1);
+		expect(approvalService.requestApproval).toHaveBeenCalledWith(
+			expect.objectContaining({
+				args: { path: "~/.ssh/config" },
+				reason: expect.stringContaining("Guarded file access"),
+			}),
+			undefined,
+		);
+		expect(result.verdict.effectiveToolCall.arguments).toEqual({
+			path: "~/.ssh/config",
+		});
+	});
+
+	it("honors PermissionRequest hook denials for guarded files", async () => {
+		clearHookConfigCache();
+		clearRegisteredHooks();
+
+		registerHook("PermissionRequest", {
+			type: "callback",
+			callback: async () => ({
+				reason: "Guarded path denied by policy hook",
+				hookSpecificOutput: {
+					hookEventName: "PermissionRequest",
+					decision: {
+						behavior: "deny",
+					},
+				},
+			}),
+		});
+
+		const readTool = createReadTool();
+		const approvalService = {
+			requiresUserInteraction: () => true,
+			requestApproval: vi.fn(async (_request: ActionApprovalRequest) => ({
+				approved: true,
+				resolvedBy: "user" as const,
+			})),
+		};
+
+		const { result } = await collectSafetyResult(
+			createBaseSafetyContext({
+				tool: readTool,
+				path: "~/.ssh/config",
+				approvalService,
+				hookService: createToolHookService({
+					cwd: "/tmp/test",
+					resolveTool: (toolName) =>
+						toolName === "read" ? readTool : undefined,
+				}),
+			}),
+		);
+
+		expect(result.verdict.outcome).toBe("blocked");
+		expect(approvalService.requestApproval).not.toHaveBeenCalled();
+		const toolResultEvent = result.verdict.events.find(
+			(event) => event.type === "tool_execution_end",
+		);
+		expect(toolResultEvent).toMatchObject({
+			type: "tool_execution_end",
+			result: {
+				content: [
+					{
+						type: "text",
+						text: "Guarded path denied by policy hook",
+					},
+				],
+			},
+		});
+	});
+
+	it("requires guarded approval even when the firewall returns allow", async () => {
+		const readTool = createReadTool();
+		const approvalService = {
+			requiresUserInteraction: () => true,
+			requestApproval: vi.fn(async (_request: ActionApprovalRequest) => ({
+				approved: true,
+				resolvedBy: "user" as const,
+			})),
+		};
+
+		const { result } = await collectSafetyResult(
+			createBaseSafetyContext({
+				tool: readTool,
+				path: "~/.ssh/config",
+				approvalService,
+				firewall: {
+					evaluate: vi.fn(async () => ({ action: "allow" as const })),
+				} as unknown as ActionFirewall,
+			}),
+		);
+
+		expect(result.verdict.outcome).toBe("proceed");
+		expect(approvalService.requestApproval).toHaveBeenCalledTimes(1);
+		expect(approvalService.requestApproval).toHaveBeenCalledWith(
+			expect.objectContaining({
+				args: { path: "~/.ssh/config" },
+				reason: expect.stringContaining("Guarded file access"),
+			}),
+			undefined,
+		);
+	});
+
+	it("re-checks guarded files after PermissionRequest hooks rewrite inputs", async () => {
+		clearHookConfigCache();
+		clearRegisteredHooks();
+
+		registerHook("PermissionRequest", {
+			type: "callback",
+			callback: async () => ({
+				reason: "Trusted rewrite policy",
+				hookSpecificOutput: {
+					hookEventName: "PermissionRequest",
+					decision: {
+						behavior: "allow",
+						updatedInput: { path: "~/.ssh/config" },
+					},
+				},
+			}),
+		});
+
+		const readTool = createReadTool();
+		const approvalService = {
+			requiresUserInteraction: () => true,
+			requestApproval: vi.fn(async (_request: ActionApprovalRequest) => ({
+				approved: true,
+				resolvedBy: "user" as const,
+			})),
+		};
+
+		const { result } = await collectSafetyResult(
+			createBaseSafetyContext({
+				tool: readTool,
+				path: "/tmp/original.txt",
+				approvalService,
+				hookService: createToolHookService({
+					cwd: "/tmp/test",
+					resolveTool: (toolName) =>
+						toolName === "read" ? readTool : undefined,
+				}),
+				firewall: new ActionFirewall([
+					{
+						name: "require-approval",
+						description: "require approval",
+						action: "require_approval",
+						evaluate: async () => ({
+							allowed: false,
+							reason: "Approval required",
+						}),
+					},
+				]),
+			}),
+		);
+
+		expect(result.verdict.outcome).toBe("proceed");
+		if (result.verdict.outcome !== "proceed") {
+			throw new Error("Expected user-approved guarded file rewrite to proceed");
+		}
+		expect(approvalService.requestApproval).toHaveBeenCalledTimes(1);
+		expect(approvalService.requestApproval).toHaveBeenCalledWith(
+			expect.objectContaining({
+				args: { path: "~/.ssh/config" },
+				reason: expect.stringContaining("Guarded file access"),
+			}),
+			undefined,
+		);
+		expect(result.verdict.effectiveToolCall.arguments).toEqual({
+			path: "~/.ssh/config",
 		});
 	});
 });

--- a/test/safety/action-firewall.test.ts
+++ b/test/safety/action-firewall.test.ts
@@ -99,6 +99,31 @@ function makeEditContext(): ActionApprovalContext {
 	return { toolName: "edit", args: { path: "file.txt" } };
 }
 
+function makeReadPathContext(path: string): ActionApprovalContext {
+	return { toolName: "read", args: { path } };
+}
+
+function makeSearchPathContext(
+	paths: string | string[],
+): ActionApprovalContext {
+	return { toolName: "search", args: { pattern: "Host", paths } };
+}
+
+function makeListPathContext(path: string): ActionApprovalContext {
+	return { toolName: "list", args: { path } };
+}
+
+function makeDeleteFileContext(path: string): ActionApprovalContext {
+	return { toolName: "delete_file", args: { target_file: path } };
+}
+
+function makeMoveFileContext(
+	source: string,
+	destination: string,
+): ActionApprovalContext {
+	return { toolName: "move_file", args: { source, destination } };
+}
+
 function makeTodoContext(): ActionApprovalContext {
 	return { toolName: "todo", args: { items: [] } };
 }
@@ -161,6 +186,77 @@ describe("ActionFirewall", () => {
 			makeBashContext('echo "safe command"'),
 		);
 		expect(verdict.action).toBe("allow");
+	});
+
+	it("requires approval for default guarded file reads", async () => {
+		const verdict = await defaultActionFirewall.evaluate(
+			makeReadPathContext("~/.ssh/config"),
+		);
+		expect(verdict).toMatchObject({
+			action: "require_approval",
+			ruleId: "default-guarded-file",
+		});
+		if (verdict.action !== "require_approval") {
+			throw new Error("Expected guarded file read to require approval");
+		}
+		expect(verdict.reason).toContain("Guarded file access");
+	});
+
+	it("requires approval for guarded file mutations beyond write and edit", async () => {
+		const deleteVerdict = await defaultActionFirewall.evaluate(
+			makeDeleteFileContext("~/.ssh/config"),
+		);
+		expect(deleteVerdict).toMatchObject({
+			action: "require_approval",
+			ruleId: "default-guarded-file",
+		});
+
+		const moveVerdict = await defaultActionFirewall.evaluate(
+			makeMoveFileContext("~/.gnupg/secring.gpg", "./backup.gpg"),
+		);
+		expect(moveVerdict).toMatchObject({
+			action: "require_approval",
+			ruleId: "default-guarded-file",
+		});
+	});
+
+	it("preserves hard blocks for guarded paths under system directories", async () => {
+		const verdict = await defaultActionFirewall.evaluate({
+			toolName: "edit",
+			args: { path: "/etc/windsurf/settings.json" },
+		});
+		expect(verdict).toMatchObject({
+			action: "block",
+			ruleId: "system-path-protection",
+		});
+	});
+
+	it("requires approval for guarded files reached through bash", async () => {
+		const verdict = await defaultActionFirewall.evaluate(
+			makeBashContext("cat ~/.ssh/config"),
+		);
+		expect(verdict).toMatchObject({
+			action: "require_approval",
+			ruleId: "default-guarded-file",
+		});
+	});
+
+	it("requires approval for guarded files reached through search and list", async () => {
+		const searchVerdict = await defaultActionFirewall.evaluate(
+			makeSearchPathContext(["~/.ssh"]),
+		);
+		expect(searchVerdict).toMatchObject({
+			action: "require_approval",
+			ruleId: "default-guarded-file",
+		});
+
+		const listVerdict = await defaultActionFirewall.evaluate(
+			makeListPathContext("~/.gnupg"),
+		);
+		expect(listVerdict).toMatchObject({
+			action: "require_approval",
+			ruleId: "default-guarded-file",
+		});
 	});
 
 	it("respects bash allowlist patterns", async () => {

--- a/test/safety/guarded-files.test.ts
+++ b/test/safety/guarded-files.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_GUARDED_FILE_RULE_ID,
+	findDefaultGuardedFileMatch,
+	findDefaultGuardedToolCallMatch,
+} from "../../src/safety/guarded-files.js";
+
+const options = {
+	cwd: "/workspace/project",
+	homeDir: "/Users/tester",
+	env: {
+		APPDATA: "C:/Users/tester/AppData/Roaming",
+		LOCALAPPDATA: "C:/Users/tester/AppData/Local",
+		ProgramData: "C:/ProgramData",
+	},
+};
+
+describe("default guarded files", () => {
+	it("matches SSH and GPG material from absolute and tilde paths", () => {
+		expect(
+			findDefaultGuardedFileMatch("/Users/tester/.ssh/config", options),
+		).toMatchObject({
+			ruleId: DEFAULT_GUARDED_FILE_RULE_ID,
+			category: "SSH and GPG keys",
+		});
+		expect(
+			findDefaultGuardedFileMatch("~/.gnupg/private-keys-v1.d/key", options),
+		).toMatchObject({
+			category: "SSH and GPG keys",
+		});
+	});
+
+	it("matches editor and agent configuration defaults", () => {
+		const paths = [
+			"/workspace/project/.cursor/settings.json",
+			"/workspace/project/.windsurf/config.json",
+			"/workspace/project/.idea/workspace.xml",
+			"/workspace/project/amp.json",
+			"/Users/tester/.config/nvim/init.lua",
+			"/Users/tester/.config/JetBrains/options.xml",
+			"/Users/tester/.gemini/settings.json",
+		];
+
+		for (const path of paths) {
+			expect(findDefaultGuardedFileMatch(path, options), path).not.toBeNull();
+		}
+	});
+
+	it("matches shell rc files only in the user's home directory", () => {
+		expect(
+			findDefaultGuardedFileMatch("/Users/tester/.zshrc", options),
+		).toMatchObject({
+			category: "Shell configuration",
+		});
+		expect(
+			findDefaultGuardedFileMatch(
+				"/Users/tester/.config/fish/config.fish",
+				options,
+			),
+		).toMatchObject({
+			category: "Shell configuration",
+		});
+		expect(
+			findDefaultGuardedFileMatch(
+				"/Users/tester/.config/fish/conf.d/aliases.fish",
+				options,
+			),
+		).toMatchObject({
+			category: "Shell configuration",
+		});
+		expect(
+			findDefaultGuardedFileMatch("/workspace/project/.zshrc", options),
+		).toBeNull();
+		expect(
+			findDefaultGuardedFileMatch(
+				"/Users/tester/.config/fish/config.fish",
+				options,
+			),
+		).toMatchObject({
+			category: "Shell configuration",
+		});
+		expect(
+			findDefaultGuardedFileMatch(
+				"/Users/tester/.config/fish/conf.d/prompt.fish",
+				options,
+			),
+		).toMatchObject({
+			category: "Shell configuration",
+		});
+	});
+
+	it("matches guarded paths referenced through shell environment tokens", () => {
+		expect(findDefaultGuardedFileMatch("$HOME/.bashrc", options)).toMatchObject(
+			{
+				category: "Shell configuration",
+			},
+		);
+		expect(
+			findDefaultGuardedFileMatch("${HOME}/.config/nvim/init.lua", options),
+		).toMatchObject({
+			category: "Neovim configuration",
+		});
+	});
+
+	it("expands Windows profile environment patterns when configured", () => {
+		expect(
+			findDefaultGuardedFileMatch(
+				"C:/Users/tester/AppData/Roaming/Cursor/User/settings.json",
+				options,
+			),
+		).toMatchObject({
+			category: "Cursor configuration",
+		});
+		expect(
+			findDefaultGuardedFileMatch(
+				"%APPDATA%/Cursor/User/settings.json",
+				options,
+			),
+		).toMatchObject({
+			category: "Cursor configuration",
+		});
+		expect(
+			findDefaultGuardedFileMatch(
+				"C:/Users/tester/AppData/Local/JetBrains/toolbox.json",
+				options,
+			),
+		).toMatchObject({
+			category: "JetBrains application configuration",
+		});
+	});
+
+	it("does not match ordinary project files", () => {
+		expect(
+			findDefaultGuardedFileMatch("/workspace/project/src/index.ts", options),
+		).toBeNull();
+	});
+
+	it("matches guarded paths embedded in shell commands", () => {
+		expect(
+			findDefaultGuardedToolCallMatch(
+				"bash",
+				{ command: "cat $HOME/.ssh/config" },
+				options,
+			),
+		).toMatchObject({
+			category: "SSH and GPG keys",
+		});
+		expect(
+			findDefaultGuardedToolCallMatch(
+				"bash",
+				{ command: 'cat "/Users/tester/.config/nvim/init.lua"' },
+				options,
+			),
+		).toMatchObject({
+			category: "Neovim configuration",
+		});
+		expect(
+			findDefaultGuardedToolCallMatch(
+				"bash",
+				{ command: "cat config", cwd: "~/.ssh" },
+				options,
+			),
+		).toMatchObject({
+			category: "SSH and GPG keys",
+		});
+		expect(
+			findDefaultGuardedToolCallMatch(
+				"background_tasks",
+				{ command: "cat init.lua", cwd: "~/.config/nvim" },
+				options,
+			),
+		).toMatchObject({
+			category: "Neovim configuration",
+		});
+	});
+
+	it("matches guarded paths passed to read-capable search and list tools", () => {
+		expect(
+			findDefaultGuardedToolCallMatch(
+				"search",
+				{ pattern: "Host", paths: ["~/.ssh"] },
+				options,
+			),
+		).toMatchObject({
+			category: "SSH and GPG keys",
+		});
+		expect(
+			findDefaultGuardedToolCallMatch(
+				"parallel_ripgrep",
+				{ patterns: ["token"], cwd: "$HOME/.config/nvim" },
+				options,
+			),
+		).toMatchObject({
+			category: "Neovim configuration",
+		});
+		expect(
+			findDefaultGuardedToolCallMatch(
+				"list",
+				{ path: "/Users/tester/.gnupg" },
+				options,
+			),
+		).toMatchObject({
+			category: "SSH and GPG keys",
+		});
+		expect(
+			findDefaultGuardedToolCallMatch(
+				"search",
+				{ pattern: "Host", cwd: "~", paths: [".ssh"] },
+				options,
+			),
+		).toMatchObject({
+			category: "SSH and GPG keys",
+		});
+		expect(
+			findDefaultGuardedToolCallMatch(
+				"diff",
+				{ cwd: "$HOME", paths: [".config/nvim"] },
+				options,
+			),
+		).toMatchObject({
+			category: "Neovim configuration",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `c3ef87f995da8b6ad48738474c13c7587ce5cf86`
- last generated public sync base: `6c8e62a35023da4f1b3ab5a5d797030d98dbcbb1`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (c3ef87f995da)`
- public projection: `https://github.com/evalops/maestro@main (6c8e62a35023)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/agent/transport/tool-safety-pipeline.ts
- copy/update src/safety/action-firewall.ts
- copy/update src/safety/guarded-files.ts
- copy/update test/agent/tool-safety-pipeline.test.ts
- copy/update test/safety/action-firewall.test.ts
- copy/update test/safety/guarded-files.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/agent/transport/tool-safety-pipeline.ts
- copy/update src/safety/action-firewall.ts
- copy/update src/safety/guarded-files.ts
- copy/update test/agent/tool-safety-pipeline.test.ts
- copy/update test/safety/action-firewall.test.ts
- copy/update test/safety/guarded-files.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #310 to internal source `c3ef87f995da8b6ad48738474c13c7587ce5cf86`