### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/design/MCP_TRUST.md
+++ b/docs/design/MCP_TRUST.md
@@ -1,0 +1,79 @@
+# MCP Workspace Trust
+
+Maestro treats MCP tool invocation trust as a property of both the MCP server and
+the current workspace. A server that is safe in one repository can still be risky
+in another repository if the workspace contains hostile instructions, different
+credentials, or project-local configuration that changes what the server can do.
+
+## Trust Model
+
+For each `(mcpServerId, workspaceUri)` tuple, trust resolves to one of:
+
+- `trusted`: the agent may invoke the MCP server's tools.
+- `ask`: the next invocation must ask the connected client before the tool call
+  reaches the MCP server.
+- `blocked`: the server is explicitly blocked for this workspace.
+- `untrusted`: the server is unavailable unless policy/config changes.
+
+When no workspace trust config exists, Maestro preserves the historical behavior
+and treats configured MCP servers as trusted. Organizations can opt into
+per-workspace prompting by setting:
+
+```json
+{
+  "workspaceTrustDefault": "ask"
+}
+```
+
+Specific server/workspace entries are configured with `trustedWorkspaces`:
+
+```json
+{
+  "trustedWorkspaces": {
+    "linear": [
+      {
+        "workspaceUri": "git:git@github.com:evalops/platform.git",
+        "mode": "trusted",
+        "grantedBy": "admin",
+        "grantedAt": "2026-05-07T00:00:00.000Z",
+        "reason": "Approved for Platform issue triage"
+      }
+    ]
+  }
+}
+```
+
+Configured entries take precedence over locally persisted user decisions so
+central policy can revoke or block a workspace even after a user previously chose
+`trust_always`. A `workspaceTrustDefault` of `untrusted` also overrides locally
+stored trust.
+
+## Workspace Identity
+
+Maestro resolves the workspace URI from the active MCP config project root:
+
+1. Prefer the Git `origin` remote URL when available, encoded as
+   `git:<remote-url>`.
+2. Fall back to the canonical local path, encoded as `file:<absolute-path>`.
+
+The Git remote form is stable across machines for cloned repositories. The file
+form keeps non-Git workspaces enforceable while acknowledging that trust is local
+to that machine/path.
+
+## Invocation Enforcement
+
+`McpClientManager.callTool()` checks workspace trust before calling the MCP SDK.
+For `ask`, it routes through the existing headless/client request path by calling
+the connected client tool service with `toolName: "mcp_elicitation"`. That maps
+to the runtime `SERVER_REQUEST_TYPE_MCP_ELICITATION` primitive instead of
+invoking the MCP tool directly after connection.
+
+The user can choose:
+
+- `trust_once`: allow this invocation only.
+- `trust_always`: persist a trusted entry for this server/workspace.
+- `block`: persist a blocked entry for this server/workspace.
+- `cancel`: deny this invocation.
+
+If no MCP elicitation-capable client is connected, ask-mode invocations fail
+closed and the MCP SDK tool call is not made.

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -106,6 +106,13 @@ export const PATHS = {
 			join(getComposerHome(), "mcp-project-approvals.json")
 		);
 	},
+	/** Per-workspace MCP invocation trust decisions */
+	get MCP_WORKSPACE_TRUST_FILE(): string {
+		return (
+			resolveEnvPath(process.env.MAESTRO_MCP_WORKSPACE_TRUST_FILE) ??
+			join(getComposerHome(), "mcp-workspace-trust.json")
+		);
+	},
 	/** Project onboarding state */
 	get PROJECT_ONBOARDING_FILE(): string {
 		return (

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -71,12 +71,16 @@ import {
 	mcpAuthPresetSchema,
 	mcpConfigSchema,
 	mcpServerSchema,
+	mcpWorkspaceTrustDefaultSchema,
+	mcpWorkspaceTrustEntrySchema,
 } from "./schema.js";
 import type {
 	McpAuthPresetConfig,
 	McpConfig,
 	McpScope,
 	McpServerConfig,
+	McpWorkspaceTrustDefault,
+	McpWorkspaceTrustEntry,
 } from "./types.js";
 
 const logger = createLogger("mcp:config");
@@ -148,6 +152,8 @@ const getEffectiveEnterpriseConfigPath = (): string =>
 type ParsedConfig = {
 	servers: McpServerConfig[];
 	authPresets: McpAuthPresetConfig[];
+	trustedWorkspaces: Record<string, McpWorkspaceTrustEntry[]>;
+	workspaceTrustDefault?: McpWorkspaceTrustDefault;
 };
 type RawMcpConfigFile = z.infer<typeof mcpConfigSchema>;
 type PersistedMcpAuthPresetConfig = Omit<McpAuthPresetInput, "name">;
@@ -208,20 +214,23 @@ export function loadMcpConfig(
 	);
 	const projectCfg = projectRoot
 		? parseConfigFile(resolve(projectRoot, PROJECT_CONFIG_NAME), "project")
-		: { servers: [], authPresets: [] };
+		: { servers: [], authPresets: [], trustedWorkspaces: {} };
 	const localCfg = projectRoot
 		? parseConfigFile(resolve(projectRoot, LOCAL_CONFIG_NAME), "local")
-		: { servers: [], authPresets: [] };
+		: { servers: [], authPresets: [], trustedWorkspaces: {} };
 	const pluginCfg: ParsedConfig = {
 		servers: [
 			...getPlatformMcpPluginServers(),
 			...(options.pluginServers ?? []),
 		],
 		authPresets: [],
+		trustedWorkspaces: {},
 	};
 
 	const merged = new Map<string, McpServerConfig>();
 	const mergedAuthPresets = new Map<string, McpAuthPresetConfig>();
+	const mergedTrustedWorkspaces: Record<string, McpWorkspaceTrustEntry[]> = {};
+	let workspaceTrustDefault: McpWorkspaceTrustDefault | undefined;
 	// precedence: enterprise -> plugin -> project -> local -> user
 	// lower precedence first, higher precedence last so later overrides earlier
 	for (const src of [userCfg, localCfg, projectCfg, pluginCfg, enterpriseCfg]) {
@@ -236,6 +245,15 @@ export function loadMcpConfig(
 			}
 			merged.set(server.name, server);
 		}
+		for (const [serverName, entries] of Object.entries(src.trustedWorkspaces)) {
+			mergedTrustedWorkspaces[serverName] = [
+				...(mergedTrustedWorkspaces[serverName] ?? []),
+				...entries,
+			];
+		}
+		if (src.workspaceTrustDefault) {
+			workspaceTrustDefault = src.workspaceTrustDefault;
+		}
 	}
 
 	const envLimits = options.includeEnvLimits
@@ -246,6 +264,11 @@ export function loadMcpConfig(
 		servers: Array.from(merged.values()),
 		authPresets: Array.from(mergedAuthPresets.values()),
 		projectRoot: projectRoot ? resolve(projectRoot) : undefined,
+		trustedWorkspaces:
+			Object.keys(mergedTrustedWorkspaces).length > 0
+				? mergedTrustedWorkspaces
+				: undefined,
+		workspaceTrustDefault,
 		envLimits,
 	};
 }
@@ -495,7 +518,7 @@ export function updateMcpAuthPresetInConfig(
 
 function parseConfigFile(path: string, scope: McpScope): ParsedConfig {
 	if (!isConfigFile(path)) {
-		return { servers: [], authPresets: [] };
+		return { servers: [], authPresets: [], trustedWorkspaces: {} };
 	}
 	try {
 		const content = readFileSync(path, "utf-8");
@@ -507,7 +530,7 @@ function parseConfigFile(path: string, scope: McpScope): ParsedConfig {
 				path,
 				error: parsed.error.issues.map((e) => e.message).join("; "),
 			});
-			return { servers: [], authPresets: [] };
+			return { servers: [], authPresets: [], trustedWorkspaces: {} };
 		}
 
 		const servers: McpServerConfig[] = [];
@@ -536,7 +559,20 @@ function parseConfigFile(path: string, scope: McpScope): ParsedConfig {
 				if (normalized) authPresets.push(normalized);
 			}
 		}
-		return { servers, authPresets };
+		return {
+			servers,
+			authPresets,
+			trustedWorkspaces: normalizeTrustedWorkspaces(
+				parsed.data.trustedWorkspaces,
+				scope,
+				path,
+			),
+			workspaceTrustDefault: normalizeWorkspaceTrustDefault(
+				parsed.data.workspaceTrustDefault,
+				scope,
+				path,
+			),
+		};
 	} catch (error) {
 		logger.warn("Failed to parse MCP config file", {
 			path,
@@ -544,8 +580,77 @@ function parseConfigFile(path: string, scope: McpScope): ParsedConfig {
 			error: error instanceof Error ? error.message : String(error),
 			stack: error instanceof Error ? error.stack : undefined,
 		});
-		return { servers: [], authPresets: [] };
+		return { servers: [], authPresets: [], trustedWorkspaces: {} };
 	}
+}
+
+function normalizeWorkspaceTrustDefault(
+	raw: unknown,
+	scope: McpScope,
+	path: string,
+): McpWorkspaceTrustDefault | undefined {
+	if (raw === undefined) {
+		return undefined;
+	}
+	const parsed = mcpWorkspaceTrustDefaultSchema.safeParse(raw);
+	if (parsed.success) {
+		return parsed.data;
+	}
+	logger.warn("Invalid MCP workspaceTrustDefault", {
+		scope,
+		path,
+		error: parsed.error.issues.map((issue) => issue.message).join("; "),
+	});
+	return undefined;
+}
+
+function normalizeTrustedWorkspaces(
+	raw: unknown,
+	scope: McpScope,
+	path: string,
+): Record<string, McpWorkspaceTrustEntry[]> {
+	if (raw === undefined) {
+		return {};
+	}
+	if (!isRecord(raw)) {
+		logger.warn("Invalid MCP trustedWorkspaces", {
+			scope,
+			path,
+			error: "expected an object keyed by MCP server name",
+		});
+		return {};
+	}
+	const trustedWorkspaces: Record<string, McpWorkspaceTrustEntry[]> = {};
+	for (const [serverName, entries] of Object.entries(raw)) {
+		if (!Array.isArray(entries)) {
+			logger.warn("Invalid MCP trustedWorkspaces entry", {
+				scope,
+				path,
+				serverName,
+				error: "expected an array of workspace trust entries",
+			});
+			continue;
+		}
+		const validEntries: McpWorkspaceTrustEntry[] = [];
+		for (const [index, entry] of entries.entries()) {
+			const parsed = mcpWorkspaceTrustEntrySchema.safeParse(entry);
+			if (!parsed.success) {
+				logger.warn("Invalid MCP trusted workspace entry", {
+					scope,
+					path,
+					serverName,
+					index,
+					error: parsed.error.issues.map((issue) => issue.message).join("; "),
+				});
+				continue;
+			}
+			validEntries.push(parsed.data);
+		}
+		if (validEntries.length > 0) {
+			trustedWorkspaces[serverName] = validEntries;
+		}
+	}
+	return trustedWorkspaces;
 }
 
 function readWritableMcpConfig(

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -82,6 +82,7 @@ import type {
 	McpServerConfig,
 	McpServerStatus,
 } from "./types.js";
+import { ensureMcpWorkspaceTrusted } from "./workspace-trust.js";
 
 const logger = createLogger("mcp:manager");
 const execFileAsync = promisify(execFile);
@@ -439,6 +440,8 @@ export class McpClientManager extends EventEmitter {
 			servers: config.servers ?? [],
 			authPresets: config.authPresets ?? [],
 			projectRoot: config.projectRoot,
+			trustedWorkspaces: config.trustedWorkspaces,
+			workspaceTrustDefault: config.workspaceTrustDefault,
 			envLimits: config.envLimits,
 		};
 		const previousAuthPresetMap = buildAuthPresetMap(this.config.authPresets);
@@ -971,6 +974,15 @@ export class McpClientManager extends EventEmitter {
 		if (!server) {
 			throw new Error(`MCP server '${serverName}' not connected`);
 		}
+		await ensureMcpWorkspaceTrusted({
+			config: this.config,
+			server: buildComparableServerConfig(
+				server.config,
+				buildAuthPresetMap(this.config.authPresets),
+			),
+			toolName,
+			clientToolService: getCurrentMcpClientToolService(),
+		});
 
 		void emitMcpToolUsageBeacon({
 			serverName,

--- a/src/mcp/schema.ts
+++ b/src/mcp/schema.ts
@@ -27,6 +27,30 @@ export const mcpAuthPresetSchema = z
 		}
 	});
 
+export const mcpWorkspaceTrustModeSchema = z.union([
+	z.literal("trusted"),
+	z.literal("ask"),
+	z.literal("blocked"),
+]);
+
+export const mcpWorkspaceTrustDefaultSchema = z.union([
+	z.literal("trusted"),
+	z.literal("ask"),
+	z.literal("untrusted"),
+]);
+
+export const mcpWorkspaceTrustEntrySchema = z
+	.object({
+		workspaceUri: z.string().min(1),
+		mode: mcpWorkspaceTrustModeSchema,
+		serverFingerprint: z.string().optional(),
+		grantedBy: z.string().optional(),
+		grantedAt: z.string().optional(),
+		expiresAt: z.string().optional(),
+		reason: z.string().optional(),
+	})
+	.strict();
+
 export const mcpServerSchema = z
 	.object({
 		name: mcpNameSchema,
@@ -81,6 +105,8 @@ export const mcpConfigSchema = z.object({
 	// allow loose objects; we normalize/validate per-entry later
 	mcpServers: z.record(z.string(), z.unknown()).optional(),
 	authPresets: z.record(z.string(), z.unknown()).optional(),
+	trustedWorkspaces: z.unknown().optional(),
+	workspaceTrustDefault: z.unknown().optional(),
 });
 
 export type McpConfigInput = z.infer<typeof mcpConfigSchema>;

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -40,6 +40,18 @@ export type McpScope = "enterprise" | "plugin" | "project" | "local" | "user";
 export type McpRemoteTrust = "official" | "custom" | "unknown";
 export type McpProjectApprovalDecision = "approved" | "denied";
 export type McpProjectApprovalStatus = "pending" | McpProjectApprovalDecision;
+export type McpWorkspaceTrustMode = "trusted" | "ask" | "blocked" | "untrusted";
+export type McpWorkspaceTrustDefault = "trusted" | "ask" | "untrusted";
+
+export interface McpWorkspaceTrustEntry {
+	workspaceUri: string;
+	mode: Exclude<McpWorkspaceTrustMode, "untrusted">;
+	serverFingerprint?: string;
+	grantedBy?: string;
+	grantedAt?: string;
+	expiresAt?: string;
+	reason?: string;
+}
 
 export interface McpOfficialRegistryInfo {
 	displayName?: string;
@@ -111,6 +123,8 @@ export interface McpConfig {
 	servers: McpServerConfig[];
 	authPresets: McpAuthPresetConfig[];
 	projectRoot?: string;
+	trustedWorkspaces?: Record<string, McpWorkspaceTrustEntry[]>;
+	workspaceTrustDefault?: McpWorkspaceTrustDefault;
 	envLimits?: Record<
 		string,
 		{ effective: number; status: string; message?: string }

--- a/src/mcp/workspace-trust.ts
+++ b/src/mcp/workspace-trust.ts
@@ -1,0 +1,400 @@
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+import type { ClientToolExecutionService } from "../agent/transport.js";
+import type { TextContent } from "../agent/types.js";
+import { PATHS } from "../config/constants.js";
+import { readJsonFile, writeJsonFile } from "../utils/fs.js";
+import type {
+	McpConfig,
+	McpServerConfig,
+	McpWorkspaceTrustEntry,
+	McpWorkspaceTrustMode,
+} from "./types.js";
+
+type StoredMcpWorkspaceTrust = {
+	version: 1;
+	servers: Record<string, McpWorkspaceTrustEntry[]>;
+};
+
+type TrustDecision = "trust_once" | "trust_always" | "block" | "cancel";
+
+const execFileAsync = promisify(execFile);
+
+function emptyStore(): StoredMcpWorkspaceTrust {
+	return {
+		version: 1,
+		servers: {},
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeTrustEntry(value: unknown): McpWorkspaceTrustEntry | null {
+	if (!isRecord(value)) {
+		return null;
+	}
+	const workspaceUri = value.workspaceUri;
+	const mode = value.mode;
+	if (
+		typeof workspaceUri !== "string" ||
+		workspaceUri.trim().length === 0 ||
+		(mode !== "trusted" && mode !== "ask" && mode !== "blocked")
+	) {
+		return null;
+	}
+	return {
+		workspaceUri: canonicalizeWorkspaceUri(workspaceUri),
+		mode,
+		serverFingerprint:
+			typeof value.serverFingerprint === "string"
+				? value.serverFingerprint
+				: undefined,
+		grantedBy:
+			typeof value.grantedBy === "string" ? value.grantedBy : undefined,
+		grantedAt:
+			typeof value.grantedAt === "string" ? value.grantedAt : undefined,
+		expiresAt:
+			typeof value.expiresAt === "string" ? value.expiresAt : undefined,
+		reason: typeof value.reason === "string" ? value.reason : undefined,
+	};
+}
+
+function normalizeStore(value: unknown): StoredMcpWorkspaceTrust {
+	if (!isRecord(value) || value.version !== 1 || !isRecord(value.servers)) {
+		return emptyStore();
+	}
+	const servers: Record<string, McpWorkspaceTrustEntry[]> = {};
+	for (const [serverName, entries] of Object.entries(value.servers)) {
+		if (!Array.isArray(entries)) {
+			continue;
+		}
+		const normalized = entries
+			.map(normalizeTrustEntry)
+			.filter((entry): entry is McpWorkspaceTrustEntry => !!entry);
+		if (normalized.length > 0) {
+			servers[serverName] = normalized;
+		}
+	}
+	return { version: 1, servers };
+}
+
+function readStore(): StoredMcpWorkspaceTrust {
+	return normalizeStore(
+		readJsonFile<unknown>(PATHS.MCP_WORKSPACE_TRUST_FILE, {
+			fallback: emptyStore(),
+		}),
+	);
+}
+
+function writeStore(store: StoredMcpWorkspaceTrust): void {
+	writeJsonFile(PATHS.MCP_WORKSPACE_TRUST_FILE, store);
+}
+
+function isExpired(entry: McpWorkspaceTrustEntry, now = Date.now()): boolean {
+	if (!entry.expiresAt) {
+		return false;
+	}
+	const expiresAt = Date.parse(entry.expiresAt);
+	return !Number.isFinite(expiresAt) || expiresAt <= now;
+}
+
+function latestMatchingEntry(
+	entries: readonly McpWorkspaceTrustEntry[] | undefined,
+	workspaceUri: string,
+	options: { serverFingerprint?: string } = {},
+): McpWorkspaceTrustEntry | undefined {
+	if (!entries) {
+		return undefined;
+	}
+	const canonicalWorkspaceUri = canonicalizeWorkspaceUri(workspaceUri);
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (!entry || isExpired(entry)) {
+			continue;
+		}
+		if (
+			canonicalizeWorkspaceUri(entry.workspaceUri) !== canonicalWorkspaceUri
+		) {
+			continue;
+		}
+		if (
+			options.serverFingerprint &&
+			entry.serverFingerprint !== options.serverFingerprint
+		) {
+			if (entry.serverFingerprint || entry.mode === "trusted") {
+				continue;
+			}
+		}
+		return entry;
+	}
+	return undefined;
+}
+
+function resolveConfiguredMcpWorkspaceTrust(options: {
+	config: Pick<McpConfig, "trustedWorkspaces" | "workspaceTrustDefault">;
+	serverName: string;
+	workspaceUri: string;
+	serverFingerprint?: string;
+	storedTrust?: Record<string, McpWorkspaceTrustEntry[]>;
+}): McpWorkspaceTrustMode {
+	const configuredEntries =
+		options.config.trustedWorkspaces?.[options.serverName];
+	const configured = latestMatchingEntry(
+		configuredEntries,
+		options.workspaceUri,
+	);
+	if (configured) {
+		return configured.mode;
+	}
+	if (options.config.workspaceTrustDefault === "untrusted") {
+		return "untrusted";
+	}
+	const stored = latestMatchingEntry(
+		options.storedTrust?.[options.serverName],
+		options.workspaceUri,
+		{ serverFingerprint: options.serverFingerprint },
+	);
+	if (stored) {
+		return stored.mode;
+	}
+	if (!options.config.workspaceTrustDefault && !configuredEntries?.length) {
+		return "trusted";
+	}
+	return options.config.workspaceTrustDefault ?? "ask";
+}
+
+function canonicalizeWorkspaceUri(workspaceUri: string): string {
+	const trimmed = workspaceUri.trim();
+	if (trimmed.startsWith("git:")) {
+		return `git:${sanitizeGitRemote(trimmed.slice("git:".length))}`;
+	}
+	return trimmed;
+}
+
+function sanitizeGitRemote(remote: string): string {
+	const trimmed = remote.trim();
+	try {
+		const url = new URL(trimmed);
+		url.username = "";
+		url.password = "";
+		url.search = "";
+		url.hash = "";
+		return url.toString();
+	} catch {
+		return trimmed
+			.replace(/^[^/@\s]+@(?=[^/:]+[:/])/, "")
+			.replace(/[?#].*$/, "");
+	}
+}
+
+function normalizeFingerprintValue(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(normalizeFingerprintValue);
+	}
+	if (isRecord(value)) {
+		return Object.fromEntries(
+			Object.entries(value)
+				.filter(([, entryValue]) => entryValue !== undefined)
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([key, entryValue]) => [
+					key,
+					normalizeFingerprintValue(entryValue),
+				]),
+		);
+	}
+	return value;
+}
+
+function fingerprintMcpServer(server: McpServerConfig): string {
+	const identity: McpServerConfig = { ...server };
+	delete identity.disabled;
+	delete identity.enabled;
+	delete identity.scope;
+	return createHash("sha256")
+		.update(JSON.stringify(normalizeFingerprintValue(identity)))
+		.digest("hex");
+}
+
+export async function resolveMcpWorkspaceUri(
+	workspaceRoot = process.cwd(),
+): Promise<string> {
+	const root = resolve(workspaceRoot);
+	try {
+		const { stdout } = await execFileAsync(
+			"git",
+			["-C", root, "config", "--get", "remote.origin.url"],
+			{
+				timeout: 1000,
+				windowsHide: true,
+				encoding: "utf8",
+			},
+		);
+		const remote = stdout.trim();
+		if (remote.length > 0) {
+			return `git:${sanitizeGitRemote(remote)}`;
+		}
+	} catch {
+		// Non-git workspaces fall back to a canonical local path.
+	}
+	return `file:${root}`;
+}
+
+function setMcpWorkspaceTrust(options: {
+	serverName: string;
+	workspaceUri: string;
+	mode: Exclude<McpWorkspaceTrustMode, "untrusted">;
+	serverFingerprint?: string;
+	grantedBy?: string;
+	reason?: string;
+}): void {
+	const store = readStore();
+	const workspaceUri = canonicalizeWorkspaceUri(options.workspaceUri);
+	const entries = (store.servers[options.serverName] ?? []).filter(
+		(entry) =>
+			canonicalizeWorkspaceUri(entry.workspaceUri) !== workspaceUri ||
+			entry.serverFingerprint !== options.serverFingerprint,
+	);
+	entries.push({
+		workspaceUri,
+		mode: options.mode,
+		serverFingerprint: options.serverFingerprint,
+		grantedBy: options.grantedBy,
+		grantedAt: new Date().toISOString(),
+		reason: options.reason,
+	});
+	store.servers[options.serverName] = entries;
+	writeStore(store);
+}
+
+function getDecision(content: TextContent[]): TrustDecision {
+	const text = content.find(
+		(item): item is TextContent =>
+			item.type === "text" && typeof item.text === "string",
+	)?.text;
+	if (!text) {
+		return "cancel";
+	}
+	try {
+		const parsed = JSON.parse(text) as unknown;
+		if (!isRecord(parsed)) {
+			return "cancel";
+		}
+		if (parsed.action === "decline" || parsed.action === "cancel") {
+			return "cancel";
+		}
+		const payload = isRecord(parsed.content) ? parsed.content : parsed;
+		const candidate = payload.decision ?? payload.choice ?? payload.action;
+		if (
+			candidate === "trust_once" ||
+			candidate === "trust_always" ||
+			candidate === "block" ||
+			candidate === "cancel"
+		) {
+			return candidate;
+		}
+	} catch {
+		return "cancel";
+	}
+	return "cancel";
+}
+
+export async function ensureMcpWorkspaceTrusted(options: {
+	config: McpConfig;
+	server: McpServerConfig;
+	toolName: string;
+	clientToolService?: ClientToolExecutionService;
+}): Promise<void> {
+	const storedTrust = readStore().servers;
+	if (
+		!options.config.workspaceTrustDefault &&
+		!options.config.trustedWorkspaces?.[options.server.name]?.length &&
+		!storedTrust[options.server.name]?.length
+	) {
+		return;
+	}
+	const workspaceUri = await resolveMcpWorkspaceUri(options.config.projectRoot);
+	const serverFingerprint = fingerprintMcpServer(options.server);
+	const mode = resolveConfiguredMcpWorkspaceTrust({
+		config: options.config,
+		serverName: options.server.name,
+		workspaceUri,
+		serverFingerprint,
+		storedTrust,
+	});
+
+	if (mode === "trusted") {
+		return;
+	}
+	if (mode === "blocked" || mode === "untrusted") {
+		throw new Error(
+			`MCP server "${options.server.name}" is not trusted for workspace ${workspaceUri}.`,
+		);
+	}
+	if (!options.clientToolService) {
+		throw new Error(
+			`MCP server "${options.server.name}" requires workspace trust before invoking "${options.toolName}", but no MCP elicitation client is connected.`,
+		);
+	}
+
+	const requestId = `mcp_trust:${options.server.name}:${options.toolName}:${randomUUID()}`;
+	const result = await options.clientToolService.requestExecution(
+		requestId,
+		"mcp_elicitation",
+		{
+			serverName: options.server.name,
+			requestId,
+			mode: "form",
+			message: `Trust MCP server "${options.server.name}" for workspace ${workspaceUri} before calling tool "${options.toolName}"?`,
+			requestedSchema: {
+				type: "object",
+				properties: {
+					decision: {
+						type: "string",
+						title: "Decision",
+						enum: ["trust_once", "trust_always", "block", "cancel"],
+					},
+				},
+				required: ["decision"],
+			},
+		},
+	);
+
+	if (result.isError) {
+		throw new Error(
+			`MCP trust prompt failed for server "${options.server.name}".`,
+		);
+	}
+
+	const decision = getDecision(result.content as TextContent[]);
+	if (decision === "trust_once") {
+		return;
+	}
+	if (decision === "trust_always") {
+		setMcpWorkspaceTrust({
+			serverName: options.server.name,
+			workspaceUri,
+			mode: "trusted",
+			serverFingerprint,
+			grantedBy: "user",
+			reason: `Accepted MCP tool invocation for ${options.toolName}`,
+		});
+		return;
+	}
+	if (decision === "block") {
+		setMcpWorkspaceTrust({
+			serverName: options.server.name,
+			workspaceUri,
+			mode: "blocked",
+			serverFingerprint,
+			grantedBy: "user",
+			reason: `Blocked MCP tool invocation for ${options.toolName}`,
+		});
+	}
+	throw new Error(
+		`MCP server "${options.server.name}" was not trusted for workspace ${workspaceUri}.`,
+	);
+}

--- a/test/agent/mcp-manager-transports.test.ts
+++ b/test/agent/mcp-manager-transports.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import {
 	chmodSync,
 	existsSync,
@@ -10,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runWithMcpClientToolService } from "../../src/mcp/elicitation.js";
+import { resolveMcpWorkspaceUri } from "../../src/mcp/workspace-trust.js";
 
 const mockClientConnect = vi.fn();
 const mockClientClose = vi.fn();
@@ -76,6 +78,10 @@ describe("MCP manager remote transports", () => {
 		manager = new McpClientManager();
 		tempDir = join(tmpdir(), `maestro-mcp-transport-${Date.now()}`);
 		mkdirSync(tempDir, { recursive: true });
+		vi.stubEnv(
+			"MAESTRO_MCP_WORKSPACE_TRUST_FILE",
+			join(tempDir, "workspace-trust.json"),
+		);
 		mockClientConnect.mockClear();
 		mockClientClose.mockClear();
 		mockCallTool.mockClear();
@@ -172,6 +178,596 @@ describe("MCP manager remote transports", () => {
 			expect(event.parameters.metadata).not.toHaveProperty("query");
 			expect(event.parameters.metadata).not.toHaveProperty("content");
 		}
+	});
+
+	it("routes untrusted workspace MCP tool calls through MCP elicitation", async () => {
+		const requestExecution = vi.fn().mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						action: "accept",
+						content: { decision: "trust_once" },
+					}),
+				},
+			],
+			isError: false,
+		});
+
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			],
+			authPresets: [],
+		});
+
+		const result = await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+
+		expect(requestExecution).toHaveBeenCalledTimes(1);
+		expect(requestExecution.mock.calls[0]?.[1]).toBe("mcp_elicitation");
+		expect(requestExecution.mock.calls[0]?.[2]).toMatchObject({
+			serverName: "remote-http",
+			mode: "form",
+			requestedSchema: {
+				properties: {
+					decision: {
+						enum: ["trust_once", "trust_always", "block", "cancel"],
+					},
+				},
+			},
+		});
+		expect(mockCallTool).toHaveBeenCalledWith({
+			name: "search",
+			arguments: { query: "docs" },
+		});
+		expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+	});
+
+	it("does not invoke MCP tools when workspace trust is denied", async () => {
+		const requestExecution = vi.fn().mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({ action: "cancel" }),
+				},
+			],
+			isError: false,
+		});
+
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			],
+			authPresets: [],
+		});
+
+		await expect(
+			runWithMcpClientToolService({ requestExecution }, () =>
+				manager.callTool("remote-http", "search", { query: "docs" }),
+			),
+		).rejects.toThrow("was not trusted");
+
+		expect(requestExecution).toHaveBeenCalledTimes(1);
+		expect(mockCallTool).not.toHaveBeenCalled();
+	});
+
+	it("honors legacy blocked trust entries without server fingerprints", async () => {
+		writeFileSync(
+			join(tempDir, "workspace-trust.json"),
+			JSON.stringify({
+				version: 1,
+				servers: {
+					"remote-http": [
+						{
+							workspaceUri: `file:${tempDir}`,
+							mode: "blocked",
+							grantedBy: "user",
+							grantedAt: "2026-05-07T00:00:00.000Z",
+						},
+					],
+				},
+			}),
+		);
+
+		await manager.configure({
+			projectRoot: tempDir,
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			],
+			authPresets: [],
+		});
+
+		await expect(
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		).rejects.toThrow("is not trusted");
+		expect(mockCallTool).not.toHaveBeenCalled();
+	});
+
+	it("blocks ask-mode MCP calls when no MCP elicitation client is connected", async () => {
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			],
+			authPresets: [],
+		});
+
+		await expect(
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		).rejects.toThrow("no MCP elicitation client is connected");
+		expect(mockCallTool).not.toHaveBeenCalled();
+	});
+
+	it("enforces configured workspace trust over stale stored trust", async () => {
+		const requestExecution = vi.fn().mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						action: "accept",
+						content: { decision: "trust_always" },
+					}),
+				},
+			],
+			isError: false,
+		});
+		const server = {
+			name: "remote-http",
+			transport: "http" as const,
+			url: "https://example.com/mcp",
+		};
+
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [server],
+			authPresets: [],
+		});
+		await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+		expect(mockCallTool).toHaveBeenCalledTimes(1);
+
+		mockCallTool.mockClear();
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			trustedWorkspaces: {
+				"remote-http": [
+					{
+						workspaceUri: `file:${tempDir}`,
+						mode: "blocked",
+						grantedBy: "admin",
+						grantedAt: "2026-05-07T00:00:00.000Z",
+						reason: "Revoked by policy",
+					},
+				],
+			},
+			servers: [server],
+			authPresets: [],
+		});
+
+		await expect(
+			runWithMcpClientToolService({ requestExecution }, () =>
+				manager.callTool("remote-http", "search", { query: "docs" }),
+			),
+		).rejects.toThrow("is not trusted");
+		expect(mockCallTool).not.toHaveBeenCalled();
+	});
+
+	it("reprompts when a stored trust decision belongs to a different server definition", async () => {
+		const requestExecution = vi.fn().mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						action: "accept",
+						content: { decision: "trust_always" },
+					}),
+				},
+			],
+			isError: false,
+		});
+
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			],
+			authPresets: [],
+		});
+		await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+
+		mockCallTool.mockClear();
+		requestExecution.mockClear().mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						action: "accept",
+						content: { decision: "trust_always" },
+					}),
+				},
+			],
+			isError: false,
+		});
+
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://different.example.com/mcp",
+				},
+			],
+			authPresets: [],
+		});
+		await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+
+		expect(requestExecution).toHaveBeenCalledTimes(1);
+		expect(mockCallTool).toHaveBeenCalledWith({
+			name: "search",
+			arguments: { query: "docs" },
+		});
+
+		const trustStore = JSON.parse(
+			readFileSync(join(tempDir, "workspace-trust.json"), "utf8"),
+		) as {
+			servers: Record<string, Array<{ serverFingerprint?: string }>>;
+		};
+		const entries = trustStore.servers["remote-http"] ?? [];
+		expect(entries).toHaveLength(2);
+		expect(new Set(entries.map((entry) => entry.serverFingerprint)).size).toBe(
+			2,
+		);
+
+		mockCallTool.mockClear();
+		requestExecution.mockClear();
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			],
+			authPresets: [],
+		});
+		await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+
+		expect(requestExecution).not.toHaveBeenCalled();
+		expect(mockCallTool).toHaveBeenCalledWith({
+			name: "search",
+			arguments: { query: "docs" },
+		});
+	});
+
+	it("reprompts when a stored trust decision belongs to changed auth preset contents", async () => {
+		const requestExecution = vi.fn().mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						action: "accept",
+						content: { decision: "trust_always" },
+					}),
+				},
+			],
+			isError: false,
+		});
+		const server = {
+			name: "remote-http",
+			transport: "http" as const,
+			url: "https://example.com/mcp",
+			authPreset: "prod",
+		};
+
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [server],
+			authPresets: [
+				{
+					name: "prod",
+					headers: { Authorization: "Bearer first" },
+				},
+			],
+		});
+		await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+
+		mockCallTool.mockClear();
+		requestExecution.mockClear().mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						action: "accept",
+						content: { decision: "trust_once" },
+					}),
+				},
+			],
+			isError: false,
+		});
+
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [server],
+			authPresets: [
+				{
+					name: "prod",
+					headers: { Authorization: "Bearer second" },
+				},
+			],
+		});
+		await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+
+		expect(requestExecution).toHaveBeenCalledTimes(1);
+		expect(mockCallTool).toHaveBeenCalledWith({
+			name: "search",
+			arguments: { query: "docs" },
+		});
+	});
+
+	it("keeps stored trust when only server metadata changes", async () => {
+		const requestExecution = vi.fn().mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						action: "accept",
+						content: { decision: "trust_always" },
+					}),
+				},
+			],
+			isError: false,
+		});
+		const server = {
+			name: "remote-http",
+			transport: "http" as const,
+			url: "https://example.com/mcp",
+		};
+
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [{ ...server, scope: "user", enabled: true }],
+			authPresets: [],
+		});
+		await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+
+		mockCallTool.mockClear();
+		requestExecution.mockClear();
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			servers: [{ ...server, scope: "enterprise", disabled: false }],
+			authPresets: [],
+		});
+		await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+
+		expect(requestExecution).not.toHaveBeenCalled();
+		expect(mockCallTool).toHaveBeenCalledWith({
+			name: "search",
+			arguments: { query: "docs" },
+		});
+	});
+
+	it("keeps trustedWorkspaces entries scoped to their server", async () => {
+		const requestExecution = vi.fn();
+
+		await manager.configure({
+			projectRoot: tempDir,
+			trustedWorkspaces: {
+				linear: [
+					{
+						workspaceUri: `file:${tempDir}`,
+						mode: "trusted",
+						grantedBy: "admin",
+						grantedAt: "2026-05-07T00:00:00.000Z",
+					},
+				],
+			},
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			],
+			authPresets: [],
+		});
+
+		await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+
+		expect(requestExecution).not.toHaveBeenCalled();
+		expect(mockCallTool).toHaveBeenCalledWith({
+			name: "search",
+			arguments: { query: "docs" },
+		});
+	});
+
+	it("expires malformed workspace trust timestamps", async () => {
+		const requestExecution = vi.fn().mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						action: "accept",
+						content: { decision: "trust_once" },
+					}),
+				},
+			],
+			isError: false,
+		});
+
+		await manager.configure({
+			workspaceTrustDefault: "ask",
+			projectRoot: tempDir,
+			trustedWorkspaces: {
+				"remote-http": [
+					{
+						workspaceUri: `file:${tempDir}`,
+						mode: "trusted",
+						expiresAt: "not-a-date",
+					},
+				],
+			},
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			],
+			authPresets: [],
+		});
+
+		await runWithMcpClientToolService({ requestExecution }, () =>
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		);
+
+		expect(requestExecution).toHaveBeenCalledTimes(1);
+		expect(mockCallTool).toHaveBeenCalledWith({
+			name: "search",
+			arguments: { query: "docs" },
+		});
+	});
+
+	it("canonicalizes configured git workspace URIs before matching policy", async () => {
+		const repoDir = join(tempDir, "canonical-policy");
+		mkdirSync(repoDir, { recursive: true });
+		execFileSync("git", ["-C", repoDir, "init"], { stdio: "ignore" });
+		execFileSync(
+			"git",
+			[
+				"-C",
+				repoDir,
+				"remote",
+				"add",
+				"origin",
+				"git@github.com:acme/private-repo.git",
+			],
+			{ stdio: "ignore" },
+		);
+
+		await manager.configure({
+			workspaceTrustDefault: "trusted",
+			projectRoot: repoDir,
+			trustedWorkspaces: {
+				"remote-http": [
+					{
+						workspaceUri: "git:git@github.com:acme/private-repo.git",
+						mode: "blocked",
+					},
+				],
+			},
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			],
+			authPresets: [],
+		});
+
+		await expect(
+			manager.callTool("remote-http", "search", { query: "docs" }),
+		).rejects.toThrow("is not trusted");
+		expect(mockCallTool).not.toHaveBeenCalled();
+	});
+
+	it("strips credentials from git remote workspace URIs", async () => {
+		const repoDir = join(tempDir, "credentialed-remote");
+		mkdirSync(repoDir, { recursive: true });
+		execFileSync("git", ["-C", repoDir, "init"], { stdio: "ignore" });
+		execFileSync(
+			"git",
+			[
+				"-C",
+				repoDir,
+				"remote",
+				"add",
+				"origin",
+				"https://token:secret@github.com/acme/private-repo.git?access_token=abc#frag",
+			],
+			{ stdio: "ignore" },
+		);
+
+		await expect(resolveMcpWorkspaceUri(repoDir)).resolves.toBe(
+			"git:https://github.com/acme/private-repo.git",
+		);
+	});
+
+	it("strips userinfo and secrets from scp-style git remote workspace URIs", async () => {
+		const repoDir = join(tempDir, "scp-credentialed-remote");
+		mkdirSync(repoDir, { recursive: true });
+		execFileSync("git", ["-C", repoDir, "init"], { stdio: "ignore" });
+		execFileSync(
+			"git",
+			[
+				"-C",
+				repoDir,
+				"remote",
+				"add",
+				"origin",
+				"token@github.com:acme/private-repo.git?access_token=abc#frag",
+			],
+			{ stdio: "ignore" },
+		);
+
+		await expect(resolveMcpWorkspaceUri(repoDir)).resolves.toBe(
+			"git:github.com:acme/private-repo.git",
+		);
 	});
 
 	it("uses SSE transport for sse servers", async () => {

--- a/test/agent/mcp.test.ts
+++ b/test/agent/mcp.test.ts
@@ -205,6 +205,91 @@ describe("MCP config loader", () => {
 		expect(config.servers[0]!.authPreset).toBe("linear-auth");
 	});
 
+	it("ignores invalid trustedWorkspaces entries without rejecting the config", () => {
+		const configDir = join(testDir, ".maestro");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			join(configDir, "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					docs: {
+						url: "https://example.com/mcp",
+					},
+				},
+				trustedWorkspaces: {
+					docs: [
+						{
+							workspaceUri: "git:https://github.com/evalops/platform.git",
+							mode: "trusted",
+						},
+						{
+							workspaceUri: "git:https://github.com/evalops/deploy.git",
+							mode: "definitely-not-valid",
+						},
+					],
+					broken: {
+						workspaceUri: "git:https://github.com/evalops/maestro.git",
+						mode: "trusted",
+					},
+				},
+			}),
+		);
+
+		const config = loadMcpConfig(testDir);
+		expect(config.servers).toHaveLength(1);
+		expect(config.servers[0]!.name).toBe("docs");
+		expect(config.trustedWorkspaces).toEqual({
+			docs: [
+				{
+					workspaceUri: "git:https://github.com/evalops/platform.git",
+					mode: "trusted",
+				},
+			],
+		});
+	});
+
+	it("ignores malformed trustedWorkspaces sections without rejecting the config", () => {
+		const configDir = join(testDir, ".maestro");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			join(configDir, "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					docs: {
+						url: "https://example.com/mcp",
+					},
+				},
+				trustedWorkspaces: [],
+			}),
+		);
+
+		const config = loadMcpConfig(testDir);
+		expect(config.servers).toHaveLength(1);
+		expect(config.servers[0]!.name).toBe("docs");
+		expect(config.trustedWorkspaces).toBeUndefined();
+	});
+
+	it("ignores invalid workspaceTrustDefault without rejecting the config", () => {
+		const configDir = join(testDir, ".maestro");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			join(configDir, "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					docs: {
+						url: "https://example.com/mcp",
+					},
+				},
+				workspaceTrustDefault: "definitely-not-valid",
+			}),
+		);
+
+		const config = loadMcpConfig(testDir);
+		expect(config.servers).toHaveLength(1);
+		expect(config.servers[0]!.name).toBe("docs");
+		expect(config.workspaceTrustDefault).toBeUndefined();
+	});
+
 	it("detects SSE transport when URL ends with /sse", () => {
 		const configDir = join(testDir, ".maestro");
 		mkdirSync(configDir, { recursive: true });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `388517ba5358c92adce1e179ac2f4fac17fd0936`
- last generated public sync base: `4a0dc0649794af45762f2c8b35e7db68ff1c4308`
- previewed public-tree drift: `9` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (388517ba5358)`
- public projection: `https://github.com/evalops/maestro@main (4a0dc0649794)`
- files to copy or update: `9`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/design/MCP_TRUST.md
- copy/update src/config/constants.ts
- copy/update src/mcp/config.ts
- copy/update src/mcp/manager.ts
- copy/update src/mcp/schema.ts
- copy/update src/mcp/types.ts
- copy/update src/mcp/workspace-trust.ts
- copy/update test/agent/mcp-manager-transports.test.ts
- copy/update test/agent/mcp.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/design/MCP_TRUST.md
- copy/update src/config/constants.ts
- copy/update src/mcp/config.ts
- copy/update src/mcp/manager.ts
- copy/update src/mcp/schema.ts
- copy/update src/mcp/types.ts
- copy/update src/mcp/workspace-trust.ts
- copy/update test/agent/mcp-manager-transports.test.ts
- copy/update test/agent/mcp.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #311 to internal source `388517ba5358c92adce1e179ac2f4fac17fd0936`