### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/design/GUARDED_FILES.md
+++ b/docs/design/GUARDED_FILES.md
@@ -1,0 +1,76 @@
+# Guarded Files
+
+Guarded files are user or editor configuration paths that Maestro must not read
+or mutate silently. The default policy is intentionally conservative: any match
+requires explicit user approval through prompt mode, even when the action
+firewall or permission hooks would otherwise allow the tool call.
+
+## Default Categories
+
+The built-in rule is `default-guarded-file`. It covers:
+
+- Cursor configuration
+- Windsurf configuration
+- Antigravity configuration
+- JetBrains application and project configuration
+- Neovim configuration
+- Amp settings
+- Shell configuration
+- SSH and GPG keys
+
+The matcher expands `~`, shell environment variables, Windows profile tokens,
+and relative paths where the tool call supplies a working directory. It checks
+direct file tools such as `read`, `write`, and `edit`, search/list tools, and
+paths found in shell commands.
+
+## Runtime Behavior
+
+Guarded file access has a hard prompt-mode requirement:
+
+1. A guarded path is detected before tool execution.
+2. PermissionRequest hooks may deny the request, but they may not auto-allow it.
+3. If approval mode is not `prompt`, the call is blocked with the guarded-file
+   reason and no approval request is sent to the approval service.
+4. If approval mode is `prompt`, Maestro emits the normal
+   `action_approval_required` event and waits for the user decision.
+
+This keeps local safety policy and MCP trust aligned around the same principle:
+tools can be powerful, but trust is explicit and scoped to the risky surface.
+MCP server trust is documented separately in [MCP Trust](MCP_TRUST.md).
+
+## Audit Contract
+
+Every guarded-file approval prompt or non-interactive guarded-file block records
+an `ApprovalHit` telemetry event with:
+
+```json
+{
+  "policy_id": "guardedFiles_block",
+  "risk_level": "guarded_file",
+  "context": {
+    "tool_name": "read",
+    "args": { "path": "~/.ssh/config" },
+    "guarded_file": {
+      "rule_id": "default-guarded-file",
+      "category": "SSH and GPG keys",
+      "pattern": "**/.ssh/**",
+      "path": "~/.ssh/config",
+      "action": "read"
+    }
+  }
+}
+```
+
+Shell-backed tools report `action: "execute"` because their command text can
+mix reads and writes. Unknown custom tools report `action: "unknown"` until they
+are classified.
+
+The event correlation uses the session id and tool-call id so Platform audit and
+governance consumers can join guarded-file decisions back to the run timeline.
+
+## Overrides
+
+The shipped surface is the default enforced policy plus audit contract. User and
+organization override management is intentionally separate from this runtime
+guard so that future UI/API work can add explicit allowlist configuration
+without weakening the default protection.

--- a/docs/design/INDEX.md
+++ b/docs/design/INDEX.md
@@ -27,6 +27,7 @@ This directory contains detailed design documentation for each major feature and
 | Document | Description |
 |----------|-------------|
 | [Safety & Firewall System](SAFETY_FIREWALL.md) | Rule-based safety enforcement, dangerous command detection |
+| [Guarded Files](GUARDED_FILES.md) | Prompt-mode guardrails and audit events for user/editor configuration files |
 | [Platform ToolExecution Bridge](PLATFORM_TOOL_EXECUTION_BRIDGE.md) | Shared policy, approval, and audit bridge for Maestro tool calls |
 | [Enterprise RBAC & Audit](ENTERPRISE_RBAC.md) | Role-based access control, audit logging, and multi-tenancy |
 

--- a/src/agent/transport/tool-safety-pipeline.ts
+++ b/src/agent/transport/tool-safety-pipeline.ts
@@ -14,12 +14,16 @@ import type { AdaptiveThresholds } from "../../safety/adaptive-thresholds.js";
 import { METRICS } from "../../safety/adaptive-thresholds.js";
 import {
 	DEFAULT_GUARDED_FILE_RULE_ID,
+	GUARDED_FILES_BLOCK_POLICY_ID,
+	type GuardedFileMatch,
+	classifyGuardedFileAccessAction,
 	describeDefaultGuardedFileMatch,
 	findDefaultGuardedToolCallMatch,
 } from "../../safety/guarded-files.js";
 import type { SafetyMiddleware } from "../../safety/safety-middleware.js";
 import type { WorkflowStateTracker } from "../../safety/workflow-state.js";
 import {
+	type RecordMaestroApprovalHitInput,
 	recordMaestroApprovalHit,
 	recordMaestroFirewallBlock,
 } from "../../telemetry/maestro-event-bus.js";
@@ -137,6 +141,44 @@ interface ApprovalRegistrationAwareService {
 		requestId: string,
 		options?: { signal?: AbortSignal },
 	) => Promise<ApprovalRegistrationMetadata | null>;
+}
+
+function guardedFileAuditContext(
+	toolName: string,
+	args: Record<string, unknown>,
+	match: GuardedFileMatch | null,
+	metadata: {
+		displayName?: string;
+		summaryLabel?: string;
+	},
+): Record<string, unknown> {
+	const context: Record<string, unknown> = {
+		tool_name: toolName,
+		display_name: metadata.displayName,
+		summary_label: metadata.summaryLabel,
+		args,
+	};
+	if (match) {
+		context.guarded_file = {
+			rule_id: match.ruleId,
+			category: match.category,
+			pattern: match.pattern,
+			path: match.path,
+			action: classifyGuardedFileAccessAction(toolName),
+		};
+	}
+	return context;
+}
+
+function guardedFileAuditFields(
+	guardedFileApprovalRequired: boolean,
+): Pick<RecordMaestroApprovalHitInput, "policy_id" | "risk_level"> {
+	return guardedFileApprovalRequired
+		? {
+				policy_id: GUARDED_FILES_BLOCK_POLICY_ID,
+				risk_level: "guarded_file",
+			}
+		: {};
 }
 
 async function waitForPendingApprovalRegistration(
@@ -526,16 +568,16 @@ export async function* evaluateToolSafety(
 		session: cfg.session,
 		userIntent: extractTextFromContent(userMessage.content),
 	});
-	const initialGuardedFileMatch = findDefaultGuardedToolCallMatch(
+	let guardedFileMatch = findDefaultGuardedToolCallMatch(
 		effectiveToolCall.name,
 		effectiveToolCall.arguments,
 	);
 	let guardedFileApprovalRequired =
-		Boolean(initialGuardedFileMatch) ||
+		Boolean(guardedFileMatch) ||
 		(verdict.action === "require_approval" &&
 			verdict.ruleId === DEFAULT_GUARDED_FILE_RULE_ID);
-	let guardedFileApprovalReason = initialGuardedFileMatch
-		? describeDefaultGuardedFileMatch(initialGuardedFileMatch)
+	let guardedFileApprovalReason = guardedFileMatch
+		? describeDefaultGuardedFileMatch(guardedFileMatch)
 		: guardedFileApprovalRequired && verdict.action === "require_approval"
 			? verdict.reason
 			: undefined;
@@ -736,6 +778,7 @@ export async function* evaluateToolSafety(
 					effectiveToolCall.arguments,
 				);
 				if (guardedMatch) {
+					guardedFileMatch = guardedMatch;
 					guardedFileApprovalRequired = true;
 					guardedFileApprovalReason =
 						describeDefaultGuardedFileMatch(guardedMatch);
@@ -791,6 +834,35 @@ export async function* evaluateToolSafety(
 			if (!permissionHookMadeDecision) {
 				approvalReason = `${guardedFileApprovalReason ?? localApprovalReason ?? "Guarded file access requires explicit approval"} Approval mode must be prompt for guarded file access.`;
 			}
+			const sanitizedApprovalArgs = safetyMiddleware.sanitizeForLogging(
+				effectiveToolCall.arguments as Record<string, unknown>,
+			);
+			const approvalDescription = describeArgs(sanitizedApprovalArgs);
+			recordMaestroApprovalHit({
+				approval_request_id:
+					toolExecutionBridgePlan?.metadata.approvalRequestId ?? toolCall.id,
+				action:
+					approvalDescription.actionDescription ??
+					approvalDescription.summaryLabel ??
+					effectiveToolCall.name,
+				command:
+					typeof sanitizedApprovalArgs.command === "string"
+						? sanitizedApprovalArgs.command
+						: undefined,
+				decision_mode: "MAESTRO_DECISION_MODE_REQUIRE_APPROVAL",
+				...guardedFileAuditFields(true),
+				reason: approvalReason,
+				context: guardedFileAuditContext(
+					effectiveToolCall.name,
+					sanitizedApprovalArgs,
+					guardedFileMatch,
+					approvalDescription,
+				),
+				correlation: {
+					session_id: cfg.session?.id,
+					agent_run_step_id: toolCall.id,
+				},
+			});
 		} else if (approvalService && !permissionHookMadeDecision) {
 			const sanitizedApprovalArgs = safetyMiddleware.sanitizeForLogging(
 				effectiveToolCall.arguments as Record<string, unknown>,
@@ -829,13 +901,17 @@ export async function* evaluateToolSafety(
 						? sanitizedApprovalArgs.command
 						: undefined,
 				decision_mode: "MAESTRO_DECISION_MODE_REQUIRE_APPROVAL",
+				...guardedFileAuditFields(guardedFileApprovalRequired),
 				reason: request.reason,
-				context: {
-					tool_name: request.toolName,
-					display_name: request.displayName,
-					summary_label: request.summaryLabel,
-					args: sanitizedApprovalArgs,
-				},
+				context: guardedFileAuditContext(
+					request.toolName,
+					sanitizedApprovalArgs,
+					guardedFileApprovalRequired ? guardedFileMatch : null,
+					{
+						displayName: request.displayName,
+						summaryLabel: request.summaryLabel,
+					},
+				),
 				correlation: {
 					session_id: cfg.session?.id,
 					agent_run_step_id: toolCall.id,

--- a/src/guardian/runner.ts
+++ b/src/guardian/runner.ts
@@ -503,6 +503,8 @@ function runHeuristicScan(files: string[], root: string): GuardianToolResult {
 		/test\/safety\/context-firewall\.test\.ts$/,
 		/test\/safety\/edge-cases\.test\.ts$/,
 		/test\/safety\/safety-middleware\.test\.ts$/,
+		/test\/telemetry\/beacon\.test\.ts$/,
+		/test\/telemetry\/telemetry-metadata-split\.test\.ts$/,
 		// The runner itself contains regex patterns that look like secrets
 		/src\/guardian\/runner\.ts$/,
 	];

--- a/src/safety/guarded-files.ts
+++ b/src/safety/guarded-files.ts
@@ -7,6 +7,9 @@ import {
 import { tokenizeSimple, unwrapShellCommand } from "./bash-safety-analyzer.js";
 
 export const DEFAULT_GUARDED_FILE_RULE_ID = "default-guarded-file";
+export const GUARDED_FILES_BLOCK_POLICY_ID = "guardedFiles_block";
+
+export type GuardedFileAccessAction = "read" | "write" | "execute" | "unknown";
 
 export interface GuardedFileRule {
 	category: string;
@@ -24,6 +27,36 @@ export interface GuardedFileMatchOptions {
 	cwd?: string;
 	homeDir?: string;
 	env?: NodeJS.ProcessEnv;
+}
+
+export function classifyGuardedFileAccessAction(
+	toolName: string,
+): GuardedFileAccessAction {
+	const normalizedToolName = toolName.toLowerCase();
+	if (
+		["write", "edit", "delete_file", "move_file", "copy_file"].includes(
+			normalizedToolName,
+		)
+	) {
+		return "write";
+	}
+	if (
+		[
+			"read",
+			"list",
+			"find",
+			"search",
+			"parallel_ripgrep",
+			"diff",
+			"status",
+		].includes(normalizedToolName)
+	) {
+		return "read";
+	}
+	if (["bash", "background_tasks"].includes(normalizedToolName)) {
+		return "execute";
+	}
+	return "unknown";
 }
 
 export const DEFAULT_GUARDED_FILE_RULES: GuardedFileRule[] = [

--- a/test/agent/tool-safety-pipeline-approval-telemetry.test.ts
+++ b/test/agent/tool-safety-pipeline-approval-telemetry.test.ts
@@ -1,8 +1,8 @@
 import { Type } from "@sinclair/typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type {
-	ActionApprovalDecision,
-	ActionApprovalRequest,
+import {
+	type ActionApprovalDecision,
+	type ActionApprovalRequest,
 	ActionApprovalService,
 } from "../../src/agent/action-approval.js";
 import { evaluateToolSafety } from "../../src/agent/transport/tool-safety-pipeline.js";
@@ -24,6 +24,62 @@ const telemetryMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../src/telemetry/maestro-event-bus.js", () => telemetryMocks);
+
+function createReadTool(): AgentTool {
+	return {
+		name: "read",
+		description: "Read a file",
+		parameters: Type.Object({
+			path: Type.String(),
+		}),
+		execute: async () => ({
+			content: [{ type: "text", text: "ok" }],
+		}),
+	};
+}
+
+function createGuardedReadSafetyContext(options: {
+	approvalService: ActionApprovalService;
+}) {
+	const readTool = createReadTool();
+	return {
+		toolCall: {
+			type: "toolCall" as const,
+			id: "call-guarded-read",
+			name: "read",
+			arguments: { path: "~/.ssh/config" },
+		},
+		tools: [readTool],
+		userMessage: {
+			role: "user" as const,
+			content: "Read the ssh config",
+			timestamp: Date.now(),
+		} satisfies Message,
+		cfg: {
+			tools: [readTool],
+			session: { id: "session-guarded", startedAt: new Date() },
+			user: { id: "user-1", orgId: "workspace-1" },
+		} as AgentRunConfig,
+		clock: { now: () => Date.now() },
+		safetyMiddleware: new SafetyMiddleware({
+			enableContextFirewall: false,
+			enableLoopDetection: false,
+			enableSequenceAnalysis: false,
+		}),
+		workflowState: new WorkflowStateTracker(),
+		adaptiveThresholds: new AdaptiveThresholds(),
+		approvalService: options.approvalService,
+		firewall: new ActionFirewall(),
+		rateLimitState: {
+			recentToolTimestamps: new Map(),
+			toolCallsThisMinute: 0,
+			minuteWindowStart: 0,
+			rateWindowMs: 10_000,
+			rateLimit: 10,
+		},
+		emitToolResult: () => [],
+	};
+}
 
 describe("evaluateToolSafety approval telemetry", () => {
 	afterEach(() => {
@@ -295,5 +351,103 @@ describe("evaluateToolSafety approval telemetry", () => {
 		} finally {
 			process.off("unhandledRejection", onUnhandledRejection);
 		}
+	});
+
+	it("marks guarded-file approval hits with structured audit context", async () => {
+		const approvalService = new ActionApprovalService("prompt");
+		const iterator = evaluateToolSafety(
+			createGuardedReadSafetyContext({ approvalService }),
+		);
+
+		expect((await iterator.next()).done).toBe(false);
+
+		const approvalRequired = await iterator.next();
+		expect(approvalRequired.done).toBe(false);
+		if (approvalRequired.done) {
+			throw new Error("Expected approval-required event");
+		}
+		expect(approvalRequired.value).toMatchObject({
+			type: "action_approval_required",
+			request: {
+				id: "call-guarded-read",
+				toolName: "read",
+				args: { path: "~/.ssh/config" },
+			},
+		});
+		expect(telemetryMocks.recordMaestroApprovalHit).toHaveBeenCalledWith(
+			expect.objectContaining({
+				approval_request_id: "call-guarded-read",
+				policy_id: "guardedFiles_block",
+				risk_level: "guarded_file",
+				decision_mode: "MAESTRO_DECISION_MODE_REQUIRE_APPROVAL",
+				reason: expect.stringContaining("Guarded file access"),
+				context: expect.objectContaining({
+					tool_name: "read",
+					args: { path: "~/.ssh/config" },
+					guarded_file: expect.objectContaining({
+						rule_id: "default-guarded-file",
+						category: "SSH and GPG keys",
+						path: "~/.ssh/config",
+						action: "read",
+					}),
+				}),
+				correlation: {
+					session_id: "session-guarded",
+					agent_run_step_id: "call-guarded-read",
+				},
+			}),
+		);
+
+		expect(approvalService.approve("call-guarded-read", "Confirmed")).toBe(
+			true,
+		);
+		expect((await iterator.next()).done).toBe(false);
+		const final = await iterator.next();
+		expect(final.done).toBe(true);
+		if (!final.done) {
+			throw new Error("Expected final safety verdict");
+		}
+		expect(final.value.verdict).toMatchObject({
+			outcome: "proceed",
+		});
+	});
+
+	it("records guarded-file audit context when non-interactive approval blocks", async () => {
+		const approvalService = new ActionApprovalService("auto");
+		const requestApproval = vi.spyOn(approvalService, "requestApproval");
+		const iterator = evaluateToolSafety(
+			createGuardedReadSafetyContext({ approvalService }),
+		);
+
+		expect((await iterator.next()).done).toBe(false);
+		const final = await iterator.next();
+
+		expect(final.done).toBe(true);
+		if (!final.done) {
+			throw new Error("Expected final safety verdict");
+		}
+		expect(final.value.verdict).toMatchObject({
+			outcome: "blocked",
+		});
+		expect(requestApproval).not.toHaveBeenCalled();
+		expect(telemetryMocks.recordMaestroApprovalHit).toHaveBeenCalledWith(
+			expect.objectContaining({
+				approval_request_id: "call-guarded-read",
+				policy_id: "guardedFiles_block",
+				risk_level: "guarded_file",
+				reason: expect.stringContaining(
+					"Approval mode must be prompt for guarded file access",
+				),
+				context: expect.objectContaining({
+					tool_name: "read",
+					args: { path: "~/.ssh/config" },
+					guarded_file: expect.objectContaining({
+						rule_id: "default-guarded-file",
+						category: "SSH and GPG keys",
+						action: "read",
+					}),
+				}),
+			}),
+		);
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `4a53db1c115161f2b4901d0bbdd0d0805cb30a1d`
- last generated public sync base: `4a0dc0649794af45762f2c8b35e7db68ff1c4308`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (4a53db1c1151)`
- public projection: `https://github.com/evalops/maestro@main (909bd2a1ab2d)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/design/GUARDED_FILES.md
- copy/update docs/design/INDEX.md
- copy/update src/agent/transport/tool-safety-pipeline.ts
- copy/update src/guardian/runner.ts
- copy/update src/safety/guarded-files.ts
- copy/update test/agent/tool-safety-pipeline-approval-telemetry.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/design/GUARDED_FILES.md
- copy/update docs/design/INDEX.md
- copy/update src/agent/transport/tool-safety-pipeline.ts
- copy/update src/guardian/runner.ts
- copy/update src/safety/guarded-files.ts
- copy/update test/agent/tool-safety-pipeline-approval-telemetry.test.ts

## Public-only commits since last generated sync

- 909bd2a1 Gate MCP tool calls on workspace trust

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #312 to internal source `4a53db1c115161f2b4901d0bbdd0d0805cb30a1d`