### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli/system-prompt.ts
+++ b/src/cli/system-prompt.ts
@@ -4,8 +4,10 @@ import {
 	openSync,
 	readFileSync,
 	readSync,
+	readdirSync,
 	statSync,
 } from "node:fs";
+import type { Dirent } from "node:fs";
 import { join, resolve } from "node:path";
 import chalk from "chalk";
 import { buildSearchGuidelines } from "../agent/search-guidance.js";
@@ -16,6 +18,10 @@ import {
 	resolveLoadedAppendSystemPromptPath,
 	resolveProjectDocCandidateFilenames,
 } from "../config/index.js";
+import {
+	DEFAULT_GUARDED_FILE_RULES,
+	findDefaultGuardedFileMatch,
+} from "../safety/guarded-files.js";
 
 // Tool descriptions for dynamic system prompt generation
 const TOOL_DESCRIPTIONS: Record<string, string> = {
@@ -455,6 +461,78 @@ function formatCurrentDateTime(): string {
 	});
 }
 
+const GUARDED_WORKSPACE_SCAN_IGNORES = new Set([
+	".git",
+	".hg",
+	".svn",
+	"node_modules",
+	"dist",
+	"build",
+	"coverage",
+	".next",
+	".turbo",
+	".nx",
+	".cache",
+	"tmp",
+]);
+
+function collectGuardedWorkspaceCategories(
+	cwd: string,
+	options: { maxEntries?: number } = {},
+): string[] {
+	const maxEntries = options.maxEntries ?? 5000;
+	const categories = new Set<string>();
+	const stack = [cwd];
+	let entriesVisited = 0;
+
+	while (stack.length > 0 && entriesVisited < maxEntries) {
+		const dir = stack.pop();
+		if (!dir) break;
+
+		let entries: Dirent[];
+		try {
+			entries = readdirSync(dir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const entry of entries) {
+			if (entriesVisited >= maxEntries) break;
+			entriesVisited += 1;
+			const path = join(dir, entry.name);
+			const match = findDefaultGuardedFileMatch(path, { cwd });
+			if (match) {
+				categories.add(match.category);
+			}
+			if (
+				entry.isDirectory() &&
+				!GUARDED_WORKSPACE_SCAN_IGNORES.has(entry.name)
+			) {
+				stack.push(path);
+			}
+		}
+	}
+
+	return DEFAULT_GUARDED_FILE_RULES.map((rule) => rule.category).filter(
+		(category) => categories.has(category),
+	);
+}
+
+function buildGuardedWorkspacePromptFragment(cwd: string): string | null {
+	const categories = collectGuardedWorkspaceCategories(cwd);
+	if (categories.length === 0) {
+		return null;
+	}
+
+	const categoryText = categories.join(", ");
+	return [
+		"# Guarded Workspace Paths",
+		"",
+		`This workspace contains paths covered by Maestro's default guarded-files policy: ${categoryText}.`,
+		"Ask for explicit user approval before attempting to read, list, search, execute against, or modify these guarded paths.",
+	].join("\n");
+}
+
 export function buildBundledSystemPromptBase(toolNames?: string[]): string {
 	const currentYear = new Date().getFullYear();
 	const activeToolNames = toolNames ?? DEFAULT_TOOL_NAMES;
@@ -483,6 +561,11 @@ export function finalizeSystemPrompt(
 		for (const { path, content } of contextFiles) {
 			prompt += `## ${path}\n\n${content}\n\n`;
 		}
+	}
+
+	const guardedWorkspaceFragment = buildGuardedWorkspacePromptFragment(cwd);
+	if (guardedWorkspaceFragment) {
+		prompt += `\n\n${guardedWorkspaceFragment}\n`;
 	}
 
 	if (appendText) {

--- a/test/cli/system-prompt.test.ts
+++ b/test/cli/system-prompt.test.ts
@@ -80,4 +80,32 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain("project specific context");
 		expect(prompt).toContain(`Current working directory: ${projectDir}`);
 	});
+
+	it("warns the agent when the workspace contains guarded path categories", () => {
+		const projectDir = join(testDir, "guarded-project");
+		mkdirSync(join(projectDir, ".idea"), { recursive: true });
+		mkdirSync(join(projectDir, ".ssh"), { recursive: true });
+		writeFileSync(join(projectDir, ".idea", "workspace.xml"), "<project />");
+		writeFileSync(join(projectDir, ".ssh", "id_ed25519"), "private key");
+
+		const prompt = finalizeSystemPrompt("base prompt", undefined, projectDir);
+
+		expect(prompt).toContain("# Guarded Workspace Paths");
+		expect(prompt).toContain("JetBrains project configuration");
+		expect(prompt).toContain("SSH and GPG keys");
+		expect(prompt).toContain("Ask for explicit user approval");
+		expect(prompt).not.toContain("workspace.xml");
+		expect(prompt).not.toContain("id_ed25519");
+		expect(prompt).not.toContain("**/.ssh/**");
+	});
+
+	it("omits guarded workspace guidance when no guarded paths are present", () => {
+		const projectDir = join(testDir, "ordinary-project");
+		mkdirSync(join(projectDir, "src"), { recursive: true });
+		writeFileSync(join(projectDir, "src", "index.ts"), "export {};");
+
+		const prompt = finalizeSystemPrompt("base prompt", undefined, projectDir);
+
+		expect(prompt).not.toContain("# Guarded Workspace Paths");
+	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `a2ed734ef5b114952d4e11c2a420d413369bbe63`
- last generated public sync base: `e4a5cf08fc61d330407321449fca089a36104f99`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (a2ed734ef5b1)`
- public projection: `https://github.com/evalops/maestro@main (4bea56425c29)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli/system-prompt.ts
- copy/update test/cli/system-prompt.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli/system-prompt.ts
- copy/update test/cli/system-prompt.test.ts

## Public-only commits since last generated sync

- 4bea5642 docs: map tasks to AgentRuntime phases

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode