### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/memory/service-client.ts
+++ b/src/memory/service-client.ts
@@ -1,5 +1,12 @@
+import { readFileSync } from "node:fs";
+import type { IncomingMessage } from "node:http";
+import {
+	type RequestOptions as HttpsRequestOptions,
+	request as httpsRequest,
+} from "node:https";
 import {
 	getEnvValue,
+	parsePositiveInt,
 	resolveOrganizationId,
 	resolvePlatformToken,
 	resolveTeamId,
@@ -17,6 +24,12 @@ const SOURCE_TAG = "source:maestro";
 const TOPIC_TAG_PREFIX = "maestro-topic:";
 const PROJECT_NAME_TAG_PREFIX = "maestro-project-name:";
 const SESSION_TAG_PREFIX = "maestro-session:";
+const MEMORY_SERVICE_TOKEN_SCOPES = [
+	"memories:read",
+	"memories:write",
+] as const;
+const DEFAULT_MEMORY_SERVICE_TOKEN_TTL_SECONDS = 300;
+const SERVICE_TOKEN_EXPIRY_SKEW_MS = 30_000;
 
 type RemoteMemoryConfig = {
 	agentId: string;
@@ -62,6 +75,23 @@ type RemoteRecallRequest = Parameters<MemoryClient["recall"]>[0] & {
 	reviewStatus?: string;
 };
 
+type CachedServiceToken = {
+	expiresAtMs: number;
+	token: string;
+};
+
+type ServiceTokenResponseBody = {
+	claims?: {
+		expires_at?: string;
+		expiresAt?: string;
+	};
+	expires_at?: string;
+	expiresAt?: string;
+	token?: string;
+};
+
+let memoryServiceTokenCache: CachedServiceToken | undefined;
+
 function normalizeTopic(topic: string): string {
 	return topic.toLowerCase().trim();
 }
@@ -105,6 +135,241 @@ function resolveMemoryAgentId(): string {
 	);
 }
 
+function resolveMemoryServiceTokenUrl(): string | undefined {
+	return getEnvValue([
+		"MAESTRO_MEMORY_IDENTITY_SERVICE_TOKENS_URL",
+		"IDENTITY_SERVICE_TOKENS_URL",
+	]);
+}
+
+function resolveMemoryServiceTokenTtlSeconds(): number {
+	return parsePositiveInt(
+		getEnvValue(["MAESTRO_MEMORY_SERVICE_TOKEN_TTL_SECONDS"]),
+		DEFAULT_MEMORY_SERVICE_TOKEN_TTL_SECONDS,
+	);
+}
+
+function resolveMemoryServiceTokenBootstrapKey(): string | undefined {
+	return getEnvValue([
+		"MAESTRO_MEMORY_IDENTITY_BOOTSTRAP_KEY",
+		"IDENTITY_BOOTSTRAP_KEY",
+	]);
+}
+
+function resolveMemoryIdentityTlsOptions(): HttpsRequestOptions {
+	const caFile = getEnvValue([
+		"MAESTRO_MEMORY_IDENTITY_TLS_CA_FILE",
+		"IDENTITY_CLIENT_TLS_CA_FILE",
+	]);
+	const certFile = getEnvValue([
+		"MAESTRO_MEMORY_IDENTITY_TLS_CERT_FILE",
+		"IDENTITY_CLIENT_TLS_CERT_FILE",
+	]);
+	const keyFile = getEnvValue([
+		"MAESTRO_MEMORY_IDENTITY_TLS_KEY_FILE",
+		"IDENTITY_CLIENT_TLS_KEY_FILE",
+	]);
+	const servername = getEnvValue([
+		"MAESTRO_MEMORY_IDENTITY_TLS_SERVER_NAME",
+		"IDENTITY_CLIENT_TLS_SERVER_NAME",
+	]);
+
+	return {
+		...(caFile ? { ca: readFileSync(caFile, "utf8") } : {}),
+		...(certFile ? { cert: readFileSync(certFile, "utf8") } : {}),
+		...(keyFile ? { key: readFileSync(keyFile, "utf8") } : {}),
+		...(servername ? { servername } : {}),
+	};
+}
+
+function serviceTokenCacheValid(
+	cached: CachedServiceToken | undefined,
+): boolean {
+	return Boolean(
+		cached && cached.expiresAtMs - SERVICE_TOKEN_EXPIRY_SKEW_MS > Date.now(),
+	);
+}
+
+function parseServiceTokenExpiresAt(
+	payload: ServiceTokenResponseBody,
+	ttlSeconds: number,
+): number {
+	const value =
+		payload.expires_at ??
+		payload.expiresAt ??
+		payload.claims?.expires_at ??
+		payload.claims?.expiresAt;
+	if (value) {
+		const parsed = Date.parse(value);
+		if (Number.isFinite(parsed)) {
+			return parsed;
+		}
+	}
+	return Date.now() + ttlSeconds * 1000;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseServiceTokenResponseBody(
+	value: unknown,
+): ServiceTokenResponseBody {
+	if (!isRecord(value)) {
+		return {};
+	}
+	const claims = isRecord(value.claims) ? value.claims : undefined;
+	return {
+		token: typeof value.token === "string" ? value.token.trim() : undefined,
+		expires_at:
+			typeof value.expires_at === "string" ? value.expires_at : undefined,
+		expiresAt:
+			typeof value.expiresAt === "string" ? value.expiresAt : undefined,
+		claims: claims
+			? {
+					expires_at:
+						typeof claims.expires_at === "string"
+							? claims.expires_at
+							: undefined,
+					expiresAt:
+						typeof claims.expiresAt === "string" ? claims.expiresAt : undefined,
+				}
+			: undefined,
+	};
+}
+
+function readResponseBody(response: IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		response.on("data", (chunk: Buffer | string) => {
+			chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+		});
+		response.on("end", () => {
+			resolve(Buffer.concat(chunks).toString("utf8"));
+		});
+		response.on("error", reject);
+	});
+}
+
+function issueMemoryServiceTokenRequest(
+	url: string,
+	organizationId: string,
+	ttlSeconds: number,
+): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const body = JSON.stringify({
+			service: MAESTRO_AGENT,
+			organization_id: organizationId,
+			scopes: MEMORY_SERVICE_TOKEN_SCOPES,
+			ttl_seconds: ttlSeconds,
+		});
+		const parsedUrl = new URL(url);
+		const bootstrapKey = resolveMemoryServiceTokenBootstrapKey();
+		const request = httpsRequest(
+			parsedUrl,
+			{
+				...resolveMemoryIdentityTlsOptions(),
+				headers: {
+					Accept: "application/json",
+					"Connect-Protocol-Version": "1",
+					"Content-Length": Buffer.byteLength(body).toString(),
+					"Content-Type": "application/json",
+					...(bootstrapKey ? { "X-Identity-Bootstrap-Key": bootstrapKey } : {}),
+				},
+				method: "POST",
+			},
+			async (response) => {
+				try {
+					const responseBody = await readResponseBody(response);
+					if (response.statusCode !== 200 && response.statusCode !== 201) {
+						reject(
+							new Error(
+								`identity service token request failed with status ${response.statusCode ?? "unknown"}`,
+							),
+						);
+						return;
+					}
+					const parsed = parseServiceTokenResponseBody(
+						JSON.parse(responseBody),
+					);
+					if (!parsed.token) {
+						reject(new Error("identity service token response missing token"));
+						return;
+					}
+					memoryServiceTokenCache = {
+						token: parsed.token,
+						expiresAtMs: parseServiceTokenExpiresAt(parsed, ttlSeconds),
+					};
+					resolve(parsed.token);
+				} catch (error) {
+					reject(error);
+				}
+			},
+		);
+		request.on("error", reject);
+		request.write(body);
+		request.end();
+	});
+}
+
+async function resolveMemoryServiceToken(
+	organizationId: string,
+): Promise<string | undefined> {
+	const url = resolveMemoryServiceTokenUrl();
+	if (!url) {
+		return undefined;
+	}
+	if (serviceTokenCacheValid(memoryServiceTokenCache)) {
+		return memoryServiceTokenCache?.token;
+	}
+
+	const bootstrapKey = resolveMemoryServiceTokenBootstrapKey();
+	const certFile = getEnvValue([
+		"MAESTRO_MEMORY_IDENTITY_TLS_CERT_FILE",
+		"IDENTITY_CLIENT_TLS_CERT_FILE",
+	]);
+	const keyFile = getEnvValue([
+		"MAESTRO_MEMORY_IDENTITY_TLS_KEY_FILE",
+		"IDENTITY_CLIENT_TLS_KEY_FILE",
+	]);
+	if (!bootstrapKey && (!certFile || !keyFile)) {
+		return undefined;
+	}
+
+	return issueMemoryServiceTokenRequest(
+		url,
+		organizationId,
+		resolveMemoryServiceTokenTtlSeconds(),
+	);
+}
+
+async function resolveMemoryAccessToken(
+	organizationId: string,
+): Promise<string | undefined> {
+	const configuredToken = getEnvValue([
+		"MAESTRO_MEMORY_ACCESS_TOKEN",
+		"MAESTRO_EVALOPS_ACCESS_TOKEN",
+		"EVALOPS_TOKEN",
+	]);
+	if (configuredToken) {
+		return configuredToken;
+	}
+
+	try {
+		const serviceToken = await resolveMemoryServiceToken(organizationId);
+		if (serviceToken) {
+			return serviceToken;
+		}
+	} catch (error) {
+		logger.warn(
+			"Failed to issue identity service token for remote memory; trying OAuth fallback",
+			{ error },
+		);
+	}
+
+	return resolvePlatformToken([]);
+}
+
 async function resolveRemoteMemoryConfig(): Promise<RemoteMemoryConfig | null> {
 	const baseUrl = getEnvValue([
 		"MAESTRO_MEMORY_BASE",
@@ -130,11 +395,7 @@ async function resolveRemoteMemoryConfig(): Promise<RemoteMemoryConfig | null> {
 		return null;
 	}
 
-	const token = await resolvePlatformToken([
-		"MAESTRO_MEMORY_ACCESS_TOKEN",
-		"MAESTRO_EVALOPS_ACCESS_TOKEN",
-		"EVALOPS_TOKEN",
-	]);
+	const token = await resolveMemoryAccessToken(organizationId);
 	if (!token) {
 		logger.warn(
 			"Remote memory configured without access token; falling back to local memory store",
@@ -155,6 +416,10 @@ async function resolveRemoteMemoryConfig(): Promise<RemoteMemoryConfig | null> {
 			"MAESTRO_LLM_GATEWAY_TEAM_ID",
 		]),
 	};
+}
+
+export function resetMemoryServiceTokenCacheForTests(): void {
+	memoryServiceTokenCache = undefined;
 }
 
 function resolveRemoteScope(options?: {

--- a/test/memory/service-client.test.ts
+++ b/test/memory/service-client.test.ts
@@ -1,7 +1,9 @@
 import { execSync } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("memory service client", () => {
@@ -25,6 +27,19 @@ describe("memory service client", () => {
 		Reflect.deleteProperty(process.env, "MAESTRO_MEMORY_AGENT_ID");
 		Reflect.deleteProperty(process.env, "MAESTRO_EVALOPS_ORG_ID");
 		Reflect.deleteProperty(process.env, "MAESTRO_MEMORY_TEAM_ID");
+		Reflect.deleteProperty(
+			process.env,
+			"MAESTRO_MEMORY_IDENTITY_SERVICE_TOKENS_URL",
+		);
+		Reflect.deleteProperty(
+			process.env,
+			"MAESTRO_MEMORY_IDENTITY_BOOTSTRAP_KEY",
+		);
+		Reflect.deleteProperty(
+			process.env,
+			"MAESTRO_MEMORY_SERVICE_TOKEN_TTL_SECONDS",
+		);
+		vi.doUnmock("node:https");
 		vi.unstubAllGlobals();
 		vi.restoreAllMocks();
 		rmSync(repoRoot, { recursive: true, force: true });
@@ -355,6 +370,136 @@ describe("memory service client", () => {
 					projectName: expect.any(String),
 				}),
 			}),
+		]);
+	});
+
+	it("uses configured memory token before identity-issued service tokens", async () => {
+		process.env.MAESTRO_MEMORY_IDENTITY_SERVICE_TOKENS_URL =
+			"https://identity.test/identity.v1.TokenService/IssueServiceToken";
+		process.env.MAESTRO_MEMORY_IDENTITY_BOOTSTRAP_KEY = "bootstrap-key";
+
+		const httpsRequest = vi.fn(() => {
+			throw new Error("identity token request should not be used");
+		});
+		vi.doMock("node:https", () => ({
+			request: httpsRequest,
+		}));
+
+		const authorizations: string[] = [];
+		const fetchMock = vi.fn(
+			async (_input: RequestInfo | URL, init?: RequestInit) => {
+				const headers = new Headers(init?.headers);
+				authorizations.push(headers.get("Authorization") ?? "");
+				return new Response(JSON.stringify({ memories: [], total: 0 }), {
+					status: 200,
+				});
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { recallRemoteDurableMemories } = await import(
+			"../../src/memory/service-client.js"
+		);
+		await recallRemoteDurableMemories("focused prs", { limit: 1 });
+
+		expect(httpsRequest).not.toHaveBeenCalled();
+		expect(authorizations).toEqual(["Bearer memory-token"]);
+	});
+
+	it("requests and caches identity-issued memory service tokens before OAuth fallback", async () => {
+		Reflect.deleteProperty(process.env, "MAESTRO_MEMORY_ACCESS_TOKEN");
+		process.env.MAESTRO_MEMORY_IDENTITY_SERVICE_TOKENS_URL =
+			"https://identity.test/identity.v1.TokenService/IssueServiceToken";
+		process.env.MAESTRO_MEMORY_IDENTITY_BOOTSTRAP_KEY = "bootstrap-key";
+		process.env.MAESTRO_MEMORY_SERVICE_TOKEN_TTL_SECONDS = "123";
+
+		const tokenRequests: Array<{
+			body: string;
+			headers: Record<string, string>;
+			url: string;
+		}> = [];
+		const httpsRequest = vi.fn(
+			(
+				url: URL,
+				options: {
+					headers?: Record<string, string>;
+					method?: string;
+				},
+				callback: (response: PassThrough & { statusCode?: number }) => void,
+			) => {
+				let body = "";
+				const request = new EventEmitter() as EventEmitter & {
+					end: () => void;
+					write: (chunk: string) => void;
+				};
+				request.write = (chunk: string) => {
+					body += chunk;
+				};
+				request.end = () => {
+					tokenRequests.push({
+						body,
+						headers: options.headers ?? {},
+						url: url.toString(),
+					});
+					const response = new PassThrough() as PassThrough & {
+						statusCode?: number;
+					};
+					response.statusCode = 201;
+					callback(response);
+					response.end(
+						JSON.stringify({
+							token: "identity-memory-token",
+							expires_at: "2099-01-01T00:00:00.000Z",
+						}),
+					);
+				};
+				return request;
+			},
+		);
+		vi.doMock("node:https", () => ({
+			request: httpsRequest,
+		}));
+
+		const authorizations: string[] = [];
+		const fetchMock = vi.fn(
+			async (_input: RequestInfo | URL, init?: RequestInit) => {
+				const headers = new Headers(init?.headers);
+				authorizations.push(headers.get("Authorization") ?? "");
+				return new Response(JSON.stringify({ memories: [], total: 0 }), {
+					status: 200,
+				});
+			},
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const {
+			recallRemoteDurableMemories,
+			resetMemoryServiceTokenCacheForTests,
+		} = await import("../../src/memory/service-client.js");
+		resetMemoryServiceTokenCacheForTests();
+		await recallRemoteDurableMemories("focused prs", { limit: 1 });
+		await recallRemoteDurableMemories("focused prs", { limit: 1 });
+
+		expect(httpsRequest).toHaveBeenCalledTimes(1);
+		expect(tokenRequests).toEqual([
+			expect.objectContaining({
+				url: "https://identity.test/identity.v1.TokenService/IssueServiceToken",
+				headers: expect.objectContaining({
+					"Connect-Protocol-Version": "1",
+					"Content-Type": "application/json",
+					"X-Identity-Bootstrap-Key": "bootstrap-key",
+				}),
+			}),
+		]);
+		expect(JSON.parse(tokenRequests[0]?.body ?? "{}")).toEqual({
+			service: "maestro",
+			organization_id: "org_123",
+			scopes: ["memories:read", "memories:write"],
+			ttl_seconds: 123,
+		});
+		expect(authorizations).toEqual([
+			"Bearer identity-memory-token",
+			"Bearer identity-memory-token",
 		]);
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `c8443665c6684887468624224f59a2340fd53f17`
- last generated public sync base: `5c9b6f9bc778966a777d0f2c29c482f0cb6410c5`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (c8443665c668)`
- public projection: `https://github.com/evalops/maestro@main (5c9b6f9bc778)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/memory/service-client.ts
- copy/update test/memory/service-client.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/memory/service-client.ts
- copy/update test/memory/service-client.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode