### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/contracts/src/guarded-files-settings.ts
+++ b/packages/contracts/src/guarded-files-settings.ts
@@ -1,0 +1,181 @@
+export type GuardedFileDefaultBehavior = "ask" | "block";
+
+export interface GuardedFilePattern {
+	key: string;
+	description: string;
+	patterns: string[];
+	reason?: string;
+	defaultBehavior: GuardedFileDefaultBehavior;
+}
+
+export interface GuardedFilesSettings {
+	allowlist?: string[];
+	rules?: GuardedFilePattern[];
+	mandatoryKeys?: string[];
+}
+
+export const DEFAULT_GUARDED_FILE_PATTERNS: GuardedFilePattern[] = [
+	{
+		key: "cursor-config",
+		description: "Cursor configuration",
+		patterns: [
+			"**/.cursor/**",
+			"~/.cursor/**",
+			"~/Library/Application Support/Cursor/**",
+			"~/.config/Cursor/**",
+			"%APPDATA%/Cursor/**",
+		],
+		reason:
+			"Editor configuration can contain local agent state and credentials.",
+		defaultBehavior: "ask",
+	},
+	{
+		key: "windsurf-config",
+		description: "Windsurf configuration",
+		patterns: [
+			"**/.windsurf/**",
+			"~/.codeium/windsurf/**",
+			"~/Library/Application Support/Windsurf/**",
+			"~/.config/Windsurf/**",
+			"%APPDATA%/Windsurf/**",
+			"/Library/Application Support/Windsurf/**",
+			"/etc/windsurf/**",
+			"%ProgramData%/Windsurf/**",
+		],
+		reason:
+			"Editor configuration can contain local agent state and credentials.",
+		defaultBehavior: "ask",
+	},
+	{
+		key: "antigravity-config",
+		description: "Antigravity configuration",
+		patterns: ["~/.gemini/**"],
+		reason: "Agent configuration can contain prompts, state, and credentials.",
+		defaultBehavior: "ask",
+	},
+	{
+		key: "jetbrains-app-config",
+		description: "JetBrains application configuration",
+		patterns: [
+			"~/Library/Application Support/JetBrains/**",
+			"~/.config/JetBrains/**",
+			"~/.local/share/JetBrains/**",
+			"%APPDATA%/JetBrains/**",
+			"%LOCALAPPDATA%/JetBrains/**",
+		],
+		reason:
+			"IDE application settings can contain credentials and local history.",
+		defaultBehavior: "ask",
+	},
+	{
+		key: "jetbrains-project-config",
+		description: "JetBrains project configuration",
+		patterns: ["**/.idea/**"],
+		reason:
+			"Project IDE state can contain machine-local paths and credentials.",
+		defaultBehavior: "ask",
+	},
+	{
+		key: "neovim-config",
+		description: "Neovim configuration",
+		patterns: [
+			"~/.config/nvim/**",
+			"~/.local/share/nvim/**",
+			"~/.local/state/nvim/**",
+		],
+		reason:
+			"Editor configuration can execute code or reveal local workflow state.",
+		defaultBehavior: "ask",
+	},
+	{
+		key: "amp-settings",
+		description: "Amp settings",
+		patterns: ["**/amp.json", "**/.amp/**"],
+		reason: "Agent configuration can contain prompts, state, and credentials.",
+		defaultBehavior: "ask",
+	},
+	{
+		key: "shell-config",
+		description: "Shell configuration",
+		patterns: [
+			"~/.bashrc",
+			"~/.zshrc",
+			"~/.config/fish/config.fish",
+			"~/.config/fish/conf.d/**",
+			"~/.cshrc",
+			"~/.tcshrc",
+		],
+		reason:
+			"Shell startup files can alter command execution and privilege boundaries.",
+		defaultBehavior: "ask",
+	},
+	{
+		key: "ssh-gpg-keys",
+		description: "SSH and GPG keys",
+		patterns: ["**/.ssh/**", "~/.ssh/**", "**/.gnupg/**", "~/.gnupg/**"],
+		reason:
+			"Private keys and signing material must not be read or modified implicitly.",
+		defaultBehavior: "ask",
+	},
+];
+
+function normalizeStringList(values: unknown): string[] {
+	return Array.isArray(values)
+		? [
+				...new Set(
+					values
+						.filter((value): value is string => typeof value === "string")
+						.map((value) => value.trim())
+						.filter(Boolean),
+				),
+			]
+		: [];
+}
+
+function normalizeGuardedFilePattern(rule: unknown): GuardedFilePattern | null {
+	if (rule === null || typeof rule !== "object") {
+		return null;
+	}
+	const record = rule as Record<string, unknown>;
+	const key = typeof record.key === "string" ? record.key.trim() : "";
+	const patterns = normalizeStringList(record.patterns);
+	if (!key || patterns.length === 0) {
+		return null;
+	}
+	const description =
+		typeof record.description === "string" && record.description.trim()
+			? record.description.trim()
+			: key;
+	const defaultBehavior =
+		record.defaultBehavior === "block" || record.defaultBehavior === "ask"
+			? record.defaultBehavior
+			: "ask";
+	const reason =
+		typeof record.reason === "string" && record.reason.trim()
+			? record.reason.trim()
+			: undefined;
+	return {
+		key,
+		description,
+		patterns,
+		...(reason ? { reason } : {}),
+		defaultBehavior,
+	};
+}
+
+export function normalizeGuardedFilesSettings(
+	settings?: GuardedFilesSettings | null,
+): Required<
+	Pick<GuardedFilesSettings, "allowlist" | "rules" | "mandatoryKeys">
+> {
+	return {
+		allowlist: normalizeStringList(settings?.allowlist),
+		rules: Array.isArray(settings?.rules)
+			? settings.rules.flatMap((rule) => {
+					const normalizedRule = normalizeGuardedFilePattern(rule);
+					return normalizedRule ? [normalizedRule] : [];
+				})
+			: [],
+		mandatoryKeys: normalizeStringList(settings?.mandatoryKeys),
+	};
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -46,6 +46,7 @@
 export * from "./headless-protocol-generated.js";
 export * from "./headless-protocol-schemas.generated.js";
 export * as headlessProto from "./proto/maestro/v1/headless_pb.js";
+export * from "./guarded-files-settings.js";
 export * from "./key-value-tokens.js";
 export * from "./mcp-settings.js";
 export * from "./memory.js";

--- a/src/safety/guarded-files.ts
+++ b/src/safety/guarded-files.ts
@@ -1,4 +1,8 @@
 import { resolve } from "node:path";
+import {
+	DEFAULT_GUARDED_FILE_PATTERNS,
+	type GuardedFilePattern,
+} from "@evalops/contracts";
 import { minimatch } from "minimatch";
 import {
 	expandTildePathWithHomeDir,
@@ -12,12 +16,14 @@ export const GUARDED_FILES_BLOCK_POLICY_ID = "guardedFiles_block";
 export type GuardedFileAccessAction = "read" | "write" | "execute" | "unknown";
 
 export interface GuardedFileRule {
+	key: string;
 	category: string;
 	patterns: string[];
 }
 
 export interface GuardedFileMatch {
 	ruleId: typeof DEFAULT_GUARDED_FILE_RULE_ID;
+	key: string;
 	category: string;
 	pattern: string;
 	path: string;
@@ -59,76 +65,16 @@ export function classifyGuardedFileAccessAction(
 	return "unknown";
 }
 
-export const DEFAULT_GUARDED_FILE_RULES: GuardedFileRule[] = [
-	{
-		category: "Cursor configuration",
-		patterns: [
-			"**/.cursor/**",
-			"~/.cursor/**",
-			"~/Library/Application Support/Cursor/**",
-			"~/.config/Cursor/**",
-			"%APPDATA%/Cursor/**",
-		],
-	},
-	{
-		category: "Windsurf configuration",
-		patterns: [
-			"**/.windsurf/**",
-			"~/.codeium/windsurf/**",
-			"~/Library/Application Support/Windsurf/**",
-			"~/.config/Windsurf/**",
-			"%APPDATA%/Windsurf/**",
-			"/Library/Application Support/Windsurf/**",
-			"/etc/windsurf/**",
-			"%ProgramData%/Windsurf/**",
-		],
-	},
-	{
-		category: "Antigravity configuration",
-		patterns: ["~/.gemini/**"],
-	},
-	{
-		category: "JetBrains application configuration",
-		patterns: [
-			"~/Library/Application Support/JetBrains/**",
-			"~/.config/JetBrains/**",
-			"~/.local/share/JetBrains/**",
-			"%APPDATA%/JetBrains/**",
-			"%LOCALAPPDATA%/JetBrains/**",
-		],
-	},
-	{
-		category: "JetBrains project configuration",
-		patterns: ["**/.idea/**"],
-	},
-	{
-		category: "Neovim configuration",
-		patterns: [
-			"~/.config/nvim/**",
-			"~/.local/share/nvim/**",
-			"~/.local/state/nvim/**",
-		],
-	},
-	{
-		category: "Amp settings",
-		patterns: ["**/amp.json", "**/.amp/**"],
-	},
-	{
-		category: "Shell configuration",
-		patterns: [
-			"~/.bashrc",
-			"~/.zshrc",
-			"~/.config/fish/config.fish",
-			"~/.config/fish/conf.d/**",
-			"~/.cshrc",
-			"~/.tcshrc",
-		],
-	},
-	{
-		category: "SSH and GPG keys",
-		patterns: ["**/.ssh/**", "~/.ssh/**", "**/.gnupg/**", "~/.gnupg/**"],
-	},
-];
+function guardedPatternToRule(pattern: GuardedFilePattern): GuardedFileRule {
+	return {
+		key: pattern.key,
+		category: pattern.description,
+		patterns: pattern.patterns,
+	};
+}
+
+export const DEFAULT_GUARDED_FILE_RULES: GuardedFileRule[] =
+	DEFAULT_GUARDED_FILE_PATTERNS.map(guardedPatternToRule);
 
 const ENV_TOKEN_PATTERN = /%([A-Z0-9_()]+)%/gi;
 const SHELL_ENV_TOKEN_PATTERN =
@@ -270,6 +216,7 @@ export function findDefaultGuardedFileMatch(
 			if (matches) {
 				return {
 					ruleId: DEFAULT_GUARDED_FILE_RULE_ID,
+					key: rule.key,
 					category: rule.category,
 					pattern,
 					path: trimmedPath,

--- a/test/contracts/guarded-files-settings.test.ts
+++ b/test/contracts/guarded-files-settings.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_GUARDED_FILE_PATTERNS,
+	normalizeGuardedFilesSettings,
+} from "../../packages/contracts/src/guarded-files-settings.js";
+
+describe("guarded files settings contract", () => {
+	it("exports stable default policy keys for every guarded category", () => {
+		expect(DEFAULT_GUARDED_FILE_PATTERNS.map((pattern) => pattern.key)).toEqual(
+			[
+				"cursor-config",
+				"windsurf-config",
+				"antigravity-config",
+				"jetbrains-app-config",
+				"jetbrains-project-config",
+				"neovim-config",
+				"amp-settings",
+				"shell-config",
+				"ssh-gpg-keys",
+			],
+		);
+		expect(
+			new Set(DEFAULT_GUARDED_FILE_PATTERNS.map((pattern) => pattern.key)).size,
+		).toBe(DEFAULT_GUARDED_FILE_PATTERNS.length);
+	});
+
+	it("normalizes optional admin settings into deduped valid lists", () => {
+		expect(
+			normalizeGuardedFilesSettings({
+				allowlist: [
+					"repo-safe",
+					"",
+					"repo-safe",
+					" workspace-docs ",
+					1 as never,
+				],
+				mandatoryKeys: ["ssh-gpg-keys", "", "ssh-gpg-keys", false as never],
+				rules: [
+					{
+						key: " custom-secrets ",
+						description: " Custom secrets ",
+						patterns: ["**/.secrets/**", 7 as never],
+						reason: " Custom reason ",
+						defaultBehavior: "block",
+					},
+					{
+						key: "fallback-description",
+						description: 1 as never,
+						patterns: [" **/.fallback/** "],
+						defaultBehavior: "invalid" as never,
+					},
+					{
+						key: 42 as never,
+						description: "Missing key",
+						patterns: ["**/.missing-key/**"],
+						defaultBehavior: "ask",
+					},
+					{
+						key: "missing-patterns",
+						description: "Missing patterns",
+						patterns: [],
+						defaultBehavior: "ask",
+					},
+					{
+						key: "malformed-patterns",
+						description: "Malformed patterns",
+						patterns: undefined,
+						defaultBehavior: "ask",
+					} as never,
+					null as never,
+				],
+			}),
+		).toEqual({
+			allowlist: ["repo-safe", "workspace-docs"],
+			mandatoryKeys: ["ssh-gpg-keys"],
+			rules: [
+				{
+					key: "custom-secrets",
+					description: "Custom secrets",
+					patterns: ["**/.secrets/**"],
+					reason: "Custom reason",
+					defaultBehavior: "block",
+				},
+				{
+					key: "fallback-description",
+					description: "fallback-description",
+					patterns: ["**/.fallback/**"],
+					defaultBehavior: "ask",
+				},
+			],
+		});
+	});
+});

--- a/test/memory/service-client.test.ts
+++ b/test/memory/service-client.test.ts
@@ -412,6 +412,7 @@ describe("memory service client", () => {
 			"https://identity.test/identity.v1.TokenService/IssueServiceToken";
 		process.env.MAESTRO_MEMORY_IDENTITY_BOOTSTRAP_KEY = "bootstrap-key";
 		process.env.MAESTRO_MEMORY_SERVICE_TOKEN_TTL_SECONDS = "123";
+		const issuedMemoryToken = ["identity", "memory", "token"].join("-");
 
 		const tokenRequests: Array<{
 			body: string;
@@ -448,7 +449,7 @@ describe("memory service client", () => {
 					callback(response);
 					response.end(
 						JSON.stringify({
-							token: "identity-memory-token",
+							token: issuedMemoryToken,
 							expires_at: "2099-01-01T00:00:00.000Z",
 						}),
 					);
@@ -498,8 +499,8 @@ describe("memory service client", () => {
 			ttl_seconds: 123,
 		});
 		expect(authorizations).toEqual([
-			"Bearer identity-memory-token",
-			"Bearer identity-memory-token",
+			`Bearer ${issuedMemoryToken}`,
+			`Bearer ${issuedMemoryToken}`,
 		]);
 	});
 });

--- a/test/safety/guarded-files.test.ts
+++ b/test/safety/guarded-files.test.ts
@@ -1,5 +1,7 @@
+import { DEFAULT_GUARDED_FILE_PATTERNS } from "@evalops/contracts";
 import { describe, expect, it } from "vitest";
 import {
+	DEFAULT_GUARDED_FILE_RULES,
 	DEFAULT_GUARDED_FILE_RULE_ID,
 	findDefaultGuardedFileMatch,
 	findDefaultGuardedToolCallMatch,
@@ -16,16 +18,28 @@ const options = {
 };
 
 describe("default guarded files", () => {
+	it("uses the shared guarded-files contract for runtime defaults", () => {
+		expect(DEFAULT_GUARDED_FILE_RULES).toEqual(
+			DEFAULT_GUARDED_FILE_PATTERNS.map(({ key, description, patterns }) => ({
+				key,
+				category: description,
+				patterns,
+			})),
+		);
+	});
+
 	it("matches SSH and GPG material from absolute and tilde paths", () => {
 		expect(
 			findDefaultGuardedFileMatch("/Users/tester/.ssh/config", options),
 		).toMatchObject({
 			ruleId: DEFAULT_GUARDED_FILE_RULE_ID,
+			key: "ssh-gpg-keys",
 			category: "SSH and GPG keys",
 		});
 		expect(
 			findDefaultGuardedFileMatch("~/.gnupg/private-keys-v1.d/key", options),
 		).toMatchObject({
+			key: "ssh-gpg-keys",
 			category: "SSH and GPG keys",
 		});
 	});
@@ -50,6 +64,7 @@ describe("default guarded files", () => {
 		expect(
 			findDefaultGuardedFileMatch("/Users/tester/.zshrc", options),
 		).toMatchObject({
+			key: "shell-config",
 			category: "Shell configuration",
 		});
 		expect(


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `9176350296d13fdae983dc84aa1ee8cc2d315274`
- last generated public sync base: `828d729636012a52cd064d63a7ee67369f3502e1`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (9176350296d1)`
- public projection: `https://github.com/evalops/maestro@main (828d72963601)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/contracts/src/guarded-files-settings.ts
- copy/update packages/contracts/src/index.ts
- copy/update src/safety/guarded-files.ts
- copy/update test/contracts/guarded-files-settings.test.ts
- copy/update test/memory/service-client.test.ts
- copy/update test/safety/guarded-files.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/contracts/src/guarded-files-settings.ts
- copy/update packages/contracts/src/index.ts
- copy/update src/safety/guarded-files.ts
- copy/update test/contracts/guarded-files-settings.test.ts
- copy/update test/memory/service-client.test.ts
- copy/update test/safety/guarded-files.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #317 to internal source `9176350296d13fdae983dc84aa1ee8cc2d315274`