### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/design/GUARDED_FILES.md
+++ b/docs/design/GUARDED_FILES.md
@@ -70,7 +70,31 @@ governance consumers can join guarded-file decisions back to the run timeline.
 
 ## Overrides
 
-The shipped surface is the default enforced policy plus audit contract. User and
-organization override management is intentionally separate from this runtime
-guard so that future UI/API work can add explicit allowlist configuration
-without weakening the default protection.
+The runtime accepts normalized user and organization `guardedFiles` settings:
+
+```json
+{
+  "guardedFiles": {
+    "allowlist": ["amp-settings", "/Users/me/special/.ssh/internal-only"],
+    "rules": [
+      {
+        "key": "org-secrets",
+        "description": "Organization secret fixtures",
+        "patterns": ["**/.secrets/**"],
+        "defaultBehavior": "block"
+      }
+    ],
+    "mandatoryKeys": ["ssh-gpg-keys"]
+  }
+}
+```
+
+Allowlist entries can be guard keys or path/glob entries. Organization and user
+custom rules extend the default list; they do not replace it. Mandatory keys win
+over allowlists, so an organization can require a guard category to remain
+approval-gated even when a user has an allowlist entry for that key or path.
+
+The current UI/API management surface is intentionally minimal. Runtime callers
+can pass the policy directly, and the database settings types preserve the
+shape for user/org settings. A fuller administration UI can build on that
+contract without weakening the default protection.

--- a/packages/contracts/src/guarded-files-settings.ts
+++ b/packages/contracts/src/guarded-files-settings.ts
@@ -14,6 +14,11 @@ export interface GuardedFilesSettings {
 	mandatoryKeys?: string[];
 }
 
+export interface GuardedFilesPolicySettings {
+	user?: GuardedFilesSettings | null;
+	organization?: GuardedFilesSettings | null;
+}
+
 export const DEFAULT_GUARDED_FILE_PATTERNS: GuardedFilePattern[] = [
 	{
 		key: "cursor-config",

--- a/src/agent/action-approval.ts
+++ b/src/agent/action-approval.ts
@@ -1,3 +1,5 @@
+import type { GuardedFilesPolicySettings } from "@evalops/contracts";
+
 /**
  * Action Approval System
  *
@@ -101,6 +103,8 @@ export interface ActionApprovalContext {
 			/** Tool interacts with external/untrusted systems */
 			openWorldHint?: boolean;
 		};
+		/** User/org guarded-files override policy for this run */
+		guardedFiles?: GuardedFilesPolicySettings;
 	};
 	/** User context for permission-based policies */
 	user?: {

--- a/src/agent/transport/tool-safety-pipeline.ts
+++ b/src/agent/transport/tool-safety-pipeline.ts
@@ -18,7 +18,7 @@ import {
 	type GuardedFileMatch,
 	classifyGuardedFileAccessAction,
 	describeDefaultGuardedFileMatch,
-	findDefaultGuardedToolCallMatch,
+	findGuardedToolCallMatch,
 } from "../../safety/guarded-files.js";
 import type { SafetyMiddleware } from "../../safety/safety-middleware.js";
 import type { WorkflowStateTracker } from "../../safety/workflow-state.js";
@@ -38,6 +38,7 @@ import {
 import type {
 	ActionApprovalDecision,
 	ActionApprovalService,
+	ActionFirewallVerdict,
 } from "../action-approval.js";
 import { validateToolArguments } from "../providers/validation.js";
 import type {
@@ -563,14 +564,16 @@ export async function* evaluateToolSafety(
 		metadata: {
 			workflowState: workflowSnapshot,
 			annotations: toolDef?.annotations,
+			guardedFiles: cfg.guardedFiles,
 		},
 		user: cfg.user,
 		session: cfg.session,
 		userIntent: extractTextFromContent(userMessage.content),
 	});
-	let guardedFileMatch = findDefaultGuardedToolCallMatch(
+	let guardedFileMatch = findGuardedToolCallMatch(
 		effectiveToolCall.name,
 		effectiveToolCall.arguments,
+		{ policy: cfg.guardedFiles },
 	);
 	let guardedFileApprovalRequired =
 		Boolean(guardedFileMatch) ||
@@ -581,17 +584,31 @@ export async function* evaluateToolSafety(
 		: guardedFileApprovalRequired && verdict.action === "require_approval"
 			? verdict.reason
 			: undefined;
+	const guardedFileBlockVerdict = (
+		match: GuardedFileMatch,
+	): Extract<ActionFirewallVerdict, { action: "block" }> => ({
+		action: "block",
+		ruleId: DEFAULT_GUARDED_FILE_RULE_ID,
+		reason: describeDefaultGuardedFileMatch(match),
+		remediation:
+			"Remove the matching custom guard or change its defaultBehavior to ask if this access should be approval-gated instead of blocked.",
+	});
 
-	if (verdict.action === "block") {
+	const emitFirewallBlock = async (
+		blockVerdict: Extract<ActionFirewallVerdict, { action: "block" }>,
+		blockedToolCall: ToolCall,
+	) => {
 		const blockedResult: ToolResultMessage = {
 			role: "toolResult",
-			toolCallId: toolCall.id,
-			toolName: toolCall.name,
+			toolCallId: blockedToolCall.id,
+			toolName: blockedToolCall.name,
 			content: [
 				{
 					type: "text",
-					text: `Action blocked by firewall: ${verdict.reason}${
-						verdict.remediation ? `\n\nSuggestion: ${verdict.remediation}` : ""
+					text: `Action blocked by firewall: ${blockVerdict.reason}${
+						blockVerdict.remediation
+							? `\n\nSuggestion: ${blockVerdict.remediation}`
+							: ""
 					}`,
 				},
 			],
@@ -600,40 +617,64 @@ export async function* evaluateToolSafety(
 		};
 		await logToolExecutionAudit(
 			auditLogger,
-			toolCall.name,
+			blockedToolCall.name,
 			safetyMiddleware.sanitizeForLogging(
-				toolCall.arguments as Record<string, unknown>,
+				blockedToolCall.arguments as Record<string, unknown>,
 			),
 			"denied",
 			0,
-			verdict.reason,
+			blockVerdict.reason,
 		);
 		const firewallBlockedEvents = recordEvents(
-			emitToolResult(blockedResult, toolCall, true),
+			emitToolResult(blockedResult, blockedToolCall, true),
 		);
 		const sanitizedFirewallArgs = safetyMiddleware.sanitizeForLogging(
-			effectiveToolCall.arguments as Record<string, unknown>,
+			blockedToolCall.arguments as Record<string, unknown>,
 		);
 		recordMaestroFirewallBlock({
-			rule_id: verdict.ruleId,
-			operation: toolCall.name,
+			rule_id: blockVerdict.ruleId,
+			operation: blockedToolCall.name,
 			target:
 				typeof sanitizedFirewallArgs.command === "string"
 					? sanitizedFirewallArgs.command
-					: toolCall.name,
-			reason: verdict.reason,
+					: blockedToolCall.name,
+			reason: blockVerdict.reason,
 			context: sanitizedFirewallArgs,
 			correlation: {
 				session_id: cfg.session?.id,
-				agent_run_step_id: toolCall.id,
+				agent_run_step_id: blockedToolCall.id,
 			},
 		});
-		for (const event of firewallBlockedEvents) {
+		const blockedToolSafetyVerdict = { outcome: "blocked" as const, events };
+		return {
+			eventsToYield: firewallBlockedEvents,
+			verdict: blockedToolSafetyVerdict,
+			rateLimitUpdate: rateLimitResult.updatedState,
+		};
+	};
+
+	if (verdict.action === "block") {
+		const blocked = await emitFirewallBlock(verdict, effectiveToolCall);
+		for (const event of blocked.eventsToYield) {
 			yield event;
 		}
 		return {
-			verdict: { outcome: "blocked", events },
-			rateLimitUpdate: rateLimitResult.updatedState,
+			verdict: blocked.verdict,
+			rateLimitUpdate: blocked.rateLimitUpdate,
+		};
+	}
+
+	if (guardedFileMatch?.defaultBehavior === "block") {
+		const blocked = await emitFirewallBlock(
+			guardedFileBlockVerdict(guardedFileMatch),
+			effectiveToolCall,
+		);
+		for (const event of blocked.eventsToYield) {
+			yield event;
+		}
+		return {
+			verdict: blocked.verdict,
+			rateLimitUpdate: blocked.rateLimitUpdate,
 		};
 	}
 
@@ -773,10 +814,49 @@ export async function* evaluateToolSafety(
 					...effectiveToolCall,
 					arguments: permissionHookResult.updatedInput,
 				};
-				const guardedMatch = findDefaultGuardedToolCallMatch(
+				const rewrittenVerdict = await firewall.evaluate({
+					toolName: effectiveToolCall.name,
+					args: effectiveToolCall.arguments,
+					metadata: {
+						workflowState: workflowSnapshot,
+						annotations: toolDef?.annotations,
+						guardedFiles: cfg.guardedFiles,
+					},
+					user: cfg.user,
+					session: cfg.session,
+					userIntent: extractTextFromContent(userMessage.content),
+				});
+				if (rewrittenVerdict.action === "block") {
+					const blocked = await emitFirewallBlock(
+						rewrittenVerdict,
+						effectiveToolCall,
+					);
+					for (const event of blocked.eventsToYield) {
+						yield event;
+					}
+					return {
+						verdict: blocked.verdict,
+						rateLimitUpdate: blocked.rateLimitUpdate,
+					};
+				}
+				const guardedMatch = findGuardedToolCallMatch(
 					effectiveToolCall.name,
 					effectiveToolCall.arguments,
+					{ policy: cfg.guardedFiles },
 				);
+				if (guardedMatch?.defaultBehavior === "block") {
+					const blocked = await emitFirewallBlock(
+						guardedFileBlockVerdict(guardedMatch),
+						effectiveToolCall,
+					);
+					for (const event of blocked.eventsToYield) {
+						yield event;
+					}
+					return {
+						verdict: blocked.verdict,
+						rateLimitUpdate: blocked.rateLimitUpdate,
+					};
+				}
 				if (guardedMatch) {
 					guardedFileMatch = guardedMatch;
 					guardedFileApprovalRequired = true;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -31,6 +31,7 @@
  * @module agent/types
  */
 
+import type { GuardedFilesPolicySettings } from "@evalops/contracts";
 import type { TSchema } from "@sinclair/typebox";
 import type { PromptMetadata } from "../prompts/types.js";
 import type { SkillArtifactMetadata } from "../skills/artifact-metadata.js";
@@ -1378,6 +1379,8 @@ export interface AgentRunConfig {
 		/** When the session started */
 		startedAt: Date;
 	};
+	/** User/org guarded-files override policy for this run */
+	guardedFiles?: GuardedFilesPolicySettings;
 	/** Optional helper function for running LLM queries (e.g., for summarization) */
 	runLLM?: (systemPrompt: string, userPrompt: string) => Promise<string>;
 	/** Optional debug checkpoint profiler for local query latency diagnostics. */

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,6 +3,7 @@
  * Supports multi-tenancy, RBAC, audit logging, and PII protection
  */
 
+import type { GuardedFilesSettings } from "@evalops/contracts";
 import { relations } from "drizzle-orm";
 import {
 	bigint,
@@ -112,6 +113,8 @@ export type OrganizationSettings = {
 	internal?: {
 		telemetryDisabled?: boolean;
 	};
+	/** Organization-level guarded-files extensions and mandatory guard keys */
+	guardedFiles?: GuardedFilesSettings;
 };
 
 // ============================================================================
@@ -151,6 +154,8 @@ export type UserSettings = {
 	};
 	preferredModels?: string[];
 	defaultThinkingLevel?: string;
+	/** User-level guarded-files allowlist and custom guard extensions */
+	guardedFiles?: GuardedFilesSettings;
 	/** 2FA configuration */
 	twoFactor?: {
 		enabled: boolean;

--- a/src/safety/action-firewall.ts
+++ b/src/safety/action-firewall.ts
@@ -74,7 +74,7 @@ import {
 import {
 	DEFAULT_GUARDED_FILE_RULE_ID,
 	describeDefaultGuardedFileMatch,
-	findDefaultGuardedToolCallMatch,
+	findGuardedToolCallMatch,
 } from "./guarded-files.js";
 import { isContainedInWorkspace, isSystemPath } from "./path-containment.js";
 import { checkPolicy } from "./policy.js";
@@ -542,10 +542,32 @@ export const defaultFirewallRules: ActionFirewallRule[] = [
 	{
 		id: DEFAULT_GUARDED_FILE_RULE_ID,
 		description:
+			"Block guarded user and editor configuration files when policy requires a hard block",
+		action: "block",
+		evaluate: (ctx) => {
+			const match = findGuardedToolCallMatch(ctx.toolName, ctx.args, {
+				policy: ctx.metadata?.guardedFiles,
+			});
+			if (match?.defaultBehavior === "block") {
+				return {
+					allowed: false,
+					reason: describeDefaultGuardedFileMatch(match),
+					remediation:
+						"Remove the matching custom guard or change its defaultBehavior to ask if this access should be approval-gated instead of blocked.",
+				};
+			}
+			return { allowed: true };
+		},
+	},
+	{
+		id: DEFAULT_GUARDED_FILE_RULE_ID,
+		description:
 			"Require explicit approval before reading or mutating guarded user and editor configuration files",
 		action: "require_approval",
 		evaluate: (ctx) => {
-			const match = findDefaultGuardedToolCallMatch(ctx.toolName, ctx.args);
+			const match = findGuardedToolCallMatch(ctx.toolName, ctx.args, {
+				policy: ctx.metadata?.guardedFiles,
+			});
 			if (match) {
 				return {
 					allowed: false,

--- a/src/safety/guarded-files.ts
+++ b/src/safety/guarded-files.ts
@@ -1,7 +1,10 @@
 import { resolve } from "node:path";
 import {
 	DEFAULT_GUARDED_FILE_PATTERNS,
+	type GuardedFileDefaultBehavior,
 	type GuardedFilePattern,
+	type GuardedFilesPolicySettings,
+	normalizeGuardedFilesSettings,
 } from "@evalops/contracts";
 import { minimatch } from "minimatch";
 import {
@@ -27,12 +30,17 @@ export interface GuardedFileMatch {
 	category: string;
 	pattern: string;
 	path: string;
+	defaultBehavior: GuardedFileDefaultBehavior;
+	mandatory: boolean;
+	reason?: string;
+	source: "default" | "organization" | "user";
 }
 
 export interface GuardedFileMatchOptions {
 	cwd?: string;
 	homeDir?: string;
 	env?: NodeJS.ProcessEnv;
+	policy?: GuardedFilesPolicySettings;
 }
 
 export function classifyGuardedFileAccessAction(
@@ -75,6 +83,58 @@ function guardedPatternToRule(pattern: GuardedFilePattern): GuardedFileRule {
 
 export const DEFAULT_GUARDED_FILE_RULES: GuardedFileRule[] =
 	DEFAULT_GUARDED_FILE_PATTERNS.map(guardedPatternToRule);
+
+interface EffectiveGuardedFileRule extends GuardedFileRule {
+	defaultBehavior: GuardedFileDefaultBehavior;
+	reason?: string;
+	source: "default" | "organization" | "user";
+}
+
+interface NormalizedGuardedFilesPolicy {
+	allowlist: string[];
+	mandatoryKeys: Set<string>;
+	rules: EffectiveGuardedFileRule[];
+}
+
+function guardedPatternToEffectiveRule(
+	pattern: GuardedFilePattern,
+	source: EffectiveGuardedFileRule["source"],
+): EffectiveGuardedFileRule {
+	return {
+		key: pattern.key,
+		category: pattern.description,
+		patterns: pattern.patterns,
+		defaultBehavior: pattern.defaultBehavior,
+		...(pattern.reason ? { reason: pattern.reason } : {}),
+		source,
+	};
+}
+
+const DEFAULT_EFFECTIVE_GUARDED_FILE_RULES: EffectiveGuardedFileRule[] =
+	DEFAULT_GUARDED_FILE_PATTERNS.map((pattern) =>
+		guardedPatternToEffectiveRule(pattern, "default"),
+	);
+
+function normalizeGuardedFilesPolicy(
+	policy?: GuardedFilesPolicySettings,
+): NormalizedGuardedFilesPolicy {
+	const organization = normalizeGuardedFilesSettings(policy?.organization);
+	const user = normalizeGuardedFilesSettings(policy?.user);
+	return {
+		allowlist: [...organization.allowlist, ...user.allowlist],
+		mandatoryKeys: new Set([
+			...organization.mandatoryKeys,
+			...user.mandatoryKeys,
+		]),
+		rules: [
+			...DEFAULT_EFFECTIVE_GUARDED_FILE_RULES,
+			...organization.rules.map((rule) =>
+				guardedPatternToEffectiveRule(rule, "organization"),
+			),
+			...user.rules.map((rule) => guardedPatternToEffectiveRule(rule, "user")),
+		],
+	};
+}
 
 const ENV_TOKEN_PATTERN = /%([A-Z0-9_()]+)%/gi;
 const SHELL_ENV_TOKEN_PATTERN =
@@ -156,6 +216,43 @@ function buildCandidatePaths(
 	return Array.from(new Set(candidates.map(normalizeForGlob)));
 }
 
+function allowlistEntryMatchesPath(
+	entry: string,
+	candidates: string[],
+	options: Required<Pick<GuardedFileMatchOptions, "cwd" | "homeDir" | "env">>,
+): boolean {
+	const normalizedEntries = normalizePatternVariants(entry, options);
+	return candidates.some((candidate) =>
+		normalizedEntries.some((normalizedEntry) =>
+			minimatch(candidate, normalizedEntry, {
+				dot: true,
+				nocase: process.platform === "win32",
+			}),
+		),
+	);
+}
+
+function isGuardedMatchAllowlisted(
+	match: Pick<GuardedFileMatch, "key" | "mandatory" | "defaultBehavior">,
+	candidates: string[],
+	policy: NormalizedGuardedFilesPolicy,
+	options: Required<Pick<GuardedFileMatchOptions, "cwd" | "homeDir" | "env">>,
+): boolean {
+	if (match.defaultBehavior === "block") {
+		return false;
+	}
+	if (match.mandatory) {
+		return false;
+	}
+	return policy.allowlist.some((entry) => {
+		const trimmed = entry.trim();
+		return (
+			trimmed === match.key ||
+			allowlistEntryMatchesPath(trimmed, candidates, options)
+		);
+	});
+}
+
 function expandShellEnvTokens(
 	path: string,
 	options: Required<Pick<GuardedFileMatchOptions, "homeDir" | "env">>,
@@ -184,7 +281,7 @@ function expandShellEnvTokens(
 	return expandedAny && !missingToken ? expanded : null;
 }
 
-export function findDefaultGuardedFileMatch(
+export function findGuardedFileMatch(
 	path: string,
 	options: GuardedFileMatchOptions = {},
 ): GuardedFileMatch | null {
@@ -198,8 +295,10 @@ export function findDefaultGuardedFileMatch(
 		env: options.env ?? process.env,
 	};
 	const candidates = buildCandidatePaths(trimmedPath, requiredOptions);
+	const policy = normalizeGuardedFilesPolicy(options.policy);
+	let firstApprovalMatch: GuardedFileMatch | null = null;
 
-	for (const rule of DEFAULT_GUARDED_FILE_RULES) {
+	for (const rule of policy.rules) {
 		for (const pattern of rule.patterns) {
 			const normalizedPatterns = normalizePatternVariants(
 				pattern,
@@ -214,18 +313,38 @@ export function findDefaultGuardedFileMatch(
 				),
 			);
 			if (matches) {
-				return {
+				const match: GuardedFileMatch = {
 					ruleId: DEFAULT_GUARDED_FILE_RULE_ID,
 					key: rule.key,
 					category: rule.category,
 					pattern,
 					path: trimmedPath,
+					defaultBehavior: rule.defaultBehavior,
+					mandatory: policy.mandatoryKeys.has(rule.key),
+					...(rule.reason ? { reason: rule.reason } : {}),
+					source: rule.source,
 				};
+				if (
+					isGuardedMatchAllowlisted(match, candidates, policy, requiredOptions)
+				) {
+					continue;
+				}
+				if (match.defaultBehavior === "block") {
+					return match;
+				}
+				firstApprovalMatch ??= match;
 			}
 		}
 	}
 
-	return null;
+	return firstApprovalMatch;
+}
+
+export function findDefaultGuardedFileMatch(
+	path: string,
+	options: GuardedFileMatchOptions = {},
+): GuardedFileMatch | null {
+	return findGuardedFileMatch(path, options);
 }
 
 function getArgsObject(args: unknown): Record<string, unknown> | null {
@@ -404,22 +523,39 @@ function extractGuardedToolCallPaths(
 	return paths;
 }
 
+export function findGuardedToolCallMatch(
+	toolName: string,
+	args: unknown,
+	options: GuardedFileMatchOptions = {},
+): GuardedFileMatch | null {
+	let firstMatch: GuardedFileMatch | null = null;
+	for (const path of extractGuardedToolCallPaths(toolName, args)) {
+		const match = findGuardedFileMatch(path, options);
+		if (match) {
+			if (match.defaultBehavior === "block") {
+				return match;
+			}
+			firstMatch ??= match;
+		}
+	}
+	return firstMatch;
+}
+
 export function findDefaultGuardedToolCallMatch(
 	toolName: string,
 	args: unknown,
 	options: GuardedFileMatchOptions = {},
 ): GuardedFileMatch | null {
-	for (const path of extractGuardedToolCallPaths(toolName, args)) {
-		const match = findDefaultGuardedFileMatch(path, options);
-		if (match) {
-			return match;
-		}
-	}
-	return null;
+	return findGuardedToolCallMatch(toolName, args, options);
 }
 
 export function describeDefaultGuardedFileMatch(
 	match: GuardedFileMatch,
 ): string {
-	return `Guarded file access requires explicit approval: ${match.category} (${match.pattern}) at ${match.path}.`;
+	const policyReason = match.reason ? ` ${match.reason}` : "";
+	const actionDescription =
+		match.defaultBehavior === "block"
+			? "is blocked by policy"
+			: "requires explicit approval";
+	return `Guarded file access ${actionDescription}: ${match.category} (${match.pattern}) at ${match.path}.${policyReason}`;
 }

--- a/test/agent/tool-safety-pipeline.test.ts
+++ b/test/agent/tool-safety-pipeline.test.ts
@@ -19,7 +19,10 @@ import {
 	createToolHookService,
 	registerHook,
 } from "../../src/hooks/index.js";
-import { ActionFirewall } from "../../src/safety/action-firewall.js";
+import {
+	ActionFirewall,
+	defaultFirewallRules,
+} from "../../src/safety/action-firewall.js";
 import { AdaptiveThresholds } from "../../src/safety/adaptive-thresholds.js";
 import { SafetyMiddleware } from "../../src/safety/safety-middleware.js";
 import { WorkflowStateTracker } from "../../src/safety/workflow-state.js";
@@ -57,6 +60,7 @@ function createBaseSafetyContext(options: {
 	approvalService?: Parameters<typeof evaluateToolSafety>[0]["approvalService"];
 	hookService?: Parameters<typeof evaluateToolSafety>[0]["hookService"];
 	firewall?: ActionFirewall;
+	cfg?: Partial<AgentRunConfig>;
 }): Parameters<typeof evaluateToolSafety>[0] {
 	return {
 		toolCall: {
@@ -71,7 +75,7 @@ function createBaseSafetyContext(options: {
 			content: "Read the file",
 			timestamp: Date.now(),
 		} satisfies Message,
-		cfg: { tools: [options.tool] } as AgentRunConfig,
+		cfg: { tools: [options.tool], ...options.cfg } as AgentRunConfig,
 		clock: { now: () => Date.now() },
 		safetyMiddleware: new SafetyMiddleware({
 			enableContextFirewall: false,
@@ -509,6 +513,59 @@ describe("evaluateToolSafety guarded files", () => {
 		);
 	});
 
+	it("blocks guardedFiles block rules even when the firewall returns allow", async () => {
+		const readTool = createReadTool();
+		const approvalService = {
+			requiresUserInteraction: () => true,
+			requestApproval: vi.fn(async (_request: ActionApprovalRequest) => ({
+				approved: true,
+				resolvedBy: "user" as const,
+			})),
+		};
+
+		const { result } = await collectSafetyResult(
+			createBaseSafetyContext({
+				tool: readTool,
+				path: "/workspace/project/.secrets/token.txt",
+				approvalService,
+				firewall: {
+					evaluate: vi.fn(async () => ({ action: "allow" as const })),
+				} as unknown as ActionFirewall,
+				cfg: {
+					guardedFiles: {
+						organization: {
+							rules: [
+								{
+									key: "org-secrets",
+									description: "Organization secret fixtures",
+									patterns: ["**/.secrets/**"],
+									defaultBehavior: "block",
+								},
+							],
+						},
+					},
+				},
+			}),
+		);
+
+		expect(result.verdict.outcome).toBe("blocked");
+		expect(approvalService.requestApproval).not.toHaveBeenCalled();
+		const toolResultEvent = result.verdict.events.find(
+			(event) => event.type === "tool_execution_end",
+		);
+		expect(toolResultEvent).toMatchObject({
+			type: "tool_execution_end",
+			result: {
+				content: [
+					{
+						type: "text",
+						text: expect.stringContaining("Organization secret fixtures"),
+					},
+				],
+			},
+		});
+	});
+
 	it("re-checks guarded files after PermissionRequest hooks rewrite inputs", async () => {
 		clearHookConfigCache();
 		clearRegisteredHooks();
@@ -574,6 +631,91 @@ describe("evaluateToolSafety guarded files", () => {
 		);
 		expect(result.verdict.effectiveToolCall.arguments).toEqual({
 			path: "~/.ssh/config",
+		});
+	});
+
+	it("blocks guardedFiles block rules after PermissionRequest hooks rewrite inputs", async () => {
+		clearHookConfigCache();
+		clearRegisteredHooks();
+
+		registerHook("PermissionRequest", {
+			type: "callback",
+			callback: async () => ({
+				reason: "Policy rewrite",
+				hookSpecificOutput: {
+					hookEventName: "PermissionRequest",
+					decision: {
+						behavior: "allow",
+						updatedInput: { path: "/workspace/project/.secrets/token.txt" },
+					},
+				},
+			}),
+		});
+
+		const readTool = createReadTool();
+		const approvalService = {
+			requiresUserInteraction: () => true,
+			requestApproval: vi.fn(async (_request: ActionApprovalRequest) => ({
+				approved: true,
+				resolvedBy: "user" as const,
+			})),
+		};
+
+		const { result } = await collectSafetyResult(
+			createBaseSafetyContext({
+				tool: readTool,
+				path: "/tmp/original.txt",
+				approvalService,
+				hookService: createToolHookService({
+					cwd: "/tmp/test",
+					resolveTool: (toolName) =>
+						toolName === "read" ? readTool : undefined,
+				}),
+				firewall: new ActionFirewall([
+					{
+						name: "require-original-approval",
+						description: "require approval for the original path",
+						action: "require_approval",
+						evaluate: async (ctx) => ({
+							allowed:
+								(ctx.args as { path?: string }).path !== "/tmp/original.txt",
+							reason: "Approval required",
+						}),
+					},
+					...defaultFirewallRules,
+				]),
+				cfg: {
+					guardedFiles: {
+						organization: {
+							rules: [
+								{
+									key: "org-secrets",
+									description: "Organization secret fixtures",
+									patterns: ["**/.secrets/**"],
+									defaultBehavior: "block",
+								},
+							],
+						},
+					},
+				},
+			}),
+		);
+
+		expect(result.verdict.outcome).toBe("blocked");
+		expect(approvalService.requestApproval).not.toHaveBeenCalled();
+		const toolResultEvent = result.verdict.events.find(
+			(event) => event.type === "tool_execution_end",
+		);
+		expect(toolResultEvent).toMatchObject({
+			type: "tool_execution_end",
+			result: {
+				content: [
+					{
+						type: "text",
+						text: expect.stringContaining("Organization secret fixtures"),
+					},
+				],
+			},
 		});
 	});
 });

--- a/test/safety/action-firewall.test.ts
+++ b/test/safety/action-firewall.test.ts
@@ -202,6 +202,92 @@ describe("ActionFirewall", () => {
 		expect(verdict.reason).toContain("Guarded file access");
 	});
 
+	it("lets explicit guardedFiles key allowlists bypass default guards", async () => {
+		const verdict = await defaultActionFirewall.evaluate({
+			...makeReadPathContext("~/.ssh/config"),
+			metadata: {
+				guardedFiles: {
+					user: { allowlist: ["ssh-gpg-keys"] },
+				},
+			},
+		});
+		expect(verdict.action).toBe("allow");
+	});
+
+	it("keeps mandatory org guardedFiles keys approval-gated", async () => {
+		const verdict = await defaultActionFirewall.evaluate({
+			...makeReadPathContext("~/.ssh/config"),
+			metadata: {
+				guardedFiles: {
+					organization: { mandatoryKeys: ["ssh-gpg-keys"] },
+					user: { allowlist: ["ssh-gpg-keys"] },
+				},
+			},
+		});
+		expect(verdict).toMatchObject({
+			action: "require_approval",
+			ruleId: "default-guarded-file",
+		});
+	});
+
+	it("blocks custom guardedFiles rules with defaultBehavior block", async () => {
+		const verdict = await defaultActionFirewall.evaluate({
+			toolName: "read",
+			args: { path: "/workspace/project/.secrets/token.txt" },
+			metadata: {
+				guardedFiles: {
+					organization: {
+						rules: [
+							{
+								key: "org-secrets",
+								description: "Organization secret fixtures",
+								patterns: ["**/.secrets/**"],
+								defaultBehavior: "block",
+							},
+						],
+					},
+				},
+			},
+		});
+		expect(verdict).toMatchObject({
+			action: "block",
+			ruleId: "default-guarded-file",
+		});
+	});
+
+	it("blocks multi-path tool calls when any guarded path is block-scoped", async () => {
+		const verdict = await defaultActionFirewall.evaluate({
+			toolName: "move_file",
+			args: {
+				source: "/workspace/project/.cursor/settings.json",
+				destination: "/workspace/project/.secrets/token.txt",
+			},
+			metadata: {
+				guardedFiles: {
+					organization: {
+						rules: [
+							{
+								key: "org-secrets",
+								description: "Organization secret fixtures",
+								patterns: ["**/.secrets/**"],
+								defaultBehavior: "block",
+							},
+						],
+					},
+				},
+			},
+		});
+		expect(verdict).toMatchObject({
+			action: "block",
+			ruleId: "default-guarded-file",
+		});
+		if (verdict.action !== "block") {
+			throw new Error("Expected multi-path guarded move to be blocked");
+		}
+		expect(verdict.reason).toContain("is blocked by policy");
+		expect(verdict.reason).not.toContain("requires explicit approval");
+	});
+
 	it("requires approval for guarded file mutations beyond write and edit", async () => {
 		const deleteVerdict = await defaultActionFirewall.evaluate(
 			makeDeleteFileContext("~/.ssh/config"),

--- a/test/safety/guarded-files.test.ts
+++ b/test/safety/guarded-files.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
 	DEFAULT_GUARDED_FILE_RULES,
 	DEFAULT_GUARDED_FILE_RULE_ID,
+	describeDefaultGuardedFileMatch,
 	findDefaultGuardedFileMatch,
 	findDefaultGuardedToolCallMatch,
+	findGuardedFileMatch,
+	findGuardedToolCallMatch,
 } from "../../src/safety/guarded-files.js";
 
 const options = {
@@ -235,5 +238,210 @@ describe("default guarded files", () => {
 		).toMatchObject({
 			category: "Neovim configuration",
 		});
+	});
+
+	it("honors user allowlist entries by guard key", () => {
+		expect(
+			findGuardedFileMatch("/Users/tester/.ssh/config", {
+				...options,
+				policy: {
+					user: { allowlist: ["ssh-gpg-keys"] },
+				},
+			}),
+		).toBeNull();
+	});
+
+	it("honors path allowlist entries without allowing sibling guarded files", () => {
+		expect(
+			findGuardedFileMatch("/Users/tester/.ssh/internal-only", {
+				...options,
+				policy: {
+					user: { allowlist: ["/Users/tester/.ssh/internal-only"] },
+				},
+			}),
+		).toBeNull();
+		expect(
+			findGuardedFileMatch("/Users/tester/.ssh/config", {
+				...options,
+				policy: {
+					user: { allowlist: ["/Users/tester/.ssh/internal-only"] },
+				},
+			}),
+		).toMatchObject({
+			key: "ssh-gpg-keys",
+		});
+	});
+
+	it("does not allow mandatory org guards to be bypassed by user allowlists", () => {
+		expect(
+			findGuardedFileMatch("/Users/tester/.ssh/config", {
+				...options,
+				policy: {
+					organization: { mandatoryKeys: ["ssh-gpg-keys"] },
+					user: { allowlist: ["ssh-gpg-keys", "/Users/tester/.ssh/config"] },
+				},
+			}),
+		).toMatchObject({
+			key: "ssh-gpg-keys",
+			mandatory: true,
+		});
+	});
+
+	it("matches custom org and user guard extensions", () => {
+		expect(
+			findGuardedToolCallMatch(
+				"read",
+				{ path: "/workspace/project/.secrets/token.txt" },
+				{
+					...options,
+					policy: {
+						organization: {
+							rules: [
+								{
+									key: "org-secrets",
+									description: "Organization secret fixtures",
+									patterns: ["**/.secrets/**"],
+									reason: "Organization policy controls secret fixtures.",
+									defaultBehavior: "block",
+								},
+							],
+						},
+					},
+				},
+			),
+		).toMatchObject({
+			key: "org-secrets",
+			source: "organization",
+			defaultBehavior: "block",
+		});
+
+		expect(
+			findGuardedFileMatch("/workspace/project/private-notes.md", {
+				...options,
+				policy: {
+					user: {
+						rules: [
+							{
+								key: "personal-notes",
+								description: "Personal notes",
+								patterns: ["**/private-notes.md"],
+								defaultBehavior: "ask",
+							},
+						],
+					},
+				},
+			}),
+		).toMatchObject({
+			key: "personal-notes",
+			source: "user",
+		});
+	});
+
+	it("prefers block matches across multi-path tool calls", () => {
+		expect(
+			findGuardedToolCallMatch(
+				"move_file",
+				{
+					source: "/workspace/project/.cursor/settings.json",
+					destination: "/workspace/project/.secrets/token.txt",
+				},
+				{
+					...options,
+					policy: {
+						organization: {
+							rules: [
+								{
+									key: "org-secrets",
+									description: "Organization secret fixtures",
+									patterns: ["**/.secrets/**"],
+									defaultBehavior: "block",
+								},
+							],
+						},
+					},
+				},
+			),
+		).toMatchObject({
+			key: "org-secrets",
+			path: "/workspace/project/.secrets/token.txt",
+			defaultBehavior: "block",
+		});
+	});
+
+	it("prefers block matches over approval matches for the same path", () => {
+		expect(
+			findGuardedFileMatch("/Users/tester/.ssh/config", {
+				...options,
+				policy: {
+					organization: {
+						rules: [
+							{
+								key: "org-ssh-freeze",
+								description: "Organization SSH freeze",
+								patterns: ["~/.ssh/config"],
+								defaultBehavior: "block",
+							},
+						],
+					},
+				},
+			}),
+		).toMatchObject({
+			key: "org-ssh-freeze",
+			defaultBehavior: "block",
+		});
+	});
+
+	it("does not allow allowlists to bypass block guards", () => {
+		expect(
+			findGuardedFileMatch("/workspace/project/.secrets/token.txt", {
+				...options,
+				policy: {
+					organization: {
+						rules: [
+							{
+								key: "org-secrets",
+								description: "Organization secret fixtures",
+								patterns: ["**/.secrets/**"],
+								defaultBehavior: "block",
+							},
+						],
+					},
+					user: {
+						allowlist: ["org-secrets", "/workspace/project/.secrets/token.txt"],
+					},
+				},
+			}),
+		).toMatchObject({
+			key: "org-secrets",
+			defaultBehavior: "block",
+		});
+	});
+
+	it("describes blocked guarded file matches as blocked", () => {
+		const match = findGuardedFileMatch(
+			"/workspace/project/.secrets/token.txt",
+			{
+				...options,
+				policy: {
+					organization: {
+						rules: [
+							{
+								key: "org-secrets",
+								description: "Organization secret fixtures",
+								patterns: ["**/.secrets/**"],
+								defaultBehavior: "block",
+							},
+						],
+					},
+				},
+			},
+		);
+		expect(match).not.toBeNull();
+		expect(describeDefaultGuardedFileMatch(match!)).toContain(
+			"is blocked by policy",
+		);
+		expect(describeDefaultGuardedFileMatch(match!)).not.toContain(
+			"requires explicit approval",
+		);
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `9633a29a810bd56ce3efb9e16af4fc7fce538512`
- last generated public sync base: `cc783a7f718c55ad6db8996caf3279b3968021e8`
- previewed public-tree drift: `11` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (9633a29a810b)`
- public projection: `https://github.com/evalops/maestro@main (cc783a7f718c)`
- files to copy or update: `11`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/design/GUARDED_FILES.md
- copy/update packages/contracts/src/guarded-files-settings.ts
- copy/update src/agent/action-approval.ts
- copy/update src/agent/transport/tool-safety-pipeline.ts
- copy/update src/agent/types.ts
- copy/update src/db/schema.ts
- copy/update src/safety/action-firewall.ts
- copy/update src/safety/guarded-files.ts
- copy/update test/agent/tool-safety-pipeline.test.ts
- copy/update test/safety/action-firewall.test.ts
- copy/update test/safety/guarded-files.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/design/GUARDED_FILES.md
- copy/update packages/contracts/src/guarded-files-settings.ts
- copy/update src/agent/action-approval.ts
- copy/update src/agent/transport/tool-safety-pipeline.ts
- copy/update src/agent/types.ts
- copy/update src/db/schema.ts
- copy/update src/safety/action-firewall.ts
- copy/update src/safety/guarded-files.ts
- copy/update test/agent/tool-safety-pipeline.test.ts
- copy/update test/safety/action-firewall.test.ts
- copy/update test/safety/guarded-files.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode