### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/pending-requests.md
+++ b/docs/protocols/pending-requests.md
@@ -37,6 +37,14 @@ Platform ToolExecution waits set:
 Approvals that are mirrored into the shared approvals service use
 `platform.source=approvals_service`.
 
+`POST /api/pending-requests/:requestId/resume` is the canonical Maestro UX
+entry point. For hosted AgentRuntime waits with an active `agentRunId`, Maestro
+calls Platform `ResumeRun` before resolving the local request. Governed
+ToolExecution approval resume tokens stay server-side inside the ToolExecution
+bridge plan; the web pending-request payload only exposes correlation ids, and
+the bridge performs `ResumeToolExecution` after the local approval decision is
+released.
+
 This contract is the Maestro-side client/read-model slice for
 `evalops/maestro-internal#1417`. Platform still owns the canonical `AgentRunWait`
 and `ApprovalRequest` APIs; Maestro uses this session projection so clients can

--- a/src/server/handlers/pending-requests.ts
+++ b/src/server/handlers/pending-requests.ts
@@ -7,7 +7,9 @@ import {
 	ComposerPendingRequestResumeRequestSchema,
 	type ComposerPendingRequestResumeResponse,
 } from "@evalops/contracts";
+import { resumeAgentRuntimeRun } from "../../platform/agent-runtime-client.js";
 import type { WebServerContext } from "../app-context.js";
+import { getAuthSubject } from "../authz.js";
 import {
 	type PendingServerRequestSnapshot,
 	serverRequestManager,
@@ -18,6 +20,178 @@ import { parseAndValidateJson } from "../validation.js";
 type PendingRequestRouteParams = {
 	requestId?: string;
 };
+
+type PendingRequestPlatformResumeOperations = {
+	resumeRun?: typeof resumeAgentRuntimeRun;
+};
+
+type PendingRequestResumeContext = WebServerContext & {
+	platformPendingRequestResume?: PendingRequestPlatformResumeOperations;
+};
+
+type PlatformResumeRetry = {
+	content: NonNullable<ComposerPendingRequestResumeRequest["content"]>;
+	isError: boolean;
+	request: PendingServerRequestSnapshot;
+	resolution: ComposerPendingRequestResolution;
+};
+
+const RESOLVED_RESPONSE_CACHE_TTL_MS = 60_000;
+const PLATFORM_RETRY_CACHE_TTL_MS = 30 * 60_000;
+const resolvedResponseCache = new Map<
+	string,
+	{
+		expiresAt: number;
+		inputFingerprint: string;
+		platformRetry?: PlatformResumeRetry;
+		response: ComposerPendingRequestResumeResponse;
+		subject: string;
+	}
+>();
+const inFlightResumes = new Map<
+	string,
+	{
+		inputFingerprint: string;
+		promise: Promise<ComposerPendingRequestResumeResponse>;
+		requestKind: ComposerPendingRequestKind;
+		sessionId?: string;
+		subject: string;
+	}
+>();
+
+class PendingRequestResolvedPlatformError extends ApiError {
+	constructor(
+		message: string,
+		readonly response: ComposerPendingRequestResumeResponse,
+		readonly platformRetry: PlatformResumeRetry,
+	) {
+		super(502, message);
+	}
+}
+
+function safeIdPart(value: string): string {
+	return value.replace(/[^A-Za-z0-9_.:-]+/g, "_").slice(0, 96) || "unknown";
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+function pruneResolvedResponseCache(now = Date.now()): void {
+	for (const [requestId, cached] of resolvedResponseCache) {
+		if (cached.expiresAt <= now) {
+			resolvedResponseCache.delete(requestId);
+		}
+	}
+}
+
+function rememberResolvedResponse(
+	requestId: string,
+	input: ComposerPendingRequestResumeRequest,
+	response: ComposerPendingRequestResumeResponse,
+	subject: string,
+	platformRetry?: PlatformResumeRetry,
+	now = Date.now(),
+): void {
+	pruneResolvedResponseCache(now);
+	resolvedResponseCache.set(requestId, {
+		expiresAt:
+			now +
+			(platformRetry
+				? PLATFORM_RETRY_CACHE_TTL_MS
+				: RESOLVED_RESPONSE_CACHE_TTL_MS),
+		inputFingerprint: resumeInputFingerprint(input, response.request),
+		platformRetry,
+		response,
+		subject,
+	});
+}
+
+function getCachedResolvedEntry(
+	requestId: string,
+	input: ComposerPendingRequestResumeRequest,
+	subject: string,
+	now = Date.now(),
+):
+	| {
+			expiresAt: number;
+			inputFingerprint: string;
+			platformRetry?: PlatformResumeRetry;
+			response: ComposerPendingRequestResumeResponse;
+			subject: string;
+	  }
+	| undefined {
+	pruneResolvedResponseCache(now);
+	const cached = resolvedResponseCache.get(requestId);
+	if (!cached) {
+		return undefined;
+	}
+	if (cached.subject !== subject) {
+		return undefined;
+	}
+	if (input.kind && input.kind !== cached.response.request.kind) {
+		return undefined;
+	}
+	if (!cachedResponseSessionMatchesInput(cached.response, input)) {
+		return undefined;
+	}
+	if (
+		cached.inputFingerprint !==
+		resumeInputFingerprint(input, cached.response.request)
+	) {
+		return undefined;
+	}
+	return cached;
+}
+
+function cachedResponseSessionMatchesInput(
+	response: ComposerPendingRequestResumeResponse,
+	input: ComposerPendingRequestResumeRequest,
+): boolean {
+	if (!input.sessionId) {
+		return true;
+	}
+	return response.request.sessionId === input.sessionId;
+}
+
+function resumeInputFingerprint(
+	input: ComposerPendingRequestResumeRequest,
+	request?: { kind?: ComposerPendingRequestKind; sessionId?: string },
+): string {
+	return JSON.stringify({
+		kind: input.kind ?? request?.kind,
+		sessionId: input.sessionId ?? request?.sessionId,
+		decision: input.decision,
+		action: input.action,
+		content: input.content,
+		isError: input.isError === true,
+		reason: input.reason,
+	});
+}
+
+function getMatchingInFlightResume(
+	requestId: string,
+	input: ComposerPendingRequestResumeRequest,
+	subject: string,
+): Promise<ComposerPendingRequestResumeResponse> | undefined {
+	const inFlight = inFlightResumes.get(requestId);
+	if (!inFlight) {
+		return undefined;
+	}
+	const inputFingerprint = resumeInputFingerprint(input, {
+		kind: inFlight.requestKind,
+		sessionId: inFlight.sessionId,
+	});
+	if (
+		inFlight.subject === subject &&
+		inFlight.inputFingerprint === inputFingerprint
+	) {
+		return inFlight.promise;
+	}
+	throw new ApiError(409, "Pending request resume already in progress");
+}
 
 function decodeRequestId(params: PendingRequestRouteParams): string {
 	const raw = params.requestId?.trim();
@@ -103,9 +277,9 @@ function platformOperationFor(
 		return undefined;
 	}
 	if (request.kind === "approval") {
-		return request.platform.source === "tool_execution"
-			? "ResumeToolExecution"
-			: "ResolveApproval";
+		return request.platform.source === "approvals_service"
+			? "ResolveApproval"
+			: undefined;
 	}
 	if (
 		request.kind === "client_tool" ||
@@ -120,7 +294,9 @@ function platformOperationFor(
 function responseFor(
 	request: PendingServerRequestSnapshot,
 	resolution: ComposerPendingRequestResolution,
+	platformOperation?: ComposerPendingRequestPlatformOperation,
 ): ComposerPendingRequestResumeResponse {
+	const operation = platformOperation ?? platformOperationFor(request);
 	return {
 		success: true,
 		request: {
@@ -128,11 +304,237 @@ function responseFor(
 			kind: request.kind,
 			sessionId: request.sessionId,
 			resolution,
-			source: request.platform ? "platform" : "local",
+			source:
+				request.platform || operation === "ResumeRun" ? "platform" : "local",
 			platform: request.platform,
-			platformOperation: platformOperationFor(request),
+			platformOperation: operation,
 		},
 	};
+}
+
+function isAgentRuntimeWaitKind(
+	kind: PendingServerRequestSnapshot["kind"],
+): kind is "client_tool" | "mcp_elicitation" | "user_input" {
+	return (
+		kind === "client_tool" ||
+		kind === "mcp_elicitation" ||
+		kind === "user_input"
+	);
+}
+
+function hostedSessionIdForRequest(
+	request: PendingServerRequestSnapshot,
+	context: PendingRequestResumeContext,
+): string | undefined {
+	return (
+		nonEmptyString(request.sessionId) ??
+		nonEmptyString(context.hostedRunner?.activeMaestroSessionId) ??
+		nonEmptyString(context.hostedRunner?.configuredMaestroSessionId)
+	);
+}
+
+function hostedAgentRunIdForRequest(
+	request: PendingServerRequestSnapshot,
+	context: PendingRequestResumeContext,
+): string | undefined {
+	const hosted = context.hostedRunner;
+	const runId = nonEmptyString(hosted?.agentRunId);
+	if (!hosted?.enabled || !runId) {
+		return undefined;
+	}
+	const hostedSessionId =
+		nonEmptyString(hosted.activeMaestroSessionId) ??
+		nonEmptyString(hosted.configuredMaestroSessionId);
+	if (
+		hostedSessionId &&
+		request.sessionId &&
+		hostedSessionId !== request.sessionId
+	) {
+		return undefined;
+	}
+	return runId;
+}
+
+function hostedWaitId(sessionId: string, requestId: string): string {
+	return `maestro:${safeIdPart(sessionId)}:wait:${safeIdPart(requestId)}`;
+}
+
+function hostedResumeEventId(sessionId: string, requestId: string): string {
+	return `maestro:${safeIdPart(sessionId)}:resume:${safeIdPart(requestId)}`;
+}
+
+function platformResumeError(message: string): ApiError {
+	return new ApiError(502, `${message}; local pending request was resolved`);
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === "AbortError";
+}
+
+async function resumePlatformAgentRuntimeWait(
+	request: PendingServerRequestSnapshot,
+	resolution: ComposerPendingRequestResolution,
+	content: NonNullable<ComposerPendingRequestResumeRequest["content"]>,
+	isError: boolean,
+	context: PendingRequestResumeContext,
+): Promise<ComposerPendingRequestPlatformOperation | undefined> {
+	if (!isAgentRuntimeWaitKind(request.kind)) {
+		return undefined;
+	}
+	const runId = hostedAgentRunIdForRequest(request, context);
+	const sessionId = hostedSessionIdForRequest(request, context);
+	if (!runId || !sessionId) {
+		return undefined;
+	}
+	const resumeRun =
+		context.platformPendingRequestResume?.resumeRun ?? resumeAgentRuntimeRun;
+	try {
+		await resumeRun({
+			runId,
+			waitId: hostedWaitId(sessionId, request.id),
+			resumeEventId: hostedResumeEventId(sessionId, request.id),
+			payload: {
+				maestro_session_id: sessionId,
+				request_id: request.id,
+				request_type: request.kind,
+				call_id: request.callId,
+				tool_name: request.toolName,
+				resolution,
+				resolved_by: "user",
+				is_error: isError,
+				content,
+			},
+		});
+	} catch (error) {
+		if (isAbortError(error)) {
+			throw error;
+		}
+		throw platformResumeError("Platform AgentRuntime resume failed");
+	}
+	return "ResumeRun";
+}
+
+async function resolvePendingRequest(
+	requestId: string,
+	input: ComposerPendingRequestResumeRequest,
+	pendingRequest: PendingServerRequestSnapshot,
+	context: PendingRequestResumeContext,
+): Promise<ComposerPendingRequestResumeResponse> {
+	assertRequestKind(pendingRequest.kind, input.kind);
+	assertSessionMatch(pendingRequest, input.sessionId);
+
+	let resolved = false;
+	let resolution: ComposerPendingRequestResolution;
+	let platformOperation: ComposerPendingRequestPlatformOperation | undefined;
+
+	switch (pendingRequest.kind) {
+		case "approval": {
+			const decision = requireApprovalDecision(input);
+			resolved = serverRequestManager.resolveApproval(requestId, {
+				approved: decision === "approved",
+				reason: input.reason,
+				resolvedBy: "user",
+			});
+			resolution = decision;
+			break;
+		}
+		case "tool_retry": {
+			const action = requireRetryAction(input);
+			resolved = serverRequestManager.resolveToolRetry(requestId, {
+				action,
+				reason: input.reason,
+				resolvedBy: "user",
+			});
+			resolution =
+				action === "retry"
+					? "retried"
+					: action === "skip"
+						? "skipped"
+						: "aborted";
+			break;
+		}
+		case "client_tool":
+		case "mcp_elicitation":
+		case "user_input": {
+			const content = requireClientToolContent(input);
+			const isError = input.isError === true;
+			resolution = resolutionForClientRequest(pendingRequest.kind, isError);
+			const claimed = serverRequestManager.claimClientTool(requestId);
+			if (!claimed) {
+				break;
+			}
+			resolved = claimed.resolve(content, isError);
+			if (!resolved) {
+				break;
+			}
+			try {
+				platformOperation = await resumePlatformAgentRuntimeWait(
+					claimed.request,
+					resolution,
+					content,
+					isError,
+					context,
+				);
+			} catch (error) {
+				const localResponse = responseFor(claimed.request, resolution);
+				if (isAbortError(error)) {
+					return localResponse;
+				}
+				const message =
+					error instanceof Error
+						? error.message
+						: "Platform AgentRuntime resume failed";
+				throw new PendingRequestResolvedPlatformError(message, localResponse, {
+					content,
+					isError,
+					request: claimed.request,
+					resolution,
+				});
+			}
+			break;
+		}
+	}
+
+	if (!resolved) {
+		throw new ApiError(404, "Pending request not found or already resolved");
+	}
+
+	return responseFor(pendingRequest, resolution, platformOperation);
+}
+
+async function replayCachedPlatformRetry(
+	requestId: string,
+	input: ComposerPendingRequestResumeRequest,
+	cached: {
+		platformRetry: PlatformResumeRetry;
+		response: ComposerPendingRequestResumeResponse;
+	},
+	subject: string,
+	context: PendingRequestResumeContext,
+): Promise<ComposerPendingRequestResumeResponse> {
+	const retry = cached.platformRetry;
+	try {
+		const platformOperation = await resumePlatformAgentRuntimeWait(
+			retry.request,
+			retry.resolution,
+			retry.content,
+			retry.isError,
+			context,
+		);
+		const response = responseFor(
+			retry.request,
+			retry.resolution,
+			platformOperation,
+		);
+		rememberResolvedResponse(requestId, input, response, subject);
+		return response;
+	} catch (error) {
+		if (isAbortError(error)) {
+			return cached.response;
+		}
+		rememberResolvedResponse(requestId, input, cached.response, subject, retry);
+		throw error;
+	}
 }
 
 export async function handlePendingRequestResume(
@@ -142,6 +544,9 @@ export async function handlePendingRequestResume(
 	params: PendingRequestRouteParams,
 ) {
 	const { corsHeaders } = context;
+	let requestId: string | undefined;
+	let input: ComposerPendingRequestResumeRequest | undefined;
+	let subject: string | undefined;
 
 	try {
 		if (req.method !== "POST") {
@@ -150,76 +555,119 @@ export async function handlePendingRequestResume(
 			return;
 		}
 
-		const requestId = decodeRequestId(params);
-		const input =
-			await parseAndValidateJson<ComposerPendingRequestResumeRequest>(
-				req,
-				ComposerPendingRequestResumeRequestSchema,
-			);
-		const pendingRequest = serverRequestManager.get(requestId);
-		if (!pendingRequest) {
-			throw new ApiError(404, "Pending request not found or already resolved");
-		}
-
-		assertRequestKind(pendingRequest.kind, input.kind);
-		assertSessionMatch(pendingRequest, input.sessionId);
-
-		let resolved = false;
-		let resolution: ComposerPendingRequestResolution;
-
-		switch (pendingRequest.kind) {
-			case "approval": {
-				const decision = requireApprovalDecision(input);
-				resolved = serverRequestManager.resolveApproval(requestId, {
-					approved: decision === "approved",
-					reason: input.reason,
-					resolvedBy: "user",
-				});
-				resolution = decision;
-				break;
-			}
-			case "tool_retry": {
-				const action = requireRetryAction(input);
-				resolved = serverRequestManager.resolveToolRetry(requestId, {
-					action,
-					reason: input.reason,
-					resolvedBy: "user",
-				});
-				resolution =
-					action === "retry"
-						? "retried"
-						: action === "skip"
-							? "skipped"
-							: "aborted";
-				break;
-			}
-			case "client_tool":
-			case "mcp_elicitation":
-			case "user_input": {
-				const content = requireClientToolContent(input);
-				const isError = input.isError === true;
-				resolved = serverRequestManager.resolveClientTool(
-					requestId,
-					content,
-					isError,
-				);
-				resolution = resolutionForClientRequest(pendingRequest.kind, isError);
-				break;
-			}
-		}
-
-		if (!resolved) {
-			throw new ApiError(404, "Pending request not found or already resolved");
-		}
-
-		sendJson(
-			res,
-			200,
-			responseFor(pendingRequest, resolution),
-			corsHeaders,
+		requestId = decodeRequestId(params);
+		input = await parseAndValidateJson<ComposerPendingRequestResumeRequest>(
 			req,
+			ComposerPendingRequestResumeRequestSchema,
 		);
+		subject = getAuthSubject(req);
+		const currentRequestId = requestId;
+		const currentInput = input;
+		const currentSubject = subject;
+		const inFlight = getMatchingInFlightResume(
+			currentRequestId,
+			currentInput,
+			currentSubject,
+		);
+		if (inFlight) {
+			sendJson(res, 200, await inFlight, corsHeaders, req);
+			return;
+		}
+
+		const pendingRequest = serverRequestManager.get(currentRequestId);
+		if (!pendingRequest) {
+			const cached = getCachedResolvedEntry(
+				currentRequestId,
+				currentInput,
+				currentSubject,
+			);
+			if (cached) {
+				if (cached.platformRetry) {
+					const retryPromise = replayCachedPlatformRetry(
+						currentRequestId,
+						currentInput,
+						{
+							platformRetry: cached.platformRetry,
+							response: cached.response,
+						},
+						currentSubject,
+						context as PendingRequestResumeContext,
+					);
+					inFlightResumes.set(currentRequestId, {
+						inputFingerprint: cached.inputFingerprint,
+						promise: retryPromise,
+						requestKind: cached.response.request.kind,
+						sessionId: cached.response.request.sessionId,
+						subject: currentSubject,
+					});
+					try {
+						const response = await retryPromise;
+						sendJson(res, 200, response, corsHeaders, req);
+						return;
+					} catch (error) {
+						respondWithApiError(res, error, 400, corsHeaders, req);
+						return;
+					} finally {
+						if (
+							inFlightResumes.get(currentRequestId)?.promise === retryPromise
+						) {
+							inFlightResumes.delete(currentRequestId);
+						}
+					}
+				}
+				sendJson(res, 200, cached.response, corsHeaders, req);
+				return;
+			}
+			throw new ApiError(404, "Pending request not found or already resolved");
+		}
+
+		const inputFingerprint = resumeInputFingerprint(input, pendingRequest);
+		const resumeContext = context as PendingRequestResumeContext;
+		const resumePromise = resolvePendingRequest(
+			currentRequestId,
+			currentInput,
+			pendingRequest,
+			resumeContext,
+		).then((response) => {
+			rememberResolvedResponse(
+				currentRequestId,
+				currentInput,
+				response,
+				currentSubject,
+			);
+			return response;
+		});
+		inFlightResumes.set(currentRequestId, {
+			inputFingerprint,
+			promise: resumePromise,
+			requestKind: pendingRequest.kind,
+			sessionId: pendingRequest.sessionId,
+			subject: currentSubject,
+		});
+		let response: ComposerPendingRequestResumeResponse;
+		try {
+			response = await resumePromise;
+		} finally {
+			if (inFlightResumes.get(currentRequestId)?.promise === resumePromise) {
+				inFlightResumes.delete(currentRequestId);
+			}
+		}
+		sendJson(res, 200, response, corsHeaders, req);
 	} catch (error) {
+		if (
+			error instanceof PendingRequestResolvedPlatformError &&
+			requestId &&
+			input &&
+			subject
+		) {
+			rememberResolvedResponse(
+				requestId,
+				input,
+				error.response,
+				subject,
+				error.platformRetry,
+			);
+		}
 		respondWithApiError(res, error, 400, corsHeaders, req);
 	}
 }

--- a/src/server/server-request-manager.ts
+++ b/src/server/server-request-manager.ts
@@ -31,6 +31,13 @@ export type ServerRequestLifecycleEvent = RuntimeServerRequestLifecycleEvent;
 
 type ServerRequestListener = (event: ServerRequestLifecycleEvent) => void;
 
+type ClaimedClientToolRequest = {
+	request: PendingServerRequestSnapshot & {
+		kind: "client_tool" | "mcp_elicitation" | "user_input";
+	};
+	resolve: (content: ToolResultContent[], isError: boolean) => boolean;
+};
+
 type ApprovalRequestEntry = PendingServerRequestSnapshot & {
 	kind: "approval";
 	timeoutMs: number;
@@ -358,6 +365,49 @@ export class ServerRequestManager {
 			});
 		}
 		return handled;
+	}
+
+	claimClientTool(id: string): ClaimedClientToolRequest | undefined {
+		const entry = this.pending.get(id);
+		if (!entry || entry.kind === "approval" || entry.kind === "tool_retry") {
+			return undefined;
+		}
+		const request = this.toSnapshot(
+			entry,
+		) as ClaimedClientToolRequest["request"];
+		this.pending.delete(id);
+		let claimed = true;
+		return {
+			request,
+			resolve: (content, isError) => {
+				if (!claimed) {
+					return false;
+				}
+				claimed = false;
+				const handled = entry.resolve(content, isError);
+				if (handled) {
+					this.emit({
+						type: "resolved",
+						request,
+						resolution: isError
+							? "failed"
+							: request.kind === "user_input" ||
+									request.kind === "mcp_elicitation"
+								? "answered"
+								: "completed",
+						reason: isError
+							? request.kind === "user_input"
+								? "User input request reported an error"
+								: request.kind === "mcp_elicitation"
+									? "MCP elicitation request reported an error"
+									: "Client tool result reported an error"
+							: undefined,
+						resolvedBy: "client",
+					});
+				}
+				return handled;
+			},
+		};
 	}
 
 	cancel(

--- a/test/agent/tool-execution-bridge.test.ts
+++ b/test/agent/tool-execution-bridge.test.ts
@@ -499,6 +499,7 @@ describe("tool execution bridge", () => {
 		if (prepared.status !== "wait_approval") {
 			throw new Error("expected approval wait");
 		}
+		expect(prepared.request.platform).not.toHaveProperty("resumeToken");
 
 		const decision: ActionApprovalDecision = {
 			approved: true,

--- a/test/web/pending-request-resume-handler.test.ts
+++ b/test/web/pending-request-resume-handler.test.ts
@@ -54,12 +54,20 @@ function makeRes(): MockResponse {
 }
 
 async function resume(requestId: string, body: unknown) {
+	return resumeWithContext(requestId, body, {});
+}
+
+async function resumeWithContext(
+	requestId: string,
+	body: unknown,
+	context: Partial<WebServerContext> & Record<string, unknown>,
+) {
 	const req = makeReq(body);
 	const res = makeRes();
 	await handlePendingRequestResume(
 		req,
 		res,
-		{ corsHeaders: cors } as WebServerContext,
+		{ corsHeaders: cors, ...context } as WebServerContext,
 		{ requestId: encodeURIComponent(requestId) },
 	);
 	return res;
@@ -71,9 +79,10 @@ describe("handlePendingRequestResume", () => {
 			serverRequestManager.cancel(request.id, "test cleanup", "runtime");
 		}
 		vi.restoreAllMocks();
+		vi.useRealTimers();
 	});
 
-	it("resumes Platform-backed approvals through the unified endpoint", async () => {
+	it("resolves ToolExecution-backed approvals locally without replaying Platform", async () => {
 		const service = new ActionApprovalService("prompt");
 		const resolve = vi.spyOn(service, "resolve").mockReturnValue(true);
 		serverRequestManager.registerApproval({
@@ -92,12 +101,16 @@ describe("handlePendingRequestResume", () => {
 			service,
 		});
 
-		const res = await resume("approval-platform", {
-			kind: "approval",
-			sessionId: "session-platform",
-			decision: "approved",
-			reason: "Looks good",
-		});
+		const res = await resumeWithContext(
+			"approval-platform",
+			{
+				kind: "approval",
+				sessionId: "session-platform",
+				decision: "approved",
+				reason: "Looks good",
+			},
+			{},
+		);
 
 		expect(res.statusCode).toBe(200);
 		expect(JSON.parse(res.body)).toEqual({
@@ -113,7 +126,6 @@ describe("handlePendingRequestResume", () => {
 					toolExecutionId: "texec-1",
 					approvalRequestId: "approval-platform",
 				},
-				platformOperation: "ResumeToolExecution",
 			},
 		});
 		expect(resolve).toHaveBeenCalledWith("approval-platform", {
@@ -122,6 +134,504 @@ describe("handlePendingRequestResume", () => {
 			resolvedBy: "user",
 		});
 		expect(serverRequestManager.get("approval-platform")).toBeUndefined();
+	});
+
+	it("keeps ToolExecution resume tokens out of pending approval snapshots", async () => {
+		const service = new ActionApprovalService("prompt");
+		serverRequestManager.registerApproval({
+			sessionId: "session-platform-private",
+			request: {
+				id: "approval-platform-private",
+				toolName: "bash",
+				args: { command: "deploy" },
+				reason: "Needs approval",
+				platform: {
+					source: "tool_execution",
+					toolExecutionId: "texec-private",
+					approvalRequestId: "approval-platform-private",
+				},
+			},
+			service,
+		});
+
+		expect(serverRequestManager.get("approval-platform-private")).toMatchObject(
+			{
+				platform: {
+					source: "tool_execution",
+					toolExecutionId: "texec-private",
+					approvalRequestId: "approval-platform-private",
+				},
+			},
+		);
+	});
+
+	it("claims hosted user-input waits before Platform AgentRuntime resume", async () => {
+		const resolve = vi.fn().mockReturnValue(true);
+		const resumeRun = vi.fn().mockImplementation(() => {
+			expect(serverRequestManager.get("ask-user-platform-1")).toBeUndefined();
+			expect(resolve).toHaveBeenCalledWith(
+				[{ type: "text", text: "Yes" }],
+				false,
+			);
+			return Promise.resolve({
+				run: { id: "run_1" },
+				event: { id: "event_resume" },
+			});
+		});
+		serverRequestManager.registerClientTool({
+			id: "ask-user-platform-1",
+			sessionId: "session-platform-wait",
+			toolName: "ask_user",
+			args: { question: "Continue?" },
+			kind: "user_input",
+			resolve,
+			cancel: vi.fn().mockReturnValue(true),
+		});
+
+		const res = await resumeWithContext(
+			"ask-user-platform-1",
+			{
+				sessionId: "session-platform-wait",
+				content: [{ type: "text", text: "Yes" }],
+			},
+			{
+				hostedRunner: {
+					enabled: true,
+					runnerSessionId: "runner_1",
+					workspaceRoot: "/workspace",
+					agentRunId: "run_1",
+					activeMaestroSessionId: "session-platform-wait",
+				},
+				platformPendingRequestResume: { resumeRun },
+			},
+		);
+
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.body)).toMatchObject({
+			success: true,
+			request: {
+				id: "ask-user-platform-1",
+				kind: "user_input",
+				sessionId: "session-platform-wait",
+				resolution: "answered",
+				source: "platform",
+				platformOperation: "ResumeRun",
+			},
+		});
+		expect(resumeRun).toHaveBeenCalledWith({
+			runId: "run_1",
+			waitId: "maestro:session-platform-wait:wait:ask-user-platform-1",
+			resumeEventId: "maestro:session-platform-wait:resume:ask-user-platform-1",
+			payload: expect.objectContaining({
+				maestro_session_id: "session-platform-wait",
+				request_id: "ask-user-platform-1",
+				request_type: "user_input",
+				resolution: "answered",
+				resolved_by: "user",
+				content: [{ type: "text", text: "Yes" }],
+			}),
+		});
+		expect(resolve).toHaveBeenCalledWith(
+			[{ type: "text", text: "Yes" }],
+			false,
+		);
+	});
+
+	it("returns local success when hosted user-input Platform resume aborts after local resolution", async () => {
+		const resolve = vi.fn().mockReturnValue(true);
+		const abortError = new Error("aborted");
+		abortError.name = "AbortError";
+		const resumeRun = vi.fn().mockRejectedValue(abortError);
+		serverRequestManager.registerClientTool({
+			id: "ask-user-platform-abort",
+			sessionId: "session-platform-wait-abort",
+			toolName: "ask_user",
+			args: { question: "Continue?" },
+			kind: "user_input",
+			resolve,
+			cancel: vi.fn().mockReturnValue(true),
+		});
+
+		const body = {
+			sessionId: "session-platform-wait-abort",
+			content: [{ type: "text", text: "Yes" }],
+		};
+
+		const res = await resumeWithContext("ask-user-platform-abort", body, {
+			hostedRunner: {
+				enabled: true,
+				runnerSessionId: "runner_1",
+				workspaceRoot: "/workspace",
+				agentRunId: "run_1",
+				activeMaestroSessionId: "session-platform-wait-abort",
+			},
+			platformPendingRequestResume: { resumeRun },
+		});
+		const retry = await resumeWithContext("ask-user-platform-abort", body, {
+			hostedRunner: {
+				enabled: true,
+				runnerSessionId: "runner_1",
+				workspaceRoot: "/workspace",
+				agentRunId: "run_1",
+				activeMaestroSessionId: "session-platform-wait-abort",
+			},
+			platformPendingRequestResume: { resumeRun },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(retry.statusCode).toBe(200);
+		expect(JSON.parse(retry.body)).toEqual(JSON.parse(res.body));
+		expect(JSON.parse(res.body)).toMatchObject({
+			success: true,
+			request: {
+				id: "ask-user-platform-abort",
+				kind: "user_input",
+				resolution: "answered",
+				source: "local",
+			},
+		});
+		expect(resolve).toHaveBeenCalledWith(
+			[{ type: "text", text: "Yes" }],
+			false,
+		);
+		expect(resumeRun).toHaveBeenCalledTimes(1);
+		expect(serverRequestManager.get("ask-user-platform-abort")).toBeUndefined();
+	});
+
+	it("caches local success when hosted user-input Platform resume fails after local resolution", async () => {
+		const resolve = vi.fn().mockReturnValue(true);
+		const resumeRun = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("network down"))
+			.mockResolvedValueOnce({
+				run: { id: "run_1" },
+				event: { id: "event_resume" },
+			});
+		serverRequestManager.registerClientTool({
+			id: "ask-user-platform-fail-after-local",
+			sessionId: "session-platform-wait-fail-after-local",
+			toolName: "ask_user",
+			args: { question: "Continue?" },
+			kind: "user_input",
+			resolve,
+			cancel: vi.fn().mockReturnValue(true),
+		});
+		const context = {
+			hostedRunner: {
+				enabled: true,
+				runnerSessionId: "runner_1",
+				workspaceRoot: "/workspace",
+				agentRunId: "run_1",
+				activeMaestroSessionId: "session-platform-wait-fail-after-local",
+			},
+			platformPendingRequestResume: { resumeRun },
+		};
+		const body = {
+			sessionId: "session-platform-wait-fail-after-local",
+			content: [{ type: "text", text: "Yes" }],
+		};
+
+		const failed = await resumeWithContext(
+			"ask-user-platform-fail-after-local",
+			body,
+			context,
+		);
+		const retry = await resumeWithContext(
+			"ask-user-platform-fail-after-local",
+			body,
+			context,
+		);
+
+		expect(failed.statusCode).toBe(502);
+		expect(JSON.parse(failed.body)).toMatchObject({
+			error:
+				"Platform AgentRuntime resume failed; local pending request was resolved",
+		});
+		expect(retry.statusCode).toBe(200);
+		expect(JSON.parse(retry.body)).toMatchObject({
+			success: true,
+			request: {
+				id: "ask-user-platform-fail-after-local",
+				kind: "user_input",
+				resolution: "answered",
+				source: "platform",
+				platformOperation: "ResumeRun",
+			},
+		});
+		expect(resolve).toHaveBeenCalledTimes(1);
+		expect(resumeRun).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps hosted Platform retry recovery available beyond the duplicate-submit cache ttl", async () => {
+		vi.useFakeTimers({ toFake: ["Date"] });
+		vi.setSystemTime(new Date("2026-05-08T00:00:00.000Z"));
+		const resolve = vi.fn().mockReturnValue(true);
+		const resumeRun = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("network down"))
+			.mockResolvedValueOnce({
+				run: { id: "run_1" },
+				event: { id: "event_resume" },
+			});
+		serverRequestManager.registerClientTool({
+			id: "ask-user-platform-long-retry",
+			sessionId: "session-platform-long-retry",
+			toolName: "ask_user",
+			args: { question: "Continue?" },
+			kind: "user_input",
+			resolve,
+			cancel: vi.fn().mockReturnValue(true),
+		});
+		const context = {
+			hostedRunner: {
+				enabled: true,
+				runnerSessionId: "runner_1",
+				workspaceRoot: "/workspace",
+				agentRunId: "run_1",
+				activeMaestroSessionId: "session-platform-long-retry",
+			},
+			platformPendingRequestResume: { resumeRun },
+		};
+		const body = {
+			sessionId: "session-platform-long-retry",
+			content: [{ type: "text", text: "Yes" }],
+		};
+
+		const failed = await resumeWithContext(
+			"ask-user-platform-long-retry",
+			body,
+			context,
+		);
+		vi.setSystemTime(new Date("2026-05-08T00:02:00.000Z"));
+		const retry = await resumeWithContext(
+			"ask-user-platform-long-retry",
+			body,
+			context,
+		);
+
+		expect(failed.statusCode).toBe(502);
+		expect(retry.statusCode).toBe(200);
+		expect(JSON.parse(retry.body)).toMatchObject({
+			success: true,
+			request: {
+				id: "ask-user-platform-long-retry",
+				kind: "user_input",
+				resolution: "answered",
+				source: "platform",
+				platformOperation: "ResumeRun",
+			},
+		});
+		expect(resolve).toHaveBeenCalledTimes(1);
+		expect(resumeRun).toHaveBeenCalledTimes(2);
+	});
+
+	it("coalesces concurrent cached hosted Platform retry replays", async () => {
+		const resolve = vi.fn().mockReturnValue(true);
+		let resolvePlatform!: () => void;
+		const resumeRun = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("network down"))
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolveResume) => {
+						resolvePlatform = () =>
+							resolveResume({
+								run: { id: "run_1" },
+								event: { id: "event_resume" },
+							});
+					}),
+			);
+		serverRequestManager.registerClientTool({
+			id: "ask-user-platform-cached-concurrent",
+			sessionId: "session-platform-cached-concurrent",
+			toolName: "ask_user",
+			args: { question: "Continue?" },
+			kind: "user_input",
+			resolve,
+			cancel: vi.fn().mockReturnValue(true),
+		});
+		const context = {
+			hostedRunner: {
+				enabled: true,
+				runnerSessionId: "runner_1",
+				workspaceRoot: "/workspace",
+				agentRunId: "run_1",
+				activeMaestroSessionId: "session-platform-cached-concurrent",
+			},
+			platformPendingRequestResume: { resumeRun },
+		};
+		const body = {
+			sessionId: "session-platform-cached-concurrent",
+			content: [{ type: "text", text: "Yes" }],
+		};
+
+		const failed = await resumeWithContext(
+			"ask-user-platform-cached-concurrent",
+			body,
+			context,
+		);
+		const firstRetryPromise = resumeWithContext(
+			"ask-user-platform-cached-concurrent",
+			body,
+			context,
+		);
+		await new Promise((resolve) => setImmediate(resolve));
+		const secondRetryPromise = resumeWithContext(
+			"ask-user-platform-cached-concurrent",
+			{ content: [{ type: "text", text: "Yes" }] },
+			context,
+		);
+		resolvePlatform();
+		const [firstRetry, secondRetry] = await Promise.all([
+			firstRetryPromise,
+			secondRetryPromise,
+		]);
+
+		expect(failed.statusCode).toBe(502);
+		expect(firstRetry.statusCode).toBe(200);
+		expect(secondRetry.statusCode).toBe(200);
+		expect(JSON.parse(secondRetry.body)).toEqual(JSON.parse(firstRetry.body));
+		expect(resolve).toHaveBeenCalledTimes(1);
+		expect(resumeRun).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns cached success for duplicate hosted wait submits without replaying Platform", async () => {
+		const resolve = vi.fn().mockReturnValue(true);
+		const resumeRun = vi.fn().mockResolvedValue({
+			run: { id: "run_1" },
+			event: { id: "event_resume" },
+		});
+		serverRequestManager.registerClientTool({
+			id: "ask-user-platform-duplicate",
+			sessionId: "session-platform-duplicate",
+			toolName: "ask_user",
+			args: { question: "Continue?" },
+			kind: "user_input",
+			resolve,
+			cancel: vi.fn().mockReturnValue(true),
+		});
+		const context = {
+			hostedRunner: {
+				enabled: true,
+				runnerSessionId: "runner_1",
+				workspaceRoot: "/workspace",
+				agentRunId: "run_1",
+				activeMaestroSessionId: "session-platform-duplicate",
+			},
+			platformPendingRequestResume: { resumeRun },
+		};
+		const firstBody = {
+			kind: "user_input",
+			sessionId: "session-platform-duplicate",
+			content: [{ type: "text", text: "Yes" }],
+		};
+		const retryBody = {
+			content: [{ type: "text", text: "Yes" }],
+		};
+
+		const first = await resumeWithContext(
+			"ask-user-platform-duplicate",
+			firstBody,
+			context,
+		);
+		const second = await resumeWithContext(
+			"ask-user-platform-duplicate",
+			retryBody,
+			context,
+		);
+		const conflicting = await resumeWithContext(
+			"ask-user-platform-duplicate",
+			{ ...retryBody, isError: true },
+			context,
+		);
+		const changedContent = await resumeWithContext(
+			"ask-user-platform-duplicate",
+			{
+				...retryBody,
+				content: [{ type: "text", text: "Actually, no" }],
+			},
+			context,
+		);
+		const mismatchedSession = await resumeWithContext(
+			"ask-user-platform-duplicate",
+			{
+				kind: "user_input",
+				sessionId: "session-other",
+				content: [{ type: "text", text: "Yes" }],
+			},
+			context,
+		);
+
+		expect(first.statusCode).toBe(200);
+		expect(second.statusCode).toBe(200);
+		expect(conflicting.statusCode).toBe(404);
+		expect(changedContent.statusCode).toBe(404);
+		expect(mismatchedSession.statusCode).toBe(404);
+		expect(JSON.parse(second.body)).toEqual(JSON.parse(first.body));
+		expect(resumeRun).toHaveBeenCalledTimes(1);
+		expect(resolve).toHaveBeenCalledTimes(1);
+	});
+
+	it("coalesces concurrent duplicate hosted wait submits before replaying Platform", async () => {
+		const resolve = vi.fn().mockReturnValue(true);
+		let resolvePlatform!: () => void;
+		const resumeRun = vi.fn(
+			() =>
+				new Promise((resolveResume) => {
+					resolvePlatform = () =>
+						resolveResume({
+							run: { id: "run_1" },
+							event: { id: "event_resume" },
+						});
+				}),
+		);
+		serverRequestManager.registerClientTool({
+			id: "ask-user-platform-concurrent",
+			sessionId: "session-platform-concurrent",
+			toolName: "ask_user",
+			args: { question: "Continue?" },
+			kind: "user_input",
+			resolve,
+			cancel: vi.fn().mockReturnValue(true),
+		});
+		const context = {
+			hostedRunner: {
+				enabled: true,
+				runnerSessionId: "runner_1",
+				workspaceRoot: "/workspace",
+				agentRunId: "run_1",
+				activeMaestroSessionId: "session-platform-concurrent",
+			},
+			platformPendingRequestResume: { resumeRun },
+		};
+		const firstBody = {
+			kind: "user_input",
+			sessionId: "session-platform-concurrent",
+			content: [{ type: "text", text: "Yes" }],
+		};
+		const retryBody = {
+			content: [{ type: "text", text: "Yes" }],
+		};
+
+		const firstPromise = resumeWithContext(
+			"ask-user-platform-concurrent",
+			firstBody,
+			context,
+		);
+		await new Promise((resolve) => setImmediate(resolve));
+		const secondPromise = resumeWithContext(
+			"ask-user-platform-concurrent",
+			retryBody,
+			context,
+		);
+		resolvePlatform();
+		const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+		expect(first.statusCode).toBe(200);
+		expect(second.statusCode).toBe(200);
+		expect(JSON.parse(second.body)).toEqual(JSON.parse(first.body));
+		expect(resumeRun).toHaveBeenCalledTimes(1);
+		expect(resolve).toHaveBeenCalledTimes(1);
 	});
 
 	it("resumes client-side prompts without the caller knowing the legacy endpoint", async () => {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `452989d25f4fc8597e07b664097d8a09da84ad10`
- last generated public sync base: `75ca03d93a27b30ef4b67c77cb0dc90cf0e78e6e`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (452989d25f4f)`
- public projection: `https://github.com/evalops/maestro@main (75ca03d93a27)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/pending-requests.md
- copy/update src/server/handlers/pending-requests.ts
- copy/update src/server/server-request-manager.ts
- copy/update test/agent/tool-execution-bridge.test.ts
- copy/update test/web/pending-request-resume-handler.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/pending-requests.md
- copy/update src/server/handlers/pending-requests.ts
- copy/update src/server/server-request-manager.ts
- copy/update test/agent/tool-execution-bridge.test.ts
- copy/update test/web/pending-request-resume-handler.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #319 to internal source `452989d25f4fc8597e07b664097d8a09da84ad10`