### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -117,6 +117,19 @@ Prefer the stable entry points above unless you need something specific; deep
 wildcard subpaths are intentionally not exported to keep the SDK surface
 predictable.
 
+## Boundary Status
+
+`@evalops/ai` is currently an internal facade package: its public subpath
+entrypoints are stable, but several implementations are still sourced from the
+root Maestro runtime under `src/`. The package declares this explicitly in
+`package.json` under `maestro.packageBoundary`, and
+`scripts/validate-package-boundaries.js` only permits those root imports while
+that metadata and rationale are present.
+
+New SDK code should live under `packages/ai/src`. Moving an existing facade
+export to package-owned source should remove the corresponding root dependency
+instead of adding another exception.
+
 You can also access these namespaces from the root entry point when you want a
 single import surface:
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -120,6 +120,13 @@
 		"url": "git+https://github.com/evalops/maestro.git",
 		"directory": "packages/ai"
 	},
+	"maestro": {
+		"packageBoundary": {
+			"mode": "internal-facade",
+			"allowedExternalSourceRoots": ["../../src"],
+			"rationale": "@evalops/ai is a stable package entrypoint over the root Maestro AI/provider runtime while the package-owned kernel is being extracted."
+		}
+	},
 	"engines": {
 		"node": ">=20.0.0"
 	},

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,6 +18,20 @@ npm install @evalops/maestro-core
 - **Swarm types** — task scheduling with dependencies for parallel agent execution
 - **Background task primitives** — restart policies, status types, health snapshots
 
+## Boundary Status
+
+`@evalops/maestro-core` is currently an internal facade package: it provides the
+stable package entrypoints for the Maestro agent/runtime kernel, but several
+exports still point at root `src/` implementation files. This is intentional
+only while the package-owned kernel is being extracted. The package declares the
+facade boundary in `package.json` under `maestro.packageBoundary`, and
+`scripts/validate-package-boundaries.js` rejects hidden root-source imports
+unless that metadata and rationale are present.
+
+New runtime primitives should be added under `packages/core/src`. When an
+existing export is moved into package-owned source, remove the facade import
+rather than broadening the exception.
+
 ## Usage
 
 ```typescript

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,13 @@
 		"url": "git+https://github.com/evalops/maestro.git",
 		"directory": "packages/core"
 	},
+	"maestro": {
+		"packageBoundary": {
+			"mode": "internal-facade",
+			"allowedExternalSourceRoots": ["../../src"],
+			"rationale": "@evalops/maestro-core is a stable package entrypoint over the root Maestro agent/runtime kernel while package-owned source is being extracted."
+		}
+	},
 	"scripts": {
 		"build": "tsc -p tsconfig.build.json",
 		"clean": "rm -rf dist"

--- a/scripts/validate-package-boundaries.js
+++ b/scripts/validate-package-boundaries.js
@@ -1,24 +1,18 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+	dirname,
+	extname,
+	isAbsolute,
+	join,
+	relative,
+	resolve,
+	sep,
+} from "node:path";
+import { pathToFileURL } from "node:url";
 import { fileURLToPath } from "node:url";
 import * as ts from "typescript";
 
 const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const packagesDir = join(repoRoot, "packages");
-const allowedOutside = [
-	{
-		filePrefix: join(packagesDir, "ai", "src") + sep,
-		allowedPrefixes: [join(repoRoot, "src") + sep],
-	},
-	{
-		filePrefix: join(packagesDir, "core", "src") + sep,
-		allowedPrefixes: [join(repoRoot, "src") + sep],
-	},
-	{
-		filePrefix: join(packagesDir, "governance", "src") + sep,
-		allowedPrefixes: [join(repoRoot, "src") + sep],
-	},
-];
 
 const sourceExtensions = new Set([".ts", ".tsx", ".js", ".jsx"]);
 const ignoredDirs = new Set(["dist", "node_modules", ".external"]);
@@ -28,7 +22,11 @@ function isSubpath(parent, child) {
 	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
-function isAllowedOutside(filePath, resolvedPath) {
+function withTrailingSep(path) {
+	return path.endsWith(sep) ? path : path + sep;
+}
+
+function isAllowedOutside(filePath, resolvedPath, allowedOutside) {
 	return allowedOutside.some((rule) => {
 		if (!filePath.startsWith(rule.filePrefix)) {
 			return false;
@@ -58,6 +56,85 @@ function resolveImportPath(fromFile, specifier) {
 	}
 
 	return resolved;
+}
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function packageBoundaryConfig(packageJson) {
+	const config = packageJson.maestro?.packageBoundary;
+	if (!config || typeof config !== "object" || Array.isArray(config)) {
+		return undefined;
+	}
+	return config;
+}
+
+function boundaryRulesForPackage(repoRoot, packageRoot, packageJson, errors) {
+	const config = packageBoundaryConfig(packageJson);
+	if (!config) {
+		return [];
+	}
+	const packageName =
+		typeof packageJson.name === "string"
+			? packageJson.name
+			: relative(repoRoot, packageRoot);
+	if (config.mode !== "internal-facade") {
+		errors.push(
+			`${relative(
+				repoRoot,
+				packageRoot,
+			)} has unsupported maestro.packageBoundary.mode ${JSON.stringify(
+				config.mode,
+			)}`,
+		);
+		return [];
+	}
+	if (typeof config.rationale !== "string" || config.rationale.trim() === "") {
+		errors.push(
+			`${packageName} declares an internal facade boundary without a rationale`,
+		);
+	}
+	if (!Array.isArray(config.allowedExternalSourceRoots)) {
+		errors.push(
+			`${packageName} declares an internal facade boundary without allowedExternalSourceRoots`,
+		);
+		return [];
+	}
+
+	const allowedPrefixes = [];
+	for (const root of config.allowedExternalSourceRoots) {
+		if (typeof root !== "string" || root.trim() === "") {
+			errors.push(
+				`${packageName} has an invalid allowedExternalSourceRoots entry`,
+			);
+			continue;
+		}
+		const resolved = resolve(packageRoot, root);
+		if (!isSubpath(repoRoot, resolved)) {
+			errors.push(
+				`${packageName} allows source root ${root} outside the repository`,
+			);
+			continue;
+		}
+		if (isSubpath(packageRoot, resolved)) {
+			errors.push(
+				`${packageName} allows source root ${root} inside its own package; remove the facade exception`,
+			);
+			continue;
+		}
+		allowedPrefixes.push(withTrailingSep(resolved));
+	}
+
+	if (allowedPrefixes.length === 0) {
+		return [];
+	}
+	return [
+		{
+			filePrefix: withTrailingSep(join(packageRoot, "src")),
+			allowedPrefixes,
+		},
+	];
 }
 
 function walk(dir, files = []) {
@@ -148,54 +225,74 @@ function collectSpecifiers(filePath, sourceText) {
 	return specifiers;
 }
 
-const packageRoots = existsSync(packagesDir)
-	? readdirSync(packagesDir, { withFileTypes: true })
-			.filter((entry) => entry.isDirectory())
-			.map((entry) => join(packagesDir, entry.name))
-			.filter((dir) => existsSync(join(dir, "package.json")))
-	: [];
+export function validatePackageBoundaries(root = repoRoot) {
+	const packagesDir = join(root, "packages");
+	const packageRoots = existsSync(packagesDir)
+		? readdirSync(packagesDir, { withFileTypes: true })
+				.filter((entry) => entry.isDirectory())
+				.map((entry) => join(packagesDir, entry.name))
+				.filter((dir) => existsSync(join(dir, "package.json")))
+		: [];
 
-const errors = [];
-
-for (const packageRoot of packageRoots) {
-	const srcRoot = join(packageRoot, "src");
-	const files = walk(srcRoot);
-	for (const filePath of files) {
-		const specifiers = collectSpecifiers(
-			filePath,
-			readFileSync(filePath, "utf8"),
+	const errors = [];
+	const packageJsonByRoot = new Map(
+		packageRoots.map((packageRoot) => [
+			packageRoot,
+			readJson(join(packageRoot, "package.json")),
+		]),
+	);
+	const allowedOutside = [];
+	for (const [packageRoot, packageJson] of packageJsonByRoot) {
+		allowedOutside.push(
+			...boundaryRulesForPackage(root, packageRoot, packageJson, errors),
 		);
-		for (const specifier of specifiers) {
-			if (specifier.startsWith(".")) {
-				const resolved = resolveImportPath(filePath, specifier);
-				if (isSubpath(packageRoot, resolved)) {
-					continue;
-				}
-				if (isAllowedOutside(filePath, resolved)) {
-					continue;
-				}
-				errors.push(
-					`${relative(repoRoot, filePath)} imports ${specifier} which resolves outside ${relative(
-						repoRoot,
-						packageRoot,
-					)}`,
-				);
-				continue;
-			}
+	}
 
-			if (/^@evalops\/.+\/(src|dist)(\/|$)/.test(specifier)) {
-				errors.push(
-					`${relative(repoRoot, filePath)} imports ${specifier}; use package entrypoints instead of /src or /dist`,
-				);
+	for (const packageRoot of packageRoots) {
+		const srcRoot = join(packageRoot, "src");
+		const files = walk(srcRoot);
+		for (const filePath of files) {
+			const specifiers = collectSpecifiers(
+				filePath,
+				readFileSync(filePath, "utf8"),
+			);
+			for (const specifier of specifiers) {
+				if (specifier.startsWith(".")) {
+					const resolved = resolveImportPath(filePath, specifier);
+					if (isSubpath(packageRoot, resolved)) {
+						continue;
+					}
+					if (isAllowedOutside(filePath, resolved, allowedOutside)) {
+						continue;
+					}
+					errors.push(
+						`${relative(root, filePath)} imports ${specifier} which resolves outside ${relative(
+							root,
+							packageRoot,
+						)}`,
+					);
+					continue;
+				}
+
+				if (/^@evalops\/.+\/(src|dist)(\/|$)/.test(specifier)) {
+					errors.push(
+						`${relative(root, filePath)} imports ${specifier}; use package entrypoints instead of /src or /dist`,
+					);
+				}
 			}
 		}
 	}
+
+	return errors;
 }
 
-if (errors.length > 0) {
-	console.error("Package boundary violations detected:");
-	for (const error of errors) {
-		console.error(`- ${error}`);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	const errors = validatePackageBoundaries();
+	if (errors.length > 0) {
+		console.error("Package boundary violations detected:");
+		for (const error of errors) {
+			console.error(`- ${error}`);
+		}
+		process.exit(1);
 	}
-	process.exit(1);
 }

--- a/test/scripts/validate-package-boundaries.test.ts
+++ b/test/scripts/validate-package-boundaries.test.ts
@@ -1,0 +1,113 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { validatePackageBoundaries } from "../../scripts/validate-package-boundaries.js";
+
+const roots: string[] = [];
+
+function makeRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), "maestro-package-boundary-"));
+	roots.push(root);
+	mkdirSync(join(root, "packages", "facade", "src"), { recursive: true });
+	mkdirSync(join(root, "src"), { recursive: true });
+	writeFileSync(
+		join(root, "src", "shared.ts"),
+		"export const shared = 'root-runtime';\n",
+	);
+	writeFileSync(
+		join(root, "packages", "facade", "src", "index.ts"),
+		"export { shared } from '../../../src/shared.js';\n",
+	);
+	return root;
+}
+
+function writePackageJson(root: string, extra: Record<string, unknown> = {}) {
+	writeFileSync(
+		join(root, "packages", "facade", "package.json"),
+		JSON.stringify(
+			{
+				name: "@evalops/facade",
+				version: "0.0.0",
+				type: "module",
+				...extra,
+			},
+			null,
+			2,
+		),
+	);
+}
+
+describe("validatePackageBoundaries", () => {
+	afterEach(() => {
+		for (const root of roots.splice(0)) {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects hidden imports from package source into root source", () => {
+		const root = makeRoot();
+		writePackageJson(root);
+
+		expect(validatePackageBoundaries(root)).toEqual([
+			"packages/facade/src/index.ts imports ../../../src/shared.js which resolves outside packages/facade",
+		]);
+	});
+
+	it("allows explicitly declared internal facade packages", () => {
+		const root = makeRoot();
+		writePackageJson(root, {
+			maestro: {
+				packageBoundary: {
+					mode: "internal-facade",
+					allowedExternalSourceRoots: ["../../src"],
+					rationale:
+						"Stable package entrypoint while the root kernel is extracted.",
+				},
+			},
+		});
+
+		expect(validatePackageBoundaries(root)).toEqual([]);
+	});
+
+	it("rejects facade source roots outside the repository", () => {
+		const root = makeRoot();
+		writePackageJson(root, {
+			maestro: {
+				packageBoundary: {
+					mode: "internal-facade",
+					allowedExternalSourceRoots: ["../../../../outside"],
+					rationale: "Invalid external root.",
+				},
+			},
+		});
+
+		expect(validatePackageBoundaries(root)).toContain(
+			"@evalops/facade allows source root ../../../../outside outside the repository",
+		);
+	});
+
+	it("can be imported when Node does not provide argv[1]", () => {
+		const output = execFileSync(
+			process.execPath,
+			[
+				"--input-type=module",
+				"-e",
+				"process.argv.splice(1); await import(process.env.VALIDATOR_URL); console.log('imported');",
+			],
+			{
+				encoding: "utf8",
+				env: {
+					...process.env,
+					VALIDATOR_URL: pathToFileURL(
+						join(process.cwd(), "scripts/validate-package-boundaries.js"),
+					).href,
+				},
+			},
+		);
+
+		expect(output.trim()).toBe("imported");
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `9e6f3c02a8f4621d29d8899847c96202658a0ad6`
- last generated public sync base: `18f6bb15ab479fa091939942b606629f8b60a53f`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (9e6f3c02a8f4)`
- public projection: `https://github.com/evalops/maestro@main (18f6bb15ab47)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/ai/README.md
- copy/update packages/ai/package.json
- copy/update packages/core/README.md
- copy/update packages/core/package.json
- copy/update scripts/validate-package-boundaries.js
- copy/update test/scripts/validate-package-boundaries.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/ai/README.md
- copy/update packages/ai/package.json
- copy/update packages/core/README.md
- copy/update packages/core/package.json
- copy/update scripts/validate-package-boundaries.js
- copy/update test/scripts/validate-package-boundaries.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode