### PR TITLE
[codex] Add permission profile algebra for sandbox policies

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -31,7 +31,7 @@ export interface Args {
 	execJson?: boolean;
 	execFullAuto?: boolean;
 	execReadOnly?: boolean;
-	/** Sandbox mode: "docker", "local", "native", or "none" */
+	/** Sandbox backend or policy mode */
 	sandbox?: string;
 	execOutputSchema?: string;
 	execOutputLast?: string;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -62,7 +62,7 @@ export function printHelp(version: string) {
 		"--mode <mode>           Output mode: text (default), json, or rpc",
 		"--auth <mode>           Credential mode: auto (default), api-key, claude",
 		"--approval-mode <mode>  Action approvals: prompt (default in TUI), auto, fail",
-		"--sandbox <mode>        Sandbox mode: docker, local, none (see docs/SAFETY.md)",
+		"--sandbox <mode>        Sandbox mode: read-only, workspace-write, danger-full-access, native, docker, local, none",
 		"--port <n>              Port for `maestro web` (defaults to PORT env or 8080)",
 		"--continue, -c          Continue previous session",
 		"--resume, -r            Select a session to resume",
@@ -131,7 +131,7 @@ export function printHelp(version: string) {
   CLAUDE_CODE_TOKEN       - Claude Code access token for --auth claude
   ANTHROPIC_OAUTH_TOKEN   - Alternate env for Claude Code bearer tokens
   MAESTRO_AGENT_DIR      - Session storage directory (default: ~/.maestro/agent)
-  MAESTRO_SANDBOX_MODE   - Sandbox mode: docker, local, none (default: none)
+  MAESTRO_SANDBOX_MODE   - Sandbox mode: read-only, workspace-write, danger-full-access
   MAESTRO_CHANGELOG      - Set to off/false/hide/hidden/skip/0 to hide startup changelog banner
   MAESTRO_TUI_MINIMAL    - Set to 1/true to disable animations and reduce TUI effects (SSH-friendly)
   MAESTRO_TUI_TOOL_MAX_CHARS - Max chars shown per tool output panel (0 = unlimited)
@@ -155,7 +155,7 @@ export function printHelp(version: string) {
     --output-schema <file|json> Validate final assistant JSON against a schema
     --output-last-message <path> Write the final assistant message to disk
     --full-auto | --read-only   Force approval policy (auto or fail)
-    --sandbox <mode>            Run in sandbox: docker, local, none
+    --sandbox <mode>            Run in sandbox: read-only, workspace-write, danger-full-access, native, docker, local, none
     --resume <sessionId>        Resume a prior exec session by id
     --last                      Resume the most recent exec session`,
 	)}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -707,7 +707,15 @@ export async function main(args: string[]) {
 	}
 
 	// Validate sandbox mode (applies to both exec and interactive modes)
-	const validSandboxModes = ["docker", "local", "none"];
+	const validSandboxModes = [
+		"docker",
+		"local",
+		"native",
+		"none",
+		"read-only",
+		"workspace-write",
+		"danger-full-access",
+	];
 	if (parsed.sandbox && !validSandboxModes.includes(parsed.sandbox)) {
 		exitWithStartupError(
 			`Unknown sandbox mode "${parsed.sandbox}". Supported: ${validSandboxModes.join(", ")}`,

--- a/src/safety/permission-profile.ts
+++ b/src/safety/permission-profile.ts
@@ -285,9 +285,7 @@ export function intersectPermissionProfiles(
 				continue;
 			}
 
-			if (
-				isPathWithin(grantedPath, requestedPath)
-			) {
+			if (isPathWithin(grantedPath, requestedPath)) {
 				acceptedEntries.push({
 					path: grantedEntry.path,
 					access: constrainAccess(requestedEntry.access, grantedEntry.access),

--- a/src/safety/permission-profile.ts
+++ b/src/safety/permission-profile.ts
@@ -1,0 +1,490 @@
+import { realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import type {
+	NativeSandboxMode,
+	NativeSandboxPolicy,
+} from "../sandbox/native-sandbox.js";
+
+export type FileSystemAccessMode = "none" | "read-only" | "read-write";
+
+export type FileSystemPermissionPath =
+	| { kind: "path"; path: string }
+	| { kind: "special"; value: "workspace" | "tmp" | "tmpdir" | "full-disk" }
+	| { kind: "glob"; pattern: string };
+
+export interface FileSystemPermissionEntry {
+	path: FileSystemPermissionPath;
+	access: FileSystemAccessMode;
+}
+
+export interface FileSystemPermissions {
+	entries: FileSystemPermissionEntry[];
+	globScanMaxDepth?: number;
+}
+
+export interface NetworkPermissions {
+	enabled: boolean;
+}
+
+export interface PermissionProfile {
+	fileSystem?: FileSystemPermissions;
+	network?: NetworkPermissions;
+}
+
+export interface NormalizePermissionProfileOptions {
+	cwd?: string;
+}
+
+export interface IntersectPermissionProfileOptions {
+	cwd?: string;
+}
+
+const ACCESS_RANK: Record<FileSystemAccessMode, number> = {
+	none: 0,
+	"read-only": 1,
+	"read-write": 2,
+};
+
+const PROFILE_DEFAULT_CWD = process.cwd();
+
+function canonicalizePath(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch {
+		return path;
+	}
+}
+
+function normalizeConcretePath(path: string, cwd: string): string {
+	return canonicalizePath(
+		isAbsolute(path) ? resolve(path) : resolve(cwd, path),
+	);
+}
+
+function permissionPathKey(path: FileSystemPermissionPath): string {
+	switch (path.kind) {
+		case "path":
+			return `path:${path.path}`;
+		case "special":
+			return `special:${path.value}`;
+		case "glob":
+			return `glob:${path.pattern}`;
+	}
+}
+
+function entryKey(entry: FileSystemPermissionEntry): string {
+	return `${permissionPathKey(entry.path)}:${entry.access}`;
+}
+
+function normalizeEntry(
+	entry: FileSystemPermissionEntry,
+	cwd: string,
+): FileSystemPermissionEntry {
+	if (entry.path.kind === "glob" && entry.access !== "none") {
+		throw new Error(
+			"Permission profile glob entries may only be deny rules for now",
+		);
+	}
+
+	if (entry.path.kind !== "path") {
+		return entry;
+	}
+
+	return {
+		...entry,
+		path: {
+			kind: "path",
+			path: normalizeConcretePath(entry.path.path, cwd),
+		},
+	};
+}
+
+function maxGlobScanDepth(
+	left: number | undefined,
+	right: number | undefined,
+): number | undefined {
+	if (left === undefined) {
+		return right;
+	}
+	if (right === undefined) {
+		return left;
+	}
+	return Math.max(left, right);
+}
+
+function resolveSpecialPath(
+	value: Extract<FileSystemPermissionPath, { kind: "special" }>["value"],
+	cwd: string,
+): string | undefined {
+	switch (value) {
+		case "workspace":
+			return normalizeConcretePath(cwd, cwd);
+		case "tmp":
+			return "/tmp";
+		case "tmpdir":
+			return process.env.TMPDIR
+				? normalizeConcretePath(process.env.TMPDIR, cwd)
+				: undefined;
+		case "full-disk":
+			return "/";
+	}
+}
+
+function materializePath(
+	path: FileSystemPermissionPath,
+	cwd: string,
+): string | undefined {
+	switch (path.kind) {
+		case "path":
+			return path.path;
+		case "special":
+			return resolveSpecialPath(path.value, cwd);
+		case "glob":
+			return undefined;
+	}
+}
+
+function isPathWithin(child: string, parent: string): boolean {
+	const normalizedChild = resolve(child);
+	const normalizedParent = resolve(parent);
+	if (normalizedChild === normalizedParent) {
+		return true;
+	}
+	if (normalizedParent === "/") {
+		return normalizedChild.startsWith("/");
+	}
+	const rel = relative(normalizedParent, normalizedChild);
+	return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+}
+
+function accessCovers(
+	requested: FileSystemAccessMode,
+	granted: FileSystemAccessMode,
+): boolean {
+	return ACCESS_RANK[requested] >= ACCESS_RANK[granted];
+}
+
+function constrainAccess(
+	requested: FileSystemAccessMode,
+	granted: FileSystemAccessMode,
+): FileSystemAccessMode {
+	return ACCESS_RANK[requested] <= ACCESS_RANK[granted] ? requested : granted;
+}
+
+function readWriteEntries(
+	profile: PermissionProfile,
+): FileSystemPermissionEntry[] {
+	return (profile.fileSystem?.entries ?? []).filter(
+		(entry) => entry.access === "read-write",
+	);
+}
+
+function denyEntries(profile: PermissionProfile): FileSystemPermissionEntry[] {
+	return (profile.fileSystem?.entries ?? []).filter(
+		(entry) => entry.access === "none",
+	);
+}
+
+function profileHasFullDiskWrite(profile: PermissionProfile): boolean {
+	return readWriteEntries(profile).some(
+		(entry) =>
+			entry.path.kind === "special" && entry.path.value === "full-disk",
+	);
+}
+
+export function normalizePermissionProfile(
+	profile: PermissionProfile,
+	options: NormalizePermissionProfileOptions = {},
+): PermissionProfile {
+	const cwd = options.cwd ?? PROFILE_DEFAULT_CWD;
+	const entriesByKey = new Map<string, FileSystemPermissionEntry>();
+
+	for (const entry of profile.fileSystem?.entries ?? []) {
+		const normalized = normalizeEntry(entry, cwd);
+		entriesByKey.set(entryKey(normalized), normalized);
+	}
+
+	const entries = [...entriesByKey.values()].sort((left, right) =>
+		entryKey(left).localeCompare(entryKey(right)),
+	);
+
+	return {
+		...(entries.length > 0 || profile.fileSystem?.globScanMaxDepth !== undefined
+			? {
+					fileSystem: {
+						entries,
+						...(profile.fileSystem?.globScanMaxDepth !== undefined
+							? {
+									globScanMaxDepth: profile.fileSystem.globScanMaxDepth,
+								}
+							: {}),
+					},
+				}
+			: {}),
+		...(profile.network
+			? { network: { enabled: profile.network.enabled === true } }
+			: {}),
+	};
+}
+
+export function mergePermissionProfiles(
+	base: PermissionProfile,
+	additional: PermissionProfile,
+	options: NormalizePermissionProfileOptions = {},
+): PermissionProfile {
+	const cwd = options.cwd ?? PROFILE_DEFAULT_CWD;
+	const normalizedBase = normalizePermissionProfile(base, { cwd });
+	const normalizedAdditional = normalizePermissionProfile(additional, { cwd });
+
+	return normalizePermissionProfile(
+		{
+			fileSystem: {
+				entries: [
+					...(normalizedBase.fileSystem?.entries ?? []),
+					...(normalizedAdditional.fileSystem?.entries ?? []),
+				],
+				globScanMaxDepth: maxGlobScanDepth(
+					normalizedBase.fileSystem?.globScanMaxDepth,
+					normalizedAdditional.fileSystem?.globScanMaxDepth,
+				),
+			},
+			network:
+				normalizedBase.network || normalizedAdditional.network
+					? {
+							enabled:
+								normalizedBase.network?.enabled === true ||
+								normalizedAdditional.network?.enabled === true,
+						}
+					: undefined,
+		},
+		{ cwd },
+	);
+}
+
+export function intersectPermissionProfiles(
+	requested: PermissionProfile,
+	granted: PermissionProfile,
+	options: IntersectPermissionProfileOptions = {},
+): PermissionProfile {
+	const cwd = options.cwd ?? PROFILE_DEFAULT_CWD;
+	const normalizedRequested = normalizePermissionProfile(requested, { cwd });
+	const normalizedGranted = normalizePermissionProfile(granted, { cwd });
+	const acceptedEntries: FileSystemPermissionEntry[] = [];
+
+	for (const grantedEntry of normalizedGranted.fileSystem?.entries ?? []) {
+		if (grantedEntry.access === "none") {
+			continue;
+		}
+
+		const grantedPath = materializePath(grantedEntry.path, cwd);
+		if (!grantedPath) {
+			continue;
+		}
+
+		for (const requestedEntry of normalizedRequested.fileSystem?.entries ??
+			[]) {
+			if (requestedEntry.access === "none") {
+				continue;
+			}
+
+			const requestedPath = materializePath(requestedEntry.path, cwd);
+			if (!requestedPath) {
+				continue;
+			}
+
+			if (
+				isPathWithin(grantedPath, requestedPath) &&
+				accessCovers(requestedEntry.access, grantedEntry.access)
+			) {
+				acceptedEntries.push({
+					path: grantedEntry.path,
+					access: constrainAccess(requestedEntry.access, grantedEntry.access),
+				});
+				break;
+			}
+		}
+	}
+
+	const deniedEntries = [
+		...denyEntries(normalizedRequested),
+		...denyEntries(normalizedGranted),
+	];
+
+	return normalizePermissionProfile(
+		{
+			fileSystem: {
+				entries: [...acceptedEntries, ...deniedEntries],
+				globScanMaxDepth: maxGlobScanDepth(
+					normalizedRequested.fileSystem?.globScanMaxDepth,
+					normalizedGranted.fileSystem?.globScanMaxDepth,
+				),
+			},
+			network:
+				normalizedRequested.network || normalizedGranted.network
+					? {
+							enabled:
+								normalizedRequested.network?.enabled === true &&
+								normalizedGranted.network?.enabled === true,
+						}
+					: undefined,
+		},
+		{ cwd },
+	);
+}
+
+export function permissionProfileFromNativeSandboxPolicy(
+	policy: NativeSandboxPolicy,
+	cwd: string = PROFILE_DEFAULT_CWD,
+): PermissionProfile {
+	if (policy.mode === "danger-full-access") {
+		return normalizePermissionProfile(
+			{
+				fileSystem: {
+					entries: [
+						{
+							path: { kind: "special", value: "full-disk" },
+							access: "read-write",
+						},
+					],
+				},
+				network: { enabled: policy.networkAccess !== false },
+			},
+			{ cwd },
+		);
+	}
+
+	const entries: FileSystemPermissionEntry[] = [];
+	if (policy.mode === "workspace-write") {
+		entries.push({
+			path: { kind: "special", value: "workspace" },
+			access: "read-write",
+		});
+
+		for (const root of policy.writableRoots ?? []) {
+			entries.push({
+				path: { kind: "path", path: root },
+				access: "read-write",
+			});
+		}
+
+		if (!policy.excludeSlashTmp) {
+			entries.push({
+				path: { kind: "special", value: "tmp" },
+				access: "read-write",
+			});
+		}
+
+		if (!policy.excludeTmpdir) {
+			entries.push({
+				path: { kind: "special", value: "tmpdir" },
+				access: "read-write",
+			});
+		}
+	}
+
+	return normalizePermissionProfile(
+		{
+			...(entries.length > 0 ? { fileSystem: { entries } } : {}),
+			network: { enabled: policy.networkAccess === true },
+		},
+		{ cwd },
+	);
+}
+
+export function nativeSandboxPolicyFromPermissionProfile(
+	profile: PermissionProfile,
+	cwd: string = PROFILE_DEFAULT_CWD,
+): NativeSandboxPolicy {
+	const normalized = normalizePermissionProfile(profile, { cwd });
+
+	if (profileHasFullDiskWrite(normalized)) {
+		return {
+			mode: "danger-full-access",
+			networkAccess: normalized.network?.enabled === true,
+		};
+	}
+
+	const writeEntries = readWriteEntries(normalized);
+	if (writeEntries.length === 0) {
+		return {
+			mode: "read-only",
+			networkAccess: normalized.network?.enabled === true,
+		};
+	}
+
+	const writableRoots: string[] = [];
+	let includesWorkspace = false;
+	let includesSlashTmp = false;
+	let includesTmpdir = false;
+
+	for (const entry of writeEntries) {
+		if (entry.path.kind === "special") {
+			switch (entry.path.value) {
+				case "workspace":
+					includesWorkspace = true;
+					break;
+				case "tmp":
+					includesSlashTmp = true;
+					break;
+				case "tmpdir":
+					includesTmpdir = true;
+					break;
+				case "full-disk":
+					break;
+			}
+			continue;
+		}
+
+		if (entry.path.kind === "path") {
+			if (
+				isPathWithin(entry.path.path, cwd) &&
+				isPathWithin(cwd, entry.path.path)
+			) {
+				includesWorkspace = true;
+			} else {
+				writableRoots.push(entry.path.path);
+			}
+		}
+	}
+
+	if (!includesWorkspace) {
+		throw new Error(
+			"Cannot convert permission profile to native workspace-write policy without granting workspace write",
+		);
+	}
+
+	return {
+		mode: "workspace-write",
+		...(writableRoots.length > 0 ? { writableRoots } : {}),
+		networkAccess: normalized.network?.enabled === true,
+		excludeSlashTmp: !includesSlashTmp,
+		excludeTmpdir: !includesTmpdir,
+	};
+}
+
+export interface NativeSandboxPolicyInput {
+	mode: NativeSandboxMode;
+	writableRoots?: string[];
+	networkAccess?: boolean;
+	excludeTmpdir?: boolean;
+	excludeSlashTmp?: boolean;
+}
+
+export function buildNativeSandboxPolicy(
+	input: NativeSandboxPolicyInput,
+	cwd: string = PROFILE_DEFAULT_CWD,
+): NativeSandboxPolicy {
+	return nativeSandboxPolicyFromPermissionProfile(
+		permissionProfileFromNativeSandboxPolicy(
+			{
+				mode: input.mode,
+				writableRoots: input.writableRoots,
+				networkAccess: input.networkAccess,
+				excludeTmpdir: input.excludeTmpdir,
+				excludeSlashTmp: input.excludeSlashTmp,
+			},
+			cwd,
+		),
+		cwd,
+	);
+}

--- a/src/safety/permission-profile.ts
+++ b/src/safety/permission-profile.ts
@@ -157,13 +157,6 @@ function isPathWithin(child: string, parent: string): boolean {
 	return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
 }
 
-function accessCovers(
-	requested: FileSystemAccessMode,
-	granted: FileSystemAccessMode,
-): boolean {
-	return ACCESS_RANK[requested] >= ACCESS_RANK[granted];
-}
-
 function constrainAccess(
 	requested: FileSystemAccessMode,
 	granted: FileSystemAccessMode,
@@ -293,8 +286,7 @@ export function intersectPermissionProfiles(
 			}
 
 			if (
-				isPathWithin(grantedPath, requestedPath) &&
-				accessCovers(requestedEntry.access, grantedEntry.access)
+				isPathWithin(grantedPath, requestedPath)
 			) {
 				acceptedEntries.push({
 					path: grantedEntry.path,

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { buildNativeSandboxPolicy } from "../safety/permission-profile.js";
 import { DockerSandbox, type DockerSandboxConfig } from "./docker-sandbox.js";
 import { LocalSandbox } from "./local-sandbox.js";
 import {
@@ -24,7 +25,8 @@ export {
 	type NativeSandboxMode,
 } from "./native-sandbox.js";
 
-export type SandboxMode = "docker" | "local" | "native" | "none";
+export type SandboxBackendMode = "docker" | "local" | "native" | "none";
+export type SandboxMode = SandboxBackendMode | NativeSandboxMode;
 
 export interface NativeSandboxConfig {
 	/** Sandbox policy mode */
@@ -33,6 +35,10 @@ export interface NativeSandboxConfig {
 	writableRoots?: string[];
 	/** Allow network access */
 	networkAccess?: boolean;
+	/** Exclude TMPDIR from writable roots */
+	excludeTmpdir?: boolean;
+	/** Exclude /tmp from writable roots */
+	excludeSlashTmp?: boolean;
 }
 
 export interface SandboxConfig {
@@ -77,6 +83,25 @@ async function isDockerAvailable(): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+function isNativeSandboxMode(mode: string): mode is NativeSandboxMode {
+	return (
+		mode === "read-only" ||
+		mode === "workspace-write" ||
+		mode === "danger-full-access"
+	);
+}
+
+function resolveSandboxMode(mode: SandboxMode): {
+	backendMode: SandboxBackendMode;
+	nativePolicy?: NativeSandboxMode;
+} {
+	if (isNativeSandboxMode(mode)) {
+		return { backendMode: "native", nativePolicy: mode };
+	}
+
+	return { backendMode: mode };
 }
 
 export interface CreateSandboxOptions {
@@ -139,8 +164,10 @@ export async function createSandbox(
 		}
 	}
 
+	const { backendMode, nativePolicy } = resolveSandboxMode(mode);
+
 	// Handle each mode
-	switch (mode) {
+	switch (backendMode) {
 		case "none":
 			return undefined;
 
@@ -164,11 +191,16 @@ export async function createSandbox(
 				return isWebServer ? undefined : new LocalSandbox();
 			}
 
-			const policy: NativeSandboxPolicy = {
-				mode: nativeConfig?.policy ?? "workspace-write",
-				writableRoots: nativeConfig?.writableRoots,
-				networkAccess: nativeConfig?.networkAccess ?? true,
-			};
+			const policy: NativeSandboxPolicy = buildNativeSandboxPolicy(
+				{
+					mode: nativePolicy ?? nativeConfig?.policy ?? "workspace-write",
+					writableRoots: nativeConfig?.writableRoots,
+					networkAccess: nativeConfig?.networkAccess ?? true,
+					excludeTmpdir: nativeConfig?.excludeTmpdir,
+					excludeSlashTmp: nativeConfig?.excludeSlashTmp,
+				},
+				cwd,
+			);
 
 			const sandbox = createNativeSandbox(policy, cwd);
 

--- a/test/safety/permission-profile.test.ts
+++ b/test/safety/permission-profile.test.ts
@@ -1,0 +1,248 @@
+import { mkdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	type PermissionProfile,
+	buildNativeSandboxPolicy,
+	intersectPermissionProfiles,
+	mergePermissionProfiles,
+	nativeSandboxPolicyFromPermissionProfile,
+	normalizePermissionProfile,
+	permissionProfileFromNativeSandboxPolicy,
+} from "../../src/safety/permission-profile.js";
+
+describe("permission profiles", () => {
+	let cwd: string;
+	let extraRoot: string;
+
+	beforeEach(() => {
+		cwd = join(tmpdir(), `permission-profile-${Date.now()}`);
+		extraRoot = join(cwd, "scratch");
+		mkdirSync(extraRoot, { recursive: true });
+		cwd = realpathSync(cwd);
+		extraRoot = realpathSync(extraRoot);
+	});
+
+	afterEach(() => {
+		rmSync(cwd, { recursive: true, force: true });
+	});
+
+	it("normalizes and deduplicates concrete paths", () => {
+		const profile = normalizePermissionProfile(
+			{
+				fileSystem: {
+					entries: [
+						{ path: { kind: "path", path: "scratch" }, access: "read-write" },
+						{
+							path: { kind: "path", path: extraRoot },
+							access: "read-write",
+						},
+					],
+				},
+				network: { enabled: true },
+			},
+			{ cwd },
+		);
+
+		expect(profile).toEqual({
+			fileSystem: {
+				entries: [
+					{ path: { kind: "path", path: extraRoot }, access: "read-write" },
+				],
+			},
+			network: { enabled: true },
+		});
+	});
+
+	it("only allows glob entries as deny constraints", () => {
+		expect(() =>
+			normalizePermissionProfile({
+				fileSystem: {
+					entries: [
+						{
+							path: { kind: "glob", pattern: "**/*.env" },
+							access: "read-write",
+						},
+					],
+				},
+			}),
+		).toThrow("glob entries may only be deny rules");
+
+		expect(
+			normalizePermissionProfile({
+				fileSystem: {
+					entries: [
+						{ path: { kind: "glob", pattern: "**/*.env" }, access: "none" },
+					],
+				},
+			}).fileSystem?.entries,
+		).toEqual([
+			{ path: { kind: "glob", pattern: "**/*.env" }, access: "none" },
+		]);
+	});
+
+	it("merges file-system entries and network grants", () => {
+		const merged = mergePermissionProfiles(
+			{
+				fileSystem: {
+					entries: [
+						{
+							path: { kind: "special", value: "workspace" },
+							access: "read-write",
+						},
+					],
+				},
+				network: { enabled: false },
+			},
+			{
+				fileSystem: {
+					entries: [
+						{ path: { kind: "path", path: extraRoot }, access: "read-write" },
+					],
+					globScanMaxDepth: 4,
+				},
+				network: { enabled: true },
+			},
+			{ cwd },
+		);
+
+		expect(merged.network).toEqual({ enabled: true });
+		expect(merged.fileSystem?.globScanMaxDepth).toBe(4);
+		expect(merged.fileSystem?.entries).toContainEqual({
+			path: { kind: "special", value: "workspace" },
+			access: "read-write",
+		});
+		expect(merged.fileSystem?.entries).toContainEqual({
+			path: { kind: "path", path: extraRoot },
+			access: "read-write",
+		});
+	});
+
+	it("intersects requested and granted file-system and network access", () => {
+		const requested: PermissionProfile = {
+			fileSystem: {
+				entries: [
+					{
+						path: { kind: "special", value: "workspace" },
+						access: "read-write",
+					},
+					{ path: { kind: "glob", pattern: "**/.env" }, access: "none" },
+				],
+			},
+			network: { enabled: false },
+		};
+		const granted: PermissionProfile = {
+			fileSystem: {
+				entries: [
+					{ path: { kind: "path", path: extraRoot }, access: "read-write" },
+					{ path: { kind: "path", path: "/var/log" }, access: "read-write" },
+				],
+			},
+			network: { enabled: true },
+		};
+
+		const intersection = intersectPermissionProfiles(requested, granted, {
+			cwd,
+		});
+
+		expect(intersection.network).toEqual({ enabled: false });
+		expect(intersection.fileSystem?.entries).toContainEqual({
+			path: { kind: "path", path: extraRoot },
+			access: "read-write",
+		});
+		expect(intersection.fileSystem?.entries).toContainEqual({
+			path: { kind: "glob", pattern: "**/.env" },
+			access: "none",
+		});
+		expect(intersection.fileSystem?.entries).not.toContainEqual({
+			path: { kind: "path", path: "/var/log" },
+			access: "read-write",
+		});
+	});
+
+	it("converts native sandbox policy to a profile", () => {
+		const profile = permissionProfileFromNativeSandboxPolicy(
+			{
+				mode: "workspace-write",
+				writableRoots: [extraRoot],
+				networkAccess: true,
+				excludeSlashTmp: true,
+				excludeTmpdir: true,
+			},
+			cwd,
+		);
+
+		expect(profile.network).toEqual({ enabled: true });
+		expect(profile.fileSystem?.entries).toContainEqual({
+			path: { kind: "special", value: "workspace" },
+			access: "read-write",
+		});
+		expect(profile.fileSystem?.entries).toContainEqual({
+			path: { kind: "path", path: extraRoot },
+			access: "read-write",
+		});
+		expect(profile.fileSystem?.entries).not.toContainEqual({
+			path: { kind: "special", value: "tmp" },
+			access: "read-write",
+		});
+	});
+
+	it("converts full-disk profile back to danger-full-access", () => {
+		const policy = nativeSandboxPolicyFromPermissionProfile({
+			fileSystem: {
+				entries: [
+					{
+						path: { kind: "special", value: "full-disk" },
+						access: "read-write",
+					},
+				],
+			},
+			network: { enabled: true },
+		});
+
+		expect(policy).toEqual({
+			mode: "danger-full-access",
+			networkAccess: true,
+		});
+	});
+
+	it("refuses native conversion when it would silently widen workspace writes", () => {
+		expect(() =>
+			nativeSandboxPolicyFromPermissionProfile(
+				{
+					fileSystem: {
+						entries: [
+							{
+								path: { kind: "path", path: extraRoot },
+								access: "read-write",
+							},
+						],
+					},
+				},
+				cwd,
+			),
+		).toThrow("without granting workspace write");
+	});
+
+	it("builds deterministic native sandbox policy from config-shaped input", () => {
+		const policy = buildNativeSandboxPolicy(
+			{
+				mode: "workspace-write",
+				writableRoots: [extraRoot],
+				networkAccess: true,
+				excludeSlashTmp: true,
+				excludeTmpdir: true,
+			},
+			cwd,
+		);
+
+		expect(policy).toEqual({
+			mode: "workspace-write",
+			writableRoots: [extraRoot],
+			networkAccess: true,
+			excludeSlashTmp: true,
+			excludeTmpdir: true,
+		});
+	});
+});

--- a/test/safety/permission-profile.test.ts
+++ b/test/safety/permission-profile.test.ts
@@ -161,6 +161,33 @@ describe("permission profiles", () => {
 		});
 	});
 
+	it("keeps matching paths when granted access is broader than requested", () => {
+		const intersection = intersectPermissionProfiles(
+			{
+				fileSystem: {
+					entries: [
+						{
+							path: { kind: "special", value: "workspace" },
+							access: "read-only",
+						},
+					],
+				},
+			},
+			{
+				fileSystem: {
+					entries: [
+						{ path: { kind: "path", path: extraRoot }, access: "read-write" },
+					],
+				},
+			},
+			{ cwd },
+		);
+
+		expect(intersection.fileSystem?.entries).toEqual([
+			{ path: { kind: "path", path: extraRoot }, access: "read-only" },
+		]);
+	});
+
 	it("converts native sandbox policy to a profile", () => {
 		const profile = permissionProfileFromNativeSandboxPolicy(
 			{

--- a/test/sandbox-integration.test.ts
+++ b/test/sandbox-integration.test.ts
@@ -173,6 +173,26 @@ describe("Sandbox", () => {
 			}
 		});
 
+		it("should treat policy MAESTRO_SANDBOX_MODE values as native sandbox requests", async () => {
+			const originalEnv = process.env.MAESTRO_SANDBOX_MODE;
+			const testDir = join(tmpdir(), `sandbox-policy-env-test-${Date.now()}`);
+			mkdirSync(testDir, { recursive: true });
+
+			try {
+				process.env.MAESTRO_SANDBOX_MODE = "workspace-write";
+				const sandbox = await createSandbox({ cwd: testDir });
+				expect(sandbox?.exec).toBeDefined();
+				await sandbox?.dispose();
+			} finally {
+				if (originalEnv === undefined) {
+					Reflect.deleteProperty(process.env, "MAESTRO_SANDBOX_MODE");
+				} else {
+					process.env.MAESTRO_SANDBOX_MODE = originalEnv;
+				}
+				rmSync(testDir, { recursive: true, force: true });
+			}
+		});
+
 		it("should use config file when no explicit mode", async () => {
 			const testDir = join(tmpdir(), `sandbox-create-test-${Date.now()}`);
 			mkdirSync(join(testDir, ".maestro"), { recursive: true });

--- a/test/sandbox/native-sandbox.test.ts
+++ b/test/sandbox/native-sandbox.test.ts
@@ -379,6 +379,24 @@ describe("Native Sandbox", () => {
 			await sandbox?.dispose();
 		});
 
+		it("treats policy modes as native sandbox requests", async () => {
+			if (!isNativeSandboxAvailable()) {
+				// Skip on platforms without native sandbox support
+				return;
+			}
+
+			const sandbox = await createSandbox({
+				mode: "workspace-write",
+				cwd: testDir,
+				native: {
+					networkAccess: true,
+				},
+			});
+
+			expect(sandbox).toBeInstanceOf(NativeSandbox);
+			await sandbox?.dispose();
+		});
+
 		it("falls back to local when native not available", async () => {
 			// This test is platform-dependent
 			// On unsupported platforms, native should fall back to local


### PR DESCRIPTION
## Summary
- add a shared permission profile algebra for file-system and network permissions
- translate native sandbox policies through the profile layer before creating native sandboxes
- allow Codex-style sandbox policy modes (`read-only`, `workspace-write`, `danger-full-access`) to resolve as native sandbox requests instead of being treated as unknown backend modes
- update CLI help/validation and cover the env/config seam with tests

## Why
Maestro already validates and emits `MAESTRO_SANDBOX_MODE` as Codex-style policy values, but sandbox creation expected backend values like `native`, `docker`, `local`, or `none`. That made `workspace-write` a footgun: it could be accepted by config/env validation and then fall through as an unknown sandbox mode.

This PR makes the policy vocabulary first-class and creates a reusable permission profile object that later slices can use for approvals, remote runners, app/server capability exchange, and tool-level permission negotiation.

## Internal source-of-truth PR
https://github.com/evalops/maestro-internal/pull/1755

## Validation
- `node ./scripts/run-vitest.js --run test/safety/permission-profile.test.ts test/sandbox/native-sandbox.test.ts test/sandbox-integration.test.ts test/config/toml-config.test.ts`
- `bunx tsc -p tsconfig.build.json --noEmit`
- commit hook: Guardian, Biome, lint/eval checks, generated protocol checks, build, and Bun compile
