### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/sandbox/native-sandbox.ts
+++ b/src/sandbox/native-sandbox.ts
@@ -620,7 +620,9 @@ export class NativeSandbox implements Sandbox {
 		}
 
 		const fullPath = this.resolvePath(path);
-		this.assertWritablePath(fullPath);
+		this.assertWritablePath(fullPath, {
+			blockReadOnlyDescendants: recursive ?? false,
+		});
 		rmSync(fullPath, { recursive: recursive ?? false, force: true });
 	}
 
@@ -670,7 +672,10 @@ export class NativeSandbox implements Sandbox {
 		this.assertWritablePath(targetPath);
 	}
 
-	private assertWritablePath(path: string): void {
+	private assertWritablePath(
+		path: string,
+		options?: { blockReadOnlyDescendants?: boolean },
+	): void {
 		if (this.policy.mode === "danger-full-access") {
 			return;
 		}
@@ -688,9 +693,14 @@ export class NativeSandbox implements Sandbox {
 
 			hasMatchingWritableRoot = true;
 			if (
-				root.readOnlySubpaths.some((readOnlySubpath) =>
-					isPathWithin(targetPath, canonicalizeForAccess(readOnlySubpath)),
-				)
+				root.readOnlySubpaths.some((readOnlySubpath) => {
+					const readOnlyPath = canonicalizeForAccess(readOnlySubpath);
+					return (
+						isPathWithin(targetPath, readOnlyPath) ||
+						(options?.blockReadOnlyDescendants === true &&
+							isPathWithin(readOnlyPath, targetPath))
+					);
+				})
 			) {
 				blockedByReadOnlySubpath = true;
 			}

--- a/test/sandbox/native-sandbox.test.ts
+++ b/test/sandbox/native-sandbox.test.ts
@@ -360,6 +360,32 @@ describe("Native Sandbox", () => {
 				await sandbox.dispose();
 			});
 
+			it("blocks recursive deletes that would remove read-only git metadata", async () => {
+				const gitDir = join(testDir, ".git");
+				mkdirSync(gitDir, { recursive: true });
+				writeFileSync(join(gitDir, "config"), "protected", "utf-8");
+				writeFileSync(join(testDir, "workspace.txt"), "content", "utf-8");
+				const sandbox = createNativeSandbox(
+					{
+						mode: "workspace-write",
+						excludeSlashTmp: true,
+						excludeTmpdir: true,
+					},
+					testDir,
+				);
+				await sandbox.initialize();
+
+				try {
+					await expect(sandbox.delete(".", true)).rejects.toThrow(
+						"Cannot write outside writable roots in workspace-write sandbox mode",
+					);
+					expect(existsSync(join(gitDir, "config"))).toBe(true);
+					expect(existsSync(join(testDir, "workspace.txt"))).toBe(true);
+				} finally {
+					await sandbox.dispose();
+				}
+			});
+
 			it("throws on delete in read-only mode", async () => {
 				const testFile = join(testDir, "protected.txt");
 				writeFileSync(testFile, "protected", "utf-8");


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `d0683bc18dc0c9421f4abc5f418073c2364c936e`
- last generated public sync base: `a5bd557c479d4e4ad2831e366ef6ecd02f513e97`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (d0683bc18dc0)`
- public projection: `https://github.com/evalops/maestro@main (a5bd557c479d)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/sandbox/native-sandbox.ts
- copy/update test/sandbox/native-sandbox.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/sandbox/native-sandbox.ts
- copy/update test/sandbox/native-sandbox.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode