### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Use this index to jump to the right guide quickly and see how the pieces connect
 ## Core Reference
 - [Tools Reference](TOOLS_REFERENCE.md) — authoritative slash command and flag definitions.
 - [Safety](SAFETY.md) — approvals, sandboxing, and firewall behavior.
+- [Agent Safety Boundary](design/AGENT_SAFETY_BOUNDARY.md) — how MCP workspace trust, guarded files, approvals, audit, and sandbox policy compose.
 - [Threat Model](THREAT_MODEL.md) — security architecture, trust boundaries, and attack mitigations.
 - [Models](MODELS.md) — provider/model registry sources, overrides, defaults, and OpenAI-compat quirks.
 - [Sessions](SESSIONS.md) — session formats, storage locations, and management commands.

--- a/docs/design/AGENT_SAFETY_BOUNDARY.md
+++ b/docs/design/AGENT_SAFETY_BOUNDARY.md
@@ -1,0 +1,97 @@
+# Agent Safety Boundary
+
+Maestro's agent safety boundary is the set of checks that run before a model
+can read, write, execute, or delegate through a tool. The boundary is deliberately
+layered: no single approval mode, MCP trust setting, or sandbox policy is treated
+as enough context to make a risky action safe.
+
+This note ties together the two user-controlled safety surfaces that are most
+likely to be confused:
+
+- [Guarded Files](GUARDED_FILES.md): path-level protection for user, editor,
+  agent, and credential configuration.
+- [MCP Workspace Trust](MCP_TRUST.md): server plus workspace trust for MCP tool
+  invocation.
+
+## Boundary Layers
+
+| Layer | Scope | Default | Override shape | Audit shape |
+| --- | --- | --- | --- | --- |
+| Tool availability | Tool name and runtime surface | Tool-specific | Runtime config and feature flags | Tool unavailable or approval events |
+| MCP trust | `(mcpServerId, workspaceUri)` | Historical trusted mode unless policy sets `ask` or `untrusted` | `trustedWorkspaces` and `workspaceTrustDefault` | MCP elicitation and trust decision events |
+| Guarded files | Path or glob category | Built-in guarded categories require prompt approval | User/org `guardedFiles` allowlists, rules, and mandatory keys | `ApprovalHit` with `policy_id: guardedFiles_block` |
+| Action firewall | Command/tool risk | Prompt or block by policy | Approval mode, hooks, governance policy | Approval and denial events |
+| Sandbox | Process/file isolation | Runtime-selected mode | Sandbox policy | Sandbox violation events |
+
+The layers are cumulative. For example, a trusted MCP server still cannot silently
+read `~/.ssh/config`, and a guarded-file allowlist does not make an untrusted MCP
+workspace callable.
+
+## MCP Trust Flow
+
+MCP calls enter the boundary in `McpClientManager.callTool()` before the MCP SDK
+invocation happens.
+
+1. Resolve the current workspace identity.
+2. Resolve server/workspace trust from configured policy and local persisted
+   decisions.
+3. If the result is `ask`, issue a server request through the existing
+   `mcp_elicitation` path, which maps to
+   `SERVER_REQUEST_TYPE_MCP_ELICITATION`.
+4. Invoke the MCP tool only after a trust decision allows the call.
+5. Block or cancel without contacting the MCP server when trust is denied.
+
+This keeps trust grants separate from normal tool invocation approval. The trust
+decision answers "may this server act in this workspace"; the later tool policy
+still answers "may this concrete call run now."
+
+## Guarded File Flow
+
+Guarded file checks run inside the tool safety pipeline before permission hooks
+or permissive approval modes can auto-allow the operation.
+
+1. Extract candidate paths from direct file tools, search/list/diff/status
+   tools, shell commands, and background tasks.
+2. Match candidates against the default guarded file categories plus org and
+   user custom rules.
+3. Apply allowlists only for non-mandatory, non-`block` matches.
+4. Require prompt approval for matching `ask` categories.
+5. Block matching `block` categories or prompt-required access when no prompt
+   surface is available.
+6. Emit a structured `ApprovalHit` with guarded file metadata.
+
+The default list ships in `@evalops/contracts` so clients and admin surfaces can
+render the same policy shape the runtime enforces.
+
+## Product Rule
+
+When a safety boundary decision can affect user data, credentials, external
+systems, or auditability, the product should expose the decision as a durable
+request or event rather than relying on local stderr or an ephemeral prompt.
+
+Today that means:
+
+- MCP trust prompts use the server-request path.
+- Guarded file prompts use normal action approval events.
+- Guarded file blocks emit `guardedFiles_block` approval telemetry.
+- Platform ToolExecution can see guarded-file denials as governed tool
+  unavailability or denial decisions.
+
+## Current Completion State
+
+The shipped boundary covers:
+
+- Default guarded file categories for editor, agent, shell, SSH, and GPG paths.
+- Read, write, search/list/diff/status, shell, and background-task path checks.
+- User and organization guarded-file rules, key/path allowlists, mandatory keys,
+  and hard block behavior.
+- Prompt-time guarded-file awareness in the system prompt.
+- Per-workspace MCP trust with `ask`, `trusted`, `blocked`, and `untrusted`
+  resolution.
+- MCP `ask` routing through the headless server-request primitive instead of a
+  direct post-connect invocation.
+- Documentation for the guarded-file and MCP trust policies.
+
+Remaining work should be filed as narrower follow-ups only when it changes a
+specific surface, such as a richer admin UI, a new audit sink, or a stricter
+org-managed default.

--- a/docs/design/INDEX.md
+++ b/docs/design/INDEX.md
@@ -28,6 +28,7 @@ This directory contains detailed design documentation for each major feature and
 | Document | Description |
 |----------|-------------|
 | [Safety & Firewall System](SAFETY_FIREWALL.md) | Rule-based safety enforcement, dangerous command detection |
+| [Agent Safety Boundary](AGENT_SAFETY_BOUNDARY.md) | Shared boundary for MCP workspace trust, guarded files, approvals, audit, and sandbox policy |
 | [Guarded Files](GUARDED_FILES.md) | Prompt-mode guardrails and audit events for user/editor configuration files |
 | [Platform ToolExecution Bridge](PLATFORM_TOOL_EXECUTION_BRIDGE.md) | Shared policy, approval, and audit bridge for Maestro tool calls |
 | [Enterprise RBAC & Audit](ENTERPRISE_RBAC.md) | Role-based access control, audit logging, and multi-tenancy |


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `09c3a11eb31ed635971c816b5d0aade5e2c036d3`
- last generated public sync base: `ac45daf06fa8d39293f53780f08536d53858f03e`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (09c3a11eb31e)`
- public projection: `https://github.com/evalops/maestro@main (ac45daf06fa8)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/README.md
- copy/update docs/design/AGENT_SAFETY_BOUNDARY.md
- copy/update docs/design/INDEX.md

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/README.md
- copy/update docs/design/AGENT_SAFETY_BOUNDARY.md
- copy/update docs/design/INDEX.md

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode