### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/CONDUCTOR_BRIDGE.md
+++ b/docs/CONDUCTOR_BRIDGE.md
@@ -49,6 +49,9 @@ The host supports:
 - `status` requests (probe `/api/bridge/status`)
 - `launch` requests (start `maestro web` if needed)
 - JSON-RPC notifications (`bridge/status`) when connectivity changes
+- CRX-style browser-control decision notifications
+  (`onBrowserControlDecision`) forwarded to Platform `RecordRunEvent` when
+  Agent Runtime configuration is present
 
 ### Install the native host manifest
 
@@ -86,6 +89,11 @@ Place the manifest in the standard Chrome location (if you did not use the scrip
 | `MAESTRO_BRIDGE_ARGS` | Extra args (JSON array or space-delimited) | empty |
 | `MAESTRO_BRIDGE_POLL_MS` | Status poll interval (ms) | `2000` |
 | `MAESTRO_BRIDGE_LAUNCH_TIMEOUT_MS` | Launch timeout (ms) | `15000` |
+| `MAESTRO_BRIDGE_AGENT_RUNTIME_URL` | Optional Agent Runtime base URL for browser-control decision events | empty |
+| `MAESTRO_BRIDGE_AGENT_RUNTIME_TOKEN` | Optional bearer token for Agent Runtime | empty |
+| `MAESTRO_BRIDGE_AGENT_RUNTIME_ORG_ID` | Optional organization header for Agent Runtime | empty |
+| `MAESTRO_BRIDGE_PLATFORM_RUN_ID` | Fallback Platform run ID when the Conductor receipt does not include one | empty |
+| `MAESTRO_BRIDGE_PLATFORM_RUNTIME_TIMEOUT_MS` | Agent Runtime event write timeout (ms) | `2000` |
 
 When the host launches Maestro, it sets:
 
@@ -96,6 +104,12 @@ MAESTRO_WEB_ORIGIN="*"
 ```
 
 Unless those variables are already set.
+
+When `onBrowserControlDecision` includes `platformRunId`, the native host writes
+a channel-safe `RUNTIME_EVENT_TYPE_AGENT_PROGRESS_RECORDED` event with
+`schemaVersion=browser-control-runtime-decision/v1`. Platform projects that
+event into the browser-control decision metric and Deploy alerts on missing or
+invalid Platform receipts.
 
 ## Notes
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -51,6 +51,7 @@ export * from "./key-value-tokens.js";
 export * from "./mcp-settings.js";
 export * from "./memory.js";
 export * from "./memory-utils.js";
+export * from "./maestro-app-server.js";
 export * from "./onboarding-utils.js";
 export * from "./proto/maestro/v1/headless_pb.js";
 export * from "./runtime-app-server.js";

--- a/packages/contracts/src/maestro-app-server.ts
+++ b/packages/contracts/src/maestro-app-server.ts
@@ -1,0 +1,182 @@
+import { type Static, Type } from "@sinclair/typebox";
+import { stringLiteralUnion } from "./typebox-utils.js";
+
+export const maestroAppServerProtocolVersion = "maestro-app-server.v1" as const;
+
+export const maestroAppServerClientMethods = [
+	"initialize",
+	"thread/list",
+	"thread/read",
+	"thread/turns/list",
+] as const;
+export type MaestroAppServerClientMethod =
+	(typeof maestroAppServerClientMethods)[number];
+
+export const maestroAppServerThreadStatuses = [
+	"notLoaded",
+	"loaded",
+	"running",
+	"interrupted",
+	"completed",
+] as const;
+export type MaestroAppServerThreadStatus =
+	(typeof maestroAppServerThreadStatuses)[number];
+
+export const maestroAppServerTurnStatuses = [
+	"completed",
+	"running",
+	"interrupted",
+	"failed",
+] as const;
+export type MaestroAppServerTurnStatus =
+	(typeof maestroAppServerTurnStatuses)[number];
+
+export const MaestroAppServerJsonRpcIdSchema = Type.Union([
+	Type.String(),
+	Type.Number(),
+]);
+const MaestroAppServerJsonRpcResponseIdSchema = Type.Union([
+	MaestroAppServerJsonRpcIdSchema,
+	Type.Null(),
+]);
+
+export const MaestroAppServerClientRequestSchema = Type.Object({
+	jsonrpc: Type.Literal("2.0"),
+	id: MaestroAppServerJsonRpcIdSchema,
+	method: Type.String(),
+	params: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+export type MaestroAppServerClientRequest = Static<
+	typeof MaestroAppServerClientRequestSchema
+>;
+
+export const MaestroAppServerCapabilitiesSchema = Type.Object({
+	sessions: Type.Boolean(),
+	threadList: Type.Boolean(),
+	threadRead: Type.Boolean(),
+	turnsList: Type.Boolean(),
+});
+export type MaestroAppServerCapabilities = Static<
+	typeof MaestroAppServerCapabilitiesSchema
+>;
+
+export const MaestroAppServerInitializeResultSchema = Type.Object({
+	protocolVersion: Type.Literal(maestroAppServerProtocolVersion),
+	serverInfo: Type.Object({
+		name: Type.String(),
+		version: Type.Optional(Type.String()),
+	}),
+	capabilities: MaestroAppServerCapabilitiesSchema,
+});
+export type MaestroAppServerInitializeResult = Static<
+	typeof MaestroAppServerInitializeResultSchema
+>;
+
+export const MaestroAppServerThreadStatusSchema = stringLiteralUnion(
+	maestroAppServerThreadStatuses,
+);
+export const MaestroAppServerTurnStatusSchema = stringLiteralUnion(
+	maestroAppServerTurnStatuses,
+);
+
+export const MaestroAppServerThreadSummarySchema = Type.Object({
+	id: Type.String(),
+	source: Type.Literal("session"),
+	status: MaestroAppServerThreadStatusSchema,
+	title: Type.Optional(Type.String()),
+	summary: Type.Optional(Type.String()),
+	resumeSummary: Type.Optional(Type.String()),
+	subject: Type.Optional(Type.String()),
+	path: Type.Optional(Type.String()),
+	createdAt: Type.String(),
+	updatedAt: Type.String(),
+	messageCount: Type.Number(),
+	favorite: Type.Boolean(),
+	tags: Type.Optional(Type.Array(Type.String())),
+});
+export type MaestroAppServerThreadSummary = Static<
+	typeof MaestroAppServerThreadSummarySchema
+>;
+
+export const MaestroAppServerThreadItemSchema = Type.Object({
+	id: Type.String(),
+	type: Type.String(),
+	timestamp: Type.Optional(Type.String()),
+	parentId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	role: Type.Optional(Type.String()),
+	content: Type.Optional(Type.Unknown()),
+	data: Type.Optional(Type.Unknown()),
+});
+export type MaestroAppServerThreadItem = Static<
+	typeof MaestroAppServerThreadItemSchema
+>;
+
+export const MaestroAppServerTurnSchema = Type.Object({
+	id: Type.String(),
+	status: MaestroAppServerTurnStatusSchema,
+	startedAt: Type.Optional(Type.String()),
+	completedAt: Type.Optional(Type.String()),
+	items: Type.Array(MaestroAppServerThreadItemSchema),
+});
+export type MaestroAppServerTurn = Static<typeof MaestroAppServerTurnSchema>;
+
+export const MaestroAppServerThreadSchema = Type.Intersect([
+	MaestroAppServerThreadSummarySchema,
+	Type.Object({
+		messagesView: Type.Union([
+			Type.Literal("full"),
+			Type.Literal("summary"),
+			Type.Literal("notLoaded"),
+		]),
+		turns: Type.Optional(Type.Array(MaestroAppServerTurnSchema)),
+	}),
+]);
+export type MaestroAppServerThread = Static<
+	typeof MaestroAppServerThreadSchema
+>;
+
+export const MaestroAppServerThreadListResultSchema = Type.Object({
+	threads: Type.Array(MaestroAppServerThreadSummarySchema),
+	nextCursor: Type.Union([Type.String(), Type.Null()]),
+});
+export type MaestroAppServerThreadListResult = Static<
+	typeof MaestroAppServerThreadListResultSchema
+>;
+
+export const MaestroAppServerThreadReadResultSchema = Type.Object({
+	thread: MaestroAppServerThreadSchema,
+});
+export type MaestroAppServerThreadReadResult = Static<
+	typeof MaestroAppServerThreadReadResultSchema
+>;
+
+export const MaestroAppServerTurnsListResultSchema = Type.Object({
+	threadId: Type.String(),
+	turns: Type.Array(MaestroAppServerTurnSchema),
+	nextCursor: Type.Union([Type.String(), Type.Null()]),
+});
+export type MaestroAppServerTurnsListResult = Static<
+	typeof MaestroAppServerTurnsListResultSchema
+>;
+
+export const MaestroAppServerResponseSchema = Type.Object({
+	jsonrpc: Type.Literal("2.0"),
+	id: MaestroAppServerJsonRpcResponseIdSchema,
+	result: Type.Optional(
+		Type.Union([
+			MaestroAppServerInitializeResultSchema,
+			MaestroAppServerThreadListResultSchema,
+			MaestroAppServerThreadReadResultSchema,
+			MaestroAppServerTurnsListResultSchema,
+		]),
+	),
+	error: Type.Optional(
+		Type.Object({
+			code: Type.Number(),
+			message: Type.String(),
+		}),
+	),
+});
+export type MaestroAppServerResponse = Static<
+	typeof MaestroAppServerResponseSchema
+>;

--- a/scripts/bridge/native-host.js
+++ b/scripts/bridge/native-host.js
@@ -21,6 +21,17 @@ const LAUNCH_TIMEOUT_MS = Number.parseInt(
 	process.env.MAESTRO_BRIDGE_LAUNCH_TIMEOUT_MS || "15000",
 	10,
 );
+const PLATFORM_RUNTIME_TIMEOUT_MS = Number.parseInt(
+	process.env.MAESTRO_BRIDGE_PLATFORM_RUNTIME_TIMEOUT_MS ||
+		process.env.MAESTRO_AGENT_RUNTIME_SERVICE_TIMEOUT_MS ||
+		"2000",
+	10,
+);
+const RECORD_RUN_EVENT_PATH =
+	"/agentruntime.v1.AgentRuntimeService/RecordRunEvent";
+const HANDLE_TRIGGER_PATH =
+	"/agentruntime.v1.AgentRuntimeService/HandleTrigger";
+const AGENT_RUNTIME_SERVICE_SUFFIX = "/agentruntime.v1.AgentRuntimeService";
 
 let webProcess = null;
 let statusTimer = null;
@@ -258,9 +269,230 @@ function sendNotification(method, params) {
 	});
 }
 
+function firstEnv(...names) {
+	for (const name of names) {
+		const value = process.env[name]?.trim();
+		if (value) return value;
+	}
+	return "";
+}
+
+function normalizeAgentRuntimeBaseUrl(value) {
+	let normalized = value.trim().replace(/\/+$/, "");
+	for (const suffix of [
+		RECORD_RUN_EVENT_PATH,
+		HANDLE_TRIGGER_PATH,
+		AGENT_RUNTIME_SERVICE_SUFFIX,
+	]) {
+		if (normalized.endsWith(suffix)) {
+			normalized = normalized.slice(0, -suffix.length).replace(/\/+$/, "");
+		}
+	}
+	return normalized;
+}
+
+function platformRuntimeConfigFromEnv() {
+	const baseUrl = firstEnv(
+		"MAESTRO_BRIDGE_AGENT_RUNTIME_URL",
+		"MAESTRO_AGENT_RUNTIME_SERVICE_URL",
+		"AGENT_RUNTIME_SERVICE_URL",
+	);
+	if (!baseUrl) return null;
+	return {
+		baseUrl: normalizeAgentRuntimeBaseUrl(baseUrl),
+		token: firstEnv(
+				"MAESTRO_BRIDGE_AGENT_RUNTIME_TOKEN",
+				"MAESTRO_AGENT_RUNTIME_SERVICE_TOKEN",
+				"AGENT_RUNTIME_SERVICE_TOKEN",
+				"MAESTRO_EVALOPS_ACCESS_TOKEN",
+				"EVALOPS_TOKEN",
+			),
+		organizationId: firstEnv(
+			"MAESTRO_BRIDGE_AGENT_RUNTIME_ORG_ID",
+			"MAESTRO_AGENT_RUNTIME_ORG_ID",
+				"MAESTRO_AGENT_RUNTIME_ORGANIZATION_ID",
+				"AGENT_RUNTIME_ORG_ID",
+				"AGENT_RUNTIME_ORGANIZATION_ID",
+				"MAESTRO_EVALOPS_ORG_ID",
+				"EVALOPS_ORGANIZATION_ID",
+				"EVALOPS_ORG_ID",
+				"MAESTRO_ENTERPRISE_ORG_ID",
+				"MAESTRO_LLM_GATEWAY_ORG_ID",
+				"MAESTRO_REMOTE_RUNNER_ORG_ID",
+			),
+		runId: firstEnv(
+			"MAESTRO_BRIDGE_PLATFORM_RUN_ID",
+			"MAESTRO_AGENT_RUNTIME_RUN_ID",
+			"AGENT_RUNTIME_RUN_ID",
+		),
+		timeoutMs: Number.isFinite(PLATFORM_RUNTIME_TIMEOUT_MS)
+			? PLATFORM_RUNTIME_TIMEOUT_MS
+			: 2000,
+	};
+}
+
+function cleanString(value, maxLength = 256) {
+	if (typeof value !== "string") return "";
+	const trimmed = value.trim();
+	if (!trimmed) return "";
+	return trimmed.slice(0, maxLength);
+}
+
+function cleanBoolean(value) {
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function compactObject(values) {
+	const result = {};
+	for (const [key, value] of Object.entries(values)) {
+		if (value === undefined || value === null || value === "") continue;
+		result[key] = value;
+	}
+	return result;
+}
+
+function browserControlDecisionRunId(params, config) {
+	return (
+		cleanString(params?.platformRunId, 160) ||
+		cleanString(params?.platform_run_id, 160) ||
+		cleanString(params?.runId, 160) ||
+		cleanString(params?.run_id, 160) ||
+		config.runId
+	);
+}
+
+function buildBrowserControlDecisionRuntimeEvent(params, config) {
+	if (!params || typeof params !== "object") return null;
+	const runId = browserControlDecisionRunId(params, config);
+	if (!runId) return null;
+	const method = cleanString(params.method, 120) || "unknown";
+	const decision = cleanString(params.decision, 32) || "unknown";
+	const denyReason = cleanString(params.denyReason ?? params.deny_reason, 120);
+	const methodProfile = cleanString(
+		params.methodProfile ?? params.method_profile,
+		120,
+	);
+	const safeSummary =
+		decision === "denied"
+			? `Browser-control denied: ${method}${denyReason ? ` (${denyReason})` : ""}`
+			: `Browser-control ${decision}: ${method}`;
+
+	return {
+		runId,
+		type: "RUNTIME_EVENT_TYPE_AGENT_PROGRESS_RECORDED",
+		message: safeSummary,
+		attributes: compactObject({
+			schemaVersion: "browser-control-runtime-decision/v1",
+			adapter: "maestro-conductor-native-host",
+			source: "conductor-browser-control-native-host",
+			nativeHost: HOST_NAME,
+			traceId: cleanString(params.traceId ?? params.trace_id, 160),
+			observedAt: cleanString(params.observedAt ?? params.observed_at, 80),
+			method,
+			methodProfile,
+			policyHash: cleanString(params.policyHash ?? params.policy_hash, 160),
+			platformReceiptPresent: cleanBoolean(
+				params.platformReceiptPresent ?? params.platform_receipt_present,
+			),
+			platformReceiptId: cleanString(
+				params.platformReceiptId ?? params.platform_receipt_id,
+				160,
+			),
+			platformRequestHash: cleanString(
+				params.platformRequestHash ?? params.platform_request_hash,
+				160,
+			),
+			approvalRequired: cleanBoolean(
+				params.approvalRequired ?? params.approval_required,
+			),
+			decision,
+			denyReason: denyReason || "none",
+			conductorContractVersion: cleanString(
+				params.conductorContractVersion ??
+					params.conductor_contract_version,
+				80,
+			),
+		}),
+		visibility: {
+			level: "RUNTIME_VISIBILITY_LEVEL_ADMIN_VISIBLE",
+			audiences: [
+				"RUNTIME_AUDIENCE_WORKSPACE_ADMINS",
+				"RUNTIME_AUDIENCE_AUDIT",
+				"RUNTIME_AUDIENCE_SYSTEM",
+			],
+			sensitivity: "RUNTIME_SENSITIVITY_INTERNAL",
+			safeSummary,
+		},
+	};
+}
+
+function runtimeHeaders(config) {
+	return compactObject({
+		Authorization: config.token ? `Bearer ${config.token}` : undefined,
+		"Content-Type": "application/json",
+		"Connect-Protocol-Version": "1",
+		"X-Organization-ID": config.organizationId,
+	});
+}
+
+async function postBrowserControlDecisionToPlatform(params) {
+	const config = platformRuntimeConfigFromEnv();
+	if (!config) {
+		return { recorded: false, reason: "platform_runtime_not_configured" };
+	}
+	const event = buildBrowserControlDecisionRuntimeEvent(params, config);
+	if (!event) {
+		return { recorded: false, reason: "platform_run_id_missing" };
+	}
+
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+	try {
+		const response = await fetch(`${config.baseUrl}${RECORD_RUN_EVENT_PATH}`, {
+			method: "POST",
+			headers: runtimeHeaders(config),
+			body: JSON.stringify(event),
+			signal: controller.signal,
+		});
+		if (!response.ok) {
+			return { recorded: false, reason: `platform_runtime_${response.status}` };
+		}
+		const body = await response.json().catch(() => ({}));
+		return {
+			recorded: true,
+			eventId: cleanString(body?.event?.id, 160),
+			sequence: typeof body?.event?.sequence === "number" ? body.event.sequence : undefined,
+		};
+	} catch (error) {
+		return {
+			recorded: false,
+			reason: error instanceof Error ? error.message : String(error),
+		};
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function handleJsonRpcNotification(message) {
+	if (
+		message.method !== "onBrowserControlDecision" ||
+		Object.hasOwn(message, "id")
+	) {
+		return false;
+	}
+	const params = message.params ?? {};
+	void postBrowserControlDecisionToPlatform(params);
+	return true;
+}
+
 function handleMessage(message) {
 	if (!message || typeof message !== "object") {
 		return;
+	}
+	if (message.jsonrpc === "2.0" && typeof message.method === "string") {
+		if (handleJsonRpcNotification(message)) {
+			return;
+		}
 	}
 	const { id, type } = message;
 	if (id == null || typeof type !== "string") {

--- a/src/app-server/in-process-client.ts
+++ b/src/app-server/in-process-client.ts
@@ -1,0 +1,138 @@
+import type {
+	MaestroAppServerClientMethod,
+	MaestroAppServerInitializeResult,
+	MaestroAppServerThreadListResult,
+	MaestroAppServerThreadReadResult,
+	MaestroAppServerTurnsListResult,
+} from "@evalops/contracts";
+import {
+	type MaestroAppServerSessionApi,
+	handleMaestroAppServerRequest,
+} from "./session-api.js";
+
+const DEFAULT_MAX_PENDING_REQUESTS = 64;
+const OVERLOADED_ERROR_CODE = -32001;
+
+export interface MaestroAppServerClientInfo {
+	name: string;
+	title?: string;
+	version: string;
+}
+
+export interface InProcessMaestroAppServerClientOptions {
+	clientInfo: MaestroAppServerClientInfo;
+	maxPendingRequests?: number;
+}
+
+type AppServerRequestMethod = Exclude<
+	MaestroAppServerClientMethod,
+	"initialize"
+>;
+
+type AppServerMethodResult<M extends AppServerRequestMethod> =
+	M extends "thread/list"
+		? MaestroAppServerThreadListResult
+		: M extends "thread/read"
+			? MaestroAppServerThreadReadResult
+			: M extends "thread/turns/list"
+				? MaestroAppServerTurnsListResult
+				: never;
+
+export class InProcessMaestroAppServerClientError extends Error {
+	constructor(
+		readonly code: number,
+		message: string,
+	) {
+		super(message);
+		this.name = "InProcessMaestroAppServerClientError";
+	}
+}
+
+export class InProcessMaestroAppServerClient {
+	private initialized = false;
+	private initializing = false;
+	private nextRequestId = 1;
+	private pendingRequests = 0;
+	private readonly maxPendingRequests: number;
+
+	constructor(
+		private readonly api: MaestroAppServerSessionApi,
+		private readonly options: InProcessMaestroAppServerClientOptions,
+	) {
+		this.maxPendingRequests = Math.max(
+			1,
+			Math.trunc(options.maxPendingRequests ?? DEFAULT_MAX_PENDING_REQUESTS),
+		);
+	}
+
+	async initialize(): Promise<MaestroAppServerInitializeResult> {
+		if (this.initialized || this.initializing) {
+			throw new InProcessMaestroAppServerClientError(
+				-32000,
+				"Already initialized",
+			);
+		}
+		this.initializing = true;
+		try {
+			const response = await handleMaestroAppServerRequest(this.api, {
+				jsonrpc: "2.0",
+				id: 0,
+				method: "initialize",
+				params: {
+					clientInfo: this.options.clientInfo,
+				},
+			});
+			if (response.error) {
+				throw new InProcessMaestroAppServerClientError(
+					response.error.code,
+					response.error.message,
+				);
+			}
+			this.initialized = true;
+			return response.result as MaestroAppServerInitializeResult;
+		} finally {
+			this.initializing = false;
+		}
+	}
+
+	async request<M extends AppServerRequestMethod>(
+		method: M,
+		params?: Record<string, unknown>,
+	): Promise<AppServerMethodResult<M>> {
+		if (!this.initialized) {
+			throw new InProcessMaestroAppServerClientError(-32000, "Not initialized");
+		}
+		if (this.pendingRequests >= this.maxPendingRequests) {
+			throw new InProcessMaestroAppServerClientError(
+				OVERLOADED_ERROR_CODE,
+				"Server overloaded; retry later.",
+			);
+		}
+
+		this.pendingRequests++;
+		try {
+			const response = await handleMaestroAppServerRequest(this.api, {
+				jsonrpc: "2.0",
+				id: this.nextRequestId++,
+				method,
+				params,
+			});
+			if (response.error) {
+				throw new InProcessMaestroAppServerClientError(
+					response.error.code,
+					response.error.message,
+				);
+			}
+			return response.result as AppServerMethodResult<M>;
+		} finally {
+			this.pendingRequests--;
+		}
+	}
+}
+
+export function createInProcessMaestroAppServerClient(
+	api: MaestroAppServerSessionApi,
+	options: InProcessMaestroAppServerClientOptions,
+): InProcessMaestroAppServerClient {
+	return new InProcessMaestroAppServerClient(api, options);
+}

--- a/src/app-server/session-api.ts
+++ b/src/app-server/session-api.ts
@@ -1,0 +1,464 @@
+import {
+	type MaestroAppServerClientRequest,
+	type MaestroAppServerResponse,
+	type MaestroAppServerThread,
+	type MaestroAppServerThreadItem,
+	type MaestroAppServerThreadListResult,
+	type MaestroAppServerThreadSummary,
+	type MaestroAppServerTurn,
+	type MaestroAppServerTurnsListResult,
+	maestroAppServerClientMethods,
+	maestroAppServerProtocolVersion,
+} from "@evalops/contracts";
+import type { AppMessage } from "../agent/types.js";
+import type { SessionManager } from "../session/manager.js";
+import { migrateToCurrentVersion } from "../session/migration.js";
+import { safeReadSessionEntries } from "../session/session-context.js";
+import type {
+	SessionEntry,
+	SessionMessagesView,
+	SessionMetadata,
+	SessionSummary,
+	SessionTreeEntry,
+} from "../session/types.js";
+import { isSessionTreeEntry } from "../session/types.js";
+
+const DEFAULT_PAGE_LIMIT = 50;
+const MAX_PAGE_LIMIT = 100;
+
+type JsonRpcId = string | number;
+
+type SessionStore = Pick<
+	SessionManager,
+	"getSessionFileById" | "loadAllSessions" | "listSessions" | "loadSession"
+> & {
+	loadEntries?: (sessionId: string) => Promise<SessionEntry[] | null>;
+};
+
+export interface MaestroAppServerSessionApi {
+	initialize(): MaestroAppServerResponse["result"];
+	listThreads(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerThreadListResult>;
+	readThread(params?: Record<string, unknown>): Promise<MaestroAppServerThread>;
+	listTurns(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerTurnsListResult>;
+}
+
+export class MaestroAppServerError extends Error {
+	constructor(
+		readonly code: number,
+		message: string,
+	) {
+		super(message);
+		this.name = "MaestroAppServerError";
+	}
+}
+
+function normalizeLimit(value: unknown): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return DEFAULT_PAGE_LIMIT;
+	}
+	return Math.min(MAX_PAGE_LIMIT, Math.max(1, Math.trunc(value)));
+}
+
+function encodeCursor(offset: number): string {
+	return Buffer.from(JSON.stringify({ offset }), "utf8").toString("base64url");
+}
+
+function decodeCursor(value: unknown): number {
+	if (value === undefined || value === null || value === "") {
+		return 0;
+	}
+	if (typeof value !== "string") {
+		throw new MaestroAppServerError(-32602, "Invalid cursor");
+	}
+	try {
+		const decoded = JSON.parse(
+			Buffer.from(value, "base64url").toString("utf8"),
+		);
+		if (
+			typeof decoded === "object" &&
+			decoded !== null &&
+			typeof decoded.offset === "number" &&
+			Number.isFinite(decoded.offset) &&
+			decoded.offset >= 0
+		) {
+			return Math.trunc(decoded.offset);
+		}
+	} catch {
+		// Fall through to the normalized JSON-RPC error below.
+	}
+	throw new MaestroAppServerError(-32602, "Invalid cursor");
+}
+
+function requireThreadId(params?: Record<string, unknown>): string {
+	const threadId = params?.threadId;
+	if (typeof threadId !== "string" || threadId.length === 0) {
+		throw new MaestroAppServerError(-32602, "Missing threadId");
+	}
+	return threadId;
+}
+
+function toThreadSummary(
+	metadata: SessionMetadata,
+	summary?: SessionSummary,
+): MaestroAppServerThreadSummary {
+	return {
+		id: metadata.id,
+		source: "session",
+		status: "notLoaded",
+		title: summary?.title ?? metadata.title ?? metadata.summary,
+		summary: metadata.summary,
+		resumeSummary: summary?.resumeSummary ?? metadata.resumeSummary,
+		subject: metadata.subject,
+		path: metadata.path,
+		createdAt: metadata.created.toISOString(),
+		updatedAt: metadata.modified.toISOString(),
+		messageCount: metadata.messageCount,
+		favorite: summary?.favorite ?? metadata.favorite,
+		tags: summary?.tags ?? metadata.tags,
+	};
+}
+
+function toThreadSummaryFromSessionSummary(
+	summary: SessionSummary,
+): MaestroAppServerThreadSummary {
+	return {
+		id: summary.id,
+		source: "session",
+		status: "notLoaded",
+		title: summary.title ?? summary.subject,
+		summary: summary.title ?? summary.subject,
+		resumeSummary: summary.resumeSummary,
+		subject: summary.subject,
+		createdAt: summary.createdAt,
+		updatedAt: summary.updatedAt,
+		messageCount: summary.messageCount,
+		favorite: summary.favorite,
+		tags: summary.tags,
+	};
+}
+
+function toThreadSummaryFromLoadedSession(loaded: {
+	id: string;
+	subject?: string;
+	title?: string;
+	summary?: string;
+	resumeSummary?: string;
+	createdAt: string;
+	updatedAt: string;
+	messageCount: number;
+	favorite: boolean;
+	tags?: string[];
+}): MaestroAppServerThreadSummary {
+	return {
+		id: loaded.id,
+		source: "session",
+		status: "notLoaded",
+		title: loaded.title ?? loaded.subject,
+		summary: loaded.summary ?? loaded.title ?? loaded.subject,
+		resumeSummary: loaded.resumeSummary,
+		subject: loaded.subject,
+		createdAt: loaded.createdAt,
+		updatedAt: loaded.updatedAt,
+		messageCount: loaded.messageCount,
+		favorite: loaded.favorite,
+		tags: loaded.tags,
+	};
+}
+
+function appMessageContent(message: AppMessage): unknown {
+	return "content" in message ? message.content : message;
+}
+
+function treeEntryToItem(entry: SessionTreeEntry): MaestroAppServerThreadItem {
+	if (entry.type === "message") {
+		return {
+			id: entry.id,
+			type: "message",
+			parentId: entry.parentId,
+			timestamp: entry.timestamp,
+			role: entry.message.role,
+			content: appMessageContent(entry.message),
+		};
+	}
+	if (entry.type === "custom_message") {
+		return {
+			id: entry.id,
+			type: entry.customType,
+			parentId: entry.parentId,
+			timestamp: entry.timestamp,
+			content: entry.content,
+			data: entry.details,
+		};
+	}
+	return {
+		id: entry.id,
+		type: entry.type,
+		parentId: entry.parentId,
+		timestamp: entry.timestamp,
+		data: entry,
+	};
+}
+
+export function buildTurnsFromSessionEntries(
+	entries: SessionEntry[],
+): MaestroAppServerTurn[] {
+	migrateToCurrentVersion(entries);
+	const turns: MaestroAppServerTurn[] = [];
+	let current: MaestroAppServerTurn | null = null;
+
+	for (const entry of activeTreeEntriesFromSessionEntries(entries)) {
+		const item = treeEntryToItem(entry);
+		const startsUserTurn =
+			entry.type === "message" && entry.message.role === "user";
+		if (startsUserTurn && current?.items.length) {
+			turns.push(current);
+			current = null;
+		}
+		if (!current) {
+			current = {
+				id: startsUserTurn ? entry.id : `turn-${entry.id}`,
+				status: "completed",
+				startedAt: entry.timestamp,
+				completedAt: entry.timestamp,
+				items: [],
+			};
+		}
+		current.items.push(item);
+		current.completedAt = entry.timestamp;
+	}
+
+	if (current?.items.length) {
+		turns.push(current);
+	}
+
+	return turns;
+}
+
+function activeTreeEntriesFromSessionEntries(
+	entries: SessionEntry[],
+): SessionTreeEntry[] {
+	const treeEntries = entries.filter(isSessionTreeEntry);
+	const leaf = treeEntries.at(-1);
+	if (!leaf) {
+		return [];
+	}
+
+	const entriesById = new Map(treeEntries.map((entry) => [entry.id, entry]));
+	const activePath: SessionTreeEntry[] = [];
+	const seen = new Set<string>();
+	let current: SessionTreeEntry | undefined = leaf;
+
+	while (current && !seen.has(current.id)) {
+		activePath.unshift(current);
+		seen.add(current.id);
+		if (!current.parentId || current.parentId === current.id) {
+			break;
+		}
+		current = entriesById.get(current.parentId);
+	}
+
+	let compactionIndex = -1;
+	for (let index = activePath.length - 1; index >= 0; index -= 1) {
+		if (activePath[index]?.type === "compaction") {
+			compactionIndex = index;
+			break;
+		}
+	}
+	if (compactionIndex === -1) {
+		return activePath;
+	}
+	const compaction = activePath[compactionIndex]!;
+	if (compaction.type !== "compaction") {
+		return activePath;
+	}
+	const firstKeptIndex = activePath.findIndex(
+		(entry, index) =>
+			index < compactionIndex && entry.id === compaction.firstKeptEntryId,
+	);
+	return activePath.slice(
+		firstKeptIndex >= 0 ? firstKeptIndex : compactionIndex,
+	);
+}
+
+function parseMessagesView(value: unknown): SessionMessagesView {
+	if (value === undefined || value === null) {
+		return "notLoaded";
+	}
+	if (value === "full" || value === "summary" || value === "notLoaded") {
+		return value;
+	}
+	throw new MaestroAppServerError(-32602, "Invalid messagesView");
+}
+
+export function createMaestroAppServerSessionApi(
+	store: SessionStore,
+): MaestroAppServerSessionApi {
+	return {
+		initialize() {
+			return {
+				protocolVersion: maestroAppServerProtocolVersion,
+				serverInfo: {
+					name: "maestro",
+				},
+				capabilities: {
+					sessions: true,
+					threadList: true,
+					threadRead: true,
+					turnsList: true,
+				},
+			};
+		},
+
+		async listThreads(params = {}) {
+			const limit = normalizeLimit(params.limit);
+			const offset = decodeCursor(params.cursor);
+			const metadata = store.loadAllSessions();
+			if (metadata.length === 0) {
+				const summaries = await store.listSessions({
+					limit: limit + 1,
+					offset,
+				});
+				const page = summaries.slice(0, limit);
+				return {
+					threads: page.map(toThreadSummaryFromSessionSummary),
+					nextCursor:
+						summaries.length > limit ? encodeCursor(offset + limit) : null,
+				};
+			}
+			const page = metadata.slice(offset, offset + limit);
+			const nextOffset = offset + page.length;
+			return {
+				threads: page.map((session) => toThreadSummary(session)),
+				nextCursor:
+					nextOffset < metadata.length ? encodeCursor(nextOffset) : null,
+			};
+		},
+
+		async readThread(params = {}) {
+			const threadId = requireThreadId(params);
+			const includeTurns = params.includeTurns === true;
+			const messagesView = parseMessagesView(params.messagesView);
+			const loaded = await store.loadSession(threadId, { messagesView });
+			if (!loaded) {
+				throw new MaestroAppServerError(-32004, "Thread not found");
+			}
+			const thread: MaestroAppServerThread = {
+				...toThreadSummaryFromLoadedSession(loaded),
+				messagesView: loaded.messagesView,
+			};
+			const sessionFile = store.getSessionFileById(threadId);
+			if (sessionFile && !sessionFile.startsWith("db:")) {
+				thread.path = sessionFile;
+			}
+			if (includeTurns) {
+				thread.turns = await loadTurnsForThread(store, threadId);
+			}
+			return thread;
+		},
+
+		async listTurns(params = {}) {
+			const threadId = requireThreadId(params);
+			const limit = normalizeLimit(params.limit);
+			const offset = decodeCursor(params.cursor);
+			const turns = await loadTurnsForThread(store, threadId);
+			const page = turns.slice(offset, offset + limit);
+			const nextOffset = offset + page.length;
+			return {
+				threadId,
+				turns: page,
+				nextCursor: nextOffset < turns.length ? encodeCursor(nextOffset) : null,
+			};
+		},
+	};
+}
+
+async function loadTurnsForThread(
+	store: SessionStore,
+	threadId: string,
+): Promise<MaestroAppServerTurn[]> {
+	if (store.loadEntries) {
+		const entries = await store.loadEntries(threadId);
+		if (entries) {
+			return buildTurnsFromSessionEntries(entries);
+		}
+	}
+	const sessionFile = store.getSessionFileById(threadId);
+	if (!sessionFile || sessionFile.startsWith("db:")) {
+		throw new MaestroAppServerError(-32004, "Thread not found");
+	}
+	return buildTurnsFromSessionEntries(safeReadSessionEntries(sessionFile));
+}
+
+function isSupportedMethod(
+	method: string,
+): method is (typeof maestroAppServerClientMethods)[number] {
+	return maestroAppServerClientMethods.includes(
+		method as (typeof maestroAppServerClientMethods)[number],
+	);
+}
+
+export async function handleMaestroAppServerRequest(
+	api: MaestroAppServerSessionApi,
+	request: MaestroAppServerClientRequest,
+): Promise<MaestroAppServerResponse> {
+	const id = request.id as JsonRpcId;
+	try {
+		if (!isSupportedMethod(request.method)) {
+			throw new MaestroAppServerError(-32601, "Method not found");
+		}
+
+		switch (request.method) {
+			case "initialize":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: api.initialize(),
+				};
+			case "thread/list":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.listThreads(request.params),
+				};
+			case "thread/read":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: {
+						thread: await api.readThread(request.params),
+					},
+				};
+			case "thread/turns/list":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.listTurns(request.params),
+				};
+			default:
+				throw new MaestroAppServerError(-32601, "Method not found");
+		}
+	} catch (error) {
+		if (error instanceof MaestroAppServerError) {
+			return {
+				jsonrpc: "2.0",
+				id,
+				error: {
+					code: error.code,
+					message: error.message,
+				},
+			};
+		}
+		return {
+			jsonrpc: "2.0",
+			id,
+			error: {
+				code: -32603,
+				message: error instanceof Error ? error.message : "Internal error",
+			},
+		};
+	}
+}

--- a/src/safety/execpolicy.ts
+++ b/src/safety/execpolicy.ts
@@ -37,7 +37,7 @@ import {
 	readFileSync,
 	writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join, win32 } from "node:path";
 import { PATHS } from "../config/constants.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -73,6 +73,7 @@ export interface PrefixPattern {
 export interface PrefixRule {
 	pattern: PrefixPattern;
 	decision: Decision;
+	justification?: string;
 }
 
 /**
@@ -84,6 +85,8 @@ export type RuleMatch =
 			type: "prefix";
 			matchedPrefix: string[];
 			decision: Decision;
+			justification?: string;
+			resolvedProgram?: string;
 	  }
 	| {
 			type: "heuristics";
@@ -100,15 +103,21 @@ export interface Evaluation {
 	matchedRules: RuleMatch[];
 }
 
+export interface PolicyCheckOptions {
+	resolveHostExecutables?: boolean;
+}
+
 /**
  * Policy containing multiple rules indexed by program name.
  * Based on Codex's Policy.
  */
 export class Policy {
 	private rulesByProgram: Map<string, PrefixRule[]>;
+	private hostExecutables: Map<string, Set<string>>;
 
 	constructor() {
 		this.rulesByProgram = new Map();
+		this.hostExecutables = new Map();
 	}
 
 	static empty(): Policy {
@@ -127,6 +136,7 @@ export class Policy {
 		decision: Decision,
 		match?: string[][],
 		notMatch?: string[][],
+		justification?: string,
 	): void {
 		if (prefix.length === 0) {
 			throw new Error("prefix cannot be empty");
@@ -140,7 +150,7 @@ export class Policy {
 			first,
 			rest: rest.map((t) => ({ type: "single", value: t })),
 		};
-		const rule: PrefixRule = { pattern, decision };
+		const rule: PrefixRule = { pattern, decision, justification };
 
 		// Validate match examples
 		if (match) {
@@ -165,6 +175,17 @@ export class Policy {
 		}
 
 		this.addRule(rule);
+	}
+
+	addHostExecutable(name: string, paths: string[]): void {
+		if (!name) {
+			throw new Error("host executable name cannot be empty");
+		}
+		const existing = this.hostExecutables.get(name) ?? new Set<string>();
+		for (const path of paths) {
+			existing.add(path);
+		}
+		this.hostExecutables.set(name, existing);
 	}
 
 	private ruleMatchesCommand(rule: PrefixRule, cmd: string[]): boolean {
@@ -203,17 +224,23 @@ export class Policy {
 	check(
 		cmd: string[],
 		heuristicsFallback?: (cmd: string[]) => Decision,
+		options: PolicyCheckOptions = {},
 	): Evaluation {
-		const matchedRules = this.matchesForCommand(cmd, heuristicsFallback);
+		const matchedRules = this.matchesForCommand(
+			cmd,
+			heuristicsFallback,
+			options,
+		);
 		return this.evaluationFromMatches(matchedRules);
 	}
 
 	checkMultiple(
 		commands: string[][],
 		heuristicsFallback?: (cmd: string[]) => Decision,
+		options: PolicyCheckOptions = {},
 	): Evaluation {
 		const matchedRules = commands.flatMap((cmd) =>
-			this.matchesForCommand(cmd, heuristicsFallback),
+			this.matchesForCommand(cmd, heuristicsFallback, options),
 		);
 		return this.evaluationFromMatches(matchedRules);
 	}
@@ -221,23 +248,38 @@ export class Policy {
 	private matchesForCommand(
 		cmd: string[],
 		heuristicsFallback?: (cmd: string[]) => Decision,
+		options: PolicyCheckOptions = {},
 	): RuleMatch[] {
 		const program = cmd[0];
 		if (!program) {
 			return [];
 		}
 
-		const rules = this.rulesByProgram.get(program) ?? [];
+		const exactRules = this.rulesByProgram.get(program) ?? [];
 
-		const matched: RuleMatch[] = [];
-		for (const rule of rules) {
-			const matchedPrefix = this.matchPrefix(rule.pattern, cmd);
-			if (matchedPrefix) {
-				matched.push({
-					type: "prefix",
-					matchedPrefix,
-					decision: rule.decision,
-				});
+		const matched = this.collectPrefixMatches(exactRules, cmd);
+		if (
+			matched.length === 0 &&
+			options.resolveHostExecutables &&
+			isPathLikeProgram(program)
+		) {
+			const resolvedProgram = program;
+			for (const fallbackProgram of this.hostExecutableFallbackPrograms(
+				resolvedProgram,
+			)) {
+				const fallbackRules = this.rulesByProgram.get(fallbackProgram) ?? [];
+				if (
+					fallbackRules.length > 0 &&
+					this.canUseHostExecutableFallback(fallbackProgram, resolvedProgram)
+				) {
+					matched.push(
+						...this.collectPrefixMatches(
+							fallbackRules,
+							[fallbackProgram, ...cmd.slice(1)],
+							resolvedProgram,
+						),
+					);
+				}
 			}
 		}
 
@@ -250,6 +292,47 @@ export class Policy {
 		}
 
 		return matched;
+	}
+
+	private hostExecutableFallbackPrograms(resolvedProgram: string): string[] {
+		const programs = new Set<string>();
+		for (const [name, paths] of this.hostExecutables) {
+			if (paths.has(resolvedProgram)) {
+				programs.add(name);
+			}
+		}
+		programs.add(hostExecutableBasename(resolvedProgram));
+		return [...programs];
+	}
+
+	private collectPrefixMatches(
+		rules: PrefixRule[],
+		cmd: string[],
+		resolvedProgram?: string,
+	): RuleMatch[] {
+		const matched: RuleMatch[] = [];
+		for (const rule of rules) {
+			const matchedPrefix = this.matchPrefix(rule.pattern, cmd);
+			if (matchedPrefix) {
+				matched.push({
+					type: "prefix",
+					matchedPrefix,
+					decision: rule.decision,
+					justification: rule.justification,
+					resolvedProgram,
+				});
+			}
+		}
+
+		return matched;
+	}
+
+	private canUseHostExecutableFallback(
+		name: string,
+		resolvedProgram: string,
+	): boolean {
+		const allowedPaths = this.hostExecutables.get(name);
+		return allowedPaths?.has(resolvedProgram) === true;
 	}
 
 	private evaluationFromMatches(matchedRules: RuleMatch[]): Evaluation {
@@ -274,6 +357,10 @@ export class Policy {
 	get rules(): Map<string, PrefixRule[]> {
 		return this.rulesByProgram;
 	}
+
+	get hostExecutablePaths(): Map<string, Set<string>> {
+		return this.hostExecutables;
+	}
 }
 
 /**
@@ -283,9 +370,25 @@ export class Policy {
 export function parsePolicy(content: string, identifier: string): Policy {
 	const policy = new Policy();
 
+	const hostExecutableRegex =
+		/host_executable\s*\(\s*([\s\S]*?)\s*\)\s*(?:,?\s*(?=host_executable|prefix_rule|$))/g;
+	for (const match of content.matchAll(hostExecutableRegex)) {
+		const args = match[1];
+		if (!args) continue;
+		try {
+			const parsed = parseHostExecutableArgs(args);
+			policy.addHostExecutable(parsed.name, parsed.paths);
+		} catch (error) {
+			logger.warn(`Failed to parse host executable in ${identifier}`, {
+				error: error instanceof Error ? error.message : String(error),
+				args: args.slice(0, 100),
+			});
+		}
+	}
+
 	// Simple regex-based parser for prefix_rule calls
 	const ruleRegex =
-		/prefix_rule\s*\(\s*([\s\S]*?)\s*\)\s*(?:,?\s*(?=prefix_rule|$))/g;
+		/prefix_rule\s*\(\s*([\s\S]*?)\s*\)\s*(?:,?\s*(?=host_executable|prefix_rule|$))/g;
 
 	for (const match of content.matchAll(ruleRegex)) {
 		const args = match[1];
@@ -317,6 +420,7 @@ export function parsePolicy(content: string, identifier: string): Policy {
 				const rule: PrefixRule = {
 					pattern: { ...pattern, first: firstAlt },
 					decision: parsed.decision,
+					justification: parsed.justification,
 				};
 
 				// Validate match examples
@@ -395,6 +499,7 @@ function matchesPrefix(pattern: PrefixPattern, cmd: string[]): boolean {
 interface ParsedPrefixRule {
 	pattern: (string | string[])[];
 	decision: Decision;
+	justification?: string;
 	match: string[][];
 	notMatch: string[][];
 }
@@ -422,6 +527,11 @@ function parsePrefixRuleArgs(args: string): ParsedPrefixRule {
 		}
 	}
 
+	const justification = parseNamedStringArg(args, "justification");
+	if (justification) {
+		result.justification = justification;
+	}
+
 	// Parse match=...
 	const matchMatch = args.match(/(?<![_])match\s*=\s*(\[[\s\S]*?\](?:\s*,)?)/);
 	if (matchMatch?.[1]) {
@@ -439,6 +549,46 @@ function parsePrefixRuleArgs(args: string): ParsedPrefixRule {
 	}
 
 	return result;
+}
+
+interface ParsedHostExecutable {
+	name: string;
+	paths: string[];
+}
+
+function parseHostExecutableArgs(args: string): ParsedHostExecutable {
+	const name = parseNamedStringArg(args, "name");
+	if (!name) {
+		throw new Error("host_executable name is required");
+	}
+
+	const pathsMatch = args.match(/paths\s*=\s*(\[[\s\S]*?\])/);
+	const paths = pathsMatch?.[1] ? parseStringArray(pathsMatch[1]) : [];
+	return {
+		name,
+		paths,
+	};
+}
+
+function parseNamedStringArg(args: string, name: string): string | undefined {
+	const doubleQuoted = new RegExp(
+		`${name}\\s*=\\s*"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"`,
+	).exec(args);
+	if (doubleQuoted?.[1] !== undefined) {
+		return unescapePolicyString(doubleQuoted[1]);
+	}
+
+	const singleQuoted = new RegExp(
+		`${name}\\s*=\\s*'([^'\\\\]*(?:\\\\.[^'\\\\]*)*)'`,
+	).exec(args);
+	if (singleQuoted?.[1] !== undefined) {
+		return unescapePolicyString(singleQuoted[1]);
+	}
+	return undefined;
+}
+
+function unescapePolicyString(value: string): string {
+	return value.replace(/\\(["'\\])/g, "$1");
 }
 
 function parsePatternArray(str: string): (string | string[])[] {
@@ -560,11 +710,12 @@ function parseExamplesArray(str: string): string[][] {
 				i++;
 			}
 			i++;
-			// Simple shell-like split
-			const tokens = value.split(/\s+/).filter(Boolean);
+			const tokens = parseCommand(value);
 			if (tokens.length > 0) {
 				result.push(tokens);
 			}
+		} else {
+			i++;
 		}
 	}
 
@@ -601,6 +752,9 @@ export function loadPolicy(workspaceDir: string): Policy {
 					policy.addRule(rule);
 				}
 			}
+			for (const [name, paths] of parsed.hostExecutablePaths) {
+				policy.addHostExecutable(name, [...paths]);
+			}
 			logger.debug("Loaded global execpolicy", { path: globalPath });
 		} catch (error) {
 			logger.warn("Failed to load global execpolicy", {
@@ -618,6 +772,9 @@ export function loadPolicy(workspaceDir: string): Policy {
 				for (const rule of rules) {
 					policy.addRule(rule);
 				}
+			}
+			for (const [name, paths] of parsed.hostExecutablePaths) {
+				policy.addHostExecutable(name, [...paths]);
 			}
 			logger.debug("Loaded project execpolicy", { path: projectPath });
 		} catch (error) {
@@ -690,17 +847,19 @@ export function parseCommand(command: string): string[] {
 	let current = "";
 	let inQuotes = false;
 	let quoteChar = "";
-	let isEscaped = false;
 
-	for (const char of command) {
-		if (isEscaped) {
-			current += char;
-			isEscaped = false;
-			continue;
-		}
-
+	for (let i = 0; i < command.length; i++) {
+		const char = command.charAt(i);
 		if (char === "\\") {
-			isEscaped = true;
+			const nextChar = command.charAt(i + 1);
+			if (shouldEscapeBackslash(nextChar, inQuotes, quoteChar)) {
+				if (nextChar !== "\n") {
+					current += nextChar;
+				}
+				i++;
+			} else {
+				current += char;
+			}
 			continue;
 		}
 
@@ -734,6 +893,37 @@ export function parseCommand(command: string): string[] {
 	return tokens;
 }
 
+function isPathLikeProgram(program: string): boolean {
+	return program.includes("/") || program.includes("\\");
+}
+
+function hostExecutableBasename(program: string): string {
+	return program.includes("\\") ? win32.basename(program) : basename(program);
+}
+
+function shouldEscapeBackslash(
+	nextChar: string,
+	inQuotes: boolean,
+	quoteChar: string,
+): boolean {
+	if (!nextChar) {
+		return false;
+	}
+	if (!inQuotes) {
+		return true;
+	}
+	if (quoteChar === "'") {
+		return false;
+	}
+	return (
+		nextChar === quoteChar ||
+		nextChar === "\\" ||
+		nextChar === "\n" ||
+		nextChar === "$" ||
+		nextChar === "`"
+	);
+}
+
 /**
  * Check a command and return the evaluation result.
  */
@@ -744,7 +934,9 @@ export function checkCommand(
 ): Evaluation {
 	const policy = loadPolicy(workspaceDir);
 	const tokens = parseCommand(command);
-	return policy.check(tokens, heuristicsFallback);
+	return policy.check(tokens, heuristicsFallback, {
+		resolveHostExecutables: true,
+	});
 }
 
 /**

--- a/src/session/session-catalog.ts
+++ b/src/session/session-catalog.ts
@@ -32,6 +32,7 @@ export interface LoadedSessionData {
 	id: string;
 	subject?: string;
 	title?: string;
+	summary?: string;
 	resumeSummary?: string;
 	messages: AppMessage[];
 	createdAt: string;
@@ -84,6 +85,7 @@ export class SessionCatalog {
 						path: filePath,
 						id: info.id,
 						subject: info.subject,
+						title: info.title,
 						created: info.created,
 						modified: stats.mtime,
 						size: stats.size,
@@ -92,6 +94,7 @@ export class SessionCatalog {
 						summary: derivedSummary,
 						resumeSummary: info.resumeSummary,
 						favorite: info.favorite,
+						tags: info.tags,
 						allMessagesText: info.allMessagesText,
 					});
 				} catch (error) {
@@ -175,11 +178,13 @@ export class SessionCatalog {
 		if (!info) {
 			return null;
 		}
+		const derivedSummary = info.summary || info.firstMessage || "(no summary)";
 
 		return {
 			id: info.id,
 			subject: info.subject,
 			title: info.title ?? info.summary,
+			summary: derivedSummary,
 			resumeSummary: info.resumeSummary,
 			messages: info.messages,
 			createdAt: info.created.toISOString(),

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -146,6 +146,7 @@ export interface SessionMetadata {
 	path: string;
 	id: string;
 	subject?: string;
+	title?: string;
 	created: Date;
 	modified: Date;
 	size: number;
@@ -154,6 +155,7 @@ export interface SessionMetadata {
 	summary: string;
 	resumeSummary?: string;
 	favorite: boolean;
+	tags?: string[];
 	allMessagesText: string;
 }
 

--- a/test/app-server/in-process-client.test.ts
+++ b/test/app-server/in-process-client.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+	type MaestroAppServerClientInfo,
+	createInProcessMaestroAppServerClient,
+} from "../../src/app-server/in-process-client.js";
+import type { MaestroAppServerSessionApi } from "../../src/app-server/session-api.js";
+
+function createApi(overrides: Partial<MaestroAppServerSessionApi> = {}) {
+	const api: MaestroAppServerSessionApi = {
+		initialize: () => ({
+			protocolVersion: "maestro-app-server.v1",
+			serverInfo: { name: "maestro" },
+			capabilities: {
+				sessions: true,
+				threadList: true,
+				threadRead: true,
+				turnsList: true,
+			},
+		}),
+		listThreads: async () => ({ threads: [], nextCursor: null }),
+		readThread: async () => {
+			throw new Error("not implemented");
+		},
+		listTurns: async () => ({
+			threadId: "thread",
+			turns: [],
+			nextCursor: null,
+		}),
+		...overrides,
+	};
+	return api;
+}
+
+const clientInfo: MaestroAppServerClientInfo = {
+	name: "maestro_test",
+	title: "Maestro Test",
+	version: "0.0.0",
+};
+
+describe("in-process Maestro app-server client", () => {
+	it("requires initialize before regular requests and rejects duplicate initialize", async () => {
+		const client = createInProcessMaestroAppServerClient(createApi(), {
+			clientInfo,
+		});
+
+		await expect(client.request("thread/list")).rejects.toMatchObject({
+			code: -32000,
+			message: "Not initialized",
+		});
+
+		await expect(client.initialize()).resolves.toMatchObject({
+			protocolVersion: "maestro-app-server.v1",
+		});
+
+		await expect(client.initialize()).rejects.toMatchObject({
+			code: -32000,
+			message: "Already initialized",
+		});
+		await expect(client.request("thread/list")).resolves.toMatchObject({
+			threads: [],
+			nextCursor: null,
+		});
+	});
+
+	it("rejects concurrent initialize calls", async () => {
+		const client = createInProcessMaestroAppServerClient(createApi(), {
+			clientInfo,
+		});
+
+		const first = client.initialize();
+		await expect(client.initialize()).rejects.toMatchObject({
+			code: -32000,
+			message: "Already initialized",
+		});
+		await expect(first).resolves.toMatchObject({
+			protocolVersion: "maestro-app-server.v1",
+		});
+	});
+
+	it("returns explicit overload errors when the in-process request queue is saturated", async () => {
+		let releaseList: (() => void) | undefined;
+		const client = createInProcessMaestroAppServerClient(
+			createApi({
+				listThreads: async () => {
+					await new Promise<void>((resolve) => {
+						releaseList = resolve;
+					});
+					return { threads: [], nextCursor: null };
+				},
+			}),
+			{ clientInfo, maxPendingRequests: 1 },
+		);
+		await client.initialize();
+
+		const first = client.request("thread/list");
+		const second = client.request("thread/list");
+
+		await expect(second).rejects.toMatchObject({
+			code: -32001,
+			message: "Server overloaded; retry later.",
+		});
+		releaseList?.();
+		await expect(first).resolves.toMatchObject({
+			threads: [],
+			nextCursor: null,
+		});
+	});
+});

--- a/test/app-server/session-api.test.ts
+++ b/test/app-server/session-api.test.ts
@@ -1,0 +1,742 @@
+import {
+	existsSync,
+	mkdirSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { Value } from "@sinclair/typebox/value";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	MaestroAppServerResponseSchema,
+	maestroAppServerProtocolVersion,
+} from "../../packages/contracts/src/maestro-app-server.js";
+import type { AgentState } from "../../src/agent/types.js";
+import {
+	buildTurnsFromSessionEntries,
+	createMaestroAppServerSessionApi,
+	handleMaestroAppServerRequest,
+} from "../../src/app-server/session-api.js";
+import { SessionManager } from "../../src/session/manager.js";
+import type { SessionEntry } from "../../src/session/types.js";
+
+function createMockState(): AgentState {
+	return {
+		steeringMode: "all",
+		followUpMode: "all",
+		queueMode: "all",
+		messages: [],
+		systemPrompt: "test system prompt",
+		model: {
+			provider: "anthropic",
+			id: "claude-sonnet-4",
+			contextWindow: 200000,
+			name: "Claude Sonnet 4",
+			api: "anthropic-messages",
+			baseUrl: "https://api.anthropic.com/v1/messages",
+			reasoning: false,
+			input: ["text", "image"],
+			cost: {
+				input: 0.003,
+				output: 0.015,
+				cacheRead: 0.0003,
+				cacheWrite: 0.00375,
+			},
+			maxTokens: 8192,
+		},
+		tools: [],
+		thinkingLevel: "off",
+		isStreaming: false,
+		streamMessage: null,
+		pendingToolCalls: new Map(),
+	};
+}
+
+function createUserMessage(text: string, timestamp = Date.now()) {
+	return {
+		role: "user" as const,
+		content: [{ type: "text" as const, text }],
+		timestamp,
+	};
+}
+
+function createAssistantMessage(text: string, timestamp = Date.now()) {
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: "anthropic-messages" as const,
+		provider: "anthropic",
+		model: "claude-sonnet-4",
+		stopReason: "stop" as const,
+		timestamp,
+		usage: {
+			input: 100,
+			output: 50,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	};
+}
+
+describe("Maestro app-server session API", () => {
+	let testDir: string;
+	const managers: SessionManager[] = [];
+
+	beforeEach(() => {
+		testDir = join(tmpdir(), `maestro-app-server-test-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		for (const manager of managers) {
+			manager.disable();
+		}
+		managers.length = 0;
+
+		if (existsSync(testDir)) {
+			rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
+	function createSessionManager(customSessionPath?: string): SessionManager {
+		const manager = new SessionManager(false, customSessionPath, {
+			sessionDir: testDir,
+		});
+		managers.push(manager);
+		return manager;
+	}
+
+	async function createPersistedSession(
+		prompt: string,
+		options: {
+			title?: string;
+			summary?: string;
+			modifiedAt?: Date;
+			resumeSummary?: string;
+			tags?: string[];
+			secondPrompt?: string;
+		} = {},
+	) {
+		const manager = createSessionManager();
+
+		const state = createMockState();
+		const firstUser = createUserMessage(prompt, 1);
+		state.messages.push(firstUser);
+		manager.saveMessage(firstUser);
+		manager.startSession(state);
+		manager.saveMessage(createAssistantMessage(`${prompt} ack`, 2));
+		if (options.secondPrompt) {
+			manager.saveMessage(createUserMessage(options.secondPrompt, 3));
+			manager.saveMessage(
+				createAssistantMessage(`${options.secondPrompt} ack`, 4),
+			);
+		}
+		await manager.flush();
+
+		const sessionFile = manager.getSessionFile();
+		if (options.title) {
+			manager.setSessionTitle(sessionFile, options.title);
+		}
+		if (options.summary) {
+			manager.saveSessionSummary(options.summary, sessionFile);
+		}
+		if (options.resumeSummary) {
+			manager.saveSessionResumeSummary(options.resumeSummary, sessionFile);
+		}
+		if (options.tags) {
+			manager.setSessionTags(sessionFile, options.tags);
+		}
+		if (
+			options.title ||
+			options.summary ||
+			options.resumeSummary ||
+			options.tags
+		) {
+			await manager.flush();
+		}
+		if (options.modifiedAt) {
+			utimesSync(sessionFile, options.modifiedAt, options.modifiedAt);
+		}
+
+		return {
+			id: manager.getSessionId(),
+			sessionFile,
+			sessionDir: dirname(sessionFile),
+		};
+	}
+
+	it("initializes with protocol metadata and validates the shared response schema", async () => {
+		const api = createMaestroAppServerSessionApi(createSessionManager());
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: 1,
+			method: "initialize",
+			params: {
+				clientInfo: {
+					name: "maestro_test",
+					title: "Maestro Test",
+					version: "0.0.0",
+				},
+			},
+		});
+
+		expect(response.result).toMatchObject({
+			protocolVersion: maestroAppServerProtocolVersion,
+			serverInfo: { name: "maestro" },
+			capabilities: {
+				sessions: true,
+				threadList: true,
+				threadRead: true,
+				turnsList: true,
+			},
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, response)).toBe(true);
+	});
+
+	it("lists persisted sessions as not-loaded threads with cursor pagination", async () => {
+		const oldest = await createPersistedSession("older prompt", {
+			modifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+			title: "Older",
+		});
+		const newest = await createPersistedSession("newer prompt", {
+			modifiedAt: new Date("2026-01-02T00:00:00.000Z"),
+			title: "Newer",
+			resumeSummary: "newer resume",
+		});
+		const manager = createSessionManager(newest.sessionFile);
+		manager.listSessions = async () => {
+			throw new Error(
+				"file-backed thread/list should use loaded metadata only",
+			);
+		};
+		const api = createMaestroAppServerSessionApi(manager);
+
+		const firstPage = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "list-1",
+			method: "thread/list",
+			params: { limit: 1 },
+		});
+
+		expect(firstPage.result).toMatchObject({
+			threads: [
+				{
+					id: newest.id,
+					title: "Newer",
+					resumeSummary: "newer resume",
+					status: "notLoaded",
+					source: "session",
+				},
+			],
+		});
+		expect(firstPage.result).toHaveProperty("nextCursor");
+		expect(Value.Check(MaestroAppServerResponseSchema, firstPage)).toBe(true);
+
+		const secondPage = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "list-2",
+			method: "thread/list",
+			params: { limit: 1, cursor: firstPage.result?.nextCursor },
+		});
+
+		expect(secondPage.result).toMatchObject({
+			threads: [
+				{
+					id: oldest.id,
+					title: "Older",
+					status: "notLoaded",
+					source: "session",
+				},
+			],
+			nextCursor: null,
+		});
+	});
+
+	it("keeps file-backed page summaries aligned when unreadable files sort before the cursor", async () => {
+		const older = await createPersistedSession("older prompt", {
+			modifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+			title: "Older title",
+			resumeSummary: "older resume",
+			tags: ["older-page"],
+		});
+		const newer = await createPersistedSession("newer prompt", {
+			modifiedAt: new Date("2026-01-02T00:00:00.000Z"),
+			title: "Newer title",
+		});
+		const unreadableBeforeCursor = join(testDir, "unreadable-newest.jsonl");
+		writeFileSync(unreadableBeforeCursor, "not-json\n");
+		utimesSync(
+			unreadableBeforeCursor,
+			new Date("2026-01-03T00:00:00.000Z"),
+			new Date("2026-01-03T00:00:00.000Z"),
+		);
+
+		const manager = createSessionManager(newer.sessionFile);
+		manager.listSessions = async () => {
+			throw new Error(
+				"file-backed thread/list must not join paged summaries by raw file offset",
+			);
+		};
+		const api = createMaestroAppServerSessionApi(manager);
+
+		const firstPage = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "unreadable-list-1",
+			method: "thread/list",
+			params: { limit: 1 },
+		});
+
+		expect(firstPage.result).toMatchObject({
+			threads: [{ id: newer.id, title: "Newer title" }],
+			nextCursor: expect.any(String),
+		});
+
+		const secondPage = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "unreadable-list-2",
+			method: "thread/list",
+			params: { limit: 1, cursor: firstPage.result?.nextCursor },
+		});
+
+		expect(secondPage.result).toMatchObject({
+			threads: [
+				{
+					id: older.id,
+					title: "Older title",
+					resumeSummary: "older resume",
+					tags: ["older-page"],
+				},
+			],
+			nextCursor: null,
+		});
+	});
+
+	it("lists hosted session summaries when file-backed metadata is unavailable", async () => {
+		const summaries = [
+			{
+				id: "hosted-newer",
+				subject: "Hosted Subject",
+				resumeSummary: "hosted resume",
+				createdAt: "2026-01-02T00:00:00.000Z",
+				updatedAt: "2026-01-02T00:01:00.000Z",
+				messageCount: 4,
+				favorite: false,
+				tags: ["hosted"],
+			},
+			{
+				id: "hosted-older",
+				title: "Hosted Older",
+				createdAt: "2026-01-01T00:00:00.000Z",
+				updatedAt: "2026-01-01T00:01:00.000Z",
+				messageCount: 2,
+				favorite: true,
+			},
+		];
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async (options?: { limit?: number; offset?: number }) =>
+				summaries.slice(
+					options?.offset ?? 0,
+					(options?.offset ?? 0) + (options?.limit ?? summaries.length),
+				),
+			loadSession: async () => null,
+			getSessionFileById: () => null,
+		});
+
+		const firstPage = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "hosted-list-1",
+			method: "thread/list",
+			params: { limit: 1 },
+		});
+
+		expect(firstPage.result).toMatchObject({
+			threads: [
+				{
+					id: "hosted-newer",
+					title: "Hosted Subject",
+					summary: "Hosted Subject",
+					subject: "Hosted Subject",
+					resumeSummary: "hosted resume",
+					status: "notLoaded",
+					source: "session",
+					tags: ["hosted"],
+				},
+			],
+			nextCursor: expect.any(String),
+		});
+
+		const secondPage = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "hosted-list-2",
+			method: "thread/list",
+			params: { limit: 1, cursor: firstPage.result?.nextCursor },
+		});
+
+		expect(secondPage.result).toMatchObject({
+			threads: [{ id: "hosted-older", favorite: true }],
+			nextCursor: null,
+		});
+	});
+
+	it("reads a thread and includes Codex-style turns only when requested", async () => {
+		const session = await createPersistedSession("first prompt", {
+			title: "Custom title",
+			summary: "Persisted runtime summary",
+			secondPrompt: "follow up",
+		});
+		const api = createMaestroAppServerSessionApi(
+			createSessionManager(session.sessionFile),
+		);
+
+		const summary = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "read-summary",
+			method: "thread/read",
+			params: { threadId: session.id },
+		});
+
+		expect(summary.result).toMatchObject({
+			thread: {
+				id: session.id,
+				status: "notLoaded",
+				title: "Custom title",
+				summary: "Persisted runtime summary",
+				messagesView: "notLoaded",
+				path: session.sessionFile,
+			},
+		});
+		expect(summary.result?.thread).not.toHaveProperty("turns");
+
+		const full = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "read-full",
+			method: "thread/read",
+			params: { threadId: session.id, includeTurns: true },
+		});
+
+		expect(full.result?.thread.turns).toHaveLength(2);
+		expect(full.result?.thread.turns?.[0]).toMatchObject({
+			status: "completed",
+			items: [
+				{ type: "message", role: "user" },
+				{ type: "message", role: "assistant" },
+			],
+		});
+		expect(full.result?.thread.turns?.[1]?.items[0]).toMatchObject({
+			type: "message",
+			role: "user",
+			content: [{ type: "text", text: "follow up" }],
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, full)).toBe(true);
+	});
+
+	it("pages turns without resuming the session", async () => {
+		const session = await createPersistedSession("first prompt", {
+			secondPrompt: "second prompt",
+		});
+		const api = createMaestroAppServerSessionApi(
+			createSessionManager(session.sessionFile),
+		);
+
+		const firstPage = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "turns-1",
+			method: "thread/turns/list",
+			params: { threadId: session.id, limit: 1 },
+		});
+
+		expect(firstPage.result?.turns).toHaveLength(1);
+		expect(firstPage.result?.turns[0]?.items[0]).toMatchObject({
+			role: "user",
+			content: [{ type: "text", text: "first prompt" }],
+		});
+		expect(firstPage.result?.nextCursor).toEqual(expect.any(String));
+
+		const secondPage = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "turns-2",
+			method: "thread/turns/list",
+			params: {
+				threadId: session.id,
+				limit: 1,
+				cursor: firstPage.result?.nextCursor,
+			},
+		});
+
+		expect(secondPage.result).toMatchObject({
+			threadId: session.id,
+			nextCursor: null,
+		});
+		expect(secondPage.result?.turns[0]?.items[0]).toMatchObject({
+			role: "user",
+			content: [{ type: "text", text: "second prompt" }],
+		});
+	});
+
+	it("builds turns from the active branch path only", () => {
+		const entries: SessionEntry[] = [
+			{
+				type: "session",
+				id: "branch-thread",
+				timestamp: "2026-01-01T00:00:00.000Z",
+				cwd: "/workspace",
+			},
+			{
+				type: "message",
+				id: "user-1",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:01.000Z",
+				message: createUserMessage("root prompt"),
+			},
+			{
+				type: "message",
+				id: "assistant-1",
+				parentId: "user-1",
+				timestamp: "2026-01-01T00:00:02.000Z",
+				message: createAssistantMessage("root response"),
+			},
+			{
+				type: "message",
+				id: "stale-user",
+				parentId: "assistant-1",
+				timestamp: "2026-01-01T00:00:03.000Z",
+				message: createUserMessage("stale branch prompt"),
+			},
+			{
+				type: "message",
+				id: "stale-assistant",
+				parentId: "stale-user",
+				timestamp: "2026-01-01T00:00:04.000Z",
+				message: createAssistantMessage("stale branch response"),
+			},
+			{
+				type: "message",
+				id: "active-user",
+				parentId: "assistant-1",
+				timestamp: "2026-01-01T00:00:05.000Z",
+				message: createUserMessage("active branch prompt"),
+			},
+			{
+				type: "message",
+				id: "active-assistant",
+				parentId: "active-user",
+				timestamp: "2026-01-01T00:00:06.000Z",
+				message: createAssistantMessage("active branch response"),
+			},
+		];
+
+		const turns = buildTurnsFromSessionEntries(entries);
+
+		expect(turns).toHaveLength(2);
+		expect(turns.map((turn) => turn.items[0]?.id)).toEqual([
+			"user-1",
+			"active-user",
+		]);
+		expect(JSON.stringify(turns)).not.toContain("stale branch");
+	});
+
+	it("respects compaction cut points when building turns", () => {
+		const entries: SessionEntry[] = [
+			{
+				type: "session",
+				id: "compacted-thread",
+				timestamp: "2026-01-01T00:00:00.000Z",
+				cwd: "/workspace",
+			},
+			{
+				type: "message",
+				id: "old-user",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:01.000Z",
+				message: createUserMessage("old prompt"),
+			},
+			{
+				type: "message",
+				id: "old-assistant",
+				parentId: "old-user",
+				timestamp: "2026-01-01T00:00:02.000Z",
+				message: createAssistantMessage("old response"),
+			},
+			{
+				type: "message",
+				id: "kept-user",
+				parentId: "old-assistant",
+				timestamp: "2026-01-01T00:00:03.000Z",
+				message: createUserMessage("kept prompt"),
+			},
+			{
+				type: "message",
+				id: "kept-assistant",
+				parentId: "kept-user",
+				timestamp: "2026-01-01T00:00:04.000Z",
+				message: createAssistantMessage("kept response"),
+			},
+			{
+				type: "compaction",
+				id: "compact-1",
+				parentId: "kept-assistant",
+				timestamp: "2026-01-01T00:00:05.000Z",
+				summary: "Compacted earlier work",
+				firstKeptEntryId: "kept-user",
+				tokensBefore: 1200,
+			},
+			{
+				type: "message",
+				id: "new-user",
+				parentId: "compact-1",
+				timestamp: "2026-01-01T00:00:06.000Z",
+				message: createUserMessage("new prompt"),
+			},
+		];
+
+		const turns = buildTurnsFromSessionEntries(entries);
+
+		expect(turns.map((turn) => turn.items[0]?.id)).toEqual([
+			"kept-user",
+			"new-user",
+		]);
+		expect(JSON.stringify(turns)).not.toContain("old prompt");
+	});
+
+	it("normalizes legacy sessions before building turns", () => {
+		const entries = [
+			{
+				type: "session",
+				id: "legacy-thread",
+				version: 1,
+				timestamp: "2026-01-01T00:00:00.000Z",
+				cwd: "/workspace",
+			},
+			{
+				type: "message",
+				timestamp: "2026-01-01T00:00:01.000Z",
+				message: createUserMessage("legacy prompt"),
+			},
+			{
+				type: "message",
+				timestamp: "2026-01-01T00:00:02.000Z",
+				message: createAssistantMessage("legacy response"),
+			},
+		] as unknown as SessionEntry[];
+
+		const turns = buildTurnsFromSessionEntries(entries);
+
+		expect(turns).toHaveLength(1);
+		expect(turns[0]?.items.map((item) => item.role)).toEqual([
+			"user",
+			"assistant",
+		]);
+	});
+
+	it("reads hosted turns from the session entry store instead of file paths", async () => {
+		const entries: SessionEntry[] = [
+			{
+				type: "session",
+				id: "hosted-thread",
+				timestamp: "2026-01-01T00:00:00.000Z",
+				cwd: "/workspace",
+			},
+			{
+				type: "message",
+				id: "user-1",
+				parentId: null,
+				timestamp: "2026-01-01T00:00:01.000Z",
+				message: createUserMessage("hosted prompt"),
+			},
+			{
+				type: "message",
+				id: "assistant-1",
+				parentId: "user-1",
+				timestamp: "2026-01-01T00:00:02.000Z",
+				message: createAssistantMessage("hosted response"),
+			},
+		];
+		let requestedMessagesView: unknown;
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async () => {
+				throw new Error("thread/read should not list every hosted session");
+			},
+			loadSession: async (sessionId, options = {}) => {
+				requestedMessagesView = options.messagesView;
+				return sessionId === "hosted-thread"
+					? {
+							id: sessionId,
+							subject: "Hosted Thread",
+							messages: [],
+							createdAt: "2026-01-01T00:00:00.000Z",
+							updatedAt: "2026-01-01T00:00:02.000Z",
+							messageCount: 2,
+							favorite: false,
+							messagesView: options.messagesView ?? "full",
+						}
+					: null;
+			},
+			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			loadEntries: async (sessionId) =>
+				sessionId === "hosted-thread" ? entries : null,
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "hosted-read",
+			method: "thread/read",
+			params: { threadId: "hosted-thread", includeTurns: true },
+		});
+
+		expect(requestedMessagesView).toBe("notLoaded");
+		expect(response.result).toMatchObject({
+			thread: {
+				id: "hosted-thread",
+				title: "Hosted Thread",
+				summary: "Hosted Thread",
+				subject: "Hosted Thread",
+				turns: [
+					{
+						items: [
+							{
+								role: "user",
+								content: [{ type: "text", text: "hosted prompt" }],
+							},
+							{
+								role: "assistant",
+								content: [{ type: "text", text: "hosted response" }],
+							},
+						],
+					},
+				],
+			},
+		});
+	});
+
+	it("returns JSON-RPC errors for unknown methods and missing threads", async () => {
+		const api = createMaestroAppServerSessionApi(createSessionManager());
+
+		const unknown = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "bad-method",
+			method: "thread/delete",
+			params: {},
+		});
+		expect(unknown).toMatchObject({
+			id: "bad-method",
+			error: { code: -32601, message: "Method not found" },
+		});
+
+		const missing = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "missing-thread",
+			method: "thread/read",
+			params: { threadId: "missing" },
+		});
+		expect(missing).toMatchObject({
+			id: "missing-thread",
+			error: { code: -32004, message: "Thread not found" },
+		});
+	});
+});

--- a/test/safety/execpolicy.test.ts
+++ b/test/safety/execpolicy.test.ts
@@ -1,15 +1,42 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	Policy,
+	checkCommand,
 	clearPolicyCache,
 	parseCommand,
 	parsePolicy,
 } from "../../src/safety/execpolicy.js";
 
 describe("execpolicy", () => {
+	const tempDirs: string[] = [];
+
 	beforeEach(() => {
 		clearPolicyCache();
 	});
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			if (existsSync(dir)) {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		}
+		clearPolicyCache();
+	});
+
+	function createWorkspacePolicy(content: string): string {
+		const workspaceDir = join(
+			tmpdir(),
+			`maestro-execpolicy-test-${Date.now()}-${tempDirs.length}`,
+		);
+		const policyDir = join(workspaceDir, ".maestro");
+		mkdirSync(policyDir, { recursive: true });
+		writeFileSync(join(policyDir, "execpolicy"), content);
+		tempDirs.push(workspaceDir);
+		return workspaceDir;
+	}
 
 	describe("parseCommand", () => {
 		it("parses simple commands", () => {
@@ -35,6 +62,27 @@ describe("execpolicy", () => {
 			]);
 		});
 
+		it("preserves shell semantics for unquoted backslash escapes", () => {
+			expect(parseCommand("r\\m -rf /")).toEqual(["rm", "-rf", "/"]);
+		});
+
+		it("removes escaped newlines inside double-quoted command tokens", () => {
+			expect(parseCommand('"r\\\nm" -rf /')).toEqual(["rm", "-rf", "/"]);
+		});
+
+		it("preserves Windows path separators inside quoted executable paths", () => {
+			expect(
+				parseCommand(
+					String.raw`"C:\Program Files\Git\bin\git.exe" push origin main`,
+				),
+			).toEqual([
+				String.raw`C:\Program Files\Git\bin\git.exe`,
+				"push",
+				"origin",
+				"main",
+			]);
+		});
+
 		it("handles empty input", () => {
 			expect(parseCommand("")).toEqual([]);
 			expect(parseCommand("   ")).toEqual([]);
@@ -57,6 +105,23 @@ describe("execpolicy", () => {
 
 			const result = policy.check(["git", "push", "origin", "main"]);
 			expect(result.decision).toBe("prompt");
+		});
+
+		it("surfaces rule justifications in matched prefix rules", () => {
+			const policy = new Policy();
+			policy.addPrefixRule(
+				["rm", "-rf"],
+				"forbidden",
+				undefined,
+				undefined,
+				"Use a targeted path or trash command instead.",
+			);
+
+			const result = policy.check(["rm", "-rf", "dist"]);
+			expect(result.matchedRules[0]).toMatchObject({
+				type: "prefix",
+				justification: "Use a targeted path or trash command instead.",
+			});
 		});
 
 		it("forbids commands matching forbidden rules", () => {
@@ -112,6 +177,23 @@ prefix_rule(
 			expect(policy.check(["git", "pull"]).matchedRules).toHaveLength(0);
 		});
 
+		it("parses justification for prompt and forbidden decisions", () => {
+			const content = `
+prefix_rule(
+    pattern=["git", "push"],
+    decision="prompt",
+    justification="Pushing changes is externally visible.",
+)
+`;
+			const policy = parsePolicy(content, "test");
+			expect(
+				policy.check(["git", "push", "origin", "main"]).matchedRules[0],
+			).toMatchObject({
+				type: "prefix",
+				justification: "Pushing changes is externally visible.",
+			});
+		});
+
 		it("parses multiple rules", () => {
 			const content = `
 prefix_rule(pattern=["git", "status"], decision="allow")
@@ -134,6 +216,19 @@ prefix_rule(
 `;
 			const policy = parsePolicy(content, "test");
 			expect(policy.check(["git", "push", "origin"]).decision).toBe("prompt");
+		});
+
+		it("tokenizes string examples with shell quoting", () => {
+			const content = `
+prefix_rule(
+    pattern=["echo", "hello world"],
+    decision="allow",
+    match=["echo 'hello world'"],
+    not_match=["echo hello"],
+)
+`;
+			const policy = parsePolicy(content, "test");
+			expect(policy.check(["echo", "hello world"]).decision).toBe("allow");
 		});
 
 		it("validates not_match examples", () => {
@@ -162,6 +257,208 @@ prefix_rule(
 			expect(policy.check(["npm", "install"]).decision).toBe("prompt");
 			expect(policy.check(["yarn", "install"]).decision).toBe("prompt");
 			expect(policy.check(["pnpm", "install"]).decision).toBe("prompt");
+		});
+
+		it("keeps host_executable content out of preceding prefix rules", () => {
+			const content = `
+prefix_rule(
+    pattern=["git", "status"],
+    decision="allow",
+    match=[["git", "status"]],
+)
+host_executable(
+    name="git",
+    paths=["/tmp/not_match=[['git', 'status']]"],
+)
+`;
+			const policy = parsePolicy(content, "test");
+			expect(policy.check(["git", "status"]).decision).toBe("allow");
+		});
+
+		it("allows absolute executable paths to fall back to basename rules when host path is trusted", () => {
+			const content = `
+host_executable(
+    name="git",
+    paths=["/usr/bin/git", "/opt/homebrew/bin/git"],
+)
+prefix_rule(
+    pattern=["git", "status"],
+    decision="allow",
+)
+`;
+			const policy = parsePolicy(content, "test");
+			const allowed = policy.check(["/usr/bin/git", "status"], undefined, {
+				resolveHostExecutables: true,
+			});
+			expect(allowed).toMatchObject({
+				decision: "allow",
+				matchedRules: [
+					{
+						type: "prefix",
+						matchedPrefix: ["git", "status"],
+						resolvedProgram: "/usr/bin/git",
+					},
+				],
+			});
+
+			const deniedFallback = policy.check(
+				["/tmp/fake/git", "status"],
+				undefined,
+				{
+					resolveHostExecutables: true,
+				},
+			);
+			expect(deniedFallback.matchedRules).toHaveLength(0);
+		});
+
+		it("does not fall back to basename rules without a host executable declaration", () => {
+			const content = `
+prefix_rule(
+    pattern=["git", "status"],
+    decision="allow",
+)
+`;
+			const policy = parsePolicy(content, "test");
+			const result = policy.check(["/tmp/fake/git", "status"], undefined, {
+				resolveHostExecutables: true,
+			});
+			expect(result.matchedRules).toHaveLength(0);
+		});
+
+		it("merges host executable paths declared in separate policy layers", () => {
+			const policy = new Policy();
+			policy.addHostExecutable("git", ["/usr/bin/git"]);
+			policy.addHostExecutable("git", ["/opt/homebrew/bin/git"]);
+			policy.addPrefixRule(["git", "status"], "allow");
+
+			expect(
+				policy.check(["/usr/bin/git", "status"], undefined, {
+					resolveHostExecutables: true,
+				}).decision,
+			).toBe("allow");
+			expect(
+				policy.check(["/opt/homebrew/bin/git", "status"], undefined, {
+					resolveHostExecutables: true,
+				}).decision,
+			).toBe("allow");
+		});
+
+		it("applies trusted host executable fallback in the normal command check path", () => {
+			const workspaceDir = createWorkspacePolicy(`
+host_executable(
+    name="git",
+    paths=["/usr/bin/git"],
+)
+prefix_rule(
+    pattern=["git", "push"],
+    decision="prompt",
+)
+`);
+			const result = checkCommand(
+				"/usr/bin/git push origin main",
+				workspaceDir,
+			);
+
+			expect(result).toMatchObject({
+				decision: "prompt",
+				matchedRules: [
+					{
+						type: "prefix",
+						matchedPrefix: ["git", "push"],
+						resolvedProgram: "/usr/bin/git",
+					},
+				],
+			});
+		});
+
+		it("applies trusted Windows host executable fallback by policy name", () => {
+			const workspaceDir = createWorkspacePolicy(String.raw`
+host_executable(
+    name="git",
+    paths=["C:\\Program Files\\Git\\bin\\git.exe"],
+)
+prefix_rule(
+    pattern=["git", "push"],
+    decision="prompt",
+)
+`);
+			const result = checkCommand(
+				String.raw`"C:\Program Files\Git\bin\git.exe" push origin main`,
+				workspaceDir,
+			);
+
+			expect(result).toMatchObject({
+				decision: "prompt",
+				matchedRules: [
+					{
+						type: "prefix",
+						matchedPrefix: ["git", "push"],
+						resolvedProgram: String.raw`C:\Program Files\Git\bin\git.exe`,
+					},
+				],
+			});
+		});
+
+		it("evaluates every trusted alias for a resolved host executable path", () => {
+			const policy = new Policy();
+			const gitPath = String.raw`C:\Program Files\Git\bin\git.exe`;
+			policy.addHostExecutable("git", [gitPath]);
+			policy.addHostExecutable("git.exe", [gitPath]);
+			policy.addPrefixRule(["git", "push"], "allow");
+			policy.addPrefixRule(["git.exe", "push"], "forbidden");
+
+			const result = policy.check(
+				[gitPath, "push", "origin", "main"],
+				undefined,
+				{
+					resolveHostExecutables: true,
+				},
+			);
+
+			expect(result.decision).toBe("forbidden");
+			expect(result.matchedRules).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						type: "prefix",
+						matchedPrefix: ["git", "push"],
+						decision: "allow",
+						resolvedProgram: gitPath,
+					}),
+					expect.objectContaining({
+						type: "prefix",
+						matchedPrefix: ["git.exe", "push"],
+						decision: "forbidden",
+						resolvedProgram: gitPath,
+					}),
+				]),
+			);
+		});
+
+		it("parses host executable declarations after prefix rules", () => {
+			const content = `
+prefix_rule(
+    pattern=["git", "status"],
+    decision="allow",
+)
+host_executable(
+    name="git",
+    paths=["/usr/bin/git"],
+)
+`;
+			const policy = parsePolicy(content, "test");
+			const result = policy.check(["/usr/bin/git", "status"], undefined, {
+				resolveHostExecutables: true,
+			});
+			expect(result).toMatchObject({
+				decision: "allow",
+				matchedRules: [
+					{
+						type: "prefix",
+						matchedPrefix: ["git", "status"],
+						resolvedProgram: "/usr/bin/git",
+					},
+				],
+			});
 		});
 	});
 

--- a/test/scripts/native-host-browser-control.test.ts
+++ b/test/scripts/native-host-browser-control.test.ts
@@ -1,0 +1,222 @@
+import { spawn } from "node:child_process";
+import { type IncomingMessage, createServer } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+
+const children: ReturnType<typeof spawn>[] = [];
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+	for (const child of children.splice(0)) {
+		child.kill();
+	}
+	await Promise.all(
+		servers.splice(0).map(
+			(server) =>
+				new Promise<void>((resolve) => {
+					server.close(() => resolve());
+				}),
+		),
+	);
+});
+
+describe("Conductor native host browser-control telemetry", () => {
+	it("forwards browser-control decision notifications to AgentRuntime", async () => {
+		const requests: Array<{
+			url: string | undefined;
+			headers: IncomingMessage["headers"];
+			body: Record<string, unknown>;
+		}> = [];
+		const server = createServer(async (request, response) => {
+			const body = JSON.parse(await readRequestBody(request)) as Record<
+				string,
+				unknown
+			>;
+			requests.push({ url: request.url, headers: request.headers, body });
+			response.writeHead(200, { "Content-Type": "application/json" });
+			response.end(JSON.stringify({ event: { id: "event-1", sequence: 3 } }));
+		});
+		servers.push(server);
+		await listen(server);
+		const address = server.address();
+		if (!address || typeof address === "string") {
+			throw new Error("test server did not expose a TCP address");
+		}
+
+		const child = spawn(process.execPath, ["scripts/bridge/native-host.js"], {
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				MAESTRO_AGENT_RUNTIME_SERVICE_URL: `http://127.0.0.1:${address.port}/agentruntime.v1.AgentRuntimeService/HandleTrigger`,
+				MAESTRO_EVALOPS_ACCESS_TOKEN: "evalops-token",
+				MAESTRO_ENTERPRISE_ORG_ID: "org-1",
+				MAESTRO_BRIDGE_PLATFORM_RUN_ID: "fallback-run",
+				MAESTRO_BRIDGE_PLATFORM_RUNTIME_TIMEOUT_MS: "5000",
+			},
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		children.push(child);
+
+		const requestRecorded = waitForRequest(requests);
+		child.stdin.write(
+			frameNativeMessage({
+				jsonrpc: "2.0",
+				method: "onBrowserControlDecision",
+				params: {
+					schemaVersion: "browser-control-runtime-decision/v1",
+					traceId: "bcdec_test_1",
+					observedAt: "2026-05-08T18:20:00.000Z",
+					method: "executeCdp",
+					methodProfile: "governed-cdp",
+					policyHash: "unknown",
+					platformReceiptPresent: true,
+					platformReceiptId: "channel_action_receipt_executeCdp",
+					platformRunId: "platform-run-1",
+					platformRequestHash:
+						"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					approvalRequired: true,
+					decision: "denied",
+					denyReason: "invalid_platform_receipt",
+					conductorContractVersion: "browsercontrol.v1/2",
+				},
+			}),
+		);
+
+		await requestRecorded;
+		expect(requests).toHaveLength(1);
+		expect(requests[0]?.url).toBe(
+			"/agentruntime.v1.AgentRuntimeService/RecordRunEvent",
+		);
+		expect(requests[0]?.headers.authorization).toBe("Bearer evalops-token");
+		expect(requests[0]?.headers["x-organization-id"]).toBe("org-1");
+		expect(requests[0]?.body).toMatchObject({
+			runId: "platform-run-1",
+			type: "RUNTIME_EVENT_TYPE_AGENT_PROGRESS_RECORDED",
+			message: "Browser-control denied: executeCdp (invalid_platform_receipt)",
+			attributes: {
+				schemaVersion: "browser-control-runtime-decision/v1",
+				adapter: "maestro-conductor-native-host",
+				source: "conductor-browser-control-native-host",
+				traceId: "bcdec_test_1",
+				method: "executeCdp",
+				methodProfile: "governed-cdp",
+				platformReceiptPresent: true,
+				platformReceiptId: "channel_action_receipt_executeCdp",
+				approvalRequired: true,
+				decision: "denied",
+				denyReason: "invalid_platform_receipt",
+			},
+			visibility: {
+				level: "RUNTIME_VISIBILITY_LEVEL_ADMIN_VISIBLE",
+				audiences: [
+					"RUNTIME_AUDIENCE_WORKSPACE_ADMINS",
+					"RUNTIME_AUDIENCE_AUDIT",
+					"RUNTIME_AUDIENCE_SYSTEM",
+				],
+				sensitivity: "RUNTIME_SENSITIVITY_INTERNAL",
+			},
+		});
+	});
+
+	it("responds to JSON-RPC requests instead of treating them as notifications", async () => {
+		const child = spawn(process.execPath, ["scripts/bridge/native-host.js"], {
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				MAESTRO_AGENT_RUNTIME_SERVICE_URL: "http://127.0.0.1:9",
+			},
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		children.push(child);
+
+		const response = waitForNativeMessage(child.stdout);
+		child.stdin.write(
+			frameNativeMessage({
+				jsonrpc: "2.0",
+				id: "bad-jsonrpc-request",
+				method: "unknownMethod",
+				params: {},
+			}),
+		);
+
+		await expect(response).resolves.toMatchObject({
+			type: "error",
+			ok: false,
+			error: "Invalid bridge message",
+		});
+	});
+});
+
+function listen(server: ReturnType<typeof createServer>): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+}
+
+function readRequestBody(request: IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		request.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+		request.on("error", reject);
+		request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+	});
+}
+
+function frameNativeMessage(message: unknown): Buffer {
+	const payload = Buffer.from(JSON.stringify(message), "utf8");
+	const header = Buffer.alloc(4);
+	header.writeUInt32LE(payload.length, 0);
+	return Buffer.concat([header, payload]);
+}
+
+function waitForNativeMessage(
+	stdout: NodeJS.ReadableStream | null,
+): Promise<Record<string, unknown>> {
+	if (!stdout) {
+		return Promise.reject(new Error("native host stdout unavailable"));
+	}
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(
+			() => reject(new Error("timed out waiting for native host response")),
+			5000,
+		);
+		let buffer = Buffer.alloc(0);
+		const onData = (chunk: Buffer) => {
+			buffer = Buffer.concat([buffer, Buffer.from(chunk)]);
+			if (buffer.length < 4) return;
+			const length = buffer.readUInt32LE(0);
+			if (buffer.length < 4 + length) return;
+			cleanup();
+			resolve(JSON.parse(buffer.subarray(4, 4 + length).toString("utf8")));
+		};
+		const onError = (error: Error) => {
+			cleanup();
+			reject(error);
+		};
+		const cleanup = () => {
+			clearTimeout(timeout);
+			stdout.off("data", onData);
+			stdout.off("error", onError);
+		};
+		stdout.on("data", onData);
+		stdout.on("error", onError);
+	});
+}
+
+function waitForRequest(requests: unknown[]): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			reject(new Error("timed out waiting for AgentRuntime request"));
+		}, 5000);
+		const poll = setInterval(() => {
+			if (requests.length > 0) {
+				clearInterval(poll);
+				clearTimeout(timeout);
+				resolve();
+			}
+		}, 10);
+	});
+}

--- a/test/session/session-catalog.test.ts
+++ b/test/session/session-catalog.test.ts
@@ -191,6 +191,7 @@ describe("SessionCatalog", () => {
 		expect(loaded).toMatchObject({
 			id: session.id,
 			title: "Review Session",
+			summary: expect.stringContaining("Deeply review the codebase"),
 			resumeSummary: "Reviewing the codebase before touching tests.",
 			favorite: true,
 			messageCount: 2,


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `fc313a66a587b0e2e7377d3091d65b291a5228c1`
- last generated public sync base: `afee9c31815e46cd9a04e2a536a69eda77818776`
- previewed public-tree drift: `14` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (fc313a66a587)`
- public projection: `https://github.com/evalops/maestro@main (81139489d270)`
- files to copy or update: `14`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/CONDUCTOR_BRIDGE.md
- copy/update packages/contracts/src/index.ts
- copy/update packages/contracts/src/maestro-app-server.ts
- copy/update scripts/bridge/native-host.js
- copy/update src/app-server/in-process-client.ts
- copy/update src/app-server/session-api.ts
- copy/update src/safety/execpolicy.ts
- copy/update src/session/session-catalog.ts
- copy/update src/session/types.ts
- copy/update test/app-server/in-process-client.test.ts
- copy/update test/app-server/session-api.test.ts
- copy/update test/safety/execpolicy.test.ts
- copy/update test/scripts/native-host-browser-control.test.ts
- copy/update test/session/session-catalog.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/CONDUCTOR_BRIDGE.md
- copy/update packages/contracts/src/index.ts
- copy/update packages/contracts/src/maestro-app-server.ts
- copy/update scripts/bridge/native-host.js
- copy/update src/app-server/in-process-client.ts
- copy/update src/app-server/session-api.ts
- copy/update src/safety/execpolicy.ts
- copy/update src/session/session-catalog.ts
- copy/update src/session/types.ts
- copy/update test/app-server/in-process-client.test.ts
- copy/update test/app-server/session-api.test.ts
- copy/update test/safety/execpolicy.test.ts
- copy/update test/scripts/native-host-browser-control.test.ts
- copy/update test/session/session-catalog.test.ts

## Public-only commits since last generated sync

- 81139489 Sync public mirror from internal

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #327 to internal source `fc313a66a587b0e2e7377d3091d65b291a5228c1`