### PR TITLE
Expand Maestro app-server parity surfaces

### DIFF
--- a/packages/contracts/src/maestro-app-server.ts
+++ b/packages/contracts/src/maestro-app-server.ts
@@ -5,8 +5,15 @@ export const maestroAppServerProtocolVersion = "maestro-app-server.v1" as const;
 
 export const maestroAppServerClientMethods = [
 	"initialize",
+	"model/list",
+	"modelProvider/capabilities/read",
 	"thread/list",
 	"thread/read",
+	"thread/metadata/update",
+	"thread/name/set",
+	"thread/goal/get",
+	"thread/goal/set",
+	"thread/goal/clear",
 	"thread/turns/list",
 ] as const;
 export type MaestroAppServerClientMethod =
@@ -52,8 +59,13 @@ export type MaestroAppServerClientRequest = Static<
 
 export const MaestroAppServerCapabilitiesSchema = Type.Object({
 	sessions: Type.Boolean(),
+	modelList: Type.Boolean(),
+	modelProviderCapabilities: Type.Boolean(),
 	threadList: Type.Boolean(),
 	threadRead: Type.Boolean(),
+	threadMetadataUpdate: Type.Boolean(),
+	threadNameSet: Type.Boolean(),
+	threadGoals: Type.Boolean(),
 	turnsList: Type.Boolean(),
 });
 export type MaestroAppServerCapabilities = Static<
@@ -96,6 +108,25 @@ export const MaestroAppServerThreadSummarySchema = Type.Object({
 });
 export type MaestroAppServerThreadSummary = Static<
 	typeof MaestroAppServerThreadSummarySchema
+>;
+
+export const MaestroAppServerThreadGoalStatuses = [
+	"active",
+	"complete",
+	"cancelled",
+] as const;
+export const MaestroAppServerThreadGoalStatusSchema = stringLiteralUnion(
+	MaestroAppServerThreadGoalStatuses,
+);
+export const MaestroAppServerThreadGoalSchema = Type.Object({
+	objective: Type.String(),
+	status: MaestroAppServerThreadGoalStatusSchema,
+	tokenBudget: Type.Optional(Type.Number()),
+	createdAt: Type.String(),
+	updatedAt: Type.String(),
+});
+export type MaestroAppServerThreadGoal = Static<
+	typeof MaestroAppServerThreadGoalSchema
 >;
 
 export const MaestroAppServerThreadItemSchema = Type.Object({
@@ -150,6 +181,21 @@ export type MaestroAppServerThreadReadResult = Static<
 	typeof MaestroAppServerThreadReadResultSchema
 >;
 
+export const MaestroAppServerThreadMetadataUpdateResultSchema = Type.Object({
+	thread: MaestroAppServerThreadSummarySchema,
+});
+export type MaestroAppServerThreadMetadataUpdateResult = Static<
+	typeof MaestroAppServerThreadMetadataUpdateResultSchema
+>;
+
+export const MaestroAppServerThreadGoalResultSchema = Type.Object({
+	threadId: Type.String(),
+	goal: Type.Union([MaestroAppServerThreadGoalSchema, Type.Null()]),
+});
+export type MaestroAppServerThreadGoalResult = Static<
+	typeof MaestroAppServerThreadGoalResultSchema
+>;
+
 export const MaestroAppServerTurnsListResultSchema = Type.Object({
 	threadId: Type.String(),
 	turns: Type.Array(MaestroAppServerTurnSchema),
@@ -159,14 +205,79 @@ export type MaestroAppServerTurnsListResult = Static<
 	typeof MaestroAppServerTurnsListResultSchema
 >;
 
+export const MaestroAppServerModelCapabilitiesSchema = Type.Object({
+	streaming: Type.Boolean(),
+	tools: Type.Boolean(),
+	vision: Type.Boolean(),
+	reasoning: Type.Boolean(),
+	responsesApi: Type.Boolean(),
+	codexBackend: Type.Boolean(),
+	local: Type.Boolean(),
+});
+export const MaestroAppServerReasoningEffortSchema = Type.Union([
+	Type.Literal("minimal"),
+	Type.Literal("low"),
+	Type.Literal("medium"),
+	Type.Literal("high"),
+	Type.Literal("ultra"),
+]);
+export const MaestroAppServerModelSchema = Type.Object({
+	id: Type.String(),
+	provider: Type.String(),
+	name: Type.String(),
+	api: Type.String(),
+	contextWindow: Type.Optional(Type.Number()),
+	maxTokens: Type.Optional(Type.Number()),
+	cost: Type.Optional(Type.Record(Type.String(), Type.Number())),
+	source: Type.Optional(
+		Type.Union([Type.Literal("builtin"), Type.Literal("custom")]),
+	),
+	supportedReasoningEfforts: Type.Optional(
+		Type.Array(MaestroAppServerReasoningEffortSchema),
+	),
+	defaultReasoningEffort: Type.Optional(MaestroAppServerReasoningEffortSchema),
+	capabilities: MaestroAppServerModelCapabilitiesSchema,
+});
+export type MaestroAppServerModel = Static<typeof MaestroAppServerModelSchema>;
+
+export const MaestroAppServerModelListResultSchema = Type.Object({
+	models: Type.Array(MaestroAppServerModelSchema),
+});
+export type MaestroAppServerModelListResult = Static<
+	typeof MaestroAppServerModelListResultSchema
+>;
+
+export const MaestroAppServerModelProviderCapabilitiesSchema = Type.Object({
+	id: Type.String(),
+	name: Type.String(),
+	apis: Type.Array(Type.String()),
+	modelCount: Type.Number(),
+	capabilities: MaestroAppServerModelCapabilitiesSchema,
+});
+export type MaestroAppServerModelProviderCapabilities = Static<
+	typeof MaestroAppServerModelProviderCapabilitiesSchema
+>;
+
+export const MaestroAppServerModelProviderCapabilitiesReadResultSchema =
+	Type.Object({
+		providers: Type.Array(MaestroAppServerModelProviderCapabilitiesSchema),
+	});
+export type MaestroAppServerModelProviderCapabilitiesReadResult = Static<
+	typeof MaestroAppServerModelProviderCapabilitiesReadResultSchema
+>;
+
 export const MaestroAppServerResponseSchema = Type.Object({
 	jsonrpc: Type.Literal("2.0"),
 	id: MaestroAppServerJsonRpcResponseIdSchema,
 	result: Type.Optional(
 		Type.Union([
 			MaestroAppServerInitializeResultSchema,
+			MaestroAppServerModelListResultSchema,
+			MaestroAppServerModelProviderCapabilitiesReadResultSchema,
 			MaestroAppServerThreadListResultSchema,
 			MaestroAppServerThreadReadResultSchema,
+			MaestroAppServerThreadMetadataUpdateResultSchema,
+			MaestroAppServerThreadGoalResultSchema,
 			MaestroAppServerTurnsListResultSchema,
 		]),
 	),

--- a/src/app-server/in-process-client.ts
+++ b/src/app-server/in-process-client.ts
@@ -1,7 +1,11 @@
 import type {
 	MaestroAppServerClientMethod,
 	MaestroAppServerInitializeResult,
+	MaestroAppServerModelListResult,
+	MaestroAppServerModelProviderCapabilitiesReadResult,
+	MaestroAppServerThreadGoalResult,
 	MaestroAppServerThreadListResult,
+	MaestroAppServerThreadMetadataUpdateResult,
 	MaestroAppServerThreadReadResult,
 	MaestroAppServerTurnsListResult,
 } from "@evalops/contracts";
@@ -30,13 +34,26 @@ type AppServerRequestMethod = Exclude<
 >;
 
 type AppServerMethodResult<M extends AppServerRequestMethod> =
-	M extends "thread/list"
-		? MaestroAppServerThreadListResult
-		: M extends "thread/read"
-			? MaestroAppServerThreadReadResult
-			: M extends "thread/turns/list"
-				? MaestroAppServerTurnsListResult
-				: never;
+	M extends "model/list"
+		? MaestroAppServerModelListResult
+		: M extends "modelProvider/capabilities/read"
+			? MaestroAppServerModelProviderCapabilitiesReadResult
+			: M extends "thread/list"
+				? MaestroAppServerThreadListResult
+				: M extends "thread/read"
+					? MaestroAppServerThreadReadResult
+					: M extends "thread/metadata/update"
+						? MaestroAppServerThreadMetadataUpdateResult
+						: M extends "thread/name/set"
+							? MaestroAppServerThreadMetadataUpdateResult
+							: M extends
+										| "thread/goal/get"
+										| "thread/goal/set"
+										| "thread/goal/clear"
+								? MaestroAppServerThreadGoalResult
+								: M extends "thread/turns/list"
+									? MaestroAppServerTurnsListResult
+									: never;
 
 export class InProcessMaestroAppServerClientError extends Error {
 	constructor(

--- a/src/app-server/session-api.ts
+++ b/src/app-server/session-api.ts
@@ -576,7 +576,9 @@ export function createMaestroAppServerSessionApi(
 			store.setSessionTags,
 	);
 	const canSetThreadName = Boolean(store.setSessionTitle);
-	const canWriteThreadGoals = Boolean(store.setSessionAppServerGoal);
+	const canUseThreadGoals = Boolean(
+		store.setSessionAppServerGoal && store.loadEntries,
+	);
 
 	return {
 		initialize() {
@@ -593,7 +595,7 @@ export function createMaestroAppServerSessionApi(
 					threadRead: true,
 					threadMetadataUpdate: canUpdateThreadMetadata,
 					threadNameSet: canSetThreadName,
-					threadGoals: canWriteThreadGoals,
+					threadGoals: canUseThreadGoals,
 					turnsList: true,
 				},
 			};

--- a/src/app-server/session-api.ts
+++ b/src/app-server/session-api.ts
@@ -443,6 +443,37 @@ function latestGoalFromEntries(
 	return goal;
 }
 
+function goalsEqual(
+	actual: MaestroAppServerThreadGoal | null,
+	expected: MaestroAppServerThreadGoal | null,
+): boolean {
+	if (actual === null || expected === null) {
+		return actual === expected;
+	}
+	return (
+		actual.objective === expected.objective &&
+		actual.status === expected.status &&
+		actual.tokenBudget === expected.tokenBudget &&
+		actual.createdAt === expected.createdAt &&
+		actual.updatedAt === expected.updatedAt
+	);
+}
+
+async function verifyThreadGoalPersisted(
+	store: SessionStore,
+	threadId: string,
+	expected: MaestroAppServerThreadGoal | null,
+): Promise<MaestroAppServerThreadGoal | null> {
+	const persisted = await loadThreadGoal(store, threadId);
+	if (!goalsEqual(persisted, expected)) {
+		throw new MaestroAppServerError(
+			-32000,
+			"Thread goal update was not persisted",
+		);
+	}
+	return persisted;
+}
+
 function normalizeGoalStatus(
 	value: unknown,
 ): MaestroAppServerThreadGoal["status"] {
@@ -770,7 +801,10 @@ export function createMaestroAppServerSessionApi(
 			}
 			await store.setSessionAppServerGoal(sessionFile, goal);
 			await flushSessionWrites(store);
-			return { threadId, goal };
+			return {
+				threadId,
+				goal: await verifyThreadGoalPersisted(store, threadId, goal),
+			};
 		},
 
 		async clearThreadGoal(params = {}) {
@@ -784,6 +818,7 @@ export function createMaestroAppServerSessionApi(
 			}
 			await store.setSessionAppServerGoal(sessionFile, null);
 			await flushSessionWrites(store);
+			await verifyThreadGoalPersisted(store, threadId, null);
 			return { threadId, goal: null };
 		},
 

--- a/src/app-server/session-api.ts
+++ b/src/app-server/session-api.ts
@@ -354,7 +354,7 @@ function optionalTrimmedString(
 	if (typeof value !== "string") {
 		throw new MaestroAppServerError(-32602, `Invalid ${field}`);
 	}
-	return value.trim();
+	return value.trim() || undefined;
 }
 
 function optionalBoolean(value: unknown, field: string): boolean | undefined {

--- a/src/app-server/session-api.ts
+++ b/src/app-server/session-api.ts
@@ -430,6 +430,42 @@ async function summarizeThreadAfterMutation(
 	return summary;
 }
 
+function tagsEqual(left: string[] | undefined, right: string[] | undefined) {
+	if (left === undefined || right === undefined) {
+		return left === right;
+	}
+	return (
+		left.length === right.length &&
+		left.every((value, index) => value === right[index])
+	);
+}
+
+function verifyThreadMetadataPersisted(
+	thread: MaestroAppServerThreadSummary,
+	expected: {
+		title?: string;
+		summary?: string;
+		resumeSummary?: string;
+		favorite?: boolean;
+		tags?: string[];
+	},
+): void {
+	const persisted =
+		(expected.title === undefined || thread.title === expected.title) &&
+		(expected.summary === undefined || thread.summary === expected.summary) &&
+		(expected.resumeSummary === undefined ||
+			thread.resumeSummary === expected.resumeSummary) &&
+		(expected.favorite === undefined ||
+			thread.favorite === expected.favorite) &&
+		(expected.tags === undefined || tagsEqual(thread.tags, expected.tags));
+	if (!persisted) {
+		throw new MaestroAppServerError(
+			-32000,
+			"Thread metadata update was not persisted",
+		);
+	}
+}
+
 function latestGoalFromEntries(
 	entries: SessionEntry[],
 ): MaestroAppServerThreadGoal | null {
@@ -747,9 +783,15 @@ export function createMaestroAppServerSessionApi(
 				}
 				await store.setSessionTags(sessionFile, tags);
 			}
-			return {
-				thread: await summarizeThreadAfterMutation(store, threadId),
-			};
+			const thread = await summarizeThreadAfterMutation(store, threadId);
+			verifyThreadMetadataPersisted(thread, {
+				title,
+				summary,
+				resumeSummary,
+				favorite,
+				tags,
+			});
+			return { thread };
 		},
 
 		async setThreadName(params = {}) {
@@ -766,9 +808,9 @@ export function createMaestroAppServerSessionApi(
 				);
 			}
 			await store.setSessionTitle(sessionFile, name);
-			return {
-				thread: await summarizeThreadAfterMutation(store, threadId),
-			};
+			const thread = await summarizeThreadAfterMutation(store, threadId);
+			verifyThreadMetadataPersisted(thread, { title: name });
+			return { thread };
 		},
 
 		async getThreadGoal(params = {}) {

--- a/src/app-server/session-api.ts
+++ b/src/app-server/session-api.ts
@@ -43,6 +43,7 @@ type SessionStore = Pick<
 	"getSessionFileById" | "loadAllSessions" | "listSessions" | "loadSession"
 > & {
 	loadEntries?: (sessionId: string) => Promise<SessionEntry[] | null>;
+	flush?: () => Promise<void>;
 	saveSessionSummary?: (
 		summary: string,
 		sessionPath?: string,
@@ -406,10 +407,15 @@ async function requireExistingThreadReference(
 	return sessionFile;
 }
 
+async function flushSessionWrites(store: SessionStore): Promise<void> {
+	await store.flush?.();
+}
+
 async function summarizeThreadAfterMutation(
 	store: SessionStore,
 	threadId: string,
 ): Promise<MaestroAppServerThreadSummary> {
+	await flushSessionWrites(store);
 	const loaded = await store.loadSession(threadId, {
 		messagesView: "notLoaded",
 	});
@@ -763,6 +769,7 @@ export function createMaestroAppServerSessionApi(
 				);
 			}
 			await store.setSessionAppServerGoal(sessionFile, goal);
+			await flushSessionWrites(store);
 			return { threadId, goal };
 		},
 
@@ -776,6 +783,7 @@ export function createMaestroAppServerSessionApi(
 				);
 			}
 			await store.setSessionAppServerGoal(sessionFile, null);
+			await flushSessionWrites(store);
 			return { threadId, goal: null };
 		},
 

--- a/src/app-server/session-api.ts
+++ b/src/app-server/session-api.ts
@@ -1,9 +1,16 @@
 import {
 	type MaestroAppServerClientRequest,
+	type MaestroAppServerModel,
+	type MaestroAppServerModelListResult,
+	type MaestroAppServerModelProviderCapabilities,
+	type MaestroAppServerModelProviderCapabilitiesReadResult,
 	type MaestroAppServerResponse,
 	type MaestroAppServerThread,
+	type MaestroAppServerThreadGoal,
+	type MaestroAppServerThreadGoalResult,
 	type MaestroAppServerThreadItem,
 	type MaestroAppServerThreadListResult,
+	type MaestroAppServerThreadMetadataUpdateResult,
 	type MaestroAppServerThreadSummary,
 	type MaestroAppServerTurn,
 	type MaestroAppServerTurnsListResult,
@@ -11,6 +18,8 @@ import {
 	maestroAppServerProtocolVersion,
 } from "@evalops/contracts";
 import type { AppMessage } from "../agent/types.js";
+import { getRegisteredModels } from "../models/registry.js";
+import type { RegisteredModel } from "../models/registry.js";
 import type { SessionManager } from "../session/manager.js";
 import { migrateToCurrentVersion } from "../session/migration.js";
 import { safeReadSessionEntries } from "../session/session-context.js";
@@ -27,20 +36,60 @@ const DEFAULT_PAGE_LIMIT = 50;
 const MAX_PAGE_LIMIT = 100;
 
 type JsonRpcId = string | number;
+type MaybePromise<T> = T | Promise<T>;
 
 type SessionStore = Pick<
 	SessionManager,
 	"getSessionFileById" | "loadAllSessions" | "listSessions" | "loadSession"
 > & {
 	loadEntries?: (sessionId: string) => Promise<SessionEntry[] | null>;
+	saveSessionSummary?: (
+		summary: string,
+		sessionPath?: string,
+	) => MaybePromise<void>;
+	saveSessionResumeSummary?: (
+		summary: string,
+		sessionPath?: string,
+	) => MaybePromise<void>;
+	setSessionFavorite?: (
+		sessionPath: string,
+		favorite: boolean,
+	) => MaybePromise<void>;
+	setSessionTitle?: (sessionPath: string, title: string) => MaybePromise<void>;
+	setSessionTags?: (sessionPath: string, tags: string[]) => MaybePromise<void>;
+	setSessionAppServerGoal?: (
+		sessionPath: string,
+		goal: MaestroAppServerThreadGoal | null,
+	) => MaybePromise<void>;
 };
 
 export interface MaestroAppServerSessionApi {
 	initialize(): MaestroAppServerResponse["result"];
+	listModels(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerModelListResult>;
+	readModelProviderCapabilities(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerModelProviderCapabilitiesReadResult>;
 	listThreads(
 		params?: Record<string, unknown>,
 	): Promise<MaestroAppServerThreadListResult>;
 	readThread(params?: Record<string, unknown>): Promise<MaestroAppServerThread>;
+	updateThreadMetadata(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerThreadMetadataUpdateResult>;
+	setThreadName(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerThreadMetadataUpdateResult>;
+	getThreadGoal(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerThreadGoalResult>;
+	setThreadGoal(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerThreadGoalResult>;
+	clearThreadGoal(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerThreadGoalResult>;
 	listTurns(
 		params?: Record<string, unknown>,
 	): Promise<MaestroAppServerTurnsListResult>;
@@ -130,7 +179,7 @@ function toThreadSummaryFromSessionSummary(
 		source: "session",
 		status: "notLoaded",
 		title: summary.title ?? summary.subject,
-		summary: summary.title ?? summary.subject,
+		summary: summary.summary ?? summary.title ?? summary.subject,
 		resumeSummary: summary.resumeSummary,
 		subject: summary.subject,
 		createdAt: summary.createdAt,
@@ -294,9 +343,204 @@ function parseMessagesView(value: unknown): SessionMessagesView {
 	throw new MaestroAppServerError(-32602, "Invalid messagesView");
 }
 
+function optionalTrimmedString(
+	value: unknown,
+	field: string,
+): string | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new MaestroAppServerError(-32602, `Invalid ${field}`);
+	}
+	return value.trim();
+}
+
+function optionalBoolean(value: unknown, field: string): boolean | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== "boolean") {
+		throw new MaestroAppServerError(-32602, `Invalid ${field}`);
+	}
+	return value;
+}
+
+function optionalStringArray(
+	value: unknown,
+	field: string,
+): string[] | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (
+		!Array.isArray(value) ||
+		value.some((entry) => typeof entry !== "string")
+	) {
+		throw new MaestroAppServerError(-32602, `Invalid ${field}`);
+	}
+	return Array.from(
+		new Set(value.map((entry) => entry.trim()).filter(Boolean)),
+	);
+}
+
+function requireThreadReference(store: SessionStore, threadId: string): string {
+	const sessionFile = store.getSessionFileById(threadId);
+	if (!sessionFile) {
+		throw new MaestroAppServerError(-32004, "Thread not found");
+	}
+	return sessionFile;
+}
+
+async function requireExistingThreadReference(
+	store: SessionStore,
+	threadId: string,
+): Promise<string> {
+	const sessionFile = requireThreadReference(store, threadId);
+	const loaded = await store.loadSession(threadId, {
+		messagesView: "notLoaded",
+	});
+	if (!loaded) {
+		throw new MaestroAppServerError(-32004, "Thread not found");
+	}
+	return sessionFile;
+}
+
+async function summarizeThreadAfterMutation(
+	store: SessionStore,
+	threadId: string,
+): Promise<MaestroAppServerThreadSummary> {
+	const loaded = await store.loadSession(threadId, {
+		messagesView: "notLoaded",
+	});
+	if (!loaded) {
+		throw new MaestroAppServerError(-32004, "Thread not found");
+	}
+	const summary = toThreadSummaryFromLoadedSession(loaded);
+	const sessionFile = store.getSessionFileById(threadId);
+	if (sessionFile && !sessionFile.startsWith("db:")) {
+		summary.path = sessionFile;
+	}
+	return summary;
+}
+
+function latestGoalFromEntries(
+	entries: SessionEntry[],
+): MaestroAppServerThreadGoal | null {
+	let goal: MaestroAppServerThreadGoal | null = null;
+	for (const entry of entries) {
+		if (entry.type !== "session_meta" || entry.appServerGoal === undefined) {
+			continue;
+		}
+		goal = entry.appServerGoal;
+	}
+	return goal;
+}
+
+function normalizeGoalStatus(
+	value: unknown,
+): MaestroAppServerThreadGoal["status"] {
+	if (value === undefined || value === null) {
+		return "active";
+	}
+	if (value === "active" || value === "complete" || value === "cancelled") {
+		return value;
+	}
+	throw new MaestroAppServerError(-32602, "Invalid status");
+}
+
+function normalizeTokenBudget(value: unknown): number | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (
+		typeof value !== "number" ||
+		!Number.isFinite(value) ||
+		value <= 0 ||
+		!Number.isInteger(value)
+	) {
+		throw new MaestroAppServerError(-32602, "Invalid tokenBudget");
+	}
+	return value;
+}
+
+function modelToAppServerModel(model: RegisteredModel): MaestroAppServerModel {
+	const responsesApi =
+		model.api === "openai-responses" || model.api === "openai-codex-responses";
+	const codexBackend = model.api === "openai-codex-responses";
+	return {
+		id: model.id,
+		provider: model.provider,
+		name: model.name || model.id,
+		api: model.api,
+		contextWindow: model.contextWindow,
+		maxTokens: model.maxTokens,
+		cost: model.cost,
+		source: model.source,
+		supportedReasoningEfforts: model.reasoning
+			? ["minimal", "low", "medium", "high", "ultra"]
+			: undefined,
+		defaultReasoningEffort: model.reasoning ? "medium" : undefined,
+		capabilities: {
+			streaming: true,
+			tools: model.toolUse === true,
+			vision: model.input?.includes("image") || false,
+			reasoning: model.reasoning || false,
+			responsesApi,
+			codexBackend,
+			local: model.isLocal,
+		},
+	};
+}
+
+function mergeProviderCapabilities(
+	current: MaestroAppServerModelProviderCapabilities | undefined,
+	model: MaestroAppServerModel,
+	providerName: string,
+): MaestroAppServerModelProviderCapabilities {
+	const capabilities = current?.capabilities ?? {
+		streaming: false,
+		tools: false,
+		vision: false,
+		reasoning: false,
+		responsesApi: false,
+		codexBackend: false,
+		local: false,
+	};
+	const apis = new Set(current?.apis ?? []);
+	apis.add(model.api);
+	return {
+		id: model.provider,
+		name: current?.name ?? providerName,
+		apis: Array.from(apis).sort(),
+		modelCount: (current?.modelCount ?? 0) + 1,
+		capabilities: {
+			streaming: capabilities.streaming || model.capabilities.streaming,
+			tools: capabilities.tools || model.capabilities.tools,
+			vision: capabilities.vision || model.capabilities.vision,
+			reasoning: capabilities.reasoning || model.capabilities.reasoning,
+			responsesApi:
+				capabilities.responsesApi || model.capabilities.responsesApi,
+			codexBackend:
+				capabilities.codexBackend || model.capabilities.codexBackend,
+			local: capabilities.local || model.capabilities.local,
+		},
+	};
+}
+
 export function createMaestroAppServerSessionApi(
 	store: SessionStore,
 ): MaestroAppServerSessionApi {
+	const canUpdateThreadMetadata = Boolean(
+		store.setSessionTitle &&
+			store.saveSessionSummary &&
+			store.saveSessionResumeSummary &&
+			store.setSessionFavorite &&
+			store.setSessionTags,
+	);
+	const canSetThreadName = Boolean(store.setSessionTitle);
+	const canWriteThreadGoals = Boolean(store.setSessionAppServerGoal);
+
 	return {
 		initialize() {
 			return {
@@ -306,10 +550,57 @@ export function createMaestroAppServerSessionApi(
 				},
 				capabilities: {
 					sessions: true,
+					modelList: true,
+					modelProviderCapabilities: true,
 					threadList: true,
 					threadRead: true,
+					threadMetadataUpdate: canUpdateThreadMetadata,
+					threadNameSet: canSetThreadName,
+					threadGoals: canWriteThreadGoals,
 					turnsList: true,
 				},
+			};
+		},
+
+		async listModels(params = {}) {
+			const provider = optionalTrimmedString(params.provider, "provider");
+			const api = optionalTrimmedString(params.api, "api");
+			const models = getRegisteredModels()
+				.filter((model) => !provider || model.provider === provider)
+				.filter((model) => !api || model.api === api)
+				.map(modelToAppServerModel)
+				.sort((left, right) =>
+					`${left.provider}/${left.id}`.localeCompare(
+						`${right.provider}/${right.id}`,
+					),
+				);
+			return { models };
+		},
+
+		async readModelProviderCapabilities(params = {}) {
+			const provider = optionalTrimmedString(params.provider, "provider");
+			const providers = new Map<
+				string,
+				MaestroAppServerModelProviderCapabilities
+			>();
+			for (const model of getRegisteredModels()) {
+				if (provider && model.provider !== provider) {
+					continue;
+				}
+				const appServerModel = modelToAppServerModel(model);
+				providers.set(
+					model.provider,
+					mergeProviderCapabilities(
+						providers.get(model.provider),
+						appServerModel,
+						model.providerName || model.provider,
+					),
+				);
+			}
+			return {
+				providers: Array.from(providers.values()).sort((left, right) =>
+					left.id.localeCompare(right.id),
+				),
 			};
 		},
 
@@ -360,6 +651,134 @@ export function createMaestroAppServerSessionApi(
 			return thread;
 		},
 
+		async updateThreadMetadata(params = {}) {
+			const threadId = requireThreadId(params);
+			const title = optionalTrimmedString(params.title, "title");
+			const summary = optionalTrimmedString(params.summary, "summary");
+			const resumeSummary = optionalTrimmedString(
+				params.resumeSummary,
+				"resumeSummary",
+			);
+			const favorite = optionalBoolean(params.favorite, "favorite");
+			const tags = optionalStringArray(params.tags, "tags");
+			const sessionFile = await requireExistingThreadReference(store, threadId);
+
+			if (title !== undefined) {
+				if (!store.setSessionTitle) {
+					throw new MaestroAppServerError(
+						-32601,
+						"Thread title updates are not available",
+					);
+				}
+				await store.setSessionTitle(sessionFile, title);
+			}
+			if (summary !== undefined) {
+				if (!store.saveSessionSummary) {
+					throw new MaestroAppServerError(
+						-32601,
+						"Thread summary updates are not available",
+					);
+				}
+				await store.saveSessionSummary(summary, sessionFile);
+			}
+			if (resumeSummary !== undefined) {
+				if (!store.saveSessionResumeSummary) {
+					throw new MaestroAppServerError(
+						-32601,
+						"Thread resume summary updates are not available",
+					);
+				}
+				await store.saveSessionResumeSummary(resumeSummary, sessionFile);
+			}
+			if (favorite !== undefined) {
+				if (!store.setSessionFavorite) {
+					throw new MaestroAppServerError(
+						-32601,
+						"Thread favorite updates are not available",
+					);
+				}
+				await store.setSessionFavorite(sessionFile, favorite);
+			}
+			if (tags !== undefined) {
+				if (!store.setSessionTags) {
+					throw new MaestroAppServerError(
+						-32601,
+						"Thread tag updates are not available",
+					);
+				}
+				await store.setSessionTags(sessionFile, tags);
+			}
+			return {
+				thread: await summarizeThreadAfterMutation(store, threadId),
+			};
+		},
+
+		async setThreadName(params = {}) {
+			const threadId = requireThreadId(params);
+			const name = optionalTrimmedString(params.name, "name");
+			if (!name) {
+				throw new MaestroAppServerError(-32602, "Missing name");
+			}
+			const sessionFile = await requireExistingThreadReference(store, threadId);
+			if (!store.setSessionTitle) {
+				throw new MaestroAppServerError(
+					-32601,
+					"Thread name updates are not available",
+				);
+			}
+			await store.setSessionTitle(sessionFile, name);
+			return {
+				thread: await summarizeThreadAfterMutation(store, threadId),
+			};
+		},
+
+		async getThreadGoal(params = {}) {
+			const threadId = requireThreadId(params);
+			return {
+				threadId,
+				goal: await loadThreadGoal(store, threadId),
+			};
+		},
+
+		async setThreadGoal(params = {}) {
+			const threadId = requireThreadId(params);
+			const sessionFile = await requireExistingThreadReference(store, threadId);
+			const objective = optionalTrimmedString(params.objective, "objective");
+			if (!objective) {
+				throw new MaestroAppServerError(-32602, "Missing objective");
+			}
+			const existing = await loadThreadGoal(store, threadId);
+			const now = new Date().toISOString();
+			const goal: MaestroAppServerThreadGoal = {
+				objective,
+				status: normalizeGoalStatus(params.status),
+				tokenBudget: normalizeTokenBudget(params.tokenBudget),
+				createdAt: existing?.createdAt ?? now,
+				updatedAt: now,
+			};
+			if (!store.setSessionAppServerGoal) {
+				throw new MaestroAppServerError(
+					-32601,
+					"Thread goal updates are not available",
+				);
+			}
+			await store.setSessionAppServerGoal(sessionFile, goal);
+			return { threadId, goal };
+		},
+
+		async clearThreadGoal(params = {}) {
+			const threadId = requireThreadId(params);
+			const sessionFile = await requireExistingThreadReference(store, threadId);
+			if (!store.setSessionAppServerGoal) {
+				throw new MaestroAppServerError(
+					-32601,
+					"Thread goal updates are not available",
+				);
+			}
+			await store.setSessionAppServerGoal(sessionFile, null);
+			return { threadId, goal: null };
+		},
+
 		async listTurns(params = {}) {
 			const threadId = requireThreadId(params);
 			const limit = normalizeLimit(params.limit);
@@ -393,6 +812,32 @@ async function loadTurnsForThread(
 	return buildTurnsFromSessionEntries(safeReadSessionEntries(sessionFile));
 }
 
+async function loadThreadGoal(
+	store: SessionStore,
+	threadId: string,
+): Promise<MaestroAppServerThreadGoal | null> {
+	if (store.loadEntries) {
+		const entries = await store.loadEntries(threadId);
+		if (entries) {
+			return latestGoalFromEntries(entries);
+		}
+	}
+	const sessionFile = store.getSessionFileById(threadId);
+	if (!sessionFile) {
+		throw new MaestroAppServerError(-32004, "Thread not found");
+	}
+	if (sessionFile.startsWith("db:")) {
+		const loaded = await store.loadSession(threadId, {
+			messagesView: "notLoaded",
+		});
+		if (!loaded) {
+			throw new MaestroAppServerError(-32004, "Thread not found");
+		}
+		return null;
+	}
+	return latestGoalFromEntries(safeReadSessionEntries(sessionFile));
+}
+
 function isSupportedMethod(
 	method: string,
 ): method is (typeof maestroAppServerClientMethods)[number] {
@@ -418,6 +863,18 @@ export async function handleMaestroAppServerRequest(
 					id,
 					result: api.initialize(),
 				};
+			case "model/list":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.listModels(request.params),
+				};
+			case "modelProvider/capabilities/read":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.readModelProviderCapabilities(request.params),
+				};
 			case "thread/list":
 				return {
 					jsonrpc: "2.0",
@@ -431,6 +888,36 @@ export async function handleMaestroAppServerRequest(
 					result: {
 						thread: await api.readThread(request.params),
 					},
+				};
+			case "thread/metadata/update":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.updateThreadMetadata(request.params),
+				};
+			case "thread/name/set":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.setThreadName(request.params),
+				};
+			case "thread/goal/get":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.getThreadGoal(request.params),
+				};
+			case "thread/goal/set":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.setThreadGoal(request.params),
+				};
+			case "thread/goal/clear":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.clearThreadGoal(request.params),
 				};
 			case "thread/turns/list":
 				return {

--- a/src/server/hosted-session-manager.ts
+++ b/src/server/hosted-session-manager.ts
@@ -117,6 +117,15 @@ export class HostedSessionManager {
 		return this.buildSessionContext().messages.length;
 	}
 
+	private resolveSessionId(sessionRef?: string): string {
+		if (!sessionRef) {
+			return this.sessionId;
+		}
+		return sessionRef.startsWith("db:")
+			? sessionRef.slice("db:".length)
+			: sessionRef;
+	}
+
 	private async ensureSessionRow(
 		sessionId: string,
 		values: Partial<typeof hostedSessions.$inferInsert> = {},
@@ -174,6 +183,48 @@ export class HostedSessionManager {
 				})
 				.where(eq(hostedSessions.sessionId, sessionId));
 		});
+	}
+
+	private appendSessionMetaEntry(
+		sessionId: string,
+		fields: Omit<SessionMetaEntry, "type" | "timestamp">,
+		rowUpdates: Partial<typeof hostedSessions.$inferInsert> = {},
+	): Promise<void> {
+		const entry: SessionMetaEntry = {
+			type: "session_meta",
+			timestamp: new Date().toISOString(),
+			...fields,
+		};
+		if (sessionId === this.sessionId) {
+			this.entries.push(entry);
+		}
+		const messageCount =
+			sessionId === this.sessionId ? this.currentMessageCount() : undefined;
+		this.enqueue(async () => {
+			if (sessionId === this.sessionId) {
+				await this.ensureSessionRow(sessionId, { messageCount });
+			}
+			await getDb().insert(hostedSessionEntries).values({
+				sessionId,
+				entryType: entry.type,
+				entry,
+			});
+			await getDb()
+				.update(hostedSessions)
+				.set({
+					...rowUpdates,
+					...(messageCount !== undefined ? { messageCount } : {}),
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(hostedSessions.sessionId, sessionId),
+						eq(hostedSessions.scope, this.scope),
+						isNull(hostedSessions.deletedAt),
+					),
+				);
+		});
+		return this.flush();
 	}
 
 	private async loadRow(sessionId: string): Promise<SessionRow | null> {
@@ -278,6 +329,7 @@ export class HostedSessionManager {
 			id: row.sessionId,
 			subject: row.subject ?? undefined,
 			title: row.title ?? undefined,
+			summary: row.summary ?? undefined,
 			resumeSummary: row.resumeSummary ?? undefined,
 			createdAt: row.createdAt.toISOString(),
 			updatedAt: row.updatedAt.toISOString(),
@@ -294,6 +346,7 @@ export class HostedSessionManager {
 		id: string;
 		subject?: string;
 		title?: string;
+		summary?: string;
 		resumeSummary?: string;
 		messages: AppMessage[];
 		createdAt: string;
@@ -314,6 +367,7 @@ export class HostedSessionManager {
 				id: row.sessionId,
 				subject: row.subject ?? undefined,
 				title: row.title ?? undefined,
+				summary: row.summary ?? undefined,
 				resumeSummary: row.resumeSummary ?? undefined,
 				messages: [],
 				createdAt: row.createdAt.toISOString(),
@@ -352,6 +406,7 @@ export class HostedSessionManager {
 			id: row.sessionId,
 			subject: row.subject ?? undefined,
 			title: row.title ?? undefined,
+			summary: row.summary ?? undefined,
 			resumeSummary: row.resumeSummary ?? undefined,
 			messages: selectedMessages,
 			createdAt: row.createdAt.toISOString(),
@@ -493,39 +548,21 @@ export class HostedSessionManager {
 		sessionId: string,
 		updates: HostedSessionMetadataUpdate,
 	): Promise<void> {
-		await this.flush();
-		const set: Partial<typeof hostedSessions.$inferInsert> = {
-			updatedAt: new Date(),
-		};
+		const set: Partial<typeof hostedSessions.$inferInsert> = {};
 		if (updates.title !== undefined) set.title = updates.title;
 		if (updates.favorite !== undefined) set.favorite = updates.favorite;
 		if (updates.tags !== undefined) set.tags = updates.tags;
-		await getDb()
-			.update(hostedSessions)
-			.set(set)
-			.where(
-				and(
-					eq(hostedSessions.sessionId, sessionId),
-					eq(hostedSessions.scope, this.scope),
-					isNull(hostedSessions.deletedAt),
-				),
-			);
-		const meta: SessionMetaEntry = {
-			type: "session_meta",
-			timestamp: new Date().toISOString(),
-			...(updates.title !== undefined ? { title: updates.title } : {}),
-			...(updates.favorite !== undefined ? { favorite: updates.favorite } : {}),
-			...(updates.tags !== undefined ? { tags: updates.tags } : {}),
-		};
-		if (sessionId === this.sessionId) {
-			this.appendEntry(meta);
-		} else {
-			await getDb().insert(hostedSessionEntries).values({
-				sessionId,
-				entryType: meta.type,
-				entry: meta,
-			});
-		}
+		await this.appendSessionMetaEntry(
+			sessionId,
+			{
+				...(updates.title !== undefined ? { title: updates.title } : {}),
+				...(updates.favorite !== undefined
+					? { favorite: updates.favorite }
+					: {}),
+				...(updates.tags !== undefined ? { tags: updates.tags } : {}),
+			},
+			set,
+		);
 	}
 
 	startSession(state: AgentState, options?: { subject?: string }): void {
@@ -684,85 +721,76 @@ export class HostedSessionManager {
 		this.appendEntry(entry);
 	}
 
-	saveSessionSummary(summary: string, _sessionRef?: string): void {
+	saveSessionSummary(summary: string, sessionRef?: string): Promise<void> {
 		const trimmed = summary.trim();
-		if (!trimmed) return;
-		const sessionId = this.sessionId;
-		const entry: SessionMetaEntry = {
-			type: "session_meta",
-			timestamp: new Date().toISOString(),
-			summary: trimmed,
-		};
-		this.appendEntry(entry);
-		this.enqueue(async () => {
-			await getDb()
-				.update(hostedSessions)
-				.set({ summary: trimmed, updatedAt: new Date() })
-				.where(
-					and(
-						eq(hostedSessions.sessionId, sessionId),
-						eq(hostedSessions.scope, this.scope),
-					),
-				);
-		});
+		if (!trimmed) return Promise.resolve();
+		const sessionId = this.resolveSessionId(sessionRef);
+		return this.appendSessionMetaEntry(
+			sessionId,
+			{ summary: trimmed },
+			{ summary: trimmed },
+		);
 	}
 
-	saveSessionResumeSummary(summary: string, _sessionRef?: string): void {
+	saveSessionResumeSummary(
+		summary: string,
+		sessionRef?: string,
+	): Promise<void> {
 		const trimmed = summary.trim();
-		if (!trimmed) return;
-		const sessionId = this.sessionId;
-		const entry: SessionMetaEntry = {
-			type: "session_meta",
-			timestamp: new Date().toISOString(),
-			resumeSummary: trimmed,
-		};
-		this.appendEntry(entry);
-		this.enqueue(async () => {
-			await getDb()
-				.update(hostedSessions)
-				.set({ resumeSummary: trimmed, updatedAt: new Date() })
-				.where(
-					and(
-						eq(hostedSessions.sessionId, sessionId),
-						eq(hostedSessions.scope, this.scope),
-					),
-				);
-		});
+		if (!trimmed) return Promise.resolve();
+		const sessionId = this.resolveSessionId(sessionRef);
+		return this.appendSessionMetaEntry(
+			sessionId,
+			{ resumeSummary: trimmed },
+			{ resumeSummary: trimmed },
+		);
 	}
 
-	saveSessionMemoryExtractionHash(hash: string, _sessionRef?: string): void {
+	saveSessionMemoryExtractionHash(
+		hash: string,
+		sessionRef?: string,
+	): Promise<void> {
 		const trimmed = hash.trim();
-		if (!trimmed) return;
-		const sessionId = this.sessionId;
-		const entry: SessionMetaEntry = {
-			type: "session_meta",
-			timestamp: new Date().toISOString(),
-			memoryExtractionHash: trimmed,
-		};
-		this.appendEntry(entry);
-		this.enqueue(async () => {
-			await getDb()
-				.update(hostedSessions)
-				.set({ memoryExtractionHash: trimmed, updatedAt: new Date() })
-				.where(
-					and(
-						eq(hostedSessions.sessionId, sessionId),
-						eq(hostedSessions.scope, this.scope),
-					),
-				);
+		if (!trimmed) return Promise.resolve();
+		const sessionId = this.resolveSessionId(sessionRef);
+		return this.appendSessionMetaEntry(
+			sessionId,
+			{ memoryExtractionHash: trimmed },
+			{ memoryExtractionHash: trimmed },
+		);
+	}
+
+	setSessionFavorite(sessionRef: string, favorite: boolean): Promise<void> {
+		return this.appendSessionMetaEntry(
+			this.resolveSessionId(sessionRef),
+			{ favorite },
+			{ favorite },
+		);
+	}
+
+	setSessionTitle(sessionRef: string, title: string): Promise<void> {
+		return this.appendSessionMetaEntry(
+			this.resolveSessionId(sessionRef),
+			{ title },
+			{ title },
+		);
+	}
+
+	setSessionTags(sessionRef: string, tags: string[]): Promise<void> {
+		return this.appendSessionMetaEntry(
+			this.resolveSessionId(sessionRef),
+			{ tags },
+			{ tags },
+		);
+	}
+
+	setSessionAppServerGoal(
+		sessionRef: string,
+		goal: NonNullable<SessionMetaEntry["appServerGoal"]> | null,
+	): Promise<void> {
+		return this.appendSessionMetaEntry(this.resolveSessionId(sessionRef), {
+			appServerGoal: goal,
 		});
-	}
-
-	setSessionFavorite(_sessionRef: string, favorite: boolean): void {
-		void this.updateSessionMetadata(this.sessionId, { favorite });
-	}
-
-	setSessionTitle(_sessionRef: string, title: string): void {
-		void this.updateSessionMetadata(this.sessionId, { title });
-	}
-
-	setSessionTags(_sessionRef: string, tags: string[]): void {
-		void this.updateSessionMetadata(this.sessionId, { tags });
 	}
 
 	getSessionId(): string {

--- a/src/server/hosted-session-manager.ts
+++ b/src/server/hosted-session-manager.ts
@@ -189,7 +189,7 @@ export class HostedSessionManager {
 		sessionId: string,
 		fields: Omit<SessionMetaEntry, "type" | "timestamp">,
 		rowUpdates: Partial<typeof hostedSessions.$inferInsert> = {},
-	): Promise<void> {
+	): void {
 		const entry: SessionMetaEntry = {
 			type: "session_meta",
 			timestamp: new Date().toISOString(),
@@ -224,7 +224,6 @@ export class HostedSessionManager {
 					),
 				);
 		});
-		return this.flush();
 	}
 
 	private async loadRow(sessionId: string): Promise<SessionRow | null> {
@@ -552,7 +551,7 @@ export class HostedSessionManager {
 		if (updates.title !== undefined) set.title = updates.title;
 		if (updates.favorite !== undefined) set.favorite = updates.favorite;
 		if (updates.tags !== undefined) set.tags = updates.tags;
-		await this.appendSessionMetaEntry(
+		this.appendSessionMetaEntry(
 			sessionId,
 			{
 				...(updates.title !== undefined ? { title: updates.title } : {}),
@@ -563,6 +562,7 @@ export class HostedSessionManager {
 			},
 			set,
 		);
+		await this.flush();
 	}
 
 	startSession(state: AgentState, options?: { subject?: string }): void {
@@ -721,63 +721,57 @@ export class HostedSessionManager {
 		this.appendEntry(entry);
 	}
 
-	saveSessionSummary(summary: string, sessionRef?: string): Promise<void> {
+	saveSessionSummary(summary: string, sessionRef?: string): void {
 		const trimmed = summary.trim();
-		if (!trimmed) return Promise.resolve();
+		if (!trimmed) return;
 		const sessionId = this.resolveSessionId(sessionRef);
-		return this.appendSessionMetaEntry(
+		this.appendSessionMetaEntry(
 			sessionId,
 			{ summary: trimmed },
 			{ summary: trimmed },
 		);
 	}
 
-	saveSessionResumeSummary(
-		summary: string,
-		sessionRef?: string,
-	): Promise<void> {
+	saveSessionResumeSummary(summary: string, sessionRef?: string): void {
 		const trimmed = summary.trim();
-		if (!trimmed) return Promise.resolve();
+		if (!trimmed) return;
 		const sessionId = this.resolveSessionId(sessionRef);
-		return this.appendSessionMetaEntry(
+		this.appendSessionMetaEntry(
 			sessionId,
 			{ resumeSummary: trimmed },
 			{ resumeSummary: trimmed },
 		);
 	}
 
-	saveSessionMemoryExtractionHash(
-		hash: string,
-		sessionRef?: string,
-	): Promise<void> {
+	saveSessionMemoryExtractionHash(hash: string, sessionRef?: string): void {
 		const trimmed = hash.trim();
-		if (!trimmed) return Promise.resolve();
+		if (!trimmed) return;
 		const sessionId = this.resolveSessionId(sessionRef);
-		return this.appendSessionMetaEntry(
+		this.appendSessionMetaEntry(
 			sessionId,
 			{ memoryExtractionHash: trimmed },
 			{ memoryExtractionHash: trimmed },
 		);
 	}
 
-	setSessionFavorite(sessionRef: string, favorite: boolean): Promise<void> {
-		return this.appendSessionMetaEntry(
+	setSessionFavorite(sessionRef: string, favorite: boolean): void {
+		this.appendSessionMetaEntry(
 			this.resolveSessionId(sessionRef),
 			{ favorite },
 			{ favorite },
 		);
 	}
 
-	setSessionTitle(sessionRef: string, title: string): Promise<void> {
-		return this.appendSessionMetaEntry(
+	setSessionTitle(sessionRef: string, title: string): void {
+		this.appendSessionMetaEntry(
 			this.resolveSessionId(sessionRef),
 			{ title },
 			{ title },
 		);
 	}
 
-	setSessionTags(sessionRef: string, tags: string[]): Promise<void> {
-		return this.appendSessionMetaEntry(
+	setSessionTags(sessionRef: string, tags: string[]): void {
+		this.appendSessionMetaEntry(
 			this.resolveSessionId(sessionRef),
 			{ tags },
 			{ tags },
@@ -787,8 +781,8 @@ export class HostedSessionManager {
 	setSessionAppServerGoal(
 		sessionRef: string,
 		goal: NonNullable<SessionMetaEntry["appServerGoal"]> | null,
-	): Promise<void> {
-		return this.appendSessionMetaEntry(this.resolveSessionId(sessionRef), {
+	): void {
+		this.appendSessionMetaEntry(this.resolveSessionId(sessionRef), {
 			appServerGoal: goal,
 		});
 	}

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -755,6 +755,7 @@ export class SessionManager {
 			favorite?: boolean;
 			title?: string;
 			tags?: string[];
+			appServerGoal?: SessionMetaEntry["appServerGoal"];
 		},
 	): void {
 		if (!existsSync(targetFile)) return;
@@ -764,7 +765,8 @@ export class SessionManager {
 			meta.memoryExtractionHash === undefined &&
 			meta.favorite === undefined &&
 			meta.title === undefined &&
-			meta.tags === undefined
+			meta.tags === undefined &&
+			meta.appServerGoal === undefined
 		) {
 			return;
 		}
@@ -884,6 +886,14 @@ export class SessionManager {
 		if (!sessionPath || !existsSync(sessionPath)) return;
 		this.appendSessionMetaEntry(sessionPath, { tags });
 		this.syncSessionMemoryEntry(sessionPath);
+	}
+
+	setSessionAppServerGoal(
+		sessionPath: string,
+		goal: NonNullable<SessionMetaEntry["appServerGoal"]> | null,
+	): void {
+		if (!sessionPath || !existsSync(sessionPath)) return;
+		this.appendSessionMetaEntry(sessionPath, { appServerGoal: goal });
 	}
 
 	private syncSessionMemoryEntry(sessionPath: string): void {
@@ -1286,6 +1296,7 @@ export class SessionManager {
 		id: string;
 		subject?: string;
 		title?: string;
+		summary?: string;
 		resumeSummary?: string;
 		messages: AppMessage[];
 		createdAt: string;

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1178,6 +1178,14 @@ export class SessionManager {
 		return this.catalog.getSessionFileById(sessionId);
 	}
 
+	async loadEntries(sessionId: string): Promise<SessionEntry[] | null> {
+		const sessionFile = this.getSessionFileById(sessionId);
+		if (!sessionFile) {
+			return null;
+		}
+		return safeReadSessionEntries(sessionFile);
+	}
+
 	/**
 	 * Set the session file to an existing session
 	 */

--- a/src/session/session-catalog.ts
+++ b/src/session/session-catalog.ts
@@ -145,6 +145,7 @@ export class SessionCatalog {
 					id: info.id,
 					subject: info.subject,
 					title: info.title ?? info.summary,
+					summary: info.summary || info.firstMessage || undefined,
 					resumeSummary: info.resumeSummary,
 					createdAt: info.created.toISOString(),
 					updatedAt: stats.mtime.toISOString(),

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -77,6 +77,13 @@ export interface SessionMetaEntry {
 	favorite?: boolean;
 	title?: string;
 	tags?: string[];
+	appServerGoal?: {
+		objective: string;
+		status: "active" | "complete" | "cancelled";
+		tokenBudget?: number;
+		createdAt: string;
+		updatedAt: string;
+	} | null;
 }
 
 export interface CompactionEntry<T = unknown> extends SessionEntryBase {
@@ -165,6 +172,7 @@ export interface SessionSummary {
 	id: string;
 	subject?: string;
 	title?: string;
+	summary?: string;
 	resumeSummary?: string;
 	createdAt: string;
 	updatedAt: string;

--- a/test/app-server/in-process-client.test.ts
+++ b/test/app-server/in-process-client.test.ts
@@ -12,15 +12,31 @@ function createApi(overrides: Partial<MaestroAppServerSessionApi> = {}) {
 			serverInfo: { name: "maestro" },
 			capabilities: {
 				sessions: true,
+				modelList: true,
+				modelProviderCapabilities: true,
 				threadList: true,
 				threadRead: true,
+				threadMetadataUpdate: true,
+				threadNameSet: true,
+				threadGoals: true,
 				turnsList: true,
 			},
 		}),
+		listModels: async () => ({ models: [] }),
+		readModelProviderCapabilities: async () => ({ providers: [] }),
 		listThreads: async () => ({ threads: [], nextCursor: null }),
 		readThread: async () => {
 			throw new Error("not implemented");
 		},
+		updateThreadMetadata: async () => {
+			throw new Error("not implemented");
+		},
+		setThreadName: async () => {
+			throw new Error("not implemented");
+		},
+		getThreadGoal: async () => ({ threadId: "thread", goal: null }),
+		setThreadGoal: async () => ({ threadId: "thread", goal: null }),
+		clearThreadGoal: async () => ({ threadId: "thread", goal: null }),
 		listTurns: async () => ({
 			threadId: "thread",
 			turns: [],

--- a/test/app-server/session-api.test.ts
+++ b/test/app-server/session-api.test.ts
@@ -786,6 +786,49 @@ describe("Maestro app-server session API", () => {
 		});
 	});
 
+	it("treats whitespace-only optional metadata strings as absent", async () => {
+		let writeCount = 0;
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async () => [],
+			loadSession: async (sessionId, options = {}) =>
+				sessionId === "blank-summary-thread"
+					? {
+							id: sessionId,
+							title: "Blank summary thread",
+							summary: "Original summary",
+							createdAt: "2026-01-01T00:00:00.000Z",
+							updatedAt: "2026-01-01T00:00:00.000Z",
+							messageCount: 1,
+							favorite: false,
+							messagesView: options.messagesView ?? "notLoaded",
+						}
+					: null,
+			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			saveSessionSummary: () => {
+				writeCount += 1;
+			},
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "blank-summary-update",
+			method: "thread/metadata/update",
+			params: {
+				threadId: "blank-summary-thread",
+				summary: "   ",
+			},
+		});
+
+		expect(response.result).toMatchObject({
+			thread: {
+				id: "blank-summary-thread",
+				summary: "Original summary",
+			},
+		});
+		expect(writeCount).toBe(0);
+	});
+
 	it("validates hosted thread existence before metadata writes", async () => {
 		let writeCount = 0;
 		const api = createMaestroAppServerSessionApi({

--- a/test/app-server/session-api.test.ts
+++ b/test/app-server/session-api.test.ts
@@ -202,6 +202,22 @@ describe("Maestro app-server session API", () => {
 		expect(Value.Check(MaestroAppServerResponseSchema, response)).toBe(true);
 	});
 
+	it("does not advertise thread goals without a durable goal read path", () => {
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async () => [],
+			loadSession: async () => null,
+			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			setSessionAppServerGoal: () => {},
+		});
+
+		expect(api.initialize()).toMatchObject({
+			capabilities: {
+				threadGoals: false,
+			},
+		});
+	});
+
 	it("lists models and provider capabilities through the app-server contract", async () => {
 		const api = createMaestroAppServerSessionApi(createSessionManager());
 
@@ -873,6 +889,12 @@ describe("Maestro app-server session API", () => {
 				if (sessionRef === "db:hosted-goal-thread") {
 					storedGoal = goal;
 				}
+			},
+		});
+
+		expect(api.initialize()).toMatchObject({
+			capabilities: {
+				threadGoals: true,
 			},
 		});
 

--- a/test/app-server/session-api.test.ts
+++ b/test/app-server/session-api.test.ts
@@ -680,6 +680,59 @@ describe("Maestro app-server session API", () => {
 		});
 	});
 
+	it("flushes queued store writes before returning metadata summaries", async () => {
+		let summary = "Original summary";
+		let pendingSummary: string | undefined;
+		let flushCount = 0;
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async () => [],
+			loadSession: async (sessionId, options = {}) =>
+				sessionId === "queued-thread"
+					? {
+							id: sessionId,
+							title: "Queued thread",
+							summary,
+							createdAt: "2026-01-01T00:00:00.000Z",
+							updatedAt: "2026-01-01T00:00:00.000Z",
+							messageCount: 1,
+							favorite: false,
+							messagesView: options.messagesView ?? "notLoaded",
+						}
+					: null,
+			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			saveSessionSummary: (nextSummary) => {
+				pendingSummary = nextSummary;
+			},
+			flush: async () => {
+				flushCount += 1;
+				await Promise.resolve();
+				if (pendingSummary !== undefined) {
+					summary = pendingSummary;
+					pendingSummary = undefined;
+				}
+			},
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "queued-summary-update",
+			method: "thread/metadata/update",
+			params: {
+				threadId: "queued-thread",
+				summary: "Flushed summary",
+			},
+		});
+
+		expect(response.result).toMatchObject({
+			thread: {
+				id: "queued-thread",
+				summary: "Flushed summary",
+			},
+		});
+		expect(flushCount).toBe(1);
+	});
+
 	it("validates hosted thread existence before metadata writes", async () => {
 		let writeCount = 0;
 		const api = createMaestroAppServerSessionApi({

--- a/test/app-server/session-api.test.ts
+++ b/test/app-server/session-api.test.ts
@@ -749,6 +749,43 @@ describe("Maestro app-server session API", () => {
 		expect(flushCount).toBe(1);
 	});
 
+	it("fails metadata updates when the writer does not persist the change", async () => {
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async () => [],
+			loadSession: async (sessionId, options = {}) =>
+				sessionId === "stale-metadata-thread"
+					? {
+							id: sessionId,
+							title: "Stale thread",
+							summary: "Original summary",
+							createdAt: "2026-01-01T00:00:00.000Z",
+							updatedAt: "2026-01-01T00:00:00.000Z",
+							messageCount: 1,
+							favorite: false,
+							messagesView: options.messagesView ?? "notLoaded",
+						}
+					: null,
+			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			saveSessionSummary: () => {},
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "stale-metadata-update",
+			method: "thread/metadata/update",
+			params: {
+				threadId: "stale-metadata-thread",
+				summary: "New summary",
+			},
+		});
+
+		expect(response.error).toMatchObject({
+			code: -32000,
+			message: "Thread metadata update was not persisted",
+		});
+	});
+
 	it("validates hosted thread existence before metadata writes", async () => {
 		let writeCount = 0;
 		const api = createMaestroAppServerSessionApi({

--- a/test/app-server/session-api.test.ts
+++ b/test/app-server/session-api.test.ts
@@ -858,6 +858,16 @@ describe("Maestro app-server session API", () => {
 						}
 					: null,
 			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			loadEntries: async (sessionId) =>
+				sessionId === "hosted-goal-thread" && storedGoal !== undefined
+					? [
+							{
+								type: "session_meta",
+								timestamp: "2026-01-01T00:00:00.000Z",
+								appServerGoal: storedGoal,
+							} as SessionEntry,
+						]
+					: [],
 			setSessionAppServerGoal: async (sessionRef, goal) => {
 				await Promise.resolve();
 				if (sessionRef === "db:hosted-goal-thread") {
@@ -888,6 +898,43 @@ describe("Maestro app-server session API", () => {
 			status: "active",
 		});
 		expect(Value.Check(MaestroAppServerResponseSchema, response)).toBe(true);
+	});
+
+	it("fails goal updates when the writer does not persist the new goal", async () => {
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async () => [],
+			loadSession: async (sessionId, options = {}) =>
+				sessionId === "stale-goal-thread"
+					? {
+							id: sessionId,
+							title: "Stale goal thread",
+							createdAt: "2026-01-01T00:00:00.000Z",
+							updatedAt: "2026-01-01T00:00:00.000Z",
+							messageCount: 1,
+							favorite: false,
+							messagesView: options.messagesView ?? "notLoaded",
+						}
+					: null,
+			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			loadEntries: async () => [],
+			setSessionAppServerGoal: () => {},
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "stale-goal-set",
+			method: "thread/goal/set",
+			params: {
+				threadId: "stale-goal-thread",
+				objective: "This must be durable",
+			},
+		});
+
+		expect(response.error).toMatchObject({
+			code: -32000,
+			message: "Thread goal update was not persisted",
+		});
 	});
 
 	it("validates hosted thread existence before clearing goals", async () => {

--- a/test/app-server/session-api.test.ts
+++ b/test/app-server/session-api.test.ts
@@ -189,12 +189,65 @@ describe("Maestro app-server session API", () => {
 			serverInfo: { name: "maestro" },
 			capabilities: {
 				sessions: true,
+				modelList: true,
+				modelProviderCapabilities: true,
 				threadList: true,
 				threadRead: true,
+				threadMetadataUpdate: true,
+				threadNameSet: true,
+				threadGoals: true,
 				turnsList: true,
 			},
 		});
 		expect(Value.Check(MaestroAppServerResponseSchema, response)).toBe(true);
+	});
+
+	it("lists models and provider capabilities through the app-server contract", async () => {
+		const api = createMaestroAppServerSessionApi(createSessionManager());
+
+		const models = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "models",
+			method: "model/list",
+			params: { provider: "openai-codex" },
+		});
+
+		expect(models.result).toMatchObject({
+			models: expect.arrayContaining([
+				expect.objectContaining({
+					id: "gpt-5.1-codex-max",
+					provider: "openai-codex",
+					capabilities: expect.objectContaining({
+						reasoning: true,
+						responsesApi: true,
+						codexBackend: true,
+					}),
+					defaultReasoningEffort: "medium",
+				}),
+			]),
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, models)).toBe(true);
+
+		const providers = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "provider-capabilities",
+			method: "modelProvider/capabilities/read",
+			params: { provider: "openai-codex" },
+		});
+
+		expect(providers.result).toMatchObject({
+			providers: [
+				{
+					id: "openai-codex",
+					capabilities: expect.objectContaining({
+						reasoning: true,
+						responsesApi: true,
+						codexBackend: true,
+					}),
+				},
+			],
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, providers)).toBe(true);
 	});
 
 	it("lists persisted sessions as not-loaded threads with cursor pagination", async () => {
@@ -433,6 +486,381 @@ describe("Maestro app-server session API", () => {
 			content: [{ type: "text", text: "follow up" }],
 		});
 		expect(Value.Check(MaestroAppServerResponseSchema, full)).toBe(true);
+	});
+
+	it("updates thread metadata and name through Codex-style app-server methods", async () => {
+		const session = await createPersistedSession("metadata prompt", {
+			title: "Original title",
+		});
+		const api = createMaestroAppServerSessionApi(
+			createSessionManager(session.sessionFile),
+		);
+
+		const metadata = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "metadata-update",
+			method: "thread/metadata/update",
+			params: {
+				threadId: session.id,
+				summary: "Updated summary",
+				resumeSummary: "Updated resume",
+				favorite: true,
+				tags: [" app-server ", "codex", "codex"],
+			},
+		});
+
+		expect(metadata.result).toMatchObject({
+			thread: {
+				id: session.id,
+				summary: "Updated summary",
+				resumeSummary: "Updated resume",
+				favorite: true,
+				tags: ["app-server", "codex"],
+			},
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, metadata)).toBe(true);
+
+		const name = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "name-set",
+			method: "thread/name/set",
+			params: { threadId: session.id, name: "Renamed thread" },
+		});
+
+		expect(name.result).toMatchObject({
+			thread: {
+				id: session.id,
+				title: "Renamed thread",
+				summary: "Updated summary",
+			},
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, name)).toBe(true);
+	});
+
+	it("uses hosted metadata writers for db-backed thread references", async () => {
+		const hostedThreads = new Map([
+			[
+				"current-thread",
+				{
+					title: "Current title",
+					summary: "Current summary",
+					resumeSummary: "Current resume",
+					favorite: false,
+					tags: [] as string[],
+				},
+			],
+			[
+				"hosted-thread",
+				{
+					title: "Hosted title",
+					summary: "Hosted summary",
+					resumeSummary: "Hosted resume",
+					favorite: false,
+					tags: [] as string[],
+				},
+			],
+		]);
+		const writtenRefs: string[] = [];
+		const readHostedThread = (sessionRef: string) =>
+			hostedThreads.get(sessionRef.replace(/^db:/, ""));
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async () => [],
+			loadSession: async (sessionId, options = {}) => {
+				const hosted = hostedThreads.get(sessionId);
+				return hosted
+					? {
+							id: sessionId,
+							title: hosted.title,
+							summary: hosted.summary,
+							resumeSummary: hosted.resumeSummary,
+							createdAt: "2026-01-01T00:00:00.000Z",
+							updatedAt: "2026-01-01T00:00:02.000Z",
+							messageCount: 2,
+							favorite: hosted.favorite,
+							tags: hosted.tags,
+							messagesView: options.messagesView ?? "notLoaded",
+						}
+					: null;
+			},
+			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			saveSessionSummary: async (summary, sessionRef) => {
+				writtenRefs.push(sessionRef ?? "");
+				await Promise.resolve();
+				const hosted = readHostedThread(sessionRef ?? "");
+				if (hosted) hosted.summary = summary;
+			},
+			saveSessionResumeSummary: async (summary, sessionRef) => {
+				writtenRefs.push(sessionRef ?? "");
+				await Promise.resolve();
+				const hosted = readHostedThread(sessionRef ?? "");
+				if (hosted) hosted.resumeSummary = summary;
+			},
+			setSessionFavorite: async (sessionRef, favorite) => {
+				writtenRefs.push(sessionRef);
+				await Promise.resolve();
+				const hosted = readHostedThread(sessionRef);
+				if (hosted) hosted.favorite = favorite;
+			},
+			setSessionTitle: async (sessionRef, title) => {
+				writtenRefs.push(sessionRef);
+				await Promise.resolve();
+				const hosted = readHostedThread(sessionRef);
+				if (hosted) hosted.title = title;
+			},
+			setSessionTags: async (sessionRef, tags) => {
+				writtenRefs.push(sessionRef);
+				await Promise.resolve();
+				const hosted = readHostedThread(sessionRef);
+				if (hosted) hosted.tags = tags;
+			},
+		});
+
+		const initialized = api.initialize();
+		expect(initialized).toMatchObject({
+			capabilities: {
+				threadMetadataUpdate: true,
+				threadNameSet: true,
+			},
+		});
+
+		const metadata = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "hosted-metadata-update",
+			method: "thread/metadata/update",
+			params: {
+				threadId: "hosted-thread",
+				summary: "Updated hosted summary",
+				resumeSummary: "Updated hosted resume",
+				favorite: true,
+				tags: ["hosted"],
+			},
+		});
+		expect(metadata.result).toMatchObject({
+			thread: {
+				id: "hosted-thread",
+				summary: "Updated hosted summary",
+				resumeSummary: "Updated hosted resume",
+				favorite: true,
+				tags: ["hosted"],
+			},
+		});
+		expect(writtenRefs).toEqual([
+			"db:hosted-thread",
+			"db:hosted-thread",
+			"db:hosted-thread",
+			"db:hosted-thread",
+		]);
+
+		const name = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "hosted-name-set",
+			method: "thread/name/set",
+			params: { threadId: "hosted-thread", name: "Renamed hosted thread" },
+		});
+		expect(name.result).toMatchObject({
+			thread: {
+				id: "hosted-thread",
+				title: "Renamed hosted thread",
+			},
+		});
+		expect(writtenRefs).toEqual([
+			"db:hosted-thread",
+			"db:hosted-thread",
+			"db:hosted-thread",
+			"db:hosted-thread",
+			"db:hosted-thread",
+		]);
+		expect(hostedThreads.get("current-thread")).toMatchObject({
+			title: "Current title",
+			summary: "Current summary",
+			resumeSummary: "Current resume",
+			favorite: false,
+			tags: [],
+		});
+	});
+
+	it("validates hosted thread existence before metadata writes", async () => {
+		let writeCount = 0;
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async () => [],
+			loadSession: async () => null,
+			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			saveSessionSummary: () => {
+				writeCount += 1;
+			},
+			saveSessionResumeSummary: () => {
+				writeCount += 1;
+			},
+			setSessionFavorite: () => {
+				writeCount += 1;
+			},
+			setSessionTitle: () => {
+				writeCount += 1;
+			},
+			setSessionTags: () => {
+				writeCount += 1;
+			},
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "missing-hosted-write",
+			method: "thread/metadata/update",
+			params: {
+				threadId: "missing-hosted-thread",
+				title: "Should not write",
+				summary: "Should not write",
+			},
+		});
+
+		expect(response.error).toMatchObject({
+			code: -32004,
+			message: "Thread not found",
+		});
+		expect(writeCount).toBe(0);
+	});
+
+	it("persists thread goals and clears them through the app-server contract", async () => {
+		const session = await createPersistedSession("goal prompt");
+		const api = createMaestroAppServerSessionApi(
+			createSessionManager(session.sessionFile),
+		);
+
+		const set = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "goal-set",
+			method: "thread/goal/set",
+			params: {
+				threadId: session.id,
+				objective: "Ship the app-server parity slice",
+				tokenBudget: 5000,
+			},
+		});
+
+		expect(set.result).toMatchObject({
+			threadId: session.id,
+			goal: {
+				objective: "Ship the app-server parity slice",
+				status: "active",
+				tokenBudget: 5000,
+				createdAt: expect.any(String),
+				updatedAt: expect.any(String),
+			},
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, set)).toBe(true);
+
+		const get = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "goal-get",
+			method: "thread/goal/get",
+			params: { threadId: session.id },
+		});
+
+		expect(get.result).toEqual(set.result);
+
+		const fractionalBudget = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "goal-fractional-budget",
+			method: "thread/goal/set",
+			params: {
+				threadId: session.id,
+				objective: "Reject fractional budgets",
+				tokenBudget: 0.5,
+			},
+		});
+
+		expect(fractionalBudget.error).toMatchObject({
+			code: -32602,
+			message: "Invalid tokenBudget",
+		});
+
+		const clear = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "goal-clear",
+			method: "thread/goal/clear",
+			params: { threadId: session.id },
+		});
+
+		expect(clear.result).toEqual({ threadId: session.id, goal: null });
+		expect(Value.Check(MaestroAppServerResponseSchema, clear)).toBe(true);
+	});
+
+	it("sets hosted thread goals without a file-backed goal read", async () => {
+		let storedGoal: unknown;
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async () => [],
+			loadSession: async (sessionId, options = {}) =>
+				sessionId === "hosted-goal-thread"
+					? {
+							id: sessionId,
+							title: "Hosted goal thread",
+							createdAt: "2026-01-01T00:00:00.000Z",
+							updatedAt: "2026-01-01T00:00:00.000Z",
+							messageCount: 1,
+							favorite: false,
+							messagesView: options.messagesView ?? "notLoaded",
+						}
+					: null,
+			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			setSessionAppServerGoal: async (sessionRef, goal) => {
+				await Promise.resolve();
+				if (sessionRef === "db:hosted-goal-thread") {
+					storedGoal = goal;
+				}
+			},
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "hosted-goal-set",
+			method: "thread/goal/set",
+			params: {
+				threadId: "hosted-goal-thread",
+				objective: "Persist hosted goals",
+			},
+		});
+
+		expect(response.result).toMatchObject({
+			threadId: "hosted-goal-thread",
+			goal: {
+				objective: "Persist hosted goals",
+				status: "active",
+			},
+		});
+		expect(storedGoal).toMatchObject({
+			objective: "Persist hosted goals",
+			status: "active",
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, response)).toBe(true);
+	});
+
+	it("validates hosted thread existence before clearing goals", async () => {
+		let writeCount = 0;
+		const api = createMaestroAppServerSessionApi({
+			loadAllSessions: () => [],
+			listSessions: async () => [],
+			loadSession: async () => null,
+			getSessionFileById: (sessionId) => `db:${sessionId}`,
+			setSessionAppServerGoal: () => {
+				writeCount += 1;
+			},
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "missing-hosted-goal-clear",
+			method: "thread/goal/clear",
+			params: { threadId: "missing-hosted-thread" },
+		});
+
+		expect(response.error).toMatchObject({
+			code: -32004,
+			message: "Thread not found",
+		});
+		expect(writeCount).toBe(0);
 	});
 
 	it("pages turns without resuming the session", async () => {

--- a/test/app-server/session-api.test.ts
+++ b/test/app-server/session-api.test.ts
@@ -553,6 +553,36 @@ describe("Maestro app-server session API", () => {
 		expect(Value.Check(MaestroAppServerResponseSchema, name)).toBe(true);
 	});
 
+	it("treats whitespace-only summary metadata updates as no-ops", async () => {
+		const session = await createPersistedSession("metadata prompt", {
+			summary: "Original summary",
+			resumeSummary: "Original resume",
+		});
+		const api = createMaestroAppServerSessionApi(
+			createSessionManager(session.sessionFile),
+		);
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "metadata-whitespace-update",
+			method: "thread/metadata/update",
+			params: {
+				threadId: session.id,
+				summary: "   ",
+				resumeSummary: "\n\t ",
+			},
+		});
+
+		expect(response.result).toMatchObject({
+			thread: {
+				id: session.id,
+				summary: "Original summary",
+				resumeSummary: "Original resume",
+			},
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, response)).toBe(true);
+	});
+
 	it("uses hosted metadata writers for db-backed thread references", async () => {
 		const hostedThreads = new Map([
 			[

--- a/test/db/hosted-session-storage.integration.test.ts
+++ b/test/db/hosted-session-storage.integration.test.ts
@@ -212,8 +212,8 @@ describeDb("hosted session database storage", () => {
 		manager.startSession(state, { subject: "key:test-subject" });
 		manager.saveMessage(firstUser);
 		manager.saveMessage(firstAssistant);
-		manager.saveSessionSummary("The session is backed by Postgres.");
-		manager.saveSessionResumeSummary(
+		await manager.saveSessionSummary("The session is backed by Postgres.");
+		await manager.saveSessionResumeSummary(
 			"Continue from the database-backed state.",
 		);
 		await manager.flush();
@@ -226,6 +226,7 @@ describeDb("hosted session database storage", () => {
 		expect(loaded).toMatchObject({
 			id: sessionId,
 			messageCount: 2,
+			summary: "The session is backed by Postgres.",
 			resumeSummary: "Continue from the database-backed state.",
 		});
 		expect(loaded?.messages.map((message) => message.role)).toEqual([
@@ -237,8 +238,15 @@ describeDb("hosted session database storage", () => {
 		).resolves.toMatchObject({
 			id: sessionId,
 			messageCount: 2,
+			summary: "The session is backed by Postgres.",
 			messagesView: "notLoaded",
 			messages: [],
+		});
+		const listed = await manager.listSessions();
+		expect(listed[0]).toMatchObject({
+			id: sessionId,
+			summary: "The session is backed by Postgres.",
+			resumeSummary: "Continue from the database-backed state.",
 		});
 
 		const resumed = createWebSessionManagerForRequest(req, false);


### PR DESCRIPTION
## Summary
- expand the Maestro app-server contract with Codex-inspired model discovery, provider capability, thread metadata/name, and persisted thread goal methods
- wire the session API and in-process client to the new methods, including OpenAI Codex model capability metadata
- persist app-server thread goals as append-only session metadata with focused schema and handler tests
- verify metadata/name and goal mutations by reading back persisted state before returning success

## Test plan
- node ./scripts/run-vitest.js --run test/app-server/session-api.test.ts test/app-server/in-process-client.test.ts
- bunx biome check packages/contracts/src/maestro-app-server.ts src/app-server/session-api.ts src/app-server/in-process-client.ts src/session/types.ts src/session/manager.ts test/app-server/session-api.test.ts test/app-server/in-process-client.test.ts
- bunx tsc -p tsconfig.build.json --noEmit
- node ./scripts/session-wire-format-codegen.mjs --check
- node ./scripts/run-vitest.js --run test/session/session-manager.test.ts test/session/session-context.test.ts test/session/migration.test.ts
- node ./scripts/run-vitest.js --run test/app-server/session-api.test.ts test/db/hosted-session-storage.integration.test.ts test/app-server/in-process-client.test.ts test/server/hosted-session-export.test.ts
- git diff --check
- commit hook: Guardian, full Biome, lint:evals, proto checks, drift/developer-surface checks, build, bun compile

## Private source-of-truth
- evalops/maestro-internal#1797
- evalops/maestro-internal#1799