### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/CONDUCTOR_BRIDGE.md
+++ b/docs/CONDUCTOR_BRIDGE.md
@@ -29,6 +29,7 @@ to the server.
 
 | Category | Examples |
 | --- | --- |
+| Operator loop | `browser_operator` observes the active page, performs one semantic action, and returns verification plus latest page state |
 | Read & search | `read_page`, `search_page`, `find_on_page`, `extract_links`, `extract_table_data`, `extract_document` |
 | Navigation & tabs | `navigate_to`, `open_links_in_tabs`, `wait_for_selector`, `scroll_page` |
 | Interaction | `click_element`, `type_text`, `select_element`, `highlight_element`, `mouse_action`, `pointer_action`, `keyboard_action` |
@@ -36,6 +37,15 @@ to the server.
 | Native actions (CDP) | `native_click`, `native_type`, `native_press`, `native_key_down`, `native_key_up` |
 | Skills & artifacts | `run_skill`, `manage_artifact`, `patch_artifact` |
 | MCP bridging | `list_mcp_servers`, `list_mcp_tools`, `list_mcp_resources`, `read_mcp_resource` |
+
+`browser_operator` is the preferred task-level browser-control surface. Call it
+first with a `goal` and no action to observe the current page. Then call it with
+the same `goal` plus an `action` such as `{ "kind": "click", "selector": "..." }`,
+`{ "kind": "type", "selector": "...", "text": "..." }`, or
+`{ "kind": "select", "selector": "...", "value": "..." }`. Conductor executes
+the action in the active tab, refreshes the page observation, and returns
+verification fields instead of making the model infer success from a low-level
+click or keypress alone.
 
 ## Optional: Native Messaging Host (Auto-Launch + Status)
 

--- a/src/tools/conductor-client.ts
+++ b/src/tools/conductor-client.ts
@@ -248,6 +248,53 @@ export const conductorHighlightElementTool: AgentTool = {
 	execute: async () => ({ content: [], isError: false }),
 };
 
+export const conductorBrowserOperatorTool: AgentTool = {
+	name: "browser_operator",
+	description:
+		"Use Conductor as a browser operator: observe the active page, execute one semantic browser action when supplied, and return verification plus the latest page state. Prefer this over chaining raw browser tools for task-level web interaction.",
+	parameters: Type.Object(
+		{
+			goal: Type.String({
+				description: "The browser task or observation goal.",
+			}),
+			action: Type.Optional(
+				Type.Object(
+					{
+						kind: Type.Union([
+							Type.Literal("click"),
+							Type.Literal("hover"),
+							Type.Literal("type"),
+							Type.Literal("select"),
+							Type.Literal("wait"),
+							Type.Literal("scroll"),
+							Type.Literal("key"),
+						]),
+						selector: Type.Optional(
+							Type.String({
+								description:
+									"CSS selector, node ref, or Conductor element ref returned by observation.",
+							}),
+						),
+						ref: Type.Optional(Type.String()),
+						text: Type.Optional(Type.String()),
+						value: Type.Optional(Type.String()),
+						key: Type.Optional(Type.String()),
+						delta_x: Type.Optional(Type.Number()),
+						delta_y: Type.Optional(Type.Number()),
+						deltaX: Type.Optional(Type.Number()),
+						deltaY: Type.Optional(Type.Number()),
+						timeout_ms: Type.Optional(Type.Number()),
+					},
+					{ additionalProperties: true },
+				),
+			),
+		},
+		{ additionalProperties: true },
+	),
+	executionLocation: "client",
+	execute: async () => ({ content: [], isError: false }),
+};
+
 export const conductorMouseActionTool: AgentTool = {
 	name: "mouse_action",
 	description:
@@ -506,6 +553,7 @@ export const conductorClientTools: AgentTool[] = [
 	conductorNavigateToTool,
 	conductorOpenLinksInTabsTool,
 	conductorHighlightElementTool,
+	conductorBrowserOperatorTool,
 	conductorMouseActionTool,
 	conductorPointerActionTool,
 	conductorKeyboardActionTool,

--- a/test/tools/conductor-client.test.ts
+++ b/test/tools/conductor-client.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { conductorListMcpResourcesTool } from "../../src/tools/conductor-client.js";
+import {
+	conductorBrowserOperatorTool,
+	conductorClientTools,
+	conductorListMcpResourcesTool,
+} from "../../src/tools/conductor-client.js";
 
 type JsonSchemaObject = {
 	type?: string;
 	required?: string[];
-	properties?: Record<string, { type?: string }>;
+	const?: string;
+	anyOf?: JsonSchemaObject[];
+	properties?: Record<string, JsonSchemaObject>;
 };
 
 describe("conductor MCP client tools", () => {
@@ -14,5 +20,30 @@ describe("conductor MCP client tools", () => {
 		expect(schema.type).toBe("object");
 		expect(schema.properties?.server?.type).toBe("string");
 		expect(schema.required ?? []).not.toContain("server");
+	});
+
+	it("publishes browser_operator as the task-level browser-control tool", () => {
+		const schema = conductorBrowserOperatorTool.parameters as JsonSchemaObject;
+
+		expect(conductorClientTools.map((tool) => tool.name)).toContain(
+			"browser_operator",
+		);
+		expect(conductorBrowserOperatorTool.executionLocation).toBe("client");
+		expect(schema.type).toBe("object");
+		expect(schema.required ?? []).toContain("goal");
+		expect(schema.properties?.action?.type).toBe("object");
+		const action = schema.properties?.action;
+		const kindValues = action?.properties?.kind?.anyOf?.map(
+			(entry) => entry.const,
+		);
+		expect(kindValues).toEqual([
+			"click",
+			"hover",
+			"type",
+			"select",
+			"wait",
+			"scroll",
+			"key",
+		]);
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `555cb95c4a5b0cb1d65b637e330f6c4791f40f46`
- last generated public sync base: `3bf1e3052d6d4942e0571c0e783a54c47cf5f8d1`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (555cb95c4a5b)`
- public projection: `https://github.com/evalops/maestro@main (3bf1e3052d6d)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/CONDUCTOR_BRIDGE.md
- copy/update src/tools/conductor-client.ts
- copy/update test/tools/conductor-client.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/CONDUCTOR_BRIDGE.md
- copy/update src/tools/conductor-client.ts
- copy/update test/tools/conductor-client.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode