### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/CONDUCTOR_BRIDGE.md
+++ b/docs/CONDUCTOR_BRIDGE.md
@@ -39,13 +39,18 @@ to the server.
 | MCP bridging | `list_mcp_servers`, `list_mcp_tools`, `list_mcp_resources`, `read_mcp_resource` |
 
 `browser_operator` is the preferred task-level browser-control surface. Call it
-first with a `goal` and no action to observe the current page. Then call it with
-the same `goal` plus an `action` such as `{ "kind": "click", "selector": "..." }`,
+first with `phase: "observe"`, a `goal`, and no action to inspect the current
+page. Then call it with `phase: "act"`, the same `goal`, the prior
+`previous_observation_id` when available, an `expected_result`, and exactly one
+semantic action such as `{ "kind": "click", "selector": "..." }`,
 `{ "kind": "type", "selector": "...", "text": "..." }`, or
-`{ "kind": "select", "selector": "...", "value": "..." }`. Conductor executes
-the action in the active tab, refreshes the page observation, and returns
-verification fields instead of making the model infer success from a low-level
-click or keypress alone.
+`{ "kind": "select", "selector": "...", "value": "..." }`.
+
+Conductor executes the action in the active tab, refreshes the page observation,
+and returns verification fields instead of making the model infer success from a
+low-level click or keypress alone. If verification fails or the selector is
+stale, call `browser_operator` again with `phase: "recover"` and no typed secret
+values; the client should re-observe before retrying.
 
 ## Optional: Native Messaging Host (Auto-Launch + Status)
 

--- a/docs/design/ADVISOR_OUTPUT.md
+++ b/docs/design/ADVISOR_OUTPUT.md
@@ -1,0 +1,25 @@
+# Advisor Output
+
+Advisor-style agents should make their recommended scope machine-readable. When
+the response is plain text, end with:
+
+```text
+Effort: <S|M|L|XL> (<rough duration or reason>)
+Revisit-if: <signal that would invalidate the estimate>
+```
+
+Use the canonical sizes:
+
+- `S`: less than 1 hour
+- `M`: 1 to 3 hours
+- `L`: 1 to 2 days
+- `XL`: more than 2 days, decompose before execution
+
+`Revisit-if` is optional but encouraged when the estimate depends on an
+assumption. For JSON-only advisors, emit an equivalent top-level `effort_signal`
+object with `size`, `justification`, and optional `revisit_if`.
+
+Callers can parse plain-text advisor output with
+`parseAdvisorEffortSignal(output)` from `@evalops/contracts`. Missing signals
+return `null` so routers can treat the estimate as unknown instead of failing the
+workflow.

--- a/packages/contracts/src/advisor-effort.ts
+++ b/packages/contracts/src/advisor-effort.ts
@@ -1,0 +1,59 @@
+export type AdvisorEffortSize = "S" | "M" | "L" | "XL";
+
+export interface AdvisorEffortSignal {
+	size: AdvisorEffortSize;
+	justification: string;
+	revisitIf?: string;
+}
+
+const EFFORT_LINE =
+	/^\s*Effort:\s*(S|M|L|XL)\s*(?:\(([^)]*)\)|[-:]\s*(.*)|\s*)$/gim;
+const REVISIT_LINE = /^\s*Revisit-if:\s*(.+)$/gim;
+const ADVISOR_EFFORT_SIZES = new Set(["S", "M", "L", "XL"]);
+
+function normalizeAdvisorEffortSize(value: string): AdvisorEffortSize {
+	const normalized = value.toUpperCase();
+	if (ADVISOR_EFFORT_SIZES.has(normalized)) {
+		return normalized as AdvisorEffortSize;
+	}
+	throw new Error(`Invalid advisor effort size: ${value}`);
+}
+
+export function parseAdvisorEffortSignal(
+	output: string,
+): AdvisorEffortSignal | null {
+	let effortMatch: RegExpExecArray | null = null;
+	for (
+		let match = EFFORT_LINE.exec(output);
+		match;
+		match = EFFORT_LINE.exec(output)
+	) {
+		effortMatch = match;
+	}
+	EFFORT_LINE.lastIndex = 0;
+
+	if (!effortMatch) {
+		return null;
+	}
+
+	const selectedEffortEnd = effortMatch.index + effortMatch[0].length;
+	const selectedEffortScope = output.slice(selectedEffortEnd);
+	let revisitMatch: RegExpExecArray | null = null;
+	for (
+		let match = REVISIT_LINE.exec(selectedEffortScope);
+		match;
+		match = REVISIT_LINE.exec(selectedEffortScope)
+	) {
+		revisitMatch = match;
+	}
+	REVISIT_LINE.lastIndex = 0;
+
+	const justification = (effortMatch[2] ?? effortMatch[3] ?? "").trim();
+	const revisitIf = revisitMatch?.[1]?.trim();
+
+	return {
+		size: normalizeAdvisorEffortSize(effortMatch[1] ?? ""),
+		justification,
+		...(revisitIf ? { revisitIf } : {}),
+	};
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -46,6 +46,7 @@
 export * from "./headless-protocol-generated.js";
 export * from "./headless-protocol-schemas.generated.js";
 export * as headlessProto from "./proto/maestro/v1/headless_pb.js";
+export * from "./advisor-effort.js";
 export * from "./delegation-prompt.js";
 export * from "./guarded-files-settings.js";
 export * from "./key-value-tokens.js";

--- a/src/cli-tui/utils/commands/review-prompt.ts
+++ b/src/cli-tui/utils/commands/review-prompt.ts
@@ -37,13 +37,18 @@ Output ONLY valid JSON (no Markdown fences) with this shape:
   ],
   "overall_correctness": "patch is correct" | "patch is incorrect",
   "overall_explanation": "<1-3 sentences>",
-  "overall_confidence_score": <0.0-1.0>
+  "overall_confidence_score": <0.0-1.0>,
+  "effort_signal": {
+    "size": "S" | "M" | "L" | "XL",
+    "justification": "<rough duration or reason>",
+    "revisit_if": "<optional signal that would invalidate the estimate>"
+  }
 }
 
 Guidance:
 - Use absolute paths (prefix with repo root); line ranges must overlap the diff and stay minimal.
 - Do NOT suggest fixes or use suggestion blocks.
-- If no issues, return an empty findings array but still fill overall_* fields.
+- If no issues, return an empty findings array but still fill overall_* fields and effort_signal.
 - Ignore trivial style unless it obscures behavior or violates repo standards.
 - Diffs may be truncated for length; [truncated …] markers mean omitted lines. Focus on available context.
 - Never wrap the JSON in fences or extra prose.`;
@@ -91,5 +96,5 @@ ${staged}
 Unstaged diff (git diff --unified=5):
 ${worktree}
 
-Task: Review ONLY the changes above. Apply the guidelines strictly. Produce the JSON output exactly as specified with no extra text. If there are no findings, use an empty findings array but still fill overall_* fields. No code fences, no commentary.`;
+Task: Review ONLY the changes above. Apply the guidelines strictly. Produce the JSON output exactly as specified with no extra text. If there are no findings, use an empty findings array but still fill overall_* fields and effort_signal. No code fences, no commentary.`;
 }

--- a/src/tools/conductor-client.ts
+++ b/src/tools/conductor-client.ts
@@ -251,12 +251,38 @@ export const conductorHighlightElementTool: AgentTool = {
 export const conductorBrowserOperatorTool: AgentTool = {
 	name: "browser_operator",
 	description:
-		"Use Conductor as a browser operator: observe the active page, execute one semantic browser action when supplied, and return verification plus the latest page state. Prefer this over chaining raw browser tools for task-level web interaction.",
+		"Use Conductor as a browser operator: observe the active page, execute one semantic browser action when supplied, and return verification plus the latest page state. Prefer this over chaining raw browser tools. Use an observe -> act -> verify loop, and re-observe before retrying stale selectors.",
 	parameters: Type.Object(
 		{
 			goal: Type.String({
 				description: "The browser task or observation goal.",
 			}),
+			phase: Type.Optional(
+				Type.Union([
+					Type.Literal("observe"),
+					Type.Literal("act"),
+					Type.Literal("verify"),
+					Type.Literal("recover"),
+				]),
+			),
+			previous_observation_id: Type.Optional(
+				Type.String({
+					description:
+						"Opaque observation id from the prior browser_operator result, when retrying or verifying a prior action.",
+				}),
+			),
+			expected_result: Type.Optional(
+				Type.String({
+					description:
+						"Short, redaction-safe success condition for the action, such as a visible result, URL/title change, or selector becoming present.",
+				}),
+			),
+			max_elements: Type.Optional(
+				Type.Number({
+					description:
+						"Maximum interactive elements to include when observing or refreshing page state.",
+				}),
+			),
 			action: Type.Optional(
 				Type.Object(
 					{

--- a/src/tools/oracle.ts
+++ b/src/tools/oracle.ts
@@ -72,7 +72,7 @@ export const oracleTool = createTool<typeof oracleSchema, OracleToolDetails>({
 			validation:
 				"Inspect referenced artifacts before drawing conclusions, cite file paths and line numbers when possible, and separate evidence from assumptions.",
 			stoppingCondition:
-				"Stop after a concise response with Summary, Insights, optional Next steps, and any uncertainties. Never edit or run code.",
+				"Stop after a concise response with Summary, Insights, optional Next steps, any uncertainties, then final lines `Effort: <S|M|L|XL> (<rough duration or reason>)` and optional `Revisit-if: <signal>`. Never edit or run code.",
 		};
 		const prompt = [
 			"You are the Seer, a read-only software architecture advisor. You must never edit or run code.",

--- a/test/cli/review-prompt.test.ts
+++ b/test/cli/review-prompt.test.ts
@@ -18,5 +18,8 @@ describe("buildReviewPrompt", () => {
 		expect(prompt).toContain("Diff summary");
 		expect(prompt).toContain("Staged diff");
 		expect(prompt).toContain("Unstaged diff");
+		expect(prompt).toContain('"effort_signal"');
+		expect(prompt).toContain('"size": "S" | "M" | "L" | "XL"');
+		expect(prompt).toContain("fill overall_* fields and effort_signal");
 	});
 });

--- a/test/contracts/advisor-effort.test.ts
+++ b/test/contracts/advisor-effort.test.ts
@@ -1,0 +1,55 @@
+import { parseAdvisorEffortSignal } from "@evalops/contracts";
+import { describe, expect, it } from "vitest";
+
+describe("parseAdvisorEffortSignal", () => {
+	it("extracts the final effort signal and revisit condition", () => {
+		expect(
+			parseAdvisorEffortSignal(
+				[
+					"Summary: ship the small fix.",
+					"Effort: S (<1h)",
+					"Effort: M (1-3h after tests)",
+					"Revisit-if: integration tests reveal a protocol mismatch",
+				].join("\n"),
+			),
+		).toEqual({
+			size: "M",
+			justification: "1-3h after tests",
+			revisitIf: "integration tests reveal a protocol mismatch",
+		});
+	});
+
+	it("does not carry a stale revisit condition onto a later effort signal", () => {
+		expect(
+			parseAdvisorEffortSignal(
+				[
+					"Effort: L (needs protocol work)",
+					"Revisit-if: hosted runtime scope changes",
+					"Correction: the contract already exists.",
+					"Effort: S (<1h)",
+				].join("\n"),
+			),
+		).toEqual({
+			size: "S",
+			justification: "<1h",
+		});
+	});
+
+	it("supports dash-separated justification", () => {
+		expect(parseAdvisorEffortSignal("Effort: XL - decompose first")).toEqual({
+			size: "XL",
+			justification: "decompose first",
+		});
+	});
+
+	it("normalizes lowercase size values to canonical uppercase", () => {
+		expect(parseAdvisorEffortSignal("effort: xl (>2d)")).toEqual({
+			size: "XL",
+			justification: ">2d",
+		});
+	});
+
+	it("returns null when no signal is present", () => {
+		expect(parseAdvisorEffortSignal("No estimate here.")).toBeNull();
+	});
+});

--- a/test/tools/conductor-client.test.ts
+++ b/test/tools/conductor-client.test.ts
@@ -31,6 +31,13 @@ describe("conductor MCP client tools", () => {
 		expect(conductorBrowserOperatorTool.executionLocation).toBe("client");
 		expect(schema.type).toBe("object");
 		expect(schema.required ?? []).toContain("goal");
+		const phaseValues = schema.properties?.phase?.anyOf?.map(
+			(entry) => entry.const,
+		);
+		expect(phaseValues).toEqual(["observe", "act", "verify", "recover"]);
+		expect(schema.properties?.previous_observation_id?.type).toBe("string");
+		expect(schema.properties?.expected_result?.type).toBe("string");
+		expect(schema.properties?.max_elements?.type).toBe("number");
 		expect(schema.properties?.action?.type).toBe("object");
 		const action = schema.properties?.action;
 		const kindValues = action?.properties?.kind?.anyOf?.map(

--- a/test/tools/oracle.test.ts
+++ b/test/tools/oracle.test.ts
@@ -93,6 +93,7 @@ describe("oracleTool", () => {
 		expect(prompt).toContain(
 			"## Stopping Condition\nStop after a concise response",
 		);
+		expect(prompt).toContain("Effort: <S|M|L|XL>");
 		expect(spawnMock).toHaveBeenCalledWith(
 			"maestro",
 			expect.arrayContaining([


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `e5e4e06022cda13a8f1ddbcd5c23471b1d4c8427`
- last generated public sync base: `d6fdac5303edcf97cec50582b635155b867b1b18`
- previewed public-tree drift: `11` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (e5e4e06022cd)`
- public projection: `https://github.com/evalops/maestro@main (d6fdac5303ed)`
- files to copy or update: `11`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/CONDUCTOR_BRIDGE.md
- copy/update docs/design/ADVISOR_OUTPUT.md
- copy/update packages/contracts/src/advisor-effort.ts
- copy/update packages/contracts/src/index.ts
- copy/update src/cli-tui/utils/commands/review-prompt.ts
- copy/update src/tools/conductor-client.ts
- copy/update src/tools/oracle.ts
- copy/update test/cli/review-prompt.test.ts
- copy/update test/contracts/advisor-effort.test.ts
- copy/update test/tools/conductor-client.test.ts
- copy/update test/tools/oracle.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/CONDUCTOR_BRIDGE.md
- copy/update docs/design/ADVISOR_OUTPUT.md
- copy/update packages/contracts/src/advisor-effort.ts
- copy/update packages/contracts/src/index.ts
- copy/update src/cli-tui/utils/commands/review-prompt.ts
- copy/update src/tools/conductor-client.ts
- copy/update src/tools/oracle.ts
- copy/update test/cli/review-prompt.test.ts
- copy/update test/contracts/advisor-effort.test.ts
- copy/update test/tools/conductor-client.test.ts
- copy/update test/tools/oracle.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #332 to internal source `e5e4e06022cda13a8f1ddbcd5c23471b1d4c8427`