### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/CONDUCTOR_BRIDGE.md
+++ b/docs/CONDUCTOR_BRIDGE.md
@@ -42,13 +42,20 @@ to the server.
 first with `phase: "observe"`, a `goal`, and no action to inspect the current
 page. Then call it with `phase: "act"`, the same `goal`, the prior
 `previous_observation_id` when available, an `expected_result`, and exactly one
-semantic action such as `{ "kind": "click", "selector": "..." }`,
-`{ "kind": "type", "selector": "...", "text": "..." }`, or
+semantic action such as `{ "kind": "click", "refId": "..." }`,
+`{ "kind": "type", "refId": "...", "text": "..." }`, or
 `{ "kind": "select", "selector": "...", "value": "..." }`.
+
+Prefer the `refId` returned by observation over a CSS selector. For targets
+inside embedded apps or iframes, preserve both `frameId` and `refId` from the
+observed element and send them back with the action. Use `include_frames: true`
+on observe/recover calls when the target may be inside a frame. Observation
+results may also include page-observer freshness metadata; if a frame changed
+after the prior observation, recover by observing again before retrying.
 
 Conductor executes the action in the active tab, refreshes the page observation,
 and returns verification fields instead of making the model infer success from a
-low-level click or keypress alone. If verification fails or the selector is
+low-level click or keypress alone. If verification fails or the ref/selector is
 stale, call `browser_operator` again with `phase: "recover"` and no typed secret
 values; the client should re-observe before retrying.
 

--- a/src/tools/conductor-client.ts
+++ b/src/tools/conductor-client.ts
@@ -251,7 +251,7 @@ export const conductorHighlightElementTool: AgentTool = {
 export const conductorBrowserOperatorTool: AgentTool = {
 	name: "browser_operator",
 	description:
-		"Use Conductor as a browser operator: observe the active page, execute one semantic browser action when supplied, and return verification plus the latest page state. Prefer this over chaining raw browser tools. Use an observe -> act -> verify loop, and re-observe before retrying stale selectors.",
+		"Use Conductor as a browser operator: observe the active page, execute one semantic browser action when supplied, and return verification plus the latest page state. Prefer this over chaining raw browser tools. Use an observe -> act -> verify loop, prefer observed refId plus frameId targets over selectors, and re-observe before retrying stale refs or selectors.",
 	parameters: Type.Object(
 		{
 			goal: Type.String({
@@ -283,6 +283,12 @@ export const conductorBrowserOperatorTool: AgentTool = {
 						"Maximum interactive elements to include when observing or refreshing page state.",
 				}),
 			),
+			include_frames: Type.Optional(
+				Type.Boolean({
+					description:
+						"Include all frame snapshots. Use this when the target may live inside an embedded app, auth, or payment frame.",
+				}),
+			),
 			action: Type.Optional(
 				Type.Object(
 					{
@@ -298,10 +304,29 @@ export const conductorBrowserOperatorTool: AgentTool = {
 						selector: Type.Optional(
 							Type.String({
 								description:
-									"CSS selector, node ref, or Conductor element ref returned by observation.",
+									"CSS selector fallback for the target. Prefer refId when observation returned one.",
 							}),
 						),
-						ref: Type.Optional(Type.String()),
+						ref: Type.Optional(
+							Type.String({
+								description:
+									"Legacy target ref. If this is a Conductor ref id, prefer putting it in refId.",
+							}),
+						),
+						refId: Type.Optional(
+							Type.String({
+								description:
+									"Stable Conductor element refId returned by observe. Prefer this over selector for follow-up actions.",
+							}),
+						),
+						ref_id: Type.Optional(Type.String()),
+						frameId: Type.Optional(
+							Type.Number({
+								description:
+									"Frame id returned by observe for iframe-scoped targets. Pass it with refId for embedded controls.",
+							}),
+						),
+						frame_id: Type.Optional(Type.Number()),
 						text: Type.Optional(Type.String()),
 						value: Type.Optional(Type.String()),
 						key: Type.Optional(Type.String()),

--- a/test/tools/conductor-client.test.ts
+++ b/test/tools/conductor-client.test.ts
@@ -38,6 +38,7 @@ describe("conductor MCP client tools", () => {
 		expect(schema.properties?.previous_observation_id?.type).toBe("string");
 		expect(schema.properties?.expected_result?.type).toBe("string");
 		expect(schema.properties?.max_elements?.type).toBe("number");
+		expect(schema.properties?.include_frames?.type).toBe("boolean");
 		expect(schema.properties?.action?.type).toBe("object");
 		const action = schema.properties?.action;
 		const kindValues = action?.properties?.kind?.anyOf?.map(
@@ -52,5 +53,10 @@ describe("conductor MCP client tools", () => {
 			"scroll",
 			"key",
 		]);
+		expect(action?.properties?.selector?.type).toBe("string");
+		expect(action?.properties?.refId?.type).toBe("string");
+		expect(action?.properties?.ref_id?.type).toBe("string");
+		expect(action?.properties?.frameId?.type).toBe("number");
+		expect(action?.properties?.frame_id?.type).toBe("number");
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `47709cb78766bb3ac1fb12c851a4f61cbab750d0`
- last generated public sync base: `a356776f91b5dc27a29c287809a78189d7c4513b`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (47709cb78766)`
- public projection: `https://github.com/evalops/maestro@main (a356776f91b5)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/CONDUCTOR_BRIDGE.md
- copy/update src/tools/conductor-client.ts
- copy/update test/tools/conductor-client.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/CONDUCTOR_BRIDGE.md
- copy/update src/tools/conductor-client.ts
- copy/update test/tools/conductor-client.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode