### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/design/RUNTIME_CONSTRAINTS.md
+++ b/docs/design/RUNTIME_CONSTRAINTS.md
@@ -1,0 +1,56 @@
+# Runtime Constraints
+
+Runtime constraint fragments are small system-prompt additions that tell the
+agent about execution limits the runtime already knows. They keep environment
+warnings close to prompt assembly instead of relying on every caller to restate
+the same sandbox, network, or checkout caveats.
+
+## Contract
+
+Fragments live in `@evalops/contracts` so every Maestro surface can share the
+same keys and wording:
+
+- `RuntimeConstraintContext` describes observed runtime facts such as
+  `sandboxMode`, `isShallowGitCheckout`, `networkAccess`, `readOnly`,
+  `hostedRunner`, and `firewallRestricted`.
+- `RuntimeConstraintDefinition` pairs a stable `contextKey`, a predicate over
+  that context, and the prompt text.
+- `getRuntimeConstraintFragments()` selects matching fragments.
+- `buildRuntimeConstraintPrompt()` formats selected fragments as a single
+  `# Runtime Constraints` system-prompt section.
+
+The contract package stays pure. Filesystem and environment detection happens in
+the caller, currently `src/cli/system-prompt.ts`, before the context is passed
+into prompt finalization.
+
+## Current Fragments
+
+| Key | Condition | Prompt behavior |
+| --- | --- | --- |
+| `sandbox.filesystem` | Sandbox mode is active | Keep reads, writes, and commands inside approved workspace paths. |
+| `sandbox.shallow-git` | Sandbox mode is active and the checkout has `.git/shallow` | Warn that history-sensitive commands need `git fetch --unshallow`. |
+| `hosted-runner.ephemeral` | Hosted runner env is detected | Treat the workspace as ephemeral and avoid printing secrets. |
+| `network.offline` | `networkAccess` is `disabled` | Skip web search and expect external network calls to fail. |
+| `network.restricted` | `networkAccess` is `restricted` or firewall restriction is detected | Avoid repeated network probes and prefer local/configured routes. |
+| `checkout.read-only` | Read-only mode is active | Inspect and plan without attempting file edits or mutating commands. |
+
+## Detection
+
+The default detector uses explicit CLI/runtime inputs first and environment
+signals second:
+
+- `MAESTRO_SANDBOX_MODE`, `CODEX_SANDBOX_MODE`, or legacy
+  `MAESTRO_SANDBOX` for sandbox mode. Policy env values are preferred over
+  backend markers.
+- `.git/shallow`, including worktree `.git` files, for shallow checkouts.
+- `MAESTRO_OFFLINE_EVAL=1` or `CODEX_OFFLINE_EVAL=1` for offline evals.
+- `MAESTRO_NETWORK_ACCESS` or `CODEX_NETWORK_ACCESS` for `available`,
+  `restricted`, or `disabled` network access.
+- `MAESTRO_FIREWALL_RESTRICTED=1` or `CODEX_FIREWALL_RESTRICTED=1` for
+  firewall-restricted network egress.
+- `MAESTRO_HOSTED_RUNNER=1` or `MAESTRO_RUNNER_KIND=hosted` for hosted runners.
+- `MAESTRO_READ_ONLY=1`, `CODEX_READ_ONLY=1`, or CLI read-only flags for
+  read-only checkouts.
+
+Callers that already have authoritative runtime facts should pass them directly
+instead of re-deriving from environment variables.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -56,6 +56,7 @@ export * from "./memory-utils.js";
 export * from "./maestro-app-server.js";
 export * from "./onboarding-utils.js";
 export * from "./proto/maestro/v1/headless_pb.js";
+export * from "./runtime-constraints.js";
 export * from "./runtime-app-server.js";
 export * from "./runtime-server-request.js";
 

--- a/packages/contracts/src/runtime-constraints.ts
+++ b/packages/contracts/src/runtime-constraints.ts
@@ -1,0 +1,130 @@
+export type RuntimeNetworkAccess =
+	| "available"
+	| "restricted"
+	| "disabled"
+	| "unknown";
+
+export interface RuntimeConstraintContext {
+	/**
+	 * Runtime sandbox mode selected by the caller, for example `workspace-write`
+	 * or `read-only`.
+	 */
+	sandboxMode?: string | null;
+	sandboxEnabled?: boolean;
+	isShallowGitCheckout?: boolean;
+	readOnly?: boolean;
+	networkAccess?: RuntimeNetworkAccess;
+	hostedRunner?: boolean;
+	firewallRestricted?: boolean;
+	runnerImage?: string | null;
+}
+
+export interface RuntimeConstraintFragment {
+	contextKey: string;
+	prompt: string;
+}
+
+export interface RuntimeConstraintDefinition extends RuntimeConstraintFragment {
+	condition: (context: RuntimeConstraintContext) => boolean;
+}
+
+export function isSandboxModeEnabled(mode?: string | null): boolean {
+	const normalized = mode?.trim().toLowerCase();
+	return Boolean(
+		normalized &&
+			normalized !== "none" &&
+			normalized !== "local" &&
+			normalized !== "danger-full-access",
+	);
+}
+
+function isSandboxEnabled(context: RuntimeConstraintContext): boolean {
+	if (context.sandboxEnabled !== undefined) {
+		return context.sandboxEnabled;
+	}
+	return isSandboxModeEnabled(context.sandboxMode);
+}
+
+function isReadOnly(context: RuntimeConstraintContext): boolean {
+	return (
+		context.readOnly === true ||
+		context.sandboxMode?.trim().toLowerCase() === "read-only"
+	);
+}
+
+export const RUNTIME_CONSTRAINT_FRAGMENTS: RuntimeConstraintDefinition[] = [
+	{
+		contextKey: "sandbox.filesystem",
+		condition: (context) => isSandboxEnabled(context),
+		prompt:
+			"Filesystem sandboxing is active. Keep file reads, writes, and command execution inside the approved workspace and use explicit user approval before attempting paths outside the sandbox.",
+	},
+	{
+		contextKey: "sandbox.shallow-git",
+		condition: (context) =>
+			isSandboxEnabled(context) && context.isShallowGitCheckout === true,
+		prompt:
+			"Git history note: this sandbox checkout is shallow. Run `git fetch --unshallow` before relying on history-sensitive commands such as `git log`, `git blame`, or commit archaeology.",
+	},
+	{
+		contextKey: "hosted-runner.ephemeral",
+		condition: (context) => context.hostedRunner === true,
+		prompt:
+			"Hosted runner note: this environment may be ephemeral. Persist user-visible outputs intentionally, treat secrets as environment-only, and do not print secret values in logs or summaries.",
+	},
+	{
+		contextKey: "network.offline",
+		condition: (context) => context.networkAccess === "disabled",
+		prompt:
+			"Offline evaluation mode is active. Web search, external fetches, MCP calls, and Platform network requests are expected to fail; skip web search and rely on local repository context unless the user provides network data.",
+	},
+	{
+		contextKey: "network.restricted",
+		condition: (context) =>
+			context.networkAccess !== "disabled" &&
+			(context.networkAccess === "restricted" ||
+				context.firewallRestricted === true),
+		prompt:
+			"Network egress is restricted. Avoid repeated failed network probes; prefer local evidence, configured internal routes, or explicit user approval before depending on external services.",
+	},
+	{
+		contextKey: "checkout.read-only",
+		condition: (context) => isReadOnly(context),
+		prompt:
+			"Read-only checkout mode is active. Do not attempt file edits or mutating commands; inspect, plan, and report the exact changes needed instead.",
+	},
+];
+
+export function getRuntimeConstraintFragments(
+	context?: RuntimeConstraintContext | null,
+): RuntimeConstraintFragment[] {
+	if (!context) {
+		return [];
+	}
+	return RUNTIME_CONSTRAINT_FRAGMENTS.filter((fragment) =>
+		fragment.condition(context),
+	).map(({ contextKey, prompt }) => ({ contextKey, prompt }));
+}
+
+export function formatRuntimeConstraintFragments(
+	fragments: RuntimeConstraintFragment[],
+): string {
+	if (fragments.length === 0) {
+		return "";
+	}
+	return [
+		"# Runtime Constraints",
+		"",
+		...fragments.map(
+			(fragment) => `## ${fragment.contextKey}\n\n${fragment.prompt}`,
+		),
+	].join("\n\n");
+}
+
+export function buildRuntimeConstraintPrompt(
+	context?: RuntimeConstraintContext | null,
+): string {
+	return formatRuntimeConstraintFragments(
+		getRuntimeConstraintFragments(context),
+	);
+}

--- a/src/cli/system-prompt.ts
+++ b/src/cli/system-prompt.ts
@@ -8,7 +8,13 @@ import {
 	statSync,
 } from "node:fs";
 import type { Dirent } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import {
+	type RuntimeConstraintContext,
+	type RuntimeNetworkAccess,
+	buildRuntimeConstraintPrompt,
+	isSandboxModeEnabled,
+} from "@evalops/contracts";
 import chalk from "chalk";
 import { buildSearchGuidelines } from "../agent/search-guidance.js";
 import { getAgentDir } from "../config/constants.js";
@@ -111,6 +117,153 @@ function loadAppendSystemPrompt(cwd: string): string | null {
 	return appendSystemPath
 		? resolveSystemPromptOverride(appendSystemPath)
 		: null;
+}
+
+interface RuntimeConstraintDetectionOptions {
+	cwd?: string;
+	sandboxMode?: string | null;
+	sandboxEnabled?: boolean;
+	readOnly?: boolean;
+	env?: Record<string, string | undefined>;
+}
+
+export interface FinalizeSystemPromptOptions {
+	runtimeConstraints?: RuntimeConstraintContext | null;
+}
+
+function readEnvFlag(
+	env: Record<string, string | undefined>,
+	name: string,
+): boolean {
+	const value = env[name]?.trim().toLowerCase();
+	return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
+function normalizeNetworkAccess(
+	value?: string,
+): RuntimeNetworkAccess | undefined {
+	const normalized = value?.trim().toLowerCase();
+	if (!normalized) {
+		return undefined;
+	}
+	if (
+		normalized === "disabled" ||
+		normalized === "offline" ||
+		normalized === "none" ||
+		normalized === "no-network"
+	) {
+		return "disabled";
+	}
+	if (
+		normalized === "restricted" ||
+		normalized === "firewall" ||
+		normalized === "gated"
+	) {
+		return "restricted";
+	}
+	if (normalized === "available" || normalized === "enabled") {
+		return "available";
+	}
+	return "unknown";
+}
+
+function resolveGitDirectoryAtPath(path: string): string | null {
+	const gitPath = join(path, ".git");
+	try {
+		const gitStat = statSync(gitPath);
+		if (gitStat.isDirectory()) {
+			return gitPath;
+		}
+		if (!gitStat.isFile()) {
+			return null;
+		}
+		const gitFile = readFileSync(gitPath, "utf8");
+		const match = /^gitdir:\s*(.+?)\s*$/m.exec(gitFile);
+		const gitDir = match?.[1];
+		if (!gitDir) {
+			return null;
+		}
+		return resolve(path, gitDir);
+	} catch {
+		return null;
+	}
+}
+
+function resolveGitDirectory(cwd: string): string | null {
+	let current = resolve(cwd);
+	while (true) {
+		const gitDir = resolveGitDirectoryAtPath(current);
+		if (gitDir) {
+			return gitDir;
+		}
+		const parent = dirname(current);
+		if (parent === current) {
+			return null;
+		}
+		current = parent;
+	}
+}
+
+function resolveGitCommonDirectory(gitDir: string): string {
+	try {
+		const commonDir = readFileSync(join(gitDir, "commondir"), "utf8").trim();
+		if (commonDir) {
+			return resolve(gitDir, commonDir);
+		}
+	} catch {
+		// Older/non-worktree repositories do not have a commondir file.
+	}
+	return gitDir;
+}
+
+function isShallowGitCheckout(cwd: string): boolean {
+	const gitDir = resolveGitDirectory(cwd);
+	if (!gitDir) {
+		return false;
+	}
+	const commonGitDir = resolveGitCommonDirectory(gitDir);
+	return (
+		existsSync(join(commonGitDir, "shallow")) ||
+		existsSync(join(gitDir, "shallow"))
+	);
+}
+
+export function detectRuntimeConstraintContext(
+	options: RuntimeConstraintDetectionOptions = {},
+): RuntimeConstraintContext {
+	const cwd = options.cwd ?? process.cwd();
+	const env = options.env ?? process.env;
+	const sandboxMode =
+		options.sandboxMode ??
+		env.MAESTRO_SANDBOX_MODE ??
+		env.CODEX_SANDBOX_MODE ??
+		env.MAESTRO_SANDBOX ??
+		null;
+	const networkAccess =
+		readEnvFlag(env, "MAESTRO_OFFLINE_EVAL") ||
+		readEnvFlag(env, "CODEX_OFFLINE_EVAL")
+			? "disabled"
+			: normalizeNetworkAccess(
+					env.MAESTRO_NETWORK_ACCESS ?? env.CODEX_NETWORK_ACCESS,
+				);
+
+	return {
+		sandboxMode,
+		sandboxEnabled: options.sandboxEnabled ?? isSandboxModeEnabled(sandboxMode),
+		isShallowGitCheckout: isShallowGitCheckout(cwd),
+		readOnly:
+			options.readOnly ??
+			(readEnvFlag(env, "MAESTRO_READ_ONLY") ||
+				readEnvFlag(env, "CODEX_READ_ONLY")),
+		networkAccess,
+		hostedRunner:
+			readEnvFlag(env, "MAESTRO_HOSTED_RUNNER") ||
+			env.MAESTRO_RUNNER_KIND?.trim().toLowerCase() === "hosted",
+		firewallRestricted:
+			readEnvFlag(env, "MAESTRO_FIREWALL_RESTRICTED") ||
+			readEnvFlag(env, "CODEX_FIREWALL_RESTRICTED"),
+		runnerImage: env.MAESTRO_RUNNER_IMAGE ?? null,
+	};
 }
 
 function buildGuidelines(toolNames: Set<string>, currentYear: number): string {
@@ -549,6 +702,7 @@ export function finalizeSystemPrompt(
 	basePrompt: string,
 	appendPrompt?: string,
 	cwd = process.cwd(),
+	options: FinalizeSystemPromptOptions = {},
 ): string {
 	const appendSource =
 		resolveSystemPromptOverride(appendPrompt) ?? loadAppendSystemPrompt(cwd);
@@ -568,6 +722,13 @@ export function finalizeSystemPrompt(
 		prompt += `\n\n${guardedWorkspaceFragment}\n`;
 	}
 
+	const runtimeConstraintPrompt = buildRuntimeConstraintPrompt(
+		options.runtimeConstraints,
+	);
+	if (runtimeConstraintPrompt) {
+		prompt += `\n\n${runtimeConstraintPrompt}\n`;
+	}
+
 	if (appendText) {
 		prompt += "\n\n# Additional System Instructions\n\n";
 		prompt += `${appendText}\n\n`;
@@ -583,9 +744,15 @@ export function buildSystemPrompt(
 	customPrompt?: string,
 	toolNames?: string[],
 	appendPrompt?: string,
+	options?: FinalizeSystemPromptOptions,
 ): string {
 	const promptSource =
 		resolveSystemPromptOverride(customPrompt) ??
 		buildBundledSystemPromptBase(toolNames);
-	return finalizeSystemPrompt(promptSource, appendPrompt);
+	return finalizeSystemPrompt(
+		promptSource,
+		appendPrompt,
+		process.cwd(),
+		options,
+	);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,7 +129,10 @@ import {
 	emitUserTurn as emitUserTurnEvent,
 } from "./cli/jsonl-writer.js";
 import { selectSession } from "./cli/session.js";
-import { resolveExplicitSystemPromptSourcePaths } from "./cli/system-prompt.js";
+import {
+	detectRuntimeConstraintContext,
+	resolveExplicitSystemPromptSourcePaths,
+} from "./cli/system-prompt.js";
 import { validateFrameworkPreference } from "./config/framework.js";
 import { loadRuntimeConfig } from "./config/runtime-config.js";
 import { loadEnv } from "./load-env.js";
@@ -152,6 +155,7 @@ import type { AuthMode } from "./providers/auth.js";
 import { AgentRuntimeController } from "./runtime/agent-runtime.js";
 import { registerBackgroundTaskShutdownHooks } from "./runtime/background-task-hooks.js";
 import { configureSafeMode } from "./safety/safe-mode.js";
+import { LocalSandbox } from "./sandbox/index.js";
 import { ServerRequestActionApprovalService } from "./server/approval-service.js";
 import { clientToolService } from "./server/client-tools-service.js";
 import { ServerRequestToolRetryService } from "./server/tool-retry-service.js";
@@ -1123,29 +1127,6 @@ export async function main(args: string[]) {
 	} catch (error) {
 		exitWithStartupError(error);
 	}
-	// ─────────────────────────────────────────────────────────────────────────────
-	// PHASE 9: System Prompt and Tool Configuration
-	// ─────────────────────────────────────────────────────────────────────────────
-
-	// Build the system prompt with project context
-	// The system prompt includes:
-	// - Base instructions for the agent
-	// - Project context files (COMPOSER.md, AGENTS.md, etc.)
-	// - Tool-specific instructions based on available tools
-	const systemPromptToolNames = parsed.tools;
-	const { systemPrompt, promptMetadata } = await resolveMaestroSystemPrompt({
-		customPrompt: parsed.systemPrompt,
-		toolNames: systemPromptToolNames,
-		appendPrompt: parsed.appendSystemPrompt,
-	});
-	startupProfiler.checkpoint("prompt:assembled", {
-		system_bytes: systemPrompt.length,
-	});
-	const systemPromptSourcePaths = resolveExplicitSystemPromptSourcePaths(
-		parsed.systemPrompt,
-		parsed.appendSystemPrompt,
-	);
-
 	// Determine approval mode for tool execution:
 	// - "prompt": Ask user before each tool execution (default for interactive)
 	// - "auto": Automatically approve all tools (default for non-interactive)
@@ -1224,6 +1205,40 @@ export async function main(args: string[]) {
 		? replaceAskUserTool(allTools)
 		: allTools;
 
+	// ─────────────────────────────────────────────────────────────────────────────
+	// PHASE 11: System Prompt Assembly
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	// Build the system prompt with project context after sandbox setup so runtime
+	// constraint fragments reflect the resolved sandbox state, not just the
+	// requested CLI mode.
+	const resolvedConstraintSandboxMode = sandbox
+		? sandbox instanceof LocalSandbox
+			? "local"
+			: (sandboxMode ?? null)
+		: "none";
+	const systemPromptToolNames = parsed.tools;
+	const runtimeConstraints = detectRuntimeConstraintContext({
+		cwd: process.cwd(),
+		sandboxMode: resolvedConstraintSandboxMode,
+		sandboxEnabled:
+			Boolean(sandbox) && resolvedConstraintSandboxMode !== "local",
+		readOnly: parsed.execReadOnly || parsed.readonly ? true : undefined,
+	});
+	const { systemPrompt, promptMetadata } = await resolveMaestroSystemPrompt({
+		customPrompt: parsed.systemPrompt,
+		toolNames: systemPromptToolNames,
+		appendPrompt: parsed.appendSystemPrompt,
+		runtimeConstraints,
+	});
+	startupProfiler.checkpoint("prompt:assembled", {
+		system_bytes: systemPrompt.length,
+	});
+	const systemPromptSourcePaths = resolveExplicitSystemPromptSourcePaths(
+		parsed.systemPrompt,
+		parsed.appendSystemPrompt,
+	);
+
 	// Register sandbox cleanup on exit (only if sandbox is active)
 	if (sandbox && toolsResult.disposeSandbox) {
 		const cleanupSandbox = toolsResult.disposeSandbox;
@@ -1242,7 +1257,7 @@ export async function main(args: string[]) {
 	}
 
 	// ─────────────────────────────────────────────────────────────────────────────
-	// PHASE 11: Agent Creation
+	// PHASE 12: Agent Creation
 	// ─────────────────────────────────────────────────────────────────────────────
 
 	const { createAgentInstance } = await import(

--- a/src/prompts/system-prompt.ts
+++ b/src/prompts/system-prompt.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { RuntimeConstraintContext } from "@evalops/contracts";
 import {
 	buildBundledSystemPromptBase,
 	finalizeSystemPrompt,
@@ -38,11 +39,17 @@ export async function resolveMaestroSystemPrompt(options?: {
 	customPrompt?: string;
 	toolNames?: string[];
 	appendPrompt?: string;
+	runtimeConstraints?: RuntimeConstraintContext | null;
 }): Promise<ResolvedSystemPrompt> {
 	const overridePrompt = resolveSystemPromptOverride(options?.customPrompt);
 	if (overridePrompt) {
 		return {
-			systemPrompt: finalizeSystemPrompt(overridePrompt, options?.appendPrompt),
+			systemPrompt: finalizeSystemPrompt(
+				overridePrompt,
+				options?.appendPrompt,
+				process.cwd(),
+				{ runtimeConstraints: options?.runtimeConstraints },
+			),
 			promptMetadata: buildPromptMetadata(overridePrompt, {
 				source: "override",
 			}),
@@ -59,6 +66,8 @@ export async function resolveMaestroSystemPrompt(options?: {
 			systemPrompt: finalizeSystemPrompt(
 				resolvedPrompt.content,
 				options?.appendPrompt,
+				process.cwd(),
+				{ runtimeConstraints: options?.runtimeConstraints },
 			),
 			promptMetadata: buildPromptMetadata(resolvedPrompt.content, {
 				source: "service",
@@ -70,7 +79,12 @@ export async function resolveMaestroSystemPrompt(options?: {
 
 	const bundledPrompt = buildBundledSystemPromptBase(options?.toolNames);
 	return {
-		systemPrompt: finalizeSystemPrompt(bundledPrompt, options?.appendPrompt),
+		systemPrompt: finalizeSystemPrompt(
+			bundledPrompt,
+			options?.appendPrompt,
+			process.cwd(),
+			{ runtimeConstraints: options?.runtimeConstraints },
+		),
 		promptMetadata: buildPromptMetadata(bundledPrompt, {
 			source: "bundled",
 		}),

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -35,6 +35,7 @@ import {
 	disposeCheckpointService,
 	initCheckpointService,
 } from "./checkpoints/index.js";
+import { detectRuntimeConstraintContext } from "./cli/system-prompt.js";
 import { composerManager } from "./composers/index.js";
 import { resolveDefaultApprovalMode } from "./config/default-approval-mode.js";
 import { initLifecycle, shutdownLifecycle } from "./lifecycle.js";
@@ -492,7 +493,13 @@ async function createAgent(
 		auditLogger,
 	});
 
-	const { systemPrompt, promptMetadata } = await resolveMaestroSystemPrompt();
+	const runtimeConstraints = detectRuntimeConstraintContext({
+		cwd,
+		sandboxMode: process.env.MAESTRO_SANDBOX_MODE ?? null,
+	});
+	const { systemPrompt, promptMetadata } = await resolveMaestroSystemPrompt({
+		runtimeConstraints,
+	});
 
 	// Only include IDE client tools when a compatible client is connected.
 	// Without a connected client, these tools will hang waiting for responses.

--- a/test/cli/system-prompt.test.ts
+++ b/test/cli/system-prompt.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	buildSystemPrompt,
+	detectRuntimeConstraintContext,
 	finalizeSystemPrompt,
 	resolveExplicitSystemPromptSourcePaths,
 } from "../../src/cli/system-prompt.js";
@@ -107,5 +108,178 @@ describe("buildSystemPrompt", () => {
 		const prompt = finalizeSystemPrompt("base prompt", undefined, projectDir);
 
 		expect(prompt).not.toContain("# Guarded Workspace Paths");
+	});
+
+	it("injects sandbox shallow-git runtime guidance", () => {
+		const projectDir = join(testDir, "shallow-project");
+		mkdirSync(join(projectDir, ".git"), { recursive: true });
+		writeFileSync(join(projectDir, ".git", "shallow"), "abc123\n");
+
+		const runtimeConstraints = detectRuntimeConstraintContext({
+			cwd: projectDir,
+			sandboxMode: "workspace-write",
+			env: {},
+		});
+		const prompt = finalizeSystemPrompt("base prompt", undefined, projectDir, {
+			runtimeConstraints,
+		});
+
+		expect(prompt).toContain("# Runtime Constraints");
+		expect(prompt).toContain("sandbox.shallow-git");
+		expect(prompt).toContain("git fetch --unshallow");
+	});
+
+	it("detects shallow git checkouts from repository subdirectories", () => {
+		const projectDir = join(testDir, "nested-shallow-project");
+		const subdir = join(projectDir, "packages", "cli");
+		mkdirSync(join(projectDir, ".git"), { recursive: true });
+		mkdirSync(subdir, { recursive: true });
+		writeFileSync(join(projectDir, ".git", "shallow"), "abc123\n");
+
+		const runtimeConstraints = detectRuntimeConstraintContext({
+			cwd: subdir,
+			sandboxMode: "workspace-write",
+			env: {},
+		});
+
+		expect(runtimeConstraints.isShallowGitCheckout).toBe(true);
+		expect(
+			finalizeSystemPrompt("base prompt", undefined, subdir, {
+				runtimeConstraints,
+			}),
+		).toContain("git fetch --unshallow");
+	});
+
+	it("detects shallow git checkouts from linked worktree common dirs", () => {
+		const projectDir = join(testDir, "linked-worktree-project");
+		const commonGitDir = join(testDir, "common-git");
+		const worktreeGitDir = join(commonGitDir, "worktrees", "linked");
+		mkdirSync(projectDir, { recursive: true });
+		mkdirSync(worktreeGitDir, { recursive: true });
+		writeFileSync(join(projectDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+		writeFileSync(join(worktreeGitDir, "commondir"), "../..\n");
+		writeFileSync(join(commonGitDir, "shallow"), "abc123\n");
+
+		const runtimeConstraints = detectRuntimeConstraintContext({
+			cwd: projectDir,
+			sandboxMode: "workspace-write",
+			env: {},
+		});
+
+		expect(runtimeConstraints.isShallowGitCheckout).toBe(true);
+		expect(
+			finalizeSystemPrompt("base prompt", undefined, projectDir, {
+				runtimeConstraints,
+			}),
+		).toContain("git fetch --unshallow");
+	});
+
+	it("trims trailing whitespace from gitdir worktree files", () => {
+		const projectDir = join(testDir, "spaced-worktree-project");
+		const commonGitDir = join(testDir, "spaced-common-git");
+		const worktreeGitDir = join(commonGitDir, "worktrees", "spaced");
+		mkdirSync(projectDir, { recursive: true });
+		mkdirSync(worktreeGitDir, { recursive: true });
+		writeFileSync(join(projectDir, ".git"), `gitdir: ${worktreeGitDir} \t\n`);
+		writeFileSync(join(worktreeGitDir, "commondir"), "../..\n");
+		writeFileSync(join(commonGitDir, "shallow"), "abc123\n");
+
+		expect(
+			detectRuntimeConstraintContext({
+				cwd: projectDir,
+				sandboxMode: "workspace-write",
+				env: {},
+			}).isShallowGitCheckout,
+		).toBe(true);
+	});
+
+	it("honors MAESTRO_SANDBOX_MODE when detecting sandbox constraints", () => {
+		const projectDir = join(testDir, "env-sandbox-project");
+		mkdirSync(projectDir, { recursive: true });
+
+		const runtimeConstraints = detectRuntimeConstraintContext({
+			cwd: projectDir,
+			env: { MAESTRO_SANDBOX_MODE: "workspace-write" },
+		});
+
+		expect(runtimeConstraints.sandboxMode).toBe("workspace-write");
+		expect(
+			finalizeSystemPrompt("base prompt", undefined, projectDir, {
+				runtimeConstraints,
+			}),
+		).toContain("sandbox.filesystem");
+	});
+
+	it("prefers sandbox policy env over backend marker env", () => {
+		const projectDir = join(testDir, "policy-env-project");
+		mkdirSync(projectDir, { recursive: true });
+
+		const runtimeConstraints = detectRuntimeConstraintContext({
+			cwd: projectDir,
+			env: {
+				MAESTRO_SANDBOX: "seatbelt",
+				MAESTRO_SANDBOX_MODE: "read-only",
+			},
+		});
+
+		expect(runtimeConstraints.sandboxMode).toBe("read-only");
+		expect(
+			finalizeSystemPrompt("base prompt", undefined, projectDir, {
+				runtimeConstraints,
+			}),
+		).toContain("checkout.read-only");
+	});
+
+	it("preserves explicit no-sandbox state over sandbox env fallback", () => {
+		const projectDir = join(testDir, "resolved-none-project");
+		mkdirSync(projectDir, { recursive: true });
+
+		const runtimeConstraints = detectRuntimeConstraintContext({
+			cwd: projectDir,
+			sandboxMode: "none",
+			sandboxEnabled: false,
+			env: { MAESTRO_SANDBOX_MODE: "read-only" },
+		});
+
+		const prompt = finalizeSystemPrompt("base prompt", undefined, projectDir, {
+			runtimeConstraints,
+		});
+
+		expect(runtimeConstraints.sandboxMode).toBe("none");
+		expect(prompt).not.toContain("checkout.read-only");
+		expect(prompt).not.toContain("# Runtime Constraints");
+	});
+
+	it("injects offline-eval runtime guidance and skips fragments by default", () => {
+		const projectDir = join(testDir, "offline-project");
+		mkdirSync(projectDir, { recursive: true });
+
+		const offlinePrompt = finalizeSystemPrompt(
+			"base prompt",
+			undefined,
+			projectDir,
+			{
+				runtimeConstraints: detectRuntimeConstraintContext({
+					cwd: projectDir,
+					env: { MAESTRO_OFFLINE_EVAL: "1" },
+				}),
+			},
+		);
+		const defaultPrompt = finalizeSystemPrompt(
+			"base prompt",
+			undefined,
+			projectDir,
+			{
+				runtimeConstraints: detectRuntimeConstraintContext({
+					cwd: projectDir,
+					env: {},
+				}),
+			},
+		);
+
+		expect(offlinePrompt).toContain("network.offline");
+		expect(offlinePrompt).toContain("skip web search");
+		expect(offlinePrompt).toContain("network requests are expected to fail");
+		expect(defaultPrompt).not.toContain("# Runtime Constraints");
 	});
 });

--- a/test/contracts/runtime-constraints.test.ts
+++ b/test/contracts/runtime-constraints.test.ts
@@ -1,0 +1,82 @@
+import {
+	buildRuntimeConstraintPrompt,
+	getRuntimeConstraintFragments,
+	isSandboxModeEnabled,
+} from "@evalops/contracts";
+import { describe, expect, it } from "vitest";
+
+describe("runtime constraint fragments", () => {
+	it("injects shallow-git guidance only for sandboxed shallow checkouts", () => {
+		expect(
+			getRuntimeConstraintFragments({
+				sandboxMode: "workspace-write",
+				isShallowGitCheckout: true,
+			}).map((fragment) => fragment.contextKey),
+		).toContain("sandbox.shallow-git");
+
+		expect(
+			getRuntimeConstraintFragments({
+				sandboxMode: "none",
+				isShallowGitCheckout: true,
+			}).map((fragment) => fragment.contextKey),
+		).not.toContain("sandbox.shallow-git");
+	});
+
+	it("lets resolved sandbox state override requested sandbox mode", () => {
+		expect(
+			getRuntimeConstraintFragments({
+				sandboxMode: "native",
+				sandboxEnabled: false,
+				isShallowGitCheckout: true,
+			}).map((fragment) => fragment.contextKey),
+		).not.toContain("sandbox.filesystem");
+	});
+
+	it("warns offline evals to skip network-dependent search", () => {
+		const prompt = buildRuntimeConstraintPrompt({
+			networkAccess: "disabled",
+		});
+
+		expect(prompt).toContain("# Runtime Constraints");
+		expect(prompt).toContain("network.offline");
+		expect(prompt).toContain("skip web search");
+		expect(prompt).toContain("network requests are expected to fail");
+	});
+
+	it("suppresses restricted-network guidance when offline mode is active", () => {
+		expect(
+			getRuntimeConstraintFragments({
+				networkAccess: "disabled",
+				firewallRestricted: true,
+			}).map((fragment) => fragment.contextKey),
+		).toEqual(["network.offline"]);
+	});
+
+	it("covers hosted, firewall-restricted, and read-only contexts", () => {
+		expect(
+			getRuntimeConstraintFragments({
+				hostedRunner: true,
+				firewallRestricted: true,
+				readOnly: true,
+			}).map((fragment) => fragment.contextKey),
+		).toEqual([
+			"hosted-runner.ephemeral",
+			"network.restricted",
+			"checkout.read-only",
+		]);
+	});
+
+	it("treats only sandboxed modes as enabled", () => {
+		expect(isSandboxModeEnabled("workspace-write")).toBe(true);
+		expect(isSandboxModeEnabled("read-only")).toBe(true);
+		expect(isSandboxModeEnabled(" danger-full-access ")).toBe(false);
+		expect(isSandboxModeEnabled("local")).toBe(false);
+		expect(isSandboxModeEnabled("none")).toBe(false);
+	});
+
+	it("omits fragments when no runtime constraints apply", () => {
+		expect(buildRuntimeConstraintPrompt({ networkAccess: "available" })).toBe(
+			"",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `8bae0cf644988e3d2f09efe0a893111a1ed033d2`
- last generated public sync base: `4ab7f2e84fc505c959756c5ade897a10648b6fff`
- previewed public-tree drift: `9` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (8bae0cf64498)`
- public projection: `https://github.com/evalops/maestro@main (4ab7f2e84fc5)`
- files to copy or update: `9`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/design/RUNTIME_CONSTRAINTS.md
- copy/update packages/contracts/src/index.ts
- copy/update packages/contracts/src/runtime-constraints.ts
- copy/update src/cli/system-prompt.ts
- copy/update src/main.ts
- copy/update src/prompts/system-prompt.ts
- copy/update src/web-server.ts
- copy/update test/cli/system-prompt.test.ts
- copy/update test/contracts/runtime-constraints.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/design/RUNTIME_CONSTRAINTS.md
- copy/update packages/contracts/src/index.ts
- copy/update packages/contracts/src/runtime-constraints.ts
- copy/update src/cli/system-prompt.ts
- copy/update src/main.ts
- copy/update src/prompts/system-prompt.ts
- copy/update src/web-server.ts
- copy/update test/cli/system-prompt.test.ts
- copy/update test/contracts/runtime-constraints.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode