### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/CONVENTIONS/agent-citations.md
+++ b/docs/CONVENTIONS/agent-citations.md
@@ -1,0 +1,63 @@
+# Agent File Citations
+
+Agent-authored responses should make file references clickable across Maestro
+surfaces. When an agent mentions a workspace file in user-facing text, it must
+link the displayed path with a Markdown `file:///` URI.
+
+## Format
+
+```md
+[<displayed-path-or-basename>](file:///<workspace-rooted-or-absolute-path>)
+```
+
+Examples:
+
+```md
+[src/auth/middleware.ts](file:///workspace/src/auth/middleware.ts)
+[My Project/test file.js](file:///Users/alice/My%20Project/test%20file.js)
+[src/auth/middleware.ts](file:///workspace/src/auth/middleware.ts#L42)
+[src/auth/middleware.ts](file:///workspace/src/auth/middleware.ts#L42-L48)
+[src/auth/middleware.ts](file:///workspace/src/auth/middleware.ts#L42C8)
+```
+
+## Rules
+
+- Display the path or basename users should read, not the raw URI.
+- Use `file:///` for local workspace files.
+- Prefer workspace-rooted paths when the file is inside the current workspace.
+- Use absolute paths when a file is outside the current workspace.
+- Percent-encode spaces and other URI characters in link targets.
+- Include line or column fragments when the agent knows the location.
+- Use GitHub blob URLs at GitHub-comment boundaries instead of `file:///`.
+
+## Prompt Rule
+
+Every Maestro system-prompt path includes the file-citation rule via
+`buildFileCitationPromptFragment()` in `src/cli/system-prompt.ts`. Keep the
+prompt fragment short enough to appear in every agent mode and custom-prompt
+flow.
+
+Good:
+
+```md
+See [src/auth/middleware.ts](file:///workspace/src/auth/middleware.ts#L42) for the validation logic.
+```
+
+Bad:
+
+```md
+See src/auth/middleware.ts for the validation logic.
+```
+
+## Surface Expectations
+
+The agent emits one canonical Markdown shape. Rendering surfaces are responsible
+for adapting it:
+
+- TUI: render as a terminal hyperlink when OSC 8 is available, otherwise show
+  text plus the visible URI.
+- Web: open the workspace file through the web/editor file-open handler.
+- VS Code and JetBrains: open the file at the cited line or column.
+- Slack: preserve Markdown so the link remains visible and clickable.
+- GitHub agent: translate local file URIs to repository blob URLs before posting.
+

--- a/src/cli/system-prompt.ts
+++ b/src/cli/system-prompt.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import type { Dirent } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
 	type RuntimeConstraintContext,
 	type RuntimeNetworkAccess,
@@ -686,6 +687,22 @@ function buildGuardedWorkspacePromptFragment(cwd: string): string | null {
 	].join("\n");
 }
 
+export function buildFileCitationPromptFragment(cwd = process.cwd()): string {
+	const examplePath = join(cwd, "src/auth/middleware.ts");
+	const exampleUri = `${pathToFileURL(examplePath).href}#L42`;
+
+	return [
+		"# File Citations",
+		"",
+		"When mentioning a workspace file in any user-facing response, link it using Markdown with a `file:///` URI so every surface can make the reference clickable.",
+		"Prefer the displayed text users expect to read, such as `src/auth/middleware.ts`, and percent-encode spaces and other URI characters in the link target.",
+		"Include known line references as URL fragments, such as `#L42`, `#L42-L48`, or `#L42C8`.",
+		"At GitHub comment boundaries, use repository blob URLs instead of local `file:///` URIs when repository metadata is available.",
+		`Good: See [src/auth/middleware.ts](${exampleUri}) for the validation logic.`,
+		"Bad: See src/auth/middleware.ts for the validation logic.",
+	].join("\n");
+}
+
 export function buildBundledSystemPromptBase(toolNames?: string[]): string {
 	const currentYear = new Date().getFullYear();
 	const activeToolNames = toolNames ?? DEFAULT_TOOL_NAMES;
@@ -728,6 +745,8 @@ export function finalizeSystemPrompt(
 	if (runtimeConstraintPrompt) {
 		prompt += `\n\n${runtimeConstraintPrompt}\n`;
 	}
+
+	prompt += `\n\n${buildFileCitationPromptFragment(cwd)}\n`;
 
 	if (appendText) {
 		prompt += "\n\n# Additional System Instructions\n\n";

--- a/test/cli/system-prompt.test.ts
+++ b/test/cli/system-prompt.test.ts
@@ -1,8 +1,10 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	buildFileCitationPromptFragment,
 	buildSystemPrompt,
 	detectRuntimeConstraintContext,
 	finalizeSystemPrompt,
@@ -47,6 +49,40 @@ describe("buildSystemPrompt", () => {
 		expect(prompt).toContain(
 			"Length limits: keep text between tool calls to <=25 words. Keep final responses to <=100 words unless the task requires more detail.",
 		);
+	});
+
+	it("injects file citation guidance into bundled and custom prompts", () => {
+		const projectDir = join(testDir, "citation-project");
+		mkdirSync(projectDir, { recursive: true });
+
+		const customPrompt = finalizeSystemPrompt(
+			"custom base prompt",
+			undefined,
+			projectDir,
+		);
+		const exampleUri = `${
+			pathToFileURL(join(projectDir, "src/auth/middleware.ts")).href
+		}#L42`;
+
+		expect(buildSystemPrompt(undefined, [], undefined, {})).toContain(
+			"# File Citations",
+		);
+		expect(customPrompt).toContain("# File Citations");
+		expect(customPrompt).toContain("[src/auth/middleware.ts]");
+		expect(customPrompt).toContain(exampleUri);
+		expect(customPrompt).not.toContain("file:///workspace/");
+		expect(customPrompt).toContain("Bad: See src/auth/middleware.ts");
+	});
+
+	it("keeps file citation guidance compact and URI-oriented", () => {
+		const fragment = buildFileCitationPromptFragment(testDir);
+
+		expect(fragment).toContain("Markdown");
+		expect(fragment).toContain("`file:///` URI");
+		expect(fragment).toContain("percent-encode spaces");
+		expect(fragment).toContain("repository blob URLs");
+		expect(fragment).toContain("#L42-L48");
+		expect(fragment.length - testDir.length).toBeLessThan(900);
 	});
 
 	it("returns exact paths for explicit prompt files only", () => {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `c92ef2a8340c9e5cae08862a7c5e886d94ff4f35`
- last generated public sync base: `f8eafcd98e9a8a612021e65d0b95f8c9380e3564`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (c92ef2a8340c)`
- public projection: `https://github.com/evalops/maestro@main (f8eafcd98e9a)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/CONVENTIONS/agent-citations.md
- copy/update src/cli/system-prompt.ts
- copy/update test/cli/system-prompt.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/CONVENTIONS/agent-citations.md
- copy/update src/cli/system-prompt.ts
- copy/update test/cli/system-prompt.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode