### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/design/AGENTS_MD_LOADING.md
+++ b/docs/design/AGENTS_MD_LOADING.md
@@ -1,0 +1,51 @@
+# AGENTS.md Loading
+
+Maestro loads project instructions from global user context first, then from the
+current workspace path from least-specific to most-specific directory. This lets
+a monorepo define broad root guidance and refine it inside individual packages.
+
+## Search Order
+
+For each instruction directory, Maestro reads the first matching file from this
+candidate list:
+
+1. `AGENTS.override.md`
+2. `AGENTS.md`
+3. `Agents.md`
+4. `agents.md`
+5. `AGENT.md`
+6. `Agent.md`
+7. `agent.md`
+8. `CLAUDE.md`
+
+`CLAUDE.md` remains a compatibility fallback when no AGENTS/AGENT file exists
+in that directory.
+
+## Directories
+
+Maestro searches:
+
+1. The configured Maestro agent directory, normally `~/.maestro/agent`.
+2. The user-global config directory, `~/.config`.
+3. Each parent directory from filesystem root down to the current working
+   directory.
+
+Only one instruction file is loaded per directory. If both `AGENTS.md` and
+`CLAUDE.md` exist in the same directory, `AGENTS.md` wins.
+
+## Prompt Format
+
+Each loaded file is inserted into the system prompt with an explicit directory
+header and XML instruction wrapper:
+
+```md
+# AGENTS.md instructions for /repo/packages/api
+
+<INSTRUCTIONS>
+Use pnpm for this package.
+</INSTRUCTIONS>
+```
+
+The wrapper keeps project-authored guidance separate from surrounding system
+prompt text and makes hierarchical instruction boundaries visible to the model.
+

--- a/src/cli/system-prompt.ts
+++ b/src/cli/system-prompt.ts
@@ -8,7 +8,7 @@ import {
 	statSync,
 } from "node:fs";
 import type { Dirent } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
 	type RuntimeConstraintContext,
@@ -18,12 +18,12 @@ import {
 } from "@evalops/contracts";
 import chalk from "chalk";
 import { buildSearchGuidelines } from "../agent/search-guidance.js";
-import { getAgentDir } from "../config/constants.js";
 import {
 	type ComposerConfig,
 	loadConfig,
 	resolveLoadedAppendSystemPromptPath,
 	resolveProjectDocCandidateFilenames,
+	resolveProjectDocGlobalDirectories,
 } from "../config/index.js";
 import {
 	DEFAULT_GUARDED_FILE_RULES,
@@ -512,11 +512,16 @@ function resolveContextCandidates(config?: ComposerConfig): string[] {
 	return resolveProjectDocCandidateFilenames(config);
 }
 
+function resolveGlobalInstructionDirs(): string[] {
+	return resolveProjectDocGlobalDirectories();
+}
+
 export function loadProjectContextFiles(
 	cwdOverride?: string,
 	options: { config?: ComposerConfig } = {},
 ): ContextFile[] {
 	const contextFiles: ContextFile[] = [];
+	const loadedContextPaths = new Set<string>();
 
 	const cwd = cwdOverride ?? process.cwd();
 	const config = options.config ?? loadConfig(cwd);
@@ -530,17 +535,27 @@ export function loadProjectContextFiles(
 	if (remainingBytes === 0) {
 		return contextFiles;
 	}
-
-	const globalContextDir = resolve(getAgentDir());
-	const globalContext = loadContextFileFromDir(globalContextDir, {
-		candidates,
-		maxBytes,
-		remainingBytes,
-	});
-	if (globalContext) {
-		contextFiles.push(globalContext.file);
+	const pushContextFile = (loaded: ContextFileLoadResult): void => {
+		const resolvedPath = resolve(loaded.file.path);
+		if (loadedContextPaths.has(resolvedPath)) {
+			return;
+		}
+		loadedContextPaths.add(resolvedPath);
+		contextFiles.push(loaded.file);
 		if (remainingBytes !== undefined) {
-			remainingBytes = Math.max(0, remainingBytes - globalContext.bytesRead);
+			remainingBytes = Math.max(0, remainingBytes - loaded.bytesRead);
+		}
+	};
+
+	for (const globalContextDir of resolveGlobalInstructionDirs()) {
+		if (remainingBytes === 0) break;
+		const globalContext = loadContextFileFromDir(globalContextDir, {
+			candidates,
+			maxBytes,
+			remainingBytes,
+		});
+		if (globalContext) {
+			pushContextFile(globalContext);
 		}
 	}
 
@@ -567,14 +582,25 @@ export function loadProjectContextFiles(
 			remainingBytes,
 		});
 		if (contextFile) {
-			contextFiles.push(contextFile.file);
-			if (remainingBytes !== undefined) {
-				remainingBytes = Math.max(0, remainingBytes - contextFile.bytesRead);
-			}
+			pushContextFile(contextFile);
 		}
 	}
 
 	return contextFiles;
+}
+
+function formatProjectContextFile(file: ContextFile): string {
+	const filename = basename(file.path);
+	const dir = dirname(file.path);
+	return [
+		`# ${filename} instructions for ${dir}`,
+		"",
+		"<INSTRUCTIONS>",
+		file.content.trimEnd(),
+		"</INSTRUCTIONS>",
+		"",
+		"",
+	].join("\n");
 }
 
 // Default tool names when no filter is applied
@@ -729,8 +755,8 @@ export function finalizeSystemPrompt(
 	if (contextFiles.length > 0) {
 		prompt += "\n\n# Project Context\n\n";
 		prompt += "The following project context files have been loaded:\n\n";
-		for (const { path, content } of contextFiles) {
-			prompt += `## ${path}\n\n${content}\n\n`;
+		for (const file of contextFiles) {
+			prompt += formatProjectContextFile(file);
 		}
 	}
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -195,7 +195,11 @@ export const PATHS = {
 	AGENT_CONTEXT_FILES: [
 		"AGENTS.override.md",
 		"AGENTS.md",
+		"Agents.md",
+		"agents.md",
 		"AGENT.md",
+		"Agent.md",
+		"agent.md",
 		"CLAUDE.md",
 	] as const,
 } as const;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -26,6 +26,7 @@ export {
 	DEFAULT_CONFIG,
 	resolveLoadedAppendSystemPromptPath,
 	resolveProjectDocCandidateFilenames,
+	resolveProjectDocGlobalDirectories,
 	resolvePromptLoadedProjectDocPaths,
 	type ComposerConfig,
 	type ConfiguredPackageSpec,

--- a/src/config/toml-config.ts
+++ b/src/config/toml-config.ts
@@ -43,6 +43,7 @@ import {
 } from "../packages/sources.js";
 import type { PackageSpec } from "../packages/types.js";
 import { createLogger } from "../utils/logger.js";
+import { getHomeDir } from "../utils/path-expansion.js";
 import { compileTypeboxSchema } from "../utils/typebox-ajv.js";
 import { PATHS, getAgentDir } from "./constants.js";
 
@@ -645,6 +646,12 @@ function resolveFirstProjectDocPathInDir(
 	return null;
 }
 
+export function resolveProjectDocGlobalDirectories(): string[] {
+	return Array.from(
+		new Set([resolve(getAgentDir()), resolve(getHomeDir(), ".config")]),
+	);
+}
+
 export function resolvePromptLoadedProjectDocPaths(
 	cwdOverride?: string,
 	config?: ComposerConfig,
@@ -662,21 +669,36 @@ export function resolvePromptLoadedProjectDocPaths(
 		return [];
 	}
 	const paths: string[] = [];
+	const loadedPaths = new Set<string>();
 
-	const globalContextDir = resolve(getAgentDir());
-	const globalContextPath = resolveFirstProjectDocPathInDir(
-		globalContextDir,
-		candidates,
-		remainingBytes,
-	);
-	if (globalContextPath) {
-		paths.push(globalContextPath.path);
-		if (remainingBytes !== undefined) {
-			remainingBytes = Math.max(
-				0,
-				remainingBytes - globalContextPath.bytesRead,
-			);
+	const pushResolvedPath = (
+		contextPath: { path: string; bytesRead: number } | null,
+	): void => {
+		if (!contextPath) {
+			return;
 		}
+		const resolvedPath = resolve(contextPath.path);
+		if (loadedPaths.has(resolvedPath)) {
+			return;
+		}
+		loadedPaths.add(resolvedPath);
+		paths.push(resolvedPath);
+		if (remainingBytes !== undefined) {
+			remainingBytes = Math.max(0, remainingBytes - contextPath.bytesRead);
+		}
+	};
+
+	for (const globalContextDir of resolveProjectDocGlobalDirectories()) {
+		if (remainingBytes === 0) {
+			break;
+		}
+		pushResolvedPath(
+			resolveFirstProjectDocPathInDir(
+				globalContextDir,
+				candidates,
+				remainingBytes,
+			),
+		);
 	}
 
 	const directories: string[] = [];
@@ -707,12 +729,7 @@ export function resolvePromptLoadedProjectDocPaths(
 			candidates,
 			remainingBytes,
 		);
-		if (contextPath) {
-			paths.push(contextPath.path);
-			if (remainingBytes !== undefined) {
-				remainingBytes = Math.max(0, remainingBytes - contextPath.bytesRead);
-			}
-		}
+		pushResolvedPath(contextPath);
 	}
 
 	return paths;

--- a/test/agent/context-loading.test.ts
+++ b/test/agent/context-loading.test.ts
@@ -12,11 +12,13 @@ describe("Hierarchical Context File Loading", () => {
 	let testDir: string;
 	let originalEnv: string | undefined;
 	let originalHome: string | undefined;
+	let originalUserHome: string | undefined;
 
 	beforeEach(() => {
 		// Save original state
 		originalEnv = process.env.MAESTRO_AGENT_DIR;
 		originalHome = process.env.MAESTRO_HOME;
+		originalUserHome = process.env.HOME;
 
 		// Create temp test directory
 		testDir = join(tmpdir(), `composer-test-${Date.now()}`);
@@ -24,6 +26,7 @@ describe("Hierarchical Context File Loading", () => {
 
 		const composerHome = join(testDir, "composer-home");
 		process.env.MAESTRO_HOME = composerHome;
+		process.env.HOME = testDir;
 		mkdirSync(composerHome, { recursive: true });
 		clearConfigCache();
 	});
@@ -39,6 +42,11 @@ describe("Hierarchical Context File Loading", () => {
 			Reflect.deleteProperty(process.env, "MAESTRO_HOME");
 		} else {
 			process.env.MAESTRO_HOME = originalHome;
+		}
+		if (originalUserHome === undefined) {
+			Reflect.deleteProperty(process.env, "HOME");
+		} else {
+			process.env.HOME = originalUserHome;
 		}
 		clearConfigCache();
 
@@ -305,6 +313,30 @@ describe("Hierarchical Context File Loading", () => {
 			expect(globalIdx).toBeLessThan(rootIdx);
 			expect(rootIdx).toBeLessThan(packagesIdx);
 			expect(packagesIdx).toBeLessThan(appIdx);
+		});
+
+		it("should not duplicate ~/.config instructions when cwd is inside ~/.config", () => {
+			const globalConfigDir = join(testDir, ".config");
+			const projectDir = join(globalConfigDir, "dotfiles");
+			mkdirSync(projectDir, { recursive: true });
+			writeFileSync(
+				join(globalConfigDir, "AGENT.md"),
+				"# Global Config\nDotfiles guidance",
+			);
+			writeFileSync(join(projectDir, "AGENT.md"), "# Dotfiles\nProject");
+
+			const contextFiles = loadProjectContextFiles(projectDir);
+			const globalMatches = contextFiles.filter(
+				(file) => file.path === join(globalConfigDir, "AGENT.md"),
+			);
+
+			expect(globalMatches).toHaveLength(1);
+			expect(contextFiles.map((file) => file.content)).toEqual(
+				expect.arrayContaining([
+					expect.stringContaining("Dotfiles guidance"),
+					expect.stringContaining("# Dotfiles"),
+				]),
+			);
 		});
 	});
 

--- a/test/agent/perform-compaction.test.ts
+++ b/test/agent/perform-compaction.test.ts
@@ -1777,6 +1777,65 @@ describe("performCompaction", () => {
 		}
 	});
 
+	it("does not restore ~/.config instructions already layered into the prompt", async () => {
+		const originalCwd = process.cwd();
+		const previousHome = process.env.HOME;
+		const previousMaestroHome = process.env.MAESTRO_HOME;
+		const workspaceDir = mkdtempSync(
+			join(tmpdir(), "maestro-user-config-context-"),
+		);
+		const projectDir = join(workspaceDir, "project");
+		const userConfigDir = join(workspaceDir, ".config");
+		const userConfigPath = join(userConfigDir, "AGENT.md");
+		mkdirSync(projectDir, { recursive: true });
+		mkdirSync(userConfigDir, { recursive: true });
+		writeFileSync(userConfigPath, "# User instructions\nUse the home config.");
+		process.env.HOME = workspaceDir;
+		process.env.MAESTRO_HOME = join(workspaceDir, ".maestro-home");
+		process.chdir(projectDir);
+		clearConfigCache();
+
+		try {
+			const messages = buildConversation(10);
+			messages.splice(
+				2,
+				0,
+				createReadToolCallMessage(userConfigPath, "call-read-user-config"),
+				createReadToolResultMessage(
+					userConfigPath,
+					"call-read-user-config",
+					"# User instructions\nOld home config",
+				),
+			);
+			const agent = createMockAgentWithoutAppendMessage(messages);
+			const sessionManager = createMockSessionManager();
+
+			const result = await performCompaction({ agent, sessionManager });
+
+			expect(result.success).toBe(true);
+			expect(getReplacedMessages(agent)).not.toContainEqual(
+				expect.objectContaining({
+					role: "hookMessage",
+					customType: "read-file",
+					details: { filePath: userConfigPath },
+				}),
+			);
+		} finally {
+			process.chdir(originalCwd);
+			if (previousHome === undefined) {
+				delete process.env.HOME;
+			} else {
+				process.env.HOME = previousHome;
+			}
+			if (previousMaestroHome === undefined) {
+				delete process.env.MAESTRO_HOME;
+			} else {
+				process.env.MAESTRO_HOME = previousMaestroHome;
+			}
+			clearConfigCache();
+		}
+	});
+
 	it("does not restore custom project doc fallback files already layered into the prompt", async () => {
 		const originalCwd = process.cwd();
 		const workspaceDir = mkdtempSync(join(tmpdir(), "maestro-project-doc-"));

--- a/test/cli/system-prompt.test.ts
+++ b/test/cli/system-prompt.test.ts
@@ -15,11 +15,13 @@ import { clearConfigCache } from "../../src/config/index.js";
 describe("buildSystemPrompt", () => {
 	let originalCwd: string;
 	let originalHome: string | undefined;
+	let originalUserHome: string | undefined;
 	let testDir: string;
 
 	beforeEach(() => {
 		originalCwd = process.cwd();
 		originalHome = process.env.MAESTRO_HOME;
+		originalUserHome = process.env.HOME;
 		testDir = join(tmpdir(), `maestro-system-prompt-${Date.now()}`);
 		mkdirSync(testDir, { recursive: true });
 		process.chdir(testDir);
@@ -27,6 +29,7 @@ describe("buildSystemPrompt", () => {
 		const maestroHome = join(testDir, "maestro-home");
 		mkdirSync(maestroHome, { recursive: true });
 		process.env.MAESTRO_HOME = maestroHome;
+		process.env.HOME = testDir;
 		clearConfigCache();
 	});
 
@@ -36,6 +39,11 @@ describe("buildSystemPrompt", () => {
 			Reflect.deleteProperty(process.env, "MAESTRO_HOME");
 		} else {
 			process.env.MAESTRO_HOME = originalHome;
+		}
+		if (originalUserHome === undefined) {
+			Reflect.deleteProperty(process.env, "HOME");
+		} else {
+			process.env.HOME = originalUserHome;
 		}
 		clearConfigCache();
 		if (existsSync(testDir)) {
@@ -115,7 +123,51 @@ describe("buildSystemPrompt", () => {
 		const prompt = finalizeSystemPrompt("base prompt", undefined, projectDir);
 
 		expect(prompt).toContain("project specific context");
+		expect(prompt).toContain(`# AGENTS.md instructions for ${projectDir}`);
+		expect(prompt).toContain("<INSTRUCTIONS>\nproject specific context");
+		expect(prompt).toContain("</INSTRUCTIONS>");
 		expect(prompt).toContain(`Current working directory: ${projectDir}`);
+	});
+
+	it("loads hierarchical agent instructions from root to cwd", () => {
+		const projectDir = join(testDir, "monorepo");
+		const packageDir = join(projectDir, "packages", "api");
+		const cwd = join(packageDir, "src");
+		mkdirSync(cwd, { recursive: true });
+		writeFileSync(join(projectDir, "AGENTS.md"), "root instructions");
+		writeFileSync(join(packageDir, "AGENT.md"), "package instructions");
+
+		const prompt = finalizeSystemPrompt("base prompt", undefined, cwd);
+
+		const rootHeader = `# AGENTS.md instructions for ${projectDir}`;
+		const packageHeader = `# AGENT.md instructions for ${packageDir}`;
+		expect(prompt).toContain(rootHeader);
+		expect(prompt).toContain(packageHeader);
+		expect(prompt.indexOf(rootHeader)).toBeLessThan(
+			prompt.indexOf(packageHeader),
+		);
+		expect(prompt).toContain("<INSTRUCTIONS>\nroot instructions");
+		expect(prompt).toContain("<INSTRUCTIONS>\npackage instructions");
+		expect(prompt).toContain(`</INSTRUCTIONS>\n\n${packageHeader}`);
+	});
+
+	it("loads user-global ~/.config/AGENT.md before project instructions", () => {
+		const projectDir = join(testDir, "global-project");
+		const globalConfigDir = join(testDir, ".config");
+		mkdirSync(projectDir, { recursive: true });
+		mkdirSync(globalConfigDir, { recursive: true });
+		writeFileSync(join(globalConfigDir, "AGENT.md"), "global instructions");
+		writeFileSync(join(projectDir, "AGENTS.md"), "project instructions");
+
+		const prompt = finalizeSystemPrompt("base prompt", undefined, projectDir);
+
+		const globalHeader = `# AGENT.md instructions for ${globalConfigDir}`;
+		const projectHeader = `# AGENTS.md instructions for ${projectDir}`;
+		expect(prompt).toContain(globalHeader);
+		expect(prompt).toContain(projectHeader);
+		expect(prompt.indexOf(globalHeader)).toBeLessThan(
+			prompt.indexOf(projectHeader),
+		);
 	});
 
 	it("warns the agent when the workspace contains guarded path categories", () => {

--- a/test/config/toml-config.test.ts
+++ b/test/config/toml-config.test.ts
@@ -25,6 +25,8 @@ describe("toml-config", () => {
 	let globalDir: string;
 	let projectDir: string;
 	let previousMaestroHome: string | undefined;
+	let previousMaestroAgentDir: string | undefined;
+	let previousHome: string | undefined;
 
 	beforeEach(() => {
 		clearConfigCache();
@@ -32,6 +34,8 @@ describe("toml-config", () => {
 		globalDir = join(testDir, "global", ".maestro");
 		projectDir = join(testDir, "project");
 		previousMaestroHome = process.env.MAESTRO_HOME;
+		previousMaestroAgentDir = process.env.MAESTRO_AGENT_DIR;
+		previousHome = process.env.HOME;
 		mkdirSync(globalDir, { recursive: true });
 		mkdirSync(join(projectDir, ".maestro"), { recursive: true });
 	});
@@ -50,6 +54,16 @@ describe("toml-config", () => {
 			Reflect.deleteProperty(process.env, "MAESTRO_HOME");
 		} else {
 			process.env.MAESTRO_HOME = previousMaestroHome;
+		}
+		if (previousMaestroAgentDir === undefined) {
+			Reflect.deleteProperty(process.env, "MAESTRO_AGENT_DIR");
+		} else {
+			process.env.MAESTRO_AGENT_DIR = previousMaestroAgentDir;
+		}
+		if (previousHome === undefined) {
+			Reflect.deleteProperty(process.env, "HOME");
+		} else {
+			process.env.HOME = previousHome;
 		}
 	});
 
@@ -856,6 +870,66 @@ experimental_instructions_file = ".maestro/instructions.md"
 			expect(resolvedPaths).toEqual(loadedPaths);
 			expect(resolvedPaths).toHaveLength(1);
 			expect(resolvedPaths[0]).toBe(resolve(join(projectDir, "AGENT.md")));
+		});
+
+		it("tracks ~/.config global instructions before project docs under the byte budget", () => {
+			const agentDir = join(testDir, "agent");
+			const configDir = join(testDir, ".config");
+			mkdirSync(agentDir, { recursive: true });
+			mkdirSync(configDir, { recursive: true });
+			writeFileSync(join(agentDir, "AGENT.md"), "A".repeat(40));
+			writeFileSync(join(configDir, "AGENT.md"), "B".repeat(40));
+			writeFileSync(join(projectDir, "AGENT.md"), "C".repeat(40));
+			process.env.MAESTRO_AGENT_DIR = agentDir;
+			process.env.HOME = testDir;
+
+			const config = {
+				...DEFAULT_CONFIG,
+				project_doc_max_bytes: 70,
+			} as ComposerConfig;
+
+			const loadedPaths = loadProjectContextFiles(projectDir, { config }).map(
+				(file) => resolve(file.path),
+			);
+			const resolvedPaths = resolvePromptLoadedProjectDocPaths(
+				projectDir,
+				config,
+			).map((filePath) => resolve(filePath));
+
+			expect(resolvedPaths).toEqual(loadedPaths);
+			expect(resolvedPaths).toEqual([
+				resolve(join(agentDir, "AGENT.md")),
+				resolve(join(configDir, "AGENT.md")),
+			]);
+		});
+
+		it("dedupes ~/.config instructions when cwd is inside ~/.config", () => {
+			const configDir = join(testDir, ".config");
+			const dotfilesDir = join(configDir, "dotfiles");
+			mkdirSync(dotfilesDir, { recursive: true });
+			writeFileSync(join(configDir, "AGENT.md"), "Config guidance");
+			writeFileSync(join(dotfilesDir, "AGENT.md"), "Dotfiles guidance");
+			process.env.MAESTRO_AGENT_DIR = join(testDir, "empty-agent-dir");
+			process.env.HOME = testDir;
+
+			const config = {
+				...DEFAULT_CONFIG,
+				project_doc_max_bytes: 100,
+			} as ComposerConfig;
+
+			const loadedPaths = loadProjectContextFiles(dotfilesDir, { config }).map(
+				(file) => resolve(file.path),
+			);
+			const resolvedPaths = resolvePromptLoadedProjectDocPaths(
+				dotfilesDir,
+				config,
+			).map((filePath) => resolve(filePath));
+			const configInstructionPath = resolve(join(configDir, "AGENT.md"));
+
+			expect(resolvedPaths).toEqual(loadedPaths);
+			expect(
+				resolvedPaths.filter((filePath) => filePath === configInstructionPath),
+			).toHaveLength(1);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `b9481e566f7d86837d0987487822c2dab2b63960`
- last generated public sync base: `966f4b9374b7d316dd34bd14474c7ec1be587f65`
- previewed public-tree drift: `9` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (b9481e566f7d)`
- public projection: `https://github.com/evalops/maestro@main (966f4b9374b7)`
- files to copy or update: `9`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/design/AGENTS_MD_LOADING.md
- copy/update src/cli/system-prompt.ts
- copy/update src/config/constants.ts
- copy/update src/config/index.ts
- copy/update src/config/toml-config.ts
- copy/update test/agent/context-loading.test.ts
- copy/update test/agent/perform-compaction.test.ts
- copy/update test/cli/system-prompt.test.ts
- copy/update test/config/toml-config.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/design/AGENTS_MD_LOADING.md
- copy/update src/cli/system-prompt.ts
- copy/update src/config/constants.ts
- copy/update src/config/index.ts
- copy/update src/config/toml-config.ts
- copy/update test/agent/context-loading.test.ts
- copy/update test/agent/perform-compaction.test.ts
- copy/update test/cli/system-prompt.test.ts
- copy/update test/config/toml-config.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode