### PR TITLE
Add Maestro entrypoint for Cerebro local E2E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ export ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY \
        OPENROUTER_API_KEY XAI_API_KEY EXA_API_KEY \
        COMPOSER_MODEL COMPOSER_MODEL_PROVIDER
 
+LOCAL_CEREBRO_REPO ?= ../cerebro
+
 .PHONY: help setup install build build-all compile run-ts run-rs run-rs-debug \
         web dev dev-all developer-surface-check test test-fast test-coverage lint check fmt fmt-unsafe \
-        smoke evals verify clean db-up db-down db-migrate
+        smoke cerebro-e2e evals verify clean db-up db-down db-migrate
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
@@ -78,6 +80,9 @@ fmt-unsafe: ## Auto-format + unsafe lint fixes
 
 smoke: build ## Smoke-test the built CLI
 	npm run smoke
+
+cerebro-e2e: ## Run the cross-repo Cerebro local E2E using this Maestro checkout
+	LOCAL_MAESTRO_REPO="$(CURDIR)" $(MAKE) -C "$(LOCAL_CEREBRO_REPO)" local-maestro-e2e
 
 evals: ## Run eval scenarios
 	npx nx run maestro:evals --skip-nx-cache

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ npx nx run maestro:test --skip-nx-cache
 npx nx run maestro:evals --skip-nx-cache
 ```
 
+To prove Maestro works against a local Cerebro stack, keep sibling checkouts and
+run:
+
+```bash
+make cerebro-e2e
+```
+
+That target delegates to Cerebro's `make local-maestro-e2e` with
+`LOCAL_MAESTRO_REPO` set to the current Maestro checkout. It builds and smokes
+Maestro, emits Maestro's canonical Platform replay, publishes it through local
+NATS, and verifies Cerebro graph projection plus MCP recall from the generated
+session traffic. Set `LOCAL_CEREBRO_REPO=/path/to/cerebro` when the checkout is
+not a sibling directory.
+
 Need Redis or PostgreSQL for a specific workflow? Start from `docker-compose.yml` and use the [Contributor Runbook](docs/CONTRIBUTOR_RUNBOOK.md) for the rest of the repo workflow.
 
 ## Repository Layout

--- a/docs/BUILD_TESTING.md
+++ b/docs/BUILD_TESTING.md
@@ -102,6 +102,19 @@ and verifies Maestro's core service paths against the generated descriptors.
 
 **Run:** `MAESTRO_PLATFORM_REPO=/path/to/platform npm run platform:sdk-smoke`
 
+### 8. Cerebro Local E2E (`make cerebro-e2e`)
+
+Cross-repo local usability smoke for Maestro plus Cerebro. From Maestro, the
+target delegates to a sibling Cerebro checkout, sets `LOCAL_MAESTRO_REPO` to the
+current Maestro checkout, builds and smokes Maestro, generates Maestro's
+canonical Platform replay, publishes that replay through Cerebro's local NATS
+stack, and verifies Cerebro graph projection plus MCP recall.
+
+**Run:** `make cerebro-e2e`
+
+Use `LOCAL_CEREBRO_REPO=/path/to/cerebro make cerebro-e2e` when Cerebro is not
+checked out next to Maestro.
+
 ## Usage
 
 ### Local Development


### PR DESCRIPTION
## Summary
- add `make cerebro-e2e` so Maestro developers can run the cross-repo local Cerebro proof from the Maestro checkout
- document the flow in the README and build testing guide, including `LOCAL_CEREBRO_REPO` for non-sibling checkouts

Internal source-of-truth PR: evalops/maestro-internal#1811

## Verification
- `npm run developer-surface:check`
- commit hook ran guardian, biome/eval lint, generated proto sync checks, developer-surface check, build, and compiled CLI
- `LOCAL_CEREBRO_REPO=/Users/jonathanhaas/Documents/Projects/.codex-worktrees/cerebro-local-e2e-smoke-20260509 make cerebro-e2e` with OTEL assertion enabled
