### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ export ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY \
        OPENROUTER_API_KEY XAI_API_KEY EXA_API_KEY \
        COMPOSER_MODEL COMPOSER_MODEL_PROVIDER
 
+LOCAL_CEREBRO_REPO ?= ../cerebro
+
 .PHONY: help setup install build build-all compile run-ts run-rs run-rs-debug \
         web dev dev-all developer-surface-check test test-fast test-coverage lint check fmt fmt-unsafe \
-        smoke evals verify clean db-up db-down db-migrate
+        smoke cerebro-e2e evals verify clean db-up db-down db-migrate
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
@@ -78,6 +80,9 @@ fmt-unsafe: ## Auto-format + unsafe lint fixes
 
 smoke: build ## Smoke-test the built CLI
 	npm run smoke
+
+cerebro-e2e: ## Run the cross-repo Cerebro local E2E using this Maestro checkout
+	LOCAL_MAESTRO_REPO="$(CURDIR)" $(MAKE) -C "$(LOCAL_CEREBRO_REPO)" local-maestro-e2e
 
 evals: ## Run eval scenarios
 	npx nx run maestro:evals --skip-nx-cache

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ npx nx run maestro:test --skip-nx-cache
 npx nx run maestro:evals --skip-nx-cache
 ```
 
+To prove Maestro works against a local Cerebro stack, keep sibling checkouts and
+run:
+
+```bash
+make cerebro-e2e
+```
+
+That target delegates to Cerebro's `make local-maestro-e2e` with
+`LOCAL_MAESTRO_REPO` set to the current Maestro checkout. It builds and smokes
+Maestro, emits Maestro's canonical Platform replay, publishes it through local
+NATS, and verifies Cerebro graph projection plus MCP recall from the generated
+session traffic. Set `LOCAL_CEREBRO_REPO=/path/to/cerebro` when the checkout is
+not a sibling directory.
+
 Need Redis or PostgreSQL for a specific workflow? Start from `docker-compose.yml` and use the [Contributor Runbook](docs/CONTRIBUTOR_RUNBOOK.md) for the rest of the repo workflow.
 
 ## Repository Layout

--- a/docs/BUILD_TESTING.md
+++ b/docs/BUILD_TESTING.md
@@ -102,6 +102,19 @@ and verifies Maestro's core service paths against the generated descriptors.
 
 **Run:** `MAESTRO_PLATFORM_REPO=/path/to/platform npm run platform:sdk-smoke`
 
+### 8. Cerebro Local E2E (`make cerebro-e2e`)
+
+Cross-repo local usability smoke for Maestro plus Cerebro. From Maestro, the
+target delegates to a sibling Cerebro checkout, sets `LOCAL_MAESTRO_REPO` to the
+current Maestro checkout, builds and smokes Maestro, generates Maestro's
+canonical Platform replay, publishes that replay through Cerebro's local NATS
+stack, and verifies Cerebro graph projection plus MCP recall.
+
+**Run:** `make cerebro-e2e`
+
+Use `LOCAL_CEREBRO_REPO=/path/to/cerebro make cerebro-e2e` when Cerebro is not
+checked out next to Maestro.
+
 ## Usage
 
 ### Local Development


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `d1a25a8996a6d5706bf42baefbae90a8e031ef81`
- last generated public sync base: `3ff5fba3b2a74a45d0d71ed892a57ea0abd188a4`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (d1a25a8996a6)`
- public projection: `https://github.com/evalops/maestro@main (3ff5fba3b2a7)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update Makefile
- copy/update README.md
- copy/update docs/BUILD_TESTING.md

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update Makefile
- copy/update README.md
- copy/update docs/BUILD_TESTING.md

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode