### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli-tui/commands/utility-handlers.ts
+++ b/src/cli-tui/commands/utility-handlers.ts
@@ -88,6 +88,26 @@ export interface InitHandlerCallbacks {
 	requestRender: () => void;
 }
 
+function buildInitRerunCommand(targetArg: string | undefined): string {
+	return targetArg ? `/init ${targetArg} --force` : "/init --force";
+}
+
+function parseInitArgs(argumentText: string): {
+	targetArg: string | undefined;
+	force: boolean;
+} {
+	const trimmed = argumentText.trim();
+	if (!trimmed) {
+		return { targetArg: undefined, force: false };
+	}
+	const forceMatch = trimmed.match(/(?:^|\s)(--force|-f)$/);
+	if (!forceMatch) {
+		return { targetArg: trimmed, force: false };
+	}
+	const targetArg = trimmed.slice(0, forceMatch.index).trim() || undefined;
+	return { targetArg, force: true };
+}
+
 /**
  * Handle /init command - scaffold AGENTS.md file
  */
@@ -96,19 +116,40 @@ export function handleInitCommand(
 	callbacks: InitHandlerCallbacks,
 ): void {
 	try {
-		const targetArg = context.argumentText.trim() || undefined;
-		const createdPath = handleAgentsInit(targetArg, { force: false });
-		const relativePath = relative(process.cwd(), createdPath);
+		const { targetArg, force } = parseInitArgs(context.argumentText);
+		const result = handleAgentsInit(targetArg, { force });
+		const rerunCommand = buildInitRerunCommand(targetArg);
+		const relativePath = relative(process.cwd(), result.path);
 		const displayPath =
 			relativePath && !relativePath.startsWith("..") && relativePath !== ""
 				? `./${relativePath}`
-				: createdPath;
-		callbacks.showSuccess(
-			`Scaffolded ${displayPath}. Update it before your next run.`,
-		);
-		callbacks.addContent(
-			`Created AGENTS instructions at ${displayPath}. Customize it with project-specific guidance to improve future sessions.`,
-		);
+				: result.path;
+		if (result.action === "preview") {
+			callbacks.showSuccess(
+				`Previewed AGENTS update for ${displayPath}. Re-run with ${rerunCommand} to apply it.`,
+			);
+			callbacks.addContent(
+				[
+					`AGENTS instructions already exist at ${displayPath}. Preview the proposed update below, then re-run with ${rerunCommand} to apply it.`,
+					"",
+					"```diff",
+					result.diff ?? "",
+					"```",
+				].join("\n"),
+			);
+			callbacks.requestRender();
+			return;
+		}
+		if (result.action === "updated") {
+			callbacks.showSuccess(`Updated AGENTS instructions at ${displayPath}.`);
+			callbacks.addContent(
+				`Updated AGENTS instructions at ${displayPath} after preview/force confirmation.`,
+			);
+			callbacks.requestRender();
+			return;
+		}
+		callbacks.showSuccess(`Scaffolded ${displayPath}.`);
+		callbacks.addContent(`Created AGENTS instructions at ${displayPath}.`);
 		callbacks.requestRender();
 	} catch (error) {
 		const message =

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -17,42 +17,36 @@ import {
 	relative,
 	resolve,
 } from "node:path";
+import * as Diff from "diff";
 import { truncateUtf8 } from "../system-prompt.js";
 
 const TEMPLATE = `# Repository Guidelines
 
-Use this as the contributor quickstart for **{{PROJECT_NAME}}**. Keep it concise, specific, and updated as the project evolves.
+Use this as the contributor quickstart for **{{PROJECT_NAME}}**.
 
-## Project Structure & Module Organization
-- Summarize top-level folders (e.g., \`src/\` for core code, \`tests/\` or \`__tests__/\` for suites, \`docs/\` for references, \`scripts/\` for tooling, \`packages/\` for monorepo packages, \`apps/\` for deployables, \`assets/\` for static files).
-- Note where configs live (\`package.json\`, \`tsconfig.json\`, bundler/tooling configs) and where CI definitions reside (typically \`.github/workflows/\`).
-- Call out any generated code or directories that should not be hand-edited.
+## Project Structure
+- Map the main source, test, docs, scripts, and config paths.
+- Call out generated, vendored, or build-output directories agents should not edit.
 
-## Build, Test, and Development Commands
-- Install dependencies: \`npm install\` (or \`pnpm install\`, \`yarn install\`, \`bun install\` as applicable).
-- Start development: \`npm run dev\` (mention default port or entrypoint).
-- Build: \`npm run build\` (or \`make build\` for binaries/containers).
-- Quality gates: \`npm run lint\`, \`npm run format\`.
-- Tests: \`npm test\`, \`npm run test:unit\`, or \`npm run test:e2e\`. Include any required setup (e.g., \`docker compose up\` for services).
+## Commands
+- Install: \`npm install\` (or the repo's package manager).
+- Develop: \`npm run dev\`; Build: \`npm run build\`.
+- Quality: \`npm run lint\`, \`npm run format\`, and \`npm test\`.
 
-## Coding Style & Naming Conventions
-- Enforce formatter (Prettier/Biome) and linter (ESLint or project default); prefer 2-space indent and consistent semicolons per config.
-- Naming: camelCase for variables/functions, PascalCase for components/classes, SCREAMING_SNAKE_CASE for constants; keep file names predictable (e.g., \`feature-name.test.ts\`).
-- Favor small, focused modules and pure functions; document non-obvious behavior with brief comments.
+## Style
+- Follow the checked-in formatter and linter; keep naming consistent with nearby code.
+- Prefer small, focused changes and comments only for non-obvious behavior.
 
-## Testing Guidelines
-- Primary framework (e.g., Vitest/Jest); colocate tests as \`*.test.ts\` near sources or group under \`tests/\`.
-- Cover success, error, and boundary cases; keep fixtures deterministic and minimal.
-- For long suites, run focused tests: \`npm test -- <pattern>\`; add coverage goals if required.
+## Testing
+- Add or update tests beside changed behavior.
+- Cover success, error, and boundary cases with deterministic fixtures.
 
-## Commit & Pull Request Guidelines
-- Branch from \`main\`; use imperative commit subjects (e.g., \`Add auth middleware\`), optionally scoped.
-- PRs: describe behavior changes, link issues, note skipped checks, and attach screenshots for UI. Include validation steps a reviewer can run.
-- Run the project's lint/test/build commands expected by CI before requesting review.
+## Pull Requests
+- Use imperative commit subjects and keep PRs scoped.
+- Include behavior changes, linked issues, validation steps, and screenshots for UI changes.
 
-## Security & Configuration Tips
-- Do not commit secrets; rely on local \`.env.local\` and checked-in \`.env.example\`.
-- Document new environment variables, migrations, and destructive scripts; prefer least-privilege defaults.
+## Security
+- Do not commit secrets; document new environment variables and migrations.
 `;
 
 const GENERATION_PROMPT = `Generate a file named AGENTS.md that serves as a contributor guide for this repository.
@@ -62,7 +56,7 @@ Your goal is to produce a clear, concise, and well-structured document with desc
 Document Requirements:
 - Title the document "Repository Guidelines".
 - Use Markdown headings (#, ##, etc.) for structure.
-- Keep the document concise; 200-400 words is optimal.
+- Keep the document concise; about 20 lines and 150-250 words is optimal.
 - Keep explanations short, direct, and specific to this repository.
 - Provide examples where helpful (commands, directory paths, naming patterns).
 - Maintain a professional, instructional tone.
@@ -78,6 +72,7 @@ Recommended Sections:
 Instructions:
 - Use the available tools to inspect this repository as needed (e.g., list directories, read configs, inspect scripts) before writing.
 - If existing AI tool rule files are supplied below, preserve their intent in the generated AGENTS.md instead of ignoring or mechanically concatenating them.
+- If an existing AGENTS.md or AGENT.md is supplied below, update its guidance instead of discarding hand-written project specifics.
 - Add a short HTML comment near the top noting which AI rule sources contributed.
 - Overwrite the entire contents of AGENTS.md at the target path.
 - Keep output scoped to the single Markdown file; do not create extra files.
@@ -112,6 +107,13 @@ function buildAgentsTemplate(projectName: string): string {
 
 export interface AgentsInitOptions {
 	force?: boolean;
+}
+
+export interface AgentsInitResult {
+	path: string;
+	action: "created" | "updated" | "preview";
+	diff?: string;
+	sources: AgentRuleSource[];
 }
 
 function resolveTargetPath(targetPath?: string): string {
@@ -286,6 +288,28 @@ function formatRulePathForHtmlComment(relativePath: string): string {
 	return JSON.stringify(relativePath).replaceAll("--", "- -");
 }
 
+function buildAgentsInitContent(
+	projectName: string,
+	ruleSources: AgentRuleSource[],
+): string {
+	return `${buildAgentsTemplate(projectName).trimEnd()}\n\n${formatRuleSourceSummary(ruleSources)}`;
+}
+
+function buildAgentsInitDiff(
+	targetPath: string,
+	oldContent: string,
+	newContent: string,
+): string {
+	return Diff.createTwoFilesPatch(
+		targetPath,
+		targetPath,
+		oldContent,
+		newContent,
+		"current",
+		"proposed",
+	);
+}
+
 function markdownFenceFor(content: string): string {
 	const longestBacktickRun = Math.max(
 		0,
@@ -322,6 +346,7 @@ export function buildAgentsInitPrompt(
 	sources: AgentRuleSource[] = discoverAgentRuleSources(
 		dirname(targetPath),
 		targetPath,
+		existsSync(targetPath),
 	),
 ): string {
 	return `${GENERATION_PROMPT}\n\nTarget path: ${targetPath}${formatRuleSourcesForPrompt(sources)}`;
@@ -330,20 +355,38 @@ export function buildAgentsInitPrompt(
 export function handleAgentsInit(
 	inputPath?: string,
 	options: AgentsInitOptions = {},
-): string {
+): AgentsInitResult {
 	const target = resolveTargetPath(inputPath);
 	const directory = dirname(target);
 	const projectName = basename(directory);
 	const exists = existsSync(target);
-	if (exists && !options.force) {
-		throw new Error(`AGENTS.md already exists at ${target}`);
-	}
 	const ruleSources = discoverAgentRuleSources(directory, target, exists);
+	const nextContent = buildAgentsInitContent(projectName, ruleSources);
+	if (exists) {
+		const previousContent = readFileSync(target, "utf-8");
+		const diff = buildAgentsInitDiff(target, previousContent, nextContent);
+		if (!options.force) {
+			return {
+				path: target,
+				action: "preview",
+				diff,
+				sources: ruleSources,
+			};
+		}
+		mkdirSync(directory, { recursive: true });
+		writeFileSync(target, nextContent, "utf-8");
+		return {
+			path: target,
+			action: "updated",
+			diff,
+			sources: ruleSources,
+		};
+	}
 	mkdirSync(directory, { recursive: true });
-	writeFileSync(
-		target,
-		`${buildAgentsTemplate(projectName).trimEnd()}\n\n${formatRuleSourceSummary(ruleSources)}`,
-		"utf-8",
-	);
-	return target;
+	writeFileSync(target, nextContent, "utf-8");
+	return {
+		path: target,
+		action: "created",
+		sources: ruleSources,
+	};
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1030,6 +1030,22 @@ export async function main(args: string[]) {
 	let agentsInitPrompt: string | null = null;
 	let agentsInitPath: string | null = null;
 
+	const quoteShellArg = (value: string): string => {
+		if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) {
+			return value;
+		}
+		if (process.platform === "win32") {
+			return `"${value.replaceAll('"', '\\"')}"`;
+		}
+		return `'${value.replaceAll("'", "'\\''")}'`;
+	};
+	const buildAgentsInitRerunCommand = (
+		targetArg: string | undefined,
+	): string =>
+		targetArg
+			? `maestro agents init ${quoteShellArg(targetArg)} --force`
+			: "maestro agents init --force";
+
 	// Handle "maestro agents init" command to generate AGENTS.md
 	if (parsed.command === "agents") {
 		const { buildAgentsInitPrompt, handleAgentsInit } = await import(
@@ -1045,9 +1061,25 @@ export async function main(args: string[]) {
 		}
 		try {
 			const targetArg = parsed.messages[0];
-			const filePath = handleAgentsInit(targetArg, { force: parsed.force });
-			agentsInitPath = filePath;
-			agentsInitPrompt = buildAgentsInitPrompt(filePath);
+			const result = handleAgentsInit(targetArg, { force: parsed.force });
+			if (result.action === "preview") {
+				const rerunCommand = buildAgentsInitRerunCommand(targetArg);
+				console.log(
+					[
+						`AGENTS instructions already exist at ${result.path}.`,
+						`Preview the proposed update below, then re-run with \`${rerunCommand}\` to apply it.`,
+						"",
+						result.diff ?? "",
+					].join("\n"),
+				);
+				return;
+			}
+			if (result.action === "updated") {
+				console.log(`Updated AGENTS instructions at ${result.path}.`);
+				return;
+			}
+			agentsInitPath = result.path;
+			agentsInitPrompt = buildAgentsInitPrompt(result.path, result.sources);
 			if (parsed.messages.length === 0) {
 				parsed.messages = [agentsInitPrompt];
 			}

--- a/test/cli-tui/commands/utility-handlers.test.ts
+++ b/test/cli-tui/commands/utility-handlers.test.ts
@@ -3,7 +3,11 @@ import type { AppMessage } from "../../../src/agent/types.js";
 import type { CommandExecutionContext } from "../../../src/cli-tui/commands/types.js";
 
 vi.mock("../../../src/cli/commands/agents.js", () => ({
-	handleAgentsInit: vi.fn(() => "/home/user/project/AGENTS.md"),
+	handleAgentsInit: vi.fn(() => ({
+		path: "/home/user/project/AGENTS.md",
+		action: "created",
+		sources: [],
+	})),
 }));
 
 import {
@@ -127,9 +131,11 @@ describe("utility-handlers", () => {
 
 	describe("handleInitCommand", () => {
 		it("calls handleAgentsInit and shows success on success", () => {
-			vi.mocked(handleAgentsInit).mockReturnValue(
-				"/home/user/project/AGENTS.md",
-			);
+			vi.mocked(handleAgentsInit).mockReturnValue({
+				path: "/home/user/project/AGENTS.md",
+				action: "created",
+				sources: [],
+			});
 
 			const ctx = createMockContext("/init", "");
 			const callbacks: InitHandlerCallbacks = {
@@ -144,6 +150,115 @@ describe("utility-handlers", () => {
 			expect(callbacks.showSuccess).toHaveBeenCalled();
 			expect(callbacks.addContent).toHaveBeenCalled();
 			expect(callbacks.requestRender).toHaveBeenCalled();
+		});
+
+		it("shows a diff preview when AGENTS instructions already exist", () => {
+			vi.mocked(handleAgentsInit).mockReturnValue({
+				path: "/home/user/project/AGENTS.md",
+				action: "preview",
+				diff: "diff --git a/AGENTS.md b/AGENTS.md\n-old\n+new",
+				sources: [],
+			});
+
+			const ctx = createMockContext("/init", "");
+			const callbacks: InitHandlerCallbacks = {
+				showSuccess: vi.fn(),
+				showError: vi.fn(),
+				addContent: vi.fn(),
+				requestRender: vi.fn(),
+			};
+
+			handleInitCommand(ctx, callbacks);
+
+			expect(callbacks.showSuccess).toHaveBeenCalledWith(
+				expect.stringContaining("Previewed AGENTS update"),
+			);
+			expect(callbacks.addContent).toHaveBeenCalledWith(
+				expect.stringContaining("```diff"),
+			);
+			expect(callbacks.addContent).toHaveBeenCalledWith(
+				expect.stringContaining("diff --git"),
+			);
+		});
+
+		it("includes the target path in preview force instructions", () => {
+			vi.mocked(handleAgentsInit).mockReturnValue({
+				path: "/custom/path/AGENTS.md",
+				action: "preview",
+				diff: "diff --git a/AGENTS.md b/AGENTS.md\n-old\n+new",
+				sources: [],
+			});
+
+			const ctx = createMockContext("/init ./custom/path", "./custom/path");
+			const callbacks: InitHandlerCallbacks = {
+				showSuccess: vi.fn(),
+				showError: vi.fn(),
+				addContent: vi.fn(),
+				requestRender: vi.fn(),
+			};
+
+			handleInitCommand(ctx, callbacks);
+
+			expect(callbacks.showSuccess).toHaveBeenCalledWith(
+				expect.stringContaining("/init ./custom/path --force"),
+			);
+			expect(callbacks.addContent).toHaveBeenCalledWith(
+				expect.stringContaining("/init ./custom/path --force"),
+			);
+		});
+
+		it("passes force when provided", () => {
+			vi.mocked(handleAgentsInit).mockReturnValue({
+				path: "/custom/path/AGENTS.md",
+				action: "updated",
+				sources: [],
+			});
+
+			const ctx = createMockContext(
+				"/init ./custom/path --force",
+				"./custom/path --force",
+			);
+			const callbacks: InitHandlerCallbacks = {
+				showSuccess: vi.fn(),
+				showError: vi.fn(),
+				addContent: vi.fn(),
+				requestRender: vi.fn(),
+			};
+
+			handleInitCommand(ctx, callbacks);
+
+			expect(handleAgentsInit).toHaveBeenCalledWith("./custom/path", {
+				force: true,
+			});
+			expect(callbacks.showSuccess).toHaveBeenCalledWith(
+				expect.stringContaining("Updated AGENTS instructions"),
+			);
+		});
+
+		it("only treats trailing force flags as /init options", () => {
+			vi.mocked(handleAgentsInit).mockReturnValue({
+				path: "/custom/path/AGENTS.md",
+				action: "created",
+				sources: [],
+			});
+
+			const ctx = createMockContext(
+				"/init docs/team --force guide/AGENTS.md",
+				"docs/team --force guide/AGENTS.md",
+			);
+			const callbacks: InitHandlerCallbacks = {
+				showSuccess: vi.fn(),
+				showError: vi.fn(),
+				addContent: vi.fn(),
+				requestRender: vi.fn(),
+			};
+
+			handleInitCommand(ctx, callbacks);
+
+			expect(handleAgentsInit).toHaveBeenCalledWith(
+				"docs/team --force guide/AGENTS.md",
+				{ force: false },
+			);
 		});
 
 		it("shows error when handleAgentsInit throws", () => {
@@ -165,7 +280,11 @@ describe("utility-handlers", () => {
 		});
 
 		it("passes target argument when provided", () => {
-			vi.mocked(handleAgentsInit).mockReturnValue("/custom/path/AGENTS.md");
+			vi.mocked(handleAgentsInit).mockReturnValue({
+				path: "/custom/path/AGENTS.md",
+				action: "created",
+				sources: [],
+			});
 
 			const ctx = createMockContext("/init ./custom/path", "./custom/path");
 			const callbacks: InitHandlerCallbacks = {

--- a/test/cli/agents-command.test.ts
+++ b/test/cli/agents-command.test.ts
@@ -34,7 +34,9 @@ describe("handleAgentsInit", () => {
 	});
 
 	it("creates AGENTS.md inside the target directory", () => {
-		const path = handleAgentsInit(tmpDir);
+		const result = handleAgentsInit(tmpDir);
+		const path = result.path;
+		expect(result.action).toBe("created");
 		expect(path).toBe(join(tmpDir, "AGENTS.md"));
 		const contents = readFileSync(path, "utf-8");
 		expect(contents).toContain("# Repository Guidelines");
@@ -42,17 +44,35 @@ describe("handleAgentsInit", () => {
 
 	it("allows targeting a specific file path", () => {
 		const customPath = join(tmpDir, "docs", "Team.md");
-		const path = handleAgentsInit(customPath, { force: true });
+		const result = handleAgentsInit(customPath, { force: true });
+		const path = result.path;
+		expect(result.action).toBe("created");
 		expect(path).toBe(customPath);
 		const contents = readFileSync(path, "utf-8");
 		expect(contents).toContain("docs");
 	});
 
-	it("throws when file exists unless force is provided", () => {
-		const path = handleAgentsInit(tmpDir);
-		expect(() => handleAgentsInit(path)).toThrow(/already exists/i);
-		const forcedPath = handleAgentsInit(path, { force: true });
-		expect(forcedPath).toBe(path);
+	it("previews a diff when file exists unless force is provided", () => {
+		const created = handleAgentsInit(tmpDir);
+		writeFileSync(created.path, "# Existing Guidance\n\nKeep this detail.\n");
+
+		const preview = handleAgentsInit(created.path);
+
+		expect(preview.action).toBe("preview");
+		expect(preview.path).toBe(created.path);
+		expect(preview.diff).toContain("--- ");
+		expect(preview.diff).toContain("+++ ");
+		expect(preview.diff).toContain("-# Existing Guidance");
+		expect(readFileSync(created.path, "utf-8")).toBe(
+			"# Existing Guidance\n\nKeep this detail.\n",
+		);
+
+		const updated = handleAgentsInit(created.path, { force: true });
+		expect(updated.action).toBe("updated");
+		expect(updated.path).toBe(created.path);
+		expect(readFileSync(created.path, "utf-8")).toContain(
+			"Imported AI Tooling Rules",
+		);
 	});
 
 	it("builds a generation prompt with the target path", () => {
@@ -60,6 +80,16 @@ describe("handleAgentsInit", () => {
 		const prompt = buildAgentsInitPrompt(target);
 		expect(prompt).toContain("AGENTS.md");
 		expect(prompt).toContain("Repository Guidelines");
+	});
+
+	it("includes an existing target AGENTS file in the one-shot generation prompt", () => {
+		const target = join(tmpDir, "AGENTS.md");
+		writeFileSync(target, "# Existing Guidance\n\nUse hand-written rules.");
+
+		const prompt = buildAgentsInitPrompt(target);
+
+		expect(prompt).toContain('### "AGENTS.md" (Existing AGENTS.md)');
+		expect(prompt).toContain("Use hand-written rules.");
 	});
 
 	it("discovers existing AI tool rule files with provenance", () => {
@@ -96,7 +126,7 @@ describe("handleAgentsInit", () => {
 		writeFileSync(join(tmpDir, ".windsurfrules"), "Prefer Bun for scripts");
 		writeFileSync(join(tmpDir, ".clinerules"), "Ask before deleting files");
 
-		const path = handleAgentsInit(tmpDir);
+		const path = handleAgentsInit(tmpDir).path;
 		const contents = readFileSync(path, "utf-8");
 
 		expect(contents).toContain("## Imported AI Tooling Rules");
@@ -178,7 +208,7 @@ describe("handleAgentsInit", () => {
 
 		const target = join(tmpDir, "AGENTS.md");
 		const prompt = buildAgentsInitPrompt(target);
-		const path = handleAgentsInit(target, { force: true });
+		const path = handleAgentsInit(target, { force: true }).path;
 		const contents = readFileSync(path, "utf-8");
 
 		expect(prompt).toContain(

--- a/test/cli/cli.integration.test.ts
+++ b/test/cli/cli.integration.test.ts
@@ -1,6 +1,7 @@
 import {
 	copyFileSync,
 	existsSync,
+	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	rmSync,
@@ -447,6 +448,39 @@ describe("CLI integration", () => {
 			traceMode: "otlp",
 		});
 		expect(stdoutLines.join("\n")).not.toContain("Loaded configuration");
+	});
+
+	it("includes custom agents init target in force rerun instructions", async () => {
+		const target = join(tempAgentDir, "docs", "team guide", "AGENTS.md");
+		mkdirSync(join(tempAgentDir, "docs", "team guide"), { recursive: true });
+		writeFileSync(target, "# Existing Guidance\n");
+
+		await main(["agents", "init", target]);
+
+		const combined = output.join("\n");
+		const quotedTarget =
+			process.platform === "win32" ? `"${target}"` : `'${target}'`;
+		expect(combined).toContain(`maestro agents init ${quotedTarget} --force`);
+		expect(combined).toContain("Index:");
+		expect(combined).toContain("--- ");
+		expect(combined).toContain("+++ ");
+		expect(readFileSync(target, "utf-8")).toBe("# Existing Guidance\n");
+	});
+
+	it("applies the previewed agents init scaffold when forced", async () => {
+		const target = join(tempAgentDir, "docs", "AGENTS.md");
+		mkdirSync(join(tempAgentDir, "docs"), { recursive: true });
+		writeFileSync(target, "# Existing Guidance\n");
+
+		await main(["agents", "init", target, "--force"]);
+
+		const combined = output.join("\n");
+		const content = readFileSync(target, "utf-8");
+		expect(combined).toContain(`Updated AGENTS instructions at ${target}.`);
+		expect(combined).not.toContain("Echo:");
+		expect(content).toContain("# Repository Guidelines");
+		expect(content).toContain("## Imported AI Tooling Rules");
+		expect(content).not.toContain("# Existing Guidance");
 	});
 
 	it("exports a saved session as portable jsonl", async () => {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `4359921056e023032178244f09d9edcdedf75c84`
- last generated public sync base: `0690c6a5a9a38e2a4033bbabd748eba97b92cd29`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (4359921056e0)`
- public projection: `https://github.com/evalops/maestro@main (0690c6a5a9a3)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli-tui/commands/utility-handlers.ts
- copy/update src/cli/commands/agents.ts
- copy/update src/main.ts
- copy/update test/cli-tui/commands/utility-handlers.test.ts
- copy/update test/cli/agents-command.test.ts
- copy/update test/cli/cli.integration.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli-tui/commands/utility-handlers.ts
- copy/update src/cli/commands/agents.ts
- copy/update src/main.ts
- copy/update test/cli-tui/commands/utility-handlers.test.ts
- copy/update test/cli/agents-command.test.ts
- copy/update test/cli/cli.integration.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode