### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
-# Composer — ergonomic Make targets wrapping npm/bun scripts
+# Maestro — ergonomic Make targets wrapping npm/bun scripts
 # Auto-loads .env when present (falls back to shell env otherwise).
 # Only the vars below are exported — bare `export` would leak MAKEFLAGS etc.
 -include .env
 export ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY \
        OPENROUTER_API_KEY XAI_API_KEY EXA_API_KEY \
-       COMPOSER_MODEL COMPOSER_MODEL_PROVIDER
+       MAESTRO_MODEL MAESTRO_MODEL_PROVIDER
 
 LOCAL_CEREBRO_REPO ?= ../cerebro
 
 .PHONY: help setup install build build-all compile run-ts run-rs run-rs-debug \
-        web dev dev-all developer-surface-check test test-fast test-coverage lint check fmt fmt-unsafe \
-        smoke cerebro-e2e evals verify clean db-up db-down db-migrate
+        web web-local dev dev-all developer-surface-check test test-fast test-coverage lint check fmt fmt-unsafe \
+        smoke cerebro-e2e cerebro-e2e-doctor evals verify clean db-up db-down db-migrate
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
@@ -32,7 +32,7 @@ build: ## Build TS CLI
 build-all: ## Build all packages (contracts, tui, web, cli, ai)
 	npm run build:all
 
-compile: ## Compile standalone binary (dist/composer-bun)
+compile: ## Compile standalone binary (dist/maestro-bun)
 	npm run bun:compile
 
 run-ts: ## Launch TS TUI (with .env)
@@ -40,14 +40,17 @@ run-ts: ## Launch TS TUI (with .env)
 
 run-rs: build ## Launch Rust TUI (release)
 	cargo build --release --manifest-path packages/tui-rs/Cargo.toml && \
-	COMPOSER_AGENT_SCRIPT="$$(pwd)/dist/cli.js" ./packages/tui-rs/target/release/composer-tui
+	MAESTRO_AGENT_SCRIPT="$$(pwd)/dist/cli.js" ./packages/tui-rs/target/release/maestro-tui
 
 run-rs-debug: build ## Launch Rust TUI (debug build)
 	cargo build --manifest-path packages/tui-rs/Cargo.toml && \
-	COMPOSER_AGENT_SCRIPT="$$(pwd)/dist/cli.js" ./packages/tui-rs/target/debug/composer-tui
+	MAESTRO_AGENT_SCRIPT="$$(pwd)/dist/cli.js" ./packages/tui-rs/target/debug/maestro-tui
 
 web: ## Web UI dev server (backend + Vite)
 	npm run web:dev
+
+web-local: ## Web UI dev server with local-only auth/Redis bypasses
+	npm run web:dev:local
 
 dev: ## TS watch mode
 	npm run dev
@@ -81,7 +84,10 @@ fmt-unsafe: ## Auto-format + unsafe lint fixes
 smoke: build ## Smoke-test the built CLI
 	npm run smoke
 
-cerebro-e2e: ## Run the cross-repo Cerebro local E2E using this Maestro checkout
+cerebro-e2e-doctor: ## Preflight the cross-repo Cerebro local E2E lane
+	LOCAL_CEREBRO_REPO="$(LOCAL_CEREBRO_REPO)" node scripts/check-cerebro-e2e.mjs
+
+cerebro-e2e: cerebro-e2e-doctor ## Run the cross-repo Cerebro local E2E using this Maestro checkout
 	LOCAL_MAESTRO_REPO="$(CURDIR)" $(MAKE) -C "$(LOCAL_CEREBRO_REPO)" local-maestro-e2e
 
 evals: ## Run eval scenarios

--- a/README.md
+++ b/README.md
@@ -114,10 +114,19 @@ npx nx run maestro:test --skip-nx-cache
 npx nx run maestro:evals --skip-nx-cache
 ```
 
+For the browser UI without local API keys or Redis, use the local-only dev
+profile:
+
+```bash
+make web-local
+curl http://localhost:8080/api/models
+```
+
 To prove Maestro works against a local Cerebro stack, keep sibling checkouts and
 run:
 
 ```bash
+make cerebro-e2e-doctor
 make cerebro-e2e
 ```
 
@@ -125,8 +134,10 @@ That target delegates to Cerebro's `make local-maestro-e2e` with
 `LOCAL_MAESTRO_REPO` set to the current Maestro checkout. It builds and smokes
 Maestro, emits Maestro's canonical Platform replay, publishes it through local
 NATS, and verifies Cerebro graph projection plus MCP recall from the generated
-session traffic. Set `LOCAL_CEREBRO_REPO=/path/to/cerebro` when the checkout is
-not a sibling directory.
+session traffic. `make cerebro-e2e-doctor` checks the Cerebro checkout, Docker
+Compose, the replay generator, and Cerebro's own local-E2E doctor before the
+full smoke starts. Set `LOCAL_CEREBRO_REPO=/path/to/cerebro` when the checkout
+is not a sibling directory.
 
 Need Redis or PostgreSQL for a specific workflow? Start from `docker-compose.yml` and use the [Contributor Runbook](docs/CONTRIBUTOR_RUNBOOK.md) for the rest of the repo workflow.
 

--- a/docs/BUILD_TESTING.md
+++ b/docs/BUILD_TESTING.md
@@ -110,10 +110,15 @@ current Maestro checkout, builds and smokes Maestro, generates Maestro's
 canonical Platform replay, publishes that replay through Cerebro's local NATS
 stack, and verifies Cerebro graph projection plus MCP recall.
 
-**Run:** `make cerebro-e2e`
+**Run:**
+
+- `make cerebro-e2e-doctor`
+- `make cerebro-e2e`
 
 Use `LOCAL_CEREBRO_REPO=/path/to/cerebro make cerebro-e2e` when Cerebro is not
-checked out next to Maestro.
+checked out next to Maestro. The doctor target verifies the Cerebro checkout,
+Docker Compose, Maestro replay generator, and Cerebro's own E2E preflight before
+the full smoke starts.
 
 ## Usage
 
@@ -133,6 +138,13 @@ bun run smoke
 
 # Run all build tests
 bunx vitest --run test/build/
+```
+
+For a credential-free browser-server smoke, run:
+
+```bash
+make web-local
+curl http://localhost:8080/api/models
 ```
 
 ### Pre-Commit Checklist

--- a/docs/WEB_UI.md
+++ b/docs/WEB_UI.md
@@ -98,6 +98,18 @@ This starts:
 - **Server**: http://localhost:8080/api (with auto-reload)
 - **UI**: http://localhost:3000 (Vite dev server)
 
+For local-only development without an API key or Redis, use the explicit local
+profile:
+
+```bash
+make web-local
+curl http://localhost:8080/api/models
+```
+
+That target sets `MAESTRO_WEB_REQUIRE_KEY=0`,
+`MAESTRO_WEB_REQUIRE_REDIS=0`, and
+`MAESTRO_WEB_ORIGIN=http://localhost:3000` before starting the same dev server.
+
 ### Production Mode
 
 Build and run:

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "web": "node dist/web-server.js",
     "web:rust-control": "packages/control-plane-rs/target/release/maestro-control-plane",
     "web:dev": "node ./scripts/ensure-deps.js --workspace @evalops/contracts && concurrently --names \"server,ui\" --prefix-colors \"blue,green\" \"tsx --watch src/web-server.ts\" \"bun run dev:web\"",
+    "web:dev:local": "MAESTRO_WEB_REQUIRE_KEY=0 MAESTRO_WEB_REQUIRE_REDIS=0 MAESTRO_WEB_ORIGIN=http://localhost:3000 npm run web:dev",
     "bun:lint": "bunx biome check . && bun run lint:evals",
     "bun:test": "node ./scripts/run-vitest.js --run",
     "bun:test:fast": "VITEST_FAST=1 node ./scripts/run-vitest.js --run",

--- a/packages/tui-rs/README.md
+++ b/packages/tui-rs/README.md
@@ -51,7 +51,7 @@ cd packages/tui-rs
 cargo build --release
 ```
 
-The binary will be at `target/release/composer-tui`.
+The binary will be at `target/release/maestro-tui`.
 
 ## Running
 
@@ -62,14 +62,14 @@ export ANTHROPIC_API_KEY=sk-...
 export OPENAI_API_KEY=sk-...
 
 # Run with default settings (uses Claude by default)
-./target/release/composer-tui
+./target/release/maestro-tui
 
 # Specify a model
-./target/release/composer-tui --model gpt-4o
-./target/release/composer-tui --model claude-sonnet-4-5-20250514
+./target/release/maestro-tui --model gpt-4o
+./target/release/maestro-tui --model claude-sonnet-4-5-20250514
 
 # Resume last session
-./target/release/composer-tui --resume
+./target/release/maestro-tui --resume
 ```
 
 ## Environment Variables

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -75,7 +75,7 @@ npm run build
 npm run web
 
 # Or via the CLI
-composer web
+maestro web
 
 # Or with custom port
 PORT=3000 npm run web

--- a/scripts/check-cerebro-e2e.mjs
+++ b/scripts/check-cerebro-e2e.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cerebroRepo = resolve(root, process.env.LOCAL_CEREBRO_REPO ?? "../cerebro");
+
+let status = 0;
+
+function ok(message) {
+	console.log(`ok   ${message}`);
+}
+
+function fail(message) {
+	console.error(`fail ${message}`);
+	status = 1;
+}
+
+function checkCommand(command, args) {
+	const result = spawnSync(command, args, { stdio: "ignore" });
+	return result.status === 0;
+}
+
+console.log("Maestro Cerebro local E2E doctor");
+console.log(`  Maestro repo: ${root}`);
+console.log(`  Cerebro repo: ${cerebroRepo}`);
+console.log("");
+
+if (existsSync(resolve(cerebroRepo, "Makefile"))) {
+	ok("Cerebro Makefile found");
+} else {
+	fail(
+		`Cerebro checkout not found at ${cerebroRepo}; set LOCAL_CEREBRO_REPO=/path/to/cerebro`,
+	);
+}
+
+if (existsSync(resolve(cerebroRepo, "scripts/local-maestro-doctor.sh"))) {
+	ok("Cerebro local Maestro doctor found");
+} else {
+	fail("Cerebro checkout is missing scripts/local-maestro-doctor.sh; pull latest main");
+}
+
+if (existsSync(resolve(root, "scripts/generate-maestro-platform-replay-fixture.ts"))) {
+	ok("Maestro replay generator found");
+} else {
+	fail("Maestro replay generator missing");
+}
+
+if (checkCommand("bun", ["--version"])) {
+	ok("command bun");
+} else {
+	fail("command bun is required");
+}
+
+if (checkCommand("docker", ["compose", "version"])) {
+	ok("docker compose plugin");
+} else {
+	fail("docker compose plugin is required");
+}
+
+if (existsSync(resolve(root, "package.json"))) {
+	const packageJson = readFileSync(resolve(root, "package.json"), "utf8");
+	if (packageJson.includes('"smoke"') && packageJson.includes('"build"')) {
+		ok("Maestro build and smoke scripts present");
+	} else {
+		fail("Maestro package.json is missing build or smoke scripts");
+	}
+}
+
+if (status === 0) {
+	const result = spawnSync("make", ["-C", cerebroRepo, "local-maestro-doctor"], {
+		stdio: "inherit",
+		env: {
+			...process.env,
+			LOCAL_MAESTRO_REPO: root,
+			LOCAL_MAESTRO_GENERATE_REPLAY: "true",
+			LOCAL_MAESTRO_DOCTOR_REPLAY:
+				process.env.LOCAL_MAESTRO_DOCTOR_REPLAY ?? "auto",
+		},
+	});
+	if (result.status !== 0) {
+		status = result.status ?? 1;
+	}
+}
+
+if (status !== 0) {
+	console.error("");
+	console.error("Maestro Cerebro local E2E doctor found blocking issues.");
+	process.exit(status);
+}
+
+console.log("");
+console.log("Ready to run: make cerebro-e2e");

--- a/scripts/check-developer-surface.mjs
+++ b/scripts/check-developer-surface.mjs
@@ -12,7 +12,11 @@ const requirements = {
 		["package.json", '"dev:all"'],
 		["package.json", '"smoke:event-bus"'],
 		["package.json", '"platform:sdk-smoke"'],
+		["package.json", '"web:dev:local"'],
 		["Makefile", "dev-all"],
+		["Makefile", "web-local"],
+		["Makefile", "cerebro-e2e-doctor"],
+		["scripts/check-cerebro-e2e.mjs", "Maestro Cerebro local E2E doctor"],
 	],
 	"local introspection": [
 		["package.json", '"telemetry:report"'],

--- a/scripts/smoke-headless.js
+++ b/scripts/smoke-headless.js
@@ -5,6 +5,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const home = mkdtempSync(join(tmpdir(), "maestro-headless-smoke-"));
+const timeoutMs =
+	Number.parseInt(process.env.MAESTRO_HEADLESS_SMOKE_TIMEOUT_MS ?? "60000", 10) ||
+	60000;
 
 function fail(message, details) {
 	console.error(message);
@@ -37,7 +40,7 @@ function runHeadless(args, input = "") {
 				OPENAI_API_KEY: "test-key",
 				ANTHROPIC_API_KEY: "test-key",
 			},
-			timeout: 15_000,
+			timeout: timeoutMs,
 		},
 	);
 }

--- a/scripts/verify-build.ts
+++ b/scripts/verify-build.ts
@@ -196,8 +196,8 @@ async function verifyCLIFunctionality() {
 
 	await check("CLI version command", async () => {
 		const output = runCli(["--version"]);
-		if (!output.includes("Composer")) {
-			throw new Error("Version output doesn't contain 'Composer'");
+		if (!output.includes("Maestro")) {
+			throw new Error("Version output doesn't contain 'Maestro'");
 		}
 	});
 


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `bfc38625c0398f7413905310f2093864f3d81aa4`
- last generated public sync base: `6ccf93416783158503a4771c25935020c2524b54`
- previewed public-tree drift: `11` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (bfc38625c039)`
- public projection: `https://github.com/evalops/maestro@main (6ccf93416783)`
- files to copy or update: `11`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update Makefile
- copy/update README.md
- copy/update docs/BUILD_TESTING.md
- copy/update docs/WEB_UI.md
- copy/update package.json
- copy/update packages/tui-rs/README.md
- copy/update packages/web/README.md
- copy/update scripts/check-cerebro-e2e.mjs
- copy/update scripts/check-developer-surface.mjs
- copy/update scripts/smoke-headless.js
- copy/update scripts/verify-build.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update Makefile
- copy/update README.md
- copy/update docs/BUILD_TESTING.md
- copy/update docs/WEB_UI.md
- copy/update package.json
- copy/update packages/tui-rs/README.md
- copy/update packages/web/README.md
- copy/update scripts/check-cerebro-e2e.mjs
- copy/update scripts/check-developer-surface.mjs
- copy/update scripts/smoke-headless.js
- copy/update scripts/verify-build.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode