### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli/commands/scenario.ts
+++ b/src/cli/commands/scenario.ts
@@ -191,16 +191,20 @@ function parseScenario(value: unknown): Scenario | null {
 	const replayFinalStatus = parseScenarioStatus(replay.finalStatus);
 	const finalStatus = parseScenarioStatus(expect.finalStatus);
 	if (!replayFinalStatus || !finalStatus) return null;
-	const replayEvents = Array.isArray(replay.events)
-		? replay.events
-				.map(parseReplayEvent)
-				.filter((event): event is ReplayEvent => event !== null)
-		: [];
-	const replaySideEffects = Array.isArray(replay.sideEffects)
-		? replay.sideEffects
-				.map(parseSideEffect)
-				.filter((effect): effect is SideEffect => effect !== null)
-		: [];
+	if (!Array.isArray(replay.events)) return null;
+	const replayEvents: ReplayEvent[] = [];
+	for (const rawEvent of replay.events) {
+		const event = parseReplayEvent(rawEvent);
+		if (!event) return null;
+		replayEvents.push(event);
+	}
+	if (!Array.isArray(replay.sideEffects)) return null;
+	const replaySideEffects: SideEffect[] = [];
+	for (const rawSideEffect of replay.sideEffects) {
+		const sideEffect = parseSideEffect(rawSideEffect);
+		if (!sideEffect) return null;
+		replaySideEffects.push(sideEffect);
+	}
 	if (!Array.isArray(expect.sideEffects)) return null;
 	const expectedSideEffects: SideEffectExpectation[] = [];
 	for (const rawSideEffect of expect.sideEffects) {

--- a/test/scenario-pack.test.ts
+++ b/test/scenario-pack.test.ts
@@ -153,6 +153,62 @@ describe("complex task scenario pack", () => {
 		);
 	});
 
+	it("rejects malformed replay events instead of dropping them", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "maestro-scenario-"));
+		const malformedPath = join(tempDir, "malformed-replay-event-pack.json");
+		const rawPack = JSON.parse(
+			await readFile(DEFAULT_SCENARIO_PACK, "utf8"),
+		) as Record<string, unknown> & {
+			scenarios: Array<{
+				id?: string;
+				replay?: { events?: Array<Record<string, unknown>> };
+			}>;
+		};
+		const scenario = rawPack.scenarios.find(
+			(candidate) => candidate.id === "slack-progress-audit",
+		);
+		expect(scenario?.replay?.events).toBeDefined();
+		if (!scenario?.replay?.events) return;
+		scenario.replay.events.push({ text: "missing kind" });
+
+		await writeFile(malformedPath, `${JSON.stringify(rawPack, null, 2)}\n`);
+
+		await expect(loadScenarioPack(malformedPath)).rejects.toThrow(
+			"Scenario pack is malformed",
+		);
+	});
+
+	it("rejects malformed replay side effects instead of dropping them", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "maestro-scenario-"));
+		const malformedPath = join(
+			tempDir,
+			"malformed-replay-side-effect-pack.json",
+		);
+		const rawPack = JSON.parse(
+			await readFile(DEFAULT_SCENARIO_PACK, "utf8"),
+		) as Record<string, unknown> & {
+			scenarios: Array<{
+				id?: string;
+				replay?: { sideEffects?: Array<Record<string, unknown>> };
+			}>;
+		};
+		const scenario = rawPack.scenarios.find(
+			(candidate) => candidate.id === "slack-progress-audit",
+		);
+		expect(scenario?.replay?.sideEffects).toBeDefined();
+		if (!scenario?.replay?.sideEffects) return;
+		scenario.replay.sideEffects.push({
+			kind: "slack.final_reply",
+			target: "evalops-alerts",
+		});
+
+		await writeFile(malformedPath, `${JSON.stringify(rawPack, null, 2)}\n`);
+
+		await expect(loadScenarioPack(malformedPath)).rejects.toThrow(
+			"Scenario pack is malformed",
+		);
+	});
+
 	it("requires explicit blocker expectations for blocked scenarios", async () => {
 		const pack = await loadMutableDefaultPack();
 		const scenario = pack.scenarios.find(


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `4b1917258beca81395e6e55aa9aee37dc330fe61`
- last generated public sync base: `e3cd09086b577a03e3d8d41596b8ede1498f3c96`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (4b1917258bec)`
- public projection: `https://github.com/evalops/maestro@main (e3cd09086b57)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli/commands/scenario.ts
- copy/update test/scenario-pack.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli/commands/scenario.ts
- copy/update test/scenario-pack.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode