### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli/commands/scenario.ts
+++ b/src/cli/commands/scenario.ts
@@ -106,6 +106,7 @@ interface ParsedScenarioArgs {
 	json: boolean;
 	junitPath?: string;
 	reportPath?: string;
+	errors: string[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -501,15 +502,26 @@ function parseScenarioArgs(args: string[]): ParsedScenarioArgs {
 	let json = false;
 	let junitPath: string | undefined;
 	let reportPath: string | undefined;
+	const errors: string[] = [];
 	for (let index = 0; index < rest.length; index++) {
 		const arg = rest[index];
 		if (arg === "--json") {
 			json = true;
 		} else if (arg === "--junit") {
-			junitPath = rest[index + 1];
+			const value = rest[index + 1];
+			if (!value || value.startsWith("-")) {
+				errors.push("--junit requires a non-flag file path");
+				continue;
+			}
+			junitPath = value;
 			index++;
 		} else if (arg === "--report") {
-			reportPath = rest[index + 1];
+			const value = rest[index + 1];
+			if (!value || value.startsWith("-")) {
+				errors.push("--report requires a non-flag file path");
+				continue;
+			}
+			reportPath = value;
 			index++;
 		} else if (arg && !arg.startsWith("-")) {
 			path = arg;
@@ -521,6 +533,7 @@ function parseScenarioArgs(args: string[]): ParsedScenarioArgs {
 		json,
 		junitPath,
 		reportPath,
+		errors,
 	};
 }
 
@@ -529,6 +542,9 @@ export async function handleScenarioCommand(args: string[]): Promise<void> {
 	if (parsed.action === "help") {
 		printScenarioHelp();
 		return;
+	}
+	if (parsed.errors.length > 0) {
+		throw new Error(`Invalid scenario arguments: ${parsed.errors.join("; ")}`);
 	}
 	const pack = await loadScenarioPack(parsed.path);
 	if (parsed.action === "validate") {

--- a/test/scenario-pack.test.ts
+++ b/test/scenario-pack.test.ts
@@ -93,6 +93,44 @@ describe("complex task scenario pack", () => {
 		expect(junit).toContain("browser-computer-grant-task");
 	});
 
+	it("rejects --junit when the value is missing or another flag", async () => {
+		await expect(
+			handleScenarioCommand(["run", DEFAULT_SCENARIO_PACK, "--junit"]),
+		).rejects.toThrow(
+			"Invalid scenario arguments: --junit requires a non-flag file path",
+		);
+
+		await expect(
+			handleScenarioCommand([
+				"run",
+				DEFAULT_SCENARIO_PACK,
+				"--junit",
+				"--json",
+			]),
+		).rejects.toThrow(
+			"Invalid scenario arguments: --junit requires a non-flag file path",
+		);
+	});
+
+	it("rejects --report when the value is missing or another flag", async () => {
+		await expect(
+			handleScenarioCommand(["run", DEFAULT_SCENARIO_PACK, "--report"]),
+		).rejects.toThrow(
+			"Invalid scenario arguments: --report requires a non-flag file path",
+		);
+
+		await expect(
+			handleScenarioCommand([
+				"run",
+				DEFAULT_SCENARIO_PACK,
+				"--report",
+				"--json",
+			]),
+		).rejects.toThrow(
+			"Invalid scenario arguments: --report requires a non-flag file path",
+		);
+	});
+
 	it("rejects malformed scenarios instead of dropping them from the pack", async () => {
 		const tempDir = await mkdtemp(join(tmpdir(), "maestro-scenario-"));
 		const malformedPath = join(tempDir, "malformed-pack.json");


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `2e524e568d3fa31c76e49b1b27cfda0022c927b6`
- last generated public sync base: `391ab2e5674c0412fff38d7d6de7f9cca10e8e62`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (2e524e568d3f)`
- public projection: `https://github.com/evalops/maestro@main (391ab2e5674c)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli/commands/scenario.ts
- copy/update test/scenario-pack.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli/commands/scenario.ts
- copy/update test/scenario-pack.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode