### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -157,6 +157,7 @@ async function loadContextManifestForCommand(
 	const { loadMcpConfig, mcpManager } = await import("../../mcp/index.js");
 	try {
 		await mcpManager.configure(loadMcpConfig(cwd, { includeEnvLimits: true }));
+		await mcpManager.connectAll();
 		return loadUnifiedContextManifest(cwd, {
 			mcpStatus: mcpManager.getStatus(),
 		});
@@ -182,6 +183,7 @@ async function loadContextManifestPairForCommand(
 		await mcpManager.configure(
 			loadMcpConfig(beforeCwd, { includeEnvLimits: true }),
 		);
+		await mcpManager.connectAll();
 		const before = loadUnifiedContextManifest(beforeCwd, {
 			mcpStatus: mcpManager.getStatus(),
 		});
@@ -189,6 +191,7 @@ async function loadContextManifestPairForCommand(
 		await mcpManager.configure(
 			loadMcpConfig(afterCwd, { includeEnvLimits: true }),
 		);
+		await mcpManager.connectAll();
 		const after = loadUnifiedContextManifest(afterCwd, {
 			mcpStatus: mcpManager.getStatus(),
 		});

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -476,6 +476,7 @@ export class McpClientManager extends EventEmitter {
 		const toAdd = nextConfig.servers.filter(
 			(server) => !oldServerNames.has(server.name),
 		);
+		const toAddNames = new Set(toAdd.map((server) => server.name));
 
 		this.config = nextConfig;
 
@@ -498,12 +499,15 @@ export class McpClientManager extends EventEmitter {
 			}),
 		);
 
-		// Connect new servers (don't wait for success)
+		// Connect new servers and unchanged servers that were explicitly disconnected.
 		await Promise.allSettled(
-			toAdd
+			nextConfig.servers
 				.filter(
 					(server) =>
-						!reconnectNames.has(server.name) &&
+						(toAddNames.has(server.name) ||
+							(oldServerNames.has(server.name) &&
+								!reconnectNames.has(server.name) &&
+								!this.servers.has(server.name))) &&
 						canConnectServer(server, nextApprovalMap),
 				)
 				.map((server) => this.connectServer(server)),

--- a/test/agent/mcp-manager-transports.test.ts
+++ b/test/agent/mcp-manager-transports.test.ts
@@ -118,6 +118,29 @@ describe("MCP manager remote transports", () => {
 		expect(manager.isConnected("remote-http")).toBe(true);
 	});
 
+	it("reconnects unchanged configured servers after disconnectAll", async () => {
+		const config = {
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http" as const,
+					url: "https://example.com/mcp",
+				},
+			],
+		};
+
+		await manager.configure(config);
+		expect(manager.isConnected("remote-http")).toBe(true);
+
+		await manager.disconnectAll();
+		expect(manager.isConnected("remote-http")).toBe(false);
+
+		await manager.configure(config);
+
+		expect(httpTransportCtor).toHaveBeenCalledTimes(2);
+		expect(manager.isConnected("remote-http")).toBe(true);
+	});
+
 	it("emits sparse MCP connection and tool usage beacons", async () => {
 		vi.stubEnv("MAESTRO_TELEMETRY", "1");
 		vi.stubEnv("MAESTRO_BEACON_FILE", join(tempDir, "beacon.jsonl"));

--- a/test/cli/context-command.test.ts
+++ b/test/cli/context-command.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	handleContextCommand,
 	renderContextManifestDiff,
@@ -11,9 +11,34 @@ import {
 	diffUnifiedContextManifests,
 	loadUnifiedContextManifest,
 } from "../../src/context/manifest.js";
+import { loadMcpConfig, mcpManager } from "../../src/mcp/index.js";
+
+vi.mock("../../src/mcp/index.js", () => ({
+	loadMcpConfig: vi.fn(() => ({ authPresets: [], servers: [] })),
+	mcpManager: {
+		configure: vi.fn(),
+		connectAll: vi.fn(),
+		disconnectAll: vi.fn(),
+		getStatus: vi.fn(() => ({ authPresets: [], servers: [] })),
+	},
+}));
 
 describe("context command", () => {
 	const tempDirs: string[] = [];
+
+	beforeEach(() => {
+		vi.mocked(loadMcpConfig)
+			.mockReset()
+			.mockReturnValue({ authPresets: [], servers: [] });
+		vi.mocked(mcpManager.configure).mockReset().mockResolvedValue(undefined);
+		vi.mocked(mcpManager.connectAll).mockReset().mockResolvedValue(undefined);
+		vi.mocked(mcpManager.disconnectAll)
+			.mockReset()
+			.mockResolvedValue(undefined);
+		vi.mocked(mcpManager.getStatus)
+			.mockReset()
+			.mockReturnValue({ authPresets: [], servers: [] });
+	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -279,5 +304,50 @@ describe("context command", () => {
 		expect(payload.beforeCwd).toBe(resolve(beforeRoot));
 		expect(payload.afterCwd).toBe(resolve(afterRoot));
 		expect(payload.changed).toHaveLength(1);
+	});
+
+	it("reconnects live MCP servers before reading runtime status", async () => {
+		const root = makeTempDir();
+		writeFileSync(join(root, "AGENTS.md"), "root rules");
+		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		await handleContextCommand("explain", [root, "--live-mcp", "--json"]);
+
+		expect(mcpManager.configure).toHaveBeenCalledTimes(1);
+		expect(mcpManager.connectAll).toHaveBeenCalledTimes(1);
+		expect(mcpManager.getStatus).toHaveBeenCalledTimes(1);
+		expect(mcpManager.disconnectAll).toHaveBeenCalledTimes(1);
+		expect(
+			vi.mocked(mcpManager.connectAll).mock.invocationCallOrder[0],
+		).toBeLessThan(
+			vi.mocked(mcpManager.getStatus).mock.invocationCallOrder[0]!,
+		);
+		expect(JSON.parse(String(log.mock.calls[0]?.[0])).version).toBe(1);
+	});
+
+	it("reconnects live MCP servers for both diff snapshots", async () => {
+		const beforeRoot = makeTempDir();
+		const afterRoot = makeTempDir();
+		writeFileSync(join(beforeRoot, "AGENTS.md"), "root rules");
+		writeFileSync(join(afterRoot, "AGENTS.md"), "new root rules");
+		vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		await handleContextCommand("diff", [
+			beforeRoot,
+			afterRoot,
+			"--live-mcp",
+			"--json",
+		]);
+
+		expect(mcpManager.configure).toHaveBeenCalledTimes(2);
+		expect(mcpManager.connectAll).toHaveBeenCalledTimes(2);
+		expect(mcpManager.getStatus).toHaveBeenCalledTimes(2);
+		expect(mcpManager.disconnectAll).toHaveBeenCalledTimes(1);
+		const connectOrders = vi.mocked(mcpManager.connectAll).mock
+			.invocationCallOrder;
+		const statusOrders = vi.mocked(mcpManager.getStatus).mock
+			.invocationCallOrder;
+		expect(connectOrders[0]).toBeLessThan(statusOrders[0]!);
+		expect(connectOrders[1]).toBeLessThan(statusOrders[1]!);
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `dce0f5f5175c1980afc1933c69aaf79eaa13c0f8`
- last generated public sync base: `ec4442db1150b907cfd1e32cae356bb8b1d97cdd`
- previewed public-tree drift: `4` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (dce0f5f5175c)`
- public projection: `https://github.com/evalops/maestro@main (ec4442db1150)`
- files to copy or update: `4`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli/commands/context.ts
- copy/update src/mcp/manager.ts
- copy/update test/agent/mcp-manager-transports.test.ts
- copy/update test/cli/context-command.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli/commands/context.ts
- copy/update src/mcp/manager.ts
- copy/update test/agent/mcp-manager-transports.test.ts
- copy/update test/cli/context-command.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #350 to internal source `dce0f5f5175c1980afc1933c69aaf79eaa13c0f8`