### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ cerebro-env: ## Print env exports for running this Maestro checkout against loca
 	@LOCAL_CEREBRO_REPO="$(LOCAL_CEREBRO_REPO)" node scripts/check-cerebro-e2e.mjs --print-maestro-env
 
 cerebro-dev: cerebro-e2e-doctor ## Start a usable local Cerebro stack with Maestro event ingestion enabled
-	@eval "$$(LOCAL_CEREBRO_REPO="$(LOCAL_CEREBRO_REPO)" node scripts/check-cerebro-e2e.mjs --print-env)" && \
+	@env_exports="$$(LOCAL_CEREBRO_REPO="$(LOCAL_CEREBRO_REPO)" node scripts/check-cerebro-e2e.mjs --print-env)" && \
+		eval "$$env_exports" && \
 		LOCAL_MAESTRO_REPO="$(CURDIR)" \
 		LOCAL_HTTP_PORT="$$LOCAL_HTTP_PORT" \
 		LOCAL_ADDR="$$LOCAL_ADDR" \
@@ -130,7 +131,8 @@ cerebro-dev: cerebro-e2e-doctor ## Start a usable local Cerebro stack with Maest
 		$(MAKE) -C "$(LOCAL_CEREBRO_REPO)" local-maestro-dev
 
 cerebro-e2e: cerebro-e2e-doctor ## Run the cross-repo Cerebro local E2E using this Maestro checkout
-	@eval "$$(LOCAL_CEREBRO_REPO="$(LOCAL_CEREBRO_REPO)" node scripts/check-cerebro-e2e.mjs --print-env)" && \
+	@env_exports="$$(LOCAL_CEREBRO_REPO="$(LOCAL_CEREBRO_REPO)" node scripts/check-cerebro-e2e.mjs --print-env)" && \
+		eval "$$env_exports" && \
 		LOCAL_MAESTRO_REPO="$(CURDIR)" \
 		LOCAL_HTTP_PORT="$$LOCAL_HTTP_PORT" \
 		LOCAL_ADDR="$$LOCAL_ADDR" \

--- a/scripts/prepare-public-release-mirror.mjs
+++ b/scripts/prepare-public-release-mirror.mjs
@@ -165,8 +165,8 @@ function createMatcher(patterns) {
 	return (relativePath) => {
 		const normalized = normalizePath(relativePath).replace(/^\.?\//u, "");
 		if (!normalized) return false;
-		if (PUBLIC_INCLUDE_OVERRIDES.has(normalized)) return false;
 		if (exact.has(normalized)) return true;
+		if (PUBLIC_INCLUDE_OVERRIDES.has(normalized)) return false;
 		if (
 			prefixes.some(
 				(prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),

--- a/test/scripts/cerebro-e2e-config.test.ts
+++ b/test/scripts/cerebro-e2e-config.test.ts
@@ -181,6 +181,8 @@ describe("Cerebro local E2E config", () => {
 		const makefile = readFileSync(resolve(root, "Makefile"), "utf8");
 
 		expect(makefile).toContain("scripts/check-cerebro-e2e.mjs --print-env");
+		expect(makefile).toContain('env_exports="$$(LOCAL_CEREBRO_REPO=');
+		expect(makefile).toContain('eval "$$env_exports" &&');
 		expect(makefile).toContain(
 			"scripts/check-cerebro-e2e.mjs --print-maestro-env",
 		);

--- a/test/scripts/prepare-public-release-mirror.test.ts
+++ b/test/scripts/prepare-public-release-mirror.test.ts
@@ -195,6 +195,47 @@ describe("prepare-public-release-mirror", () => {
 		expect(existsSync(join(target, "public-mirror"))).toBe(false);
 	});
 
+	it("lets explicit excludes remove public include override files", () => {
+		const { source, target } = makeFixture();
+		write(
+			join(source, "package.json"),
+			JSON.stringify(
+				{
+					name: internalPackageName,
+					version: "1.2.3",
+					maestro: {
+						canonicalPackageName: publicPackageName,
+					},
+				},
+				null,
+				2,
+			),
+		);
+		write(join(source, "README.md"), "public readme\n");
+		write(join(source, ".env.example"), "INTERNAL_DEFAULT=value\n");
+		write(
+			join(source, ".github/public-release-mirror.exclude"),
+			".env.example\n",
+		);
+
+		execFileSync(
+			process.execPath,
+			[
+				"scripts/prepare-public-release-mirror.mjs",
+				"--source",
+				source,
+				"--target",
+				target,
+			],
+			{ cwd: process.cwd(), stdio: "pipe" },
+		);
+
+		expect(readFileSync(join(target, "README.md"), "utf8")).toBe(
+			"public readme\n",
+		);
+		expect(existsSync(join(target, ".env.example"))).toBe(false);
+	});
+
 	it("excludes docs/release-ops.md from the default fallback excludes", () => {
 		const { source, target, root } = makeFixture();
 		write(


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `aca5c30647e624115039715317154bc7993f820e`
- last generated public sync base: `d61a33e392daf6de66e7d0d3560646bd7bb5bfa7`
- previewed public-tree drift: `4` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (aca5c30647e6)`
- public projection: `https://github.com/evalops/maestro@main (d61a33e392da)`
- files to copy or update: `4`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update Makefile
- copy/update scripts/prepare-public-release-mirror.mjs
- copy/update test/scripts/cerebro-e2e-config.test.ts
- copy/update test/scripts/prepare-public-release-mirror.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update Makefile
- copy/update scripts/prepare-public-release-mirror.mjs
- copy/update test/scripts/cerebro-e2e-config.test.ts
- copy/update test/scripts/prepare-public-release-mirror.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode