### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli-tui/commands/utility-handlers.ts
+++ b/src/cli-tui/commands/utility-handlers.ts
@@ -10,6 +10,7 @@
 import { relative } from "node:path";
 import type { AppMessage } from "../../agent/types.js";
 import { handleAgentsInit } from "../../cli/commands/agents.js";
+import { sanitizeTerminalPreview } from "../utils/text-formatting.js";
 import type { CommandExecutionContext } from "./types.js";
 
 export interface CopyHandlerDeps {
@@ -89,10 +90,10 @@ export interface InitHandlerCallbacks {
 }
 
 function buildInitRerunCommand(targetArg: string | undefined): string {
-	return targetArg ? `/init ${targetArg} --force` : "/init --force";
+	return targetArg ? `/init --force ${targetArg}` : "/init --force";
 }
 
-function parseInitArgs(argumentText: string): {
+export function parseInitArgs(argumentText: string): {
 	targetArg: string | undefined;
 	force: boolean;
 } {
@@ -100,12 +101,16 @@ function parseInitArgs(argumentText: string): {
 	if (!trimmed) {
 		return { targetArg: undefined, force: false };
 	}
-	const forceMatch = trimmed.match(/(?:^|\s)(--force|-f)$/);
-	if (!forceMatch) {
-		return { targetArg: trimmed, force: false };
+	if (trimmed === "--force" || trimmed === "-f") {
+		return { targetArg: undefined, force: true };
 	}
-	const targetArg = trimmed.slice(0, forceMatch.index).trim() || undefined;
-	return { targetArg, force: true };
+	for (const flag of ["--force ", "-f "]) {
+		if (trimmed.startsWith(flag)) {
+			const targetArg = trimmed.slice(flag.length).trim() || undefined;
+			return { targetArg, force: true };
+		}
+	}
+	return { targetArg: trimmed, force: false };
 }
 
 /**
@@ -133,7 +138,7 @@ export function handleInitCommand(
 					`AGENTS instructions already exist at ${displayPath}. Preview the proposed update below, then re-run with ${rerunCommand} to apply it.`,
 					"",
 					"```diff",
-					result.diff ?? "",
+					sanitizeTerminalPreview(result.diff ?? ""),
 					"```",
 				].join("\n"),
 			);

--- a/src/cli-tui/utils/text-formatting.ts
+++ b/src/cli-tui/utils/text-formatting.ts
@@ -13,6 +13,14 @@ export function stripAnsiSequences(text: string): string {
 	return text.replace(ANSI_ESCAPE_SEQUENCE, "");
 }
 
+export function sanitizeTerminalPreview(text: string): string {
+	return stripAnsiSequences(text).replace(
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: preview text may come from repository files and must not emit terminal controls.
+		/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g,
+		"",
+	);
+}
+
 function consumeAnsiSequence(text: string, index: number): number {
 	if (text[index] !== "\x1B") {
 		return index + 1;

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -285,7 +285,9 @@ function formatRulePathForMarkdown(relativePath: string): string {
 }
 
 function formatRulePathForHtmlComment(relativePath: string): string {
-	return JSON.stringify(relativePath).replaceAll("--", "- -");
+	return JSON.stringify(relativePath).replace(/-{2,}/g, (dashes) =>
+		dashes.split("").join(" "),
+	);
 }
 
 function buildAgentsInitContent(

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,6 +114,7 @@ import {
 } from "./checkpoints/index.js";
 import { TuiClientToolService } from "./cli-tui/client-tools/local-client-tool-service.js";
 import { TuiRenderer } from "./cli-tui/tui-renderer.js";
+import { sanitizeTerminalPreview } from "./cli-tui/utils/text-formatting.js";
 import { type Mode, parseArgs } from "./cli/args.js";
 import {
 	EXEC_SESSION_SUMMARY_PREFIX,
@@ -1044,7 +1045,13 @@ export async function main(args: string[]) {
 			return value;
 		}
 		if (process.platform === "win32") {
-			return `"${value.replaceAll('"', '\\"')}"`;
+			const escaped = value
+				.replace(
+					/(\\*)"/g,
+					(_match, slashes: string) => `${slashes}${slashes}\\"`,
+				)
+				.replace(/\\+$/g, (slashes) => `${slashes}${slashes}`);
+			return `"${escaped}"`;
 		}
 		return `'${value.replaceAll("'", "'\\''")}'`;
 	};
@@ -1078,7 +1085,7 @@ export async function main(args: string[]) {
 						`AGENTS instructions already exist at ${result.path}.`,
 						`Preview the proposed update below, then re-run with \`${rerunCommand}\` to apply it.`,
 						"",
-						result.diff ?? "",
+						sanitizeTerminalPreview(result.diff ?? ""),
 					].join("\n"),
 				);
 				return;

--- a/test/cli-tui/commands/utility-handlers.test.ts
+++ b/test/cli-tui/commands/utility-handlers.test.ts
@@ -18,6 +18,7 @@ import {
 	handleCopyCommand,
 	handleInitCommand,
 	handleReportCommand,
+	parseInitArgs,
 } from "../../../src/cli-tui/commands/utility-handlers.js";
 import { handleAgentsInit } from "../../../src/cli/commands/agents.js";
 
@@ -200,10 +201,10 @@ describe("utility-handlers", () => {
 			handleInitCommand(ctx, callbacks);
 
 			expect(callbacks.showSuccess).toHaveBeenCalledWith(
-				expect.stringContaining("/init ./custom/path --force"),
+				expect.stringContaining("/init --force ./custom/path"),
 			);
 			expect(callbacks.addContent).toHaveBeenCalledWith(
-				expect.stringContaining("/init ./custom/path --force"),
+				expect.stringContaining("/init --force ./custom/path"),
 			);
 		});
 
@@ -215,8 +216,8 @@ describe("utility-handlers", () => {
 			});
 
 			const ctx = createMockContext(
-				"/init ./custom/path --force",
-				"./custom/path --force",
+				"/init --force ./custom/path",
+				"--force ./custom/path",
 			);
 			const callbacks: InitHandlerCallbacks = {
 				showSuccess: vi.fn(),
@@ -235,7 +236,7 @@ describe("utility-handlers", () => {
 			);
 		});
 
-		it("only treats trailing force flags as /init options", () => {
+		it("preserves literal targets that end with force-looking segments", () => {
 			vi.mocked(handleAgentsInit).mockReturnValue({
 				path: "/custom/path/AGENTS.md",
 				action: "created",
@@ -243,8 +244,8 @@ describe("utility-handlers", () => {
 			});
 
 			const ctx = createMockContext(
-				"/init docs/team --force guide/AGENTS.md",
-				"docs/team --force guide/AGENTS.md",
+				"/init docs/team --force",
+				"docs/team --force",
 			);
 			const callbacks: InitHandlerCallbacks = {
 				showSuccess: vi.fn(),
@@ -255,10 +256,44 @@ describe("utility-handlers", () => {
 
 			handleInitCommand(ctx, callbacks);
 
-			expect(handleAgentsInit).toHaveBeenCalledWith(
-				"docs/team --force guide/AGENTS.md",
-				{ force: false },
-			);
+			expect(handleAgentsInit).toHaveBeenCalledWith("docs/team --force", {
+				force: false,
+			});
+		});
+
+		it("parses leading force flags for /init updates", () => {
+			expect(parseInitArgs("--force docs/team")).toEqual({
+				targetArg: "docs/team",
+				force: true,
+			});
+			expect(parseInitArgs("-f")).toEqual({
+				targetArg: undefined,
+				force: true,
+			});
+		});
+
+		it("strips terminal controls from diff previews", () => {
+			vi.mocked(handleAgentsInit).mockReturnValue({
+				path: "/custom/path/AGENTS.md",
+				action: "preview",
+				diff: `${String.fromCharCode(27)}[2J-old${String.fromCharCode(7)}\n+new`,
+				sources: [],
+			});
+
+			const ctx = createMockContext("/init", "");
+			const callbacks: InitHandlerCallbacks = {
+				showSuccess: vi.fn(),
+				showError: vi.fn(),
+				addContent: vi.fn(),
+				requestRender: vi.fn(),
+			};
+
+			handleInitCommand(ctx, callbacks);
+
+			const preview = vi.mocked(callbacks.addContent).mock.calls[0]?.[0] ?? "";
+			expect(preview).toContain("-old\n+new");
+			expect(preview).not.toContain(String.fromCharCode(27));
+			expect(preview).not.toContain(String.fromCharCode(7));
 		});
 
 		it("shows error when handleAgentsInit throws", () => {

--- a/test/cli/agents-command.test.ts
+++ b/test/cli/agents-command.test.ts
@@ -165,6 +165,20 @@ describe("handleAgentsInit", () => {
 		expect(prompt).toContain("# Inner fence\n```\nThen continue.\n````");
 	});
 
+	it("escapes repeated dashes in imported rule HTML comments", () => {
+		const rulesDir = join(tmpDir, ".cursor", "rules");
+		mkdirSync(rulesDir, { recursive: true });
+		writeFileSync(join(rulesDir, "bad--->rule.md"), "Do not close comments");
+
+		const target = join(tmpDir, "AGENTS.md");
+		handleAgentsInit(target);
+		const contents = readFileSync(target, "utf-8");
+
+		expect(contents).toContain(
+			'<!-- Imported by maestro /init from: ".cursor/rules/bad- - ->rule.md" -->',
+		);
+	});
+
 	it("does not read symlinked rule files", () => {
 		const outsideDir = mkdtempSync(join(tmpdir(), "agents-secret-"));
 		try {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `8b05af62ba43dafd5a3e611d1bd5c0f4fa2cc578`
- last generated public sync base: `b9e8d215b98002f5a2612411768f91d9838c42ea`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (8b05af62ba43)`
- public projection: `https://github.com/evalops/maestro@main (b9e8d215b980)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli-tui/commands/utility-handlers.ts
- copy/update src/cli-tui/utils/text-formatting.ts
- copy/update src/cli/commands/agents.ts
- copy/update src/main.ts
- copy/update test/cli-tui/commands/utility-handlers.test.ts
- copy/update test/cli/agents-command.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli-tui/commands/utility-handlers.ts
- copy/update src/cli-tui/utils/text-formatting.ts
- copy/update src/cli/commands/agents.ts
- copy/update src/main.ts
- copy/update test/cli-tui/commands/utility-handlers.test.ts
- copy/update test/cli/agents-command.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode