### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/safety/execpolicy.ts
+++ b/src/safety/execpolicy.ts
@@ -1055,9 +1055,14 @@ export function isCommandForbidden(
  * Whitelist a command by adding an allow rule to the project policy.
  */
 export function whitelistCommand(workspaceDir: string, command: string): void {
-	const tokens = parseCommand(command);
 	const policyPath = join(workspaceDir, ".maestro", "execpolicy");
-	appendAllowPrefixRule(policyPath, tokens);
+	const commands = parseCommandSequence(command);
+	if (commands.length === 0) {
+		throw new Error("prefix cannot be empty");
+	}
+	for (const tokens of commands) {
+		appendAllowPrefixRule(policyPath, tokens);
+	}
 }
 
 /**

--- a/test/safety/execpolicy.test.ts
+++ b/test/safety/execpolicy.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -8,6 +14,7 @@ import {
 	clearPolicyCache,
 	parseCommand,
 	parsePolicy,
+	whitelistCommand,
 } from "../../src/safety/execpolicy.js";
 
 describe("execpolicy", () => {
@@ -536,6 +543,26 @@ prefix_rule(
 					},
 				],
 			});
+		});
+
+		it("whitelists every simple command in a compound shell command", () => {
+			const workspaceDir = createWorkspacePolicy("");
+
+			whitelistCommand(workspaceDir, "echo hello && printf done");
+			const policy = readFileSync(
+				join(workspaceDir, ".maestro", "execpolicy"),
+				"utf-8",
+			);
+
+			expect(policy).toContain(
+				'prefix_rule(pattern=["echo", "hello"], decision="allow")',
+			);
+			expect(policy).toContain(
+				'prefix_rule(pattern=["printf", "done"], decision="allow")',
+			);
+			expect(
+				checkCommand("echo hello && printf done", workspaceDir).decision,
+			).toBe("allow");
 		});
 
 		it("evaluates every trusted alias for a resolved host executable path", () => {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `eb3294d6f766753e7ee90bba706073c38298a8f2`
- last generated public sync base: `9da8f7f310d2ede013ec10aa0344e2f33344e5dc`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (eb3294d6f766)`
- public projection: `https://github.com/evalops/maestro@main (9da8f7f310d2)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/safety/execpolicy.ts
- copy/update test/safety/execpolicy.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/safety/execpolicy.ts
- copy/update test/safety/execpolicy.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode