### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -24,7 +24,7 @@ This document describes Maestro's security architecture, trust boundaries, and m
 │  │                                                                         │  │
 │  │  ┌─────────────┐   ┌─────────────┐   ┌─────────────────────────────┐  │  │
 │  │  │   Agent     │◄──│   Safety    │◄──│     Tool Execution          │  │  │
-│  │  │   Core      │   │   Layer     │   │  bash · read · write · edit │  │  │
+│  │  │   Core      │   │   Layer     │   │ bash · read · patch/edit │  │  │
 │  │  └─────────────┘   └─────────────┘   └─────────────────────────────┘  │  │
 │  │         │                │                         │                   │  │
 │  │         │                ▼                         ▼                   │  │
@@ -131,7 +131,7 @@ maestro --approval-mode fail
 **Risk:** Agent reads or writes files outside the intended workspace.
 
 **Attack Surface:**
-- `read`, `write`, `edit` tools with path arguments
+- `read`, `apply_patch`, `write`, `edit` tools with path arguments
 - Symlink following
 - Parent directory escapes (`../`)
 

--- a/docs/TOOLS_REFERENCE.md
+++ b/docs/TOOLS_REFERENCE.md
@@ -61,6 +61,7 @@ export const myTool = createTool({
 | `diff` | Wrapper around `git diff`. | Modes: workspace, staged, or custom ranges. Also supports `mode: "status"` (legacy) but prefer the dedicated `status` tool. |
 | `status` | Structured `git status` (porcelain v2). | Options: `branchSummary` (-b), `includeIgnored` (`--ignored=matching`), `paths`. Returns parsed status in details + summary text. |
 | `bash` | Executes shell commands (`bash -lc`). | Default timeout 90s (max 600s) and 40KB output cap; mutating commands require a plan when safe-mode is on. Runs from repo root; stdout/stderr streamed. In bash mode, `cd` is handled internally. |
+| `apply_patch` | Applies Codex-native `*** Begin Patch` blocks. | Accepts `patch` and optional `dryRun`. Supports Add/Update/Delete File operations, reports touched files, diffs, hunk counts, diagnostic delta, and validator results. Failed hunks are retryable tool errors with conflict details. |
 | `edit` | Structured find/replace writer. | Accepts `path`, `oldText`, `newText`. Supports `edits` array for multiple sequential edits, `replaceAll` for bulk replacements, and `dryRun` for previews. |
 | `write` | Writes or overwrites files. | Takes `path` + `contents`. Creates directories automatically. |
 | `todo` | Generates TodoWrite-style task lists. | Stored near the project (`~/.maestro/todos.json`). Integrates with `/plan`. |

--- a/docs/WEB_UI.md
+++ b/docs/WEB_UI.md
@@ -283,6 +283,7 @@ Tools run with **auto-approval** in web mode:
 Available tools:
 - `bash` - Execute shell commands
 - `read` - Read files
+- `apply_patch` - Apply Codex-native patch blocks
 - `write` - Create/overwrite files
 - `edit` - Find and replace in files
 - ... (all Maestro tools)

--- a/docs/opencode-parity.md
+++ b/docs/opencode-parity.md
@@ -5,7 +5,7 @@ Updated: 2026-01-19
 This note captures the quickest path to close the gaps called out during the OpenCode comparison (2025-11-23). Items are ordered by implementation cost vs impact.
 
 ## Status Snapshot
-- ✅ Plan Mode (ask-before-write/bash): `/plan-mode on|off` + `MAESTRO_PLAN_MODE=1` gates `write/edit/bash` in the safety firewall and surfaces status in `/status`.
+- ✅ Plan Mode (ask-before-write/bash): `/plan-mode on|off` + `MAESTRO_PLAN_MODE=1` gates `apply_patch`/`write`/`edit`/`bash` in the safety firewall and surfaces status in `/status`.
 - ✅ User Command Catalog: JSON commands in `~/.maestro/commands/*.json` or `.maestro/commands/`, exposed via `/commands list|run` and the command palette.
 - ✅ Session Share (read-only live view): `/api/sessions/:id/share` and `/share/:token` tokens in the web UI; TUI also supports `/share` HTML exports.
 - ✅ LSP Auto-Attach: `MAESTRO_LSP_AUTOSTART=1` triggers `src/lsp/autostart.ts` detection and `/lsp status|restart`.

--- a/evals/tools/surface-smoke-cases.json
+++ b/evals/tools/surface-smoke-cases.json
@@ -15,6 +15,7 @@
 				"diff",
 				"bash",
 				"background_tasks",
+				"apply_patch",
 				"edit",
 				"write",
 				"notebook_edit",
@@ -33,6 +34,7 @@
 				"pipeline_log_activity"
 			],
 			"registryNames": [
+				"apply_patch",
 				"ask_user",
 				"background_tasks",
 				"bash",
@@ -67,8 +69,9 @@
 		"kind": "apiTools",
 		"judgeRubric": "The API tools endpoint should enumerate the coding tools completely and report the correct coding count.",
 		"expected": {
-			"codingCount": 26,
+			"codingCount": 27,
 			"codingNames": [
+				"apply_patch",
 				"ask_user",
 				"background_tasks",
 				"bash",

--- a/scripts/check-prepared-public-mirror-tree.mjs
+++ b/scripts/check-prepared-public-mirror-tree.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+function parseArgs(argv) {
+	const args = {
+		target: "",
+	};
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		switch (arg) {
+			case "--target":
+				args.target = argv[++index] ?? "";
+				break;
+			default:
+				throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+	if (!args.target) {
+		throw new Error("Missing required --target <path>");
+	}
+	return args;
+}
+
+function fail(message) {
+	console.error(message);
+	process.exit(1);
+}
+
+const options = parseArgs(process.argv.slice(2));
+const targetRoot = resolve(options.target);
+
+if (!existsSync(targetRoot)) {
+	fail(`Prepared public mirror target does not exist: ${targetRoot}`);
+}
+
+if (existsSync(resolve(targetRoot, ".github/public-release-mirror.exclude"))) {
+	fail(".github/public-release-mirror.exclude must not exist in the prepared public mirror tree.");
+}
+
+const boundaryScript = resolve(
+	targetRoot,
+	"scripts/check-public-surface-boundary.mjs",
+);
+if (!existsSync(boundaryScript)) {
+	fail(`Missing public surface boundary checker in prepared public mirror tree: ${boundaryScript}`);
+}
+
+const result = spawnSync(process.execPath, [boundaryScript], {
+	cwd: targetRoot,
+	encoding: "utf8",
+});
+
+if (result.stdout) {
+	process.stdout.write(result.stdout);
+}
+if (result.stderr) {
+	process.stderr.write(result.stderr);
+}
+
+if (result.status !== 0) {
+	fail(`Public surface boundary smoke failed with exit code ${result.status ?? "unknown"}.`);
+}
+
+console.log("Prepared public mirror tree smoke passed.");

--- a/src/agent/subagent-specs.ts
+++ b/src/agent/subagent-specs.ts
@@ -43,7 +43,7 @@ export const TOOL_CATEGORIES = {
 		"status",
 	],
 	/** File modification tools */
-	write: ["edit", "write", "notebook_edit"],
+	write: ["apply_patch", "edit", "write", "notebook_edit"],
 	/** Shell execution */
 	shell: ["bash", "background_tasks"],
 	/** Web and external tools */

--- a/src/agent/transport/tool-safety-pipeline.ts
+++ b/src/agent/transport/tool-safety-pipeline.ts
@@ -257,7 +257,11 @@ function checkRateLimit(ctx: ToolSafetyContext):
 	const toolNameLower = toolCall.name.toLowerCase();
 	if (toolNameLower === "read" || toolNameLower === "glob") {
 		adaptiveThresholds.recordObservation(METRICS.READS_PER_MINUTE, 1);
-	} else if (toolNameLower === "write" || toolNameLower === "edit") {
+	} else if (
+		toolNameLower === "write" ||
+		toolNameLower === "edit" ||
+		toolNameLower === "apply_patch"
+	) {
 		adaptiveThresholds.recordObservation(METRICS.WRITES_PER_MINUTE, 1);
 	} else if (
 		toolNameLower === "webfetch" ||

--- a/src/safety/action-firewall.ts
+++ b/src/safety/action-firewall.ts
@@ -53,6 +53,7 @@ import type {
 	WorkflowStateSnapshot,
 } from "../agent/action-approval.js";
 export type { ActionApprovalContext } from "../agent/action-approval.js";
+import { parseApplyPatchPaths } from "../tools/apply-patch-parser.js";
 import { createLogger } from "../utils/logger.js";
 import { isCommandAllowlisted } from "./bash-allowlist.js";
 import {
@@ -426,6 +427,12 @@ function extractFilePaths(context: ActionApprovalContext): string[] {
 			getStringArg(context, "file_path") || getStringArg(context, "path");
 		if (p) paths.push(p);
 	}
+	if (toolName === "apply_patch") {
+		const patch = getStringArg(context, "patch");
+		if (patch) {
+			paths.push(...parseApplyPatchPaths(patch));
+		}
+	}
 	if (toolName === "delete_file") {
 		const p =
 			getStringArg(context, "file_path") ||
@@ -513,9 +520,14 @@ export const defaultFirewallRules: ActionFirewallRule[] = [
 		evaluate: (ctx) => {
 			// Only check file mutation tools
 			if (
-				!["write", "edit", "delete_file", "move_file", "copy_file"].includes(
-					ctx.toolName,
-				)
+				![
+					"write",
+					"edit",
+					"apply_patch",
+					"delete_file",
+					"move_file",
+					"copy_file",
+				].includes(ctx.toolName)
 			) {
 				return { allowed: true };
 			}
@@ -585,9 +597,14 @@ export const defaultFirewallRules: ActionFirewallRule[] = [
 		evaluate: (ctx) => {
 			// Only check file mutation tools
 			if (
-				!["write", "edit", "delete_file", "move_file", "copy_file"].includes(
-					ctx.toolName,
-				)
+				![
+					"write",
+					"edit",
+					"apply_patch",
+					"delete_file",
+					"move_file",
+					"copy_file",
+				].includes(ctx.toolName)
 			) {
 				return { allowed: true };
 			}
@@ -654,7 +671,14 @@ export const defaultFirewallRules: ActionFirewallRule[] = [
 		match: (ctx) => {
 			if (process.env.MAESTRO_PLAN_MODE !== "1") return false;
 			const name = ctx.toolName;
-			if (name === "write" || name === "edit" || name === "bash") return true;
+			if (
+				name === "write" ||
+				name === "edit" ||
+				name === "apply_patch" ||
+				name === "bash"
+			) {
+				return true;
+			}
 			if (name === "todo") return true;
 			if (name === "gh_pr") {
 				const action = getStringArg(ctx, "action");

--- a/src/safety/guarded-files.ts
+++ b/src/safety/guarded-files.ts
@@ -7,6 +7,7 @@ import {
 	normalizeGuardedFilesSettings,
 } from "@evalops/contracts";
 import { minimatch } from "minimatch";
+import { parseApplyPatchPaths } from "../tools/apply-patch-parser.js";
 import {
 	expandTildePathWithHomeDir,
 	getOsHomeDir,
@@ -48,9 +49,14 @@ export function classifyGuardedFileAccessAction(
 ): GuardedFileAccessAction {
 	const normalizedToolName = toolName.toLowerCase();
 	if (
-		["write", "edit", "delete_file", "move_file", "copy_file"].includes(
-			normalizedToolName,
-		)
+		[
+			"write",
+			"edit",
+			"apply_patch",
+			"delete_file",
+			"move_file",
+			"copy_file",
+		].includes(normalizedToolName)
 	) {
 		return "write";
 	}
@@ -453,6 +459,12 @@ function extractGuardedToolCallPaths(
 			getStringArg(argsObject, "file_path") || getStringArg(argsObject, "path");
 		if (path) {
 			paths.push(path);
+		}
+	}
+	if (normalizedToolName === "apply_patch") {
+		const patch = getStringArg(argsObject, "patch");
+		if (patch) {
+			paths.push(...parseApplyPatchPaths(patch));
 		}
 	}
 	if (normalizedToolName === "delete_file") {

--- a/src/safety/tool-categorization.ts
+++ b/src/safety/tool-categorization.ts
@@ -13,7 +13,7 @@ export const TOOL_TAGS: Record<string, string[]> = {
 	// Read operations
 	read: ["read", "file_read", "cat", "head", "tail", "grep"],
 	// Write operations
-	write: ["write", "edit", "file_write", "touch", "mkdir"],
+	write: ["write", "edit", "apply_patch", "file_write", "touch", "mkdir"],
 	// Delete operations
 	delete: ["delete_file", "rm", "rmdir", "unlink"],
 	// Network egress

--- a/src/server/handlers/pending-requests.ts
+++ b/src/server/handlers/pending-requests.ts
@@ -306,7 +306,9 @@ function responseFor(
 			sessionId: request.sessionId,
 			resolution,
 			source:
-				request.platform || operation === "ResumeRun" ? "platform" : "local",
+				Boolean(request.platform) || operation === "ResumeRun"
+					? "platform"
+					: "local",
 			platform: request.platform,
 			platformOperation: operation,
 		},

--- a/src/testing/test-verification-hook.ts
+++ b/src/testing/test-verification-hook.ts
@@ -20,6 +20,7 @@ import type {
 	HookJsonOutput,
 	PostToolUseHookInput,
 } from "../hooks/types.js";
+import { parseApplyPatchPaths } from "../tools/apply-patch-parser.js";
 import { createLogger } from "../utils/logger.js";
 import {
 	type AutoVerifyConfig,
@@ -37,7 +38,12 @@ const logger = createLogger("test-verification-hook");
 /**
  * Tools that modify files and should trigger test verification.
  */
-const FILE_MODIFYING_TOOLS = new Set(["edit", "write", "notebook_edit"]);
+const FILE_MODIFYING_TOOLS = new Set([
+	"apply_patch",
+	"edit",
+	"write",
+	"notebook_edit",
+]);
 let registeredTestVerificationHookUnregisters: Array<() => void> = [];
 let registeredTestVerificationService: AutoVerifyService | null = null;
 
@@ -53,25 +59,30 @@ function clearRegisteredTestVerificationHooks(): void {
 /**
  * Extract file path from tool input based on tool type.
  */
-function extractFilePath(
+function extractFilePaths(
 	toolName: string,
 	toolInput: Record<string, unknown>,
-): string | null {
+): string[] {
 	switch (toolName) {
 		case "edit":
 			return typeof toolInput.file_path === "string"
-				? toolInput.file_path
-				: null;
+				? [toolInput.file_path]
+				: [];
+		case "apply_patch":
+			if (typeof toolInput.patch !== "string") {
+				return [];
+			}
+			return parseApplyPatchPaths(toolInput.patch);
 		case "write":
 			return typeof toolInput.file_path === "string"
-				? toolInput.file_path
-				: null;
+				? [toolInput.file_path]
+				: [];
 		case "notebook_edit":
 			return typeof toolInput.notebook_path === "string"
-				? toolInput.notebook_path
-				: null;
+				? [toolInput.notebook_path]
+				: [];
 		default:
-			return null;
+			return [];
 	}
 }
 
@@ -99,23 +110,28 @@ function createTestVerificationCallback(
 			return null;
 		}
 
-		// Extract file path from tool input
-		const filePath = extractFilePath(postInput.tool_name, postInput.tool_input);
-		if (!filePath) {
+		// Extract file paths from tool input
+		const filePaths = extractFilePaths(
+			postInput.tool_name,
+			postInput.tool_input,
+		);
+		if (filePaths.length === 0) {
 			return null;
 		}
 
-		// Record the file change (this will debounce and eventually trigger tests)
-		const absolutePath = isAbsolute(filePath)
-			? filePath
-			: join(postInput.cwd, filePath);
+		for (const filePath of filePaths) {
+			// Record the file change (this will debounce and eventually trigger tests)
+			const absolutePath = isAbsolute(filePath)
+				? filePath
+				: join(postInput.cwd, filePath);
 
-		logger.debug("Recording file change from tool", {
-			tool: postInput.tool_name,
-			filePath: absolutePath,
-		});
+			logger.debug("Recording file change from tool", {
+				tool: postInput.tool_name,
+				filePath: absolutePath,
+			});
 
-		service.recordFileChange(absolutePath);
+			service.recordFileChange(absolutePath);
+		}
 
 		// Return null to not interfere with the hook flow
 		// Tests will run asynchronously after debounce period

--- a/src/tools/apply-patch-parser.ts
+++ b/src/tools/apply-patch-parser.ts
@@ -1,0 +1,177 @@
+export type ApplyPatchHunk = {
+	oldLines: string[];
+	newLines: string[];
+};
+
+export type ApplyPatchOperation =
+	| {
+			type: "add";
+			path: string;
+			lines: string[];
+	  }
+	| {
+			type: "delete";
+			path: string;
+	  }
+	| {
+			type: "update";
+			path: string;
+			moveTo?: string;
+			hunks: ApplyPatchHunk[];
+	  };
+
+export type ApplyPatchDocument = {
+	operations: ApplyPatchOperation[];
+};
+
+export function parseApplyPatchPaths(patch: string): string[] {
+	try {
+		return [
+			...new Set(
+				parseApplyPatch(patch).operations.flatMap((operation) =>
+					operation.type === "update" && operation.moveTo
+						? [operation.path, operation.moveTo]
+						: [operation.path],
+				),
+			),
+		];
+	} catch {
+		return [];
+	}
+}
+
+export function parseApplyPatch(patch: string): ApplyPatchDocument {
+	const lines = patch.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+	if (lines.at(-1) === "") {
+		lines.pop();
+	}
+	if (lines[0] !== "*** Begin Patch") {
+		throw new Error("apply_patch must start with *** Begin Patch");
+	}
+	if (lines.at(-1) !== "*** End Patch") {
+		throw new Error("apply_patch must end with *** End Patch");
+	}
+
+	const operations: ApplyPatchOperation[] = [];
+	let index = 1;
+	const endIndex = lines.length - 1;
+	while (index < endIndex) {
+		const line = lines[index] ?? "";
+		if (line.startsWith("*** Add File: ")) {
+			const path = requirePatchPath(line.slice("*** Add File: ".length));
+			index++;
+			const addLines: string[] = [];
+			while (index < endIndex && !isOperationHeader(lines[index] ?? "")) {
+				const bodyLine = lines[index] ?? "";
+				if (!bodyLine.startsWith("+")) {
+					throw new Error(
+						`Add File ${path} contains a non-added line: ${bodyLine}`,
+					);
+				}
+				addLines.push(bodyLine.slice(1));
+				index++;
+			}
+			operations.push({ type: "add", path, lines: addLines });
+			continue;
+		}
+
+		if (line.startsWith("*** Delete File: ")) {
+			operations.push({
+				type: "delete",
+				path: requirePatchPath(line.slice("*** Delete File: ".length)),
+			});
+			index++;
+			continue;
+		}
+
+		if (line.startsWith("*** Update File: ")) {
+			const path = requirePatchPath(line.slice("*** Update File: ".length));
+			index++;
+			let moveTo: string | undefined;
+			if ((lines[index] ?? "").startsWith("*** Move to: ")) {
+				moveTo = requirePatchPath(
+					(lines[index] ?? "").slice("*** Move to: ".length),
+				);
+				index++;
+			}
+			const hunks: ApplyPatchHunk[] = [];
+			while (index < endIndex && !isOperationHeader(lines[index] ?? "")) {
+				if ((lines[index] ?? "").startsWith("@@")) {
+					index++;
+				}
+				const hunk: ApplyPatchHunk = { oldLines: [], newLines: [] };
+				while (index < endIndex) {
+					const bodyLine = lines[index] ?? "";
+					if (bodyLine.startsWith("@@") || isOperationHeader(bodyLine)) {
+						break;
+					}
+					if (bodyLine.startsWith("*** Move to: ")) {
+						throw new Error(
+							`Update File ${path} must place Move to before hunks`,
+						);
+					}
+					if (bodyLine === "\\ No newline at end of file") {
+						index++;
+						continue;
+					}
+					if (bodyLine === "*** End of File") {
+						index++;
+						continue;
+					}
+					const prefix = bodyLine[0];
+					const content = bodyLine.slice(1);
+					if (prefix === " ") {
+						hunk.oldLines.push(content);
+						hunk.newLines.push(content);
+					} else if (prefix === "-") {
+						hunk.oldLines.push(content);
+					} else if (prefix === "+") {
+						hunk.newLines.push(content);
+					} else {
+						throw new Error(
+							`Update File ${path} contains an invalid hunk line: ${bodyLine}`,
+						);
+					}
+					index++;
+				}
+				if (hunk.oldLines.length === 0 && hunk.newLines.length === 0) {
+					throw new Error(`Update File ${path} contains an empty hunk`);
+				}
+				hunks.push(hunk);
+			}
+			if (hunks.length === 0 && !moveTo) {
+				throw new Error(`Update File ${path} must contain at least one hunk`);
+			}
+			operations.push({
+				type: "update",
+				path,
+				...(moveTo ? { moveTo } : {}),
+				hunks,
+			});
+			continue;
+		}
+
+		throw new Error(`Unknown apply_patch operation: ${line}`);
+	}
+
+	if (operations.length === 0) {
+		throw new Error("apply_patch must contain at least one file operation");
+	}
+	return { operations };
+}
+
+function requirePatchPath(path: string): string {
+	const trimmed = path.trim();
+	if (!trimmed) {
+		throw new Error("apply_patch operation is missing a file path");
+	}
+	return trimmed;
+}
+
+function isOperationHeader(line: string): boolean {
+	return (
+		line.startsWith("*** Add File: ") ||
+		line.startsWith("*** Update File: ") ||
+		line.startsWith("*** Delete File: ")
+	);
+}

--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -1,0 +1,707 @@
+import crypto from "node:crypto";
+import { constants } from "node:fs";
+import {
+	access,
+	mkdir,
+	readFile,
+	rename,
+	rm,
+	unlink,
+	writeFile,
+} from "node:fs/promises";
+import { dirname, resolve as resolvePath } from "node:path";
+import { Type } from "@sinclair/typebox";
+import {
+	captureDiagnosticBaseline,
+	collectDiagnosticDelta,
+} from "../lsp/diagnostic-deltas.js";
+import {
+	type DiagnosticDeltaToolSummary,
+	buildDiagnosticDeltaToolSummary,
+	formatDiagnosticDeltaForToolOutput,
+} from "../lsp/diagnostic-repair.js";
+import { assertTeamMemoryContentSafe } from "../memory/team-memory.js";
+import {
+	requirePlanCheck,
+	runValidatorsOnSuccess,
+} from "../safety/safe-mode.js";
+import type { ValidatorRunResult } from "../safety/safe-mode.js";
+import type { Sandbox } from "../sandbox/types.js";
+import {
+	type ApplyPatchDocument,
+	type ApplyPatchHunk,
+	parseApplyPatch,
+} from "./apply-patch-parser.js";
+import { generateDiffString } from "./diff-utils.js";
+import { ToolError, createTool, expandUserPath } from "./tool-dsl.js";
+
+type LineEnding = "\n" | "\r\n" | "\r";
+
+type NormalizedDocument = {
+	original: string;
+	lines: string[];
+	hadFinalNewline: boolean;
+	bom: string;
+	lineEnding: LineEnding;
+};
+
+type PlannedFileChange = {
+	path: string;
+	absolutePath: string;
+	previousContent: string | null;
+	nextContent: string | null;
+	operation: "add" | "update" | "delete";
+	hunksApplied: number;
+	diff?: string;
+};
+
+type DiagnosticBaseline = Awaited<ReturnType<typeof captureDiagnosticBaseline>>;
+
+type ApplyPatchPlan = {
+	filesModified: string[];
+	filesCreated: string[];
+	filesDeleted: string[];
+	hunksApplied: number;
+	hunksFailed: number;
+	conflictDetails?: string[];
+	changes: PlannedFileChange[];
+};
+
+const applyPatchSchema = Type.Object({
+	patch: Type.String({
+		description:
+			"OpenAI apply_patch block from *** Begin Patch to *** End Patch",
+		minLength: 1,
+	}),
+	dryRun: Type.Optional(
+		Type.Boolean({
+			description: "Preview the patch without writing changes",
+			default: false,
+		}),
+	),
+});
+
+export type ApplyPatchToolDetails = {
+	filesModified: string[];
+	filesCreated: string[];
+	filesDeleted: string[];
+	hunksApplied: number;
+	hunksFailed: number;
+	conflictDetails?: string[];
+	diffs?: Record<string, string>;
+	validators?: ValidatorRunResult[];
+	diagnosticDelta?: DiagnosticDeltaToolSummary;
+	diagnosticDeltas?: DiagnosticDeltaToolSummary[];
+	editGrammar: "apply_patch";
+	mode?: "sandbox";
+};
+
+class ApplyPatchConflictError extends ToolError {
+	constructor(message: string, details: ApplyPatchToolDetails) {
+		super(message, "APPLY_PATCH_CONFLICT", details);
+	}
+}
+
+export const applyPatchTool = createTool<
+	typeof applyPatchSchema,
+	ApplyPatchToolDetails
+>({
+	name: "apply_patch",
+	label: "apply_patch",
+	description: `Apply an OpenAI/Codex apply_patch block directly.
+
+Parameters:
+- patch: Patch text using *** Begin Patch / *** End Patch with Add, Update, or Delete File operations.
+- dryRun: Preview only (default: false).
+
+Use this when a Codex-family model emits its native apply_patch grammar. Use edit for targeted find-and-replace edits.`,
+	schema: applyPatchSchema,
+	shouldRetry: (error) => error instanceof ApplyPatchConflictError,
+	async run({ patch, dryRun = false }, { signal, respond, sandbox }) {
+		requirePlanCheck("apply_patch");
+		const throwIfAborted = () => {
+			if (signal?.aborted) {
+				throw new Error("Operation aborted");
+			}
+		};
+
+		const document = parseApplyPatch(patch);
+		const plan = sandbox
+			? await planSandboxPatch(document, sandbox)
+			: await planFilesystemPatch(document);
+		const details = buildDetails(plan, sandbox ? "sandbox" : undefined);
+
+		if (plan.hunksFailed > 0) {
+			throw new ApplyPatchConflictError(
+				`apply_patch failed: ${plan.hunksFailed} hunk(s) could not be applied. Re-read the affected file(s), re-author the patch with fresh context, and retry.`,
+				details,
+			);
+		}
+
+		throwIfAborted();
+		let postWriteOutput = "";
+		if (!dryRun) {
+			if (sandbox) {
+				await writeSandboxChanges(plan, sandbox);
+			} else {
+				const baselines = await captureWriteBaselines(plan);
+				throwIfAborted();
+				try {
+					await writeFilesystemChanges(plan, throwIfAborted);
+					const postWriteDetails = await collectPostWriteDetails(
+						plan,
+						baselines,
+						throwIfAborted,
+					);
+					Object.assign(details, postWriteDetails);
+					if (postWriteDetails.diagnosticDelta) {
+						postWriteOutput = formatDiagnosticDeltaForToolOutput(
+							postWriteDetails.diagnosticDelta,
+						);
+					}
+				} catch (error) {
+					await rollbackFilesystemChanges(plan);
+					throw error;
+				}
+			}
+		}
+
+		const changedFileCount =
+			plan.filesCreated.length +
+			plan.filesModified.length +
+			plan.filesDeleted.length;
+		return respond
+			.text(
+				[
+					dryRun
+						? `Dry run: apply_patch would update ${changedFileCount} file(s) with ${plan.hunksApplied} hunk(s).`
+						: `Applied patch to ${changedFileCount} file(s) with ${plan.hunksApplied} hunk(s).`,
+					postWriteOutput,
+				]
+					.filter(Boolean)
+					.join("\n"),
+			)
+			.detail(details);
+	},
+});
+
+async function planFilesystemPatch(
+	document: ApplyPatchDocument,
+): Promise<ApplyPatchPlan> {
+	const plan = emptyPlan();
+	for (const operation of document.operations) {
+		const absolutePath = resolvePath(expandUserPath(operation.path));
+		if (operation.type === "add") {
+			await assertFileDoesNotExist(absolutePath, operation.path);
+			const nextContent = serializeLines(operation.lines, true);
+			assertTeamMemoryContentSafe(absolutePath, nextContent);
+			addPlannedChange(plan, {
+				path: operation.path,
+				absolutePath,
+				previousContent: null,
+				nextContent,
+				operation: "add",
+				hunksApplied: 1,
+				diff: generateDiffString("", nextContent),
+			});
+		} else if (operation.type === "delete") {
+			const previousContent = await readExistingFile(
+				absolutePath,
+				operation.path,
+			);
+			addPlannedChange(plan, {
+				path: operation.path,
+				absolutePath,
+				previousContent,
+				nextContent: null,
+				operation: "delete",
+				hunksApplied: 1,
+				diff: generateDiffString(previousContent, ""),
+			});
+		} else {
+			const previousContent = await readExistingFile(
+				absolutePath,
+				operation.path,
+			);
+			const applied =
+				operation.hunks.length > 0
+					? applyUpdateHunks(previousContent, operation.hunks)
+					: { content: previousContent, hunksApplied: 0, conflicts: [] };
+			if (applied.conflicts.length > 0) {
+				recordConflicts(plan, operation.path, applied.conflicts);
+				continue;
+			}
+			const nextContent = applied.content;
+			if (operation.moveTo) {
+				const destinationAbsolutePath = resolvePath(
+					expandUserPath(operation.moveTo),
+				);
+				await assertFileDoesNotExist(destinationAbsolutePath, operation.moveTo);
+				assertTeamMemoryContentSafe(destinationAbsolutePath, nextContent);
+				addPlannedChange(plan, {
+					path: operation.path,
+					absolutePath,
+					previousContent,
+					nextContent: null,
+					operation: "delete",
+					hunksApplied: 0,
+					diff: generateDiffString(previousContent, ""),
+				});
+				addPlannedChange(plan, {
+					path: operation.moveTo,
+					absolutePath: destinationAbsolutePath,
+					previousContent: null,
+					nextContent,
+					operation: "add",
+					hunksApplied: applied.hunksApplied,
+					diff: generateDiffString("", nextContent),
+				});
+				continue;
+			}
+			assertTeamMemoryContentSafe(absolutePath, nextContent);
+			addPlannedChange(plan, {
+				path: operation.path,
+				absolutePath,
+				previousContent,
+				nextContent,
+				operation: "update",
+				hunksApplied: applied.hunksApplied,
+				diff: generateDiffString(previousContent, nextContent),
+			});
+		}
+	}
+	return plan;
+}
+
+async function planSandboxPatch(
+	document: ApplyPatchDocument,
+	sandbox: Sandbox,
+): Promise<ApplyPatchPlan> {
+	const plan = emptyPlan();
+	for (const operation of document.operations) {
+		const absolutePath = resolvePath(expandUserPath(operation.path));
+		if (operation.type === "add") {
+			if (await sandbox.exists(operation.path)) {
+				throw new Error(`File already exists: ${operation.path}`);
+			}
+			const nextContent = serializeLines(operation.lines, true);
+			assertTeamMemoryContentSafe(absolutePath, nextContent);
+			addPlannedChange(plan, {
+				path: operation.path,
+				absolutePath,
+				previousContent: null,
+				nextContent,
+				operation: "add",
+				hunksApplied: 1,
+				diff: generateDiffString("", nextContent),
+			});
+		} else if (operation.type === "delete") {
+			if (!(await sandbox.exists(operation.path))) {
+				throw new Error(`File not found in sandbox: ${operation.path}`);
+			}
+			const previousContent = await sandbox.readFile(operation.path);
+			addPlannedChange(plan, {
+				path: operation.path,
+				absolutePath,
+				previousContent,
+				nextContent: null,
+				operation: "delete",
+				hunksApplied: 1,
+				diff: generateDiffString(previousContent, ""),
+			});
+		} else {
+			if (!(await sandbox.exists(operation.path))) {
+				throw new Error(`File not found in sandbox: ${operation.path}`);
+			}
+			const previousContent = await sandbox.readFile(operation.path);
+			const applied =
+				operation.hunks.length > 0
+					? applyUpdateHunks(previousContent, operation.hunks)
+					: { content: previousContent, hunksApplied: 0, conflicts: [] };
+			if (applied.conflicts.length > 0) {
+				recordConflicts(plan, operation.path, applied.conflicts);
+				continue;
+			}
+			const nextContent = applied.content;
+			if (operation.moveTo) {
+				if (await sandbox.exists(operation.moveTo)) {
+					throw new Error(
+						`File already exists in sandbox: ${operation.moveTo}`,
+					);
+				}
+				const destinationAbsolutePath = resolvePath(
+					expandUserPath(operation.moveTo),
+				);
+				assertTeamMemoryContentSafe(destinationAbsolutePath, nextContent);
+				addPlannedChange(plan, {
+					path: operation.path,
+					absolutePath,
+					previousContent,
+					nextContent: null,
+					operation: "delete",
+					hunksApplied: 0,
+					diff: generateDiffString(previousContent, ""),
+				});
+				addPlannedChange(plan, {
+					path: operation.moveTo,
+					absolutePath: destinationAbsolutePath,
+					previousContent: null,
+					nextContent,
+					operation: "add",
+					hunksApplied: applied.hunksApplied,
+					diff: generateDiffString("", nextContent),
+				});
+				continue;
+			}
+			assertTeamMemoryContentSafe(absolutePath, nextContent);
+			addPlannedChange(plan, {
+				path: operation.path,
+				absolutePath,
+				previousContent,
+				nextContent,
+				operation: "update",
+				hunksApplied: applied.hunksApplied,
+				diff: generateDiffString(previousContent, nextContent),
+			});
+		}
+	}
+	return plan;
+}
+
+function applyUpdateHunks(
+	previousContent: string,
+	hunks: ApplyPatchHunk[],
+): { content: string; hunksApplied: number; conflicts: string[] } {
+	const document = normalizeDocument(previousContent);
+	let lines = [...document.lines];
+	const conflicts: string[] = [];
+	let hunksApplied = 0;
+	for (const [index, hunk] of hunks.entries()) {
+		if (hunk.oldLines.length === 0) {
+			lines = [...lines, ...hunk.newLines];
+			hunksApplied++;
+			continue;
+		}
+		const matches = findLineSequence(lines, hunk.oldLines);
+		if (matches.length === 0) {
+			conflicts.push(`hunk ${index + 1}: context not found`);
+			continue;
+		}
+		if (matches.length > 1) {
+			conflicts.push(
+				`hunk ${index + 1}: context matched ${matches.length} times`,
+			);
+			continue;
+		}
+		const start = matches[0] ?? 0;
+		lines = [
+			...lines.slice(0, start),
+			...hunk.newLines,
+			...lines.slice(start + hunk.oldLines.length),
+		];
+		hunksApplied++;
+	}
+	return {
+		content: restoreDocumentContent(lines, document),
+		hunksApplied,
+		conflicts,
+	};
+}
+
+function findLineSequence(lines: string[], needle: string[]): number[] {
+	const matches: number[] = [];
+	if (needle.length === 0 || needle.length > lines.length) {
+		return matches;
+	}
+	for (let index = 0; index <= lines.length - needle.length; index++) {
+		let matched = true;
+		for (let offset = 0; offset < needle.length; offset++) {
+			if (lines[index + offset] !== needle[offset]) {
+				matched = false;
+				break;
+			}
+		}
+		if (matched) {
+			matches.push(index);
+		}
+	}
+	return matches;
+}
+
+async function writeFilesystemChanges(
+	plan: ApplyPatchPlan,
+	throwIfAborted: () => void,
+): Promise<void> {
+	for (const change of plan.changes) {
+		throwIfAborted();
+		if (change.nextContent === null) {
+			await rm(change.absolutePath, { force: true });
+			continue;
+		}
+		await mkdir(dirname(change.absolutePath), { recursive: true });
+		await writeFileAtomically(change.absolutePath, change.nextContent);
+	}
+}
+
+async function writeSandboxChanges(
+	plan: ApplyPatchPlan,
+	sandbox: Sandbox,
+): Promise<void> {
+	validateSandboxRollbackSupport(plan, sandbox);
+	try {
+		for (const change of plan.changes) {
+			if (change.nextContent === null) {
+				if (!sandbox.delete) {
+					throw new Error("Sandbox does not support deleting files");
+				}
+				await sandbox.delete(change.path, false);
+			} else {
+				await sandbox.writeFile(change.path, change.nextContent);
+			}
+		}
+	} catch (error) {
+		await rollbackSandboxChanges(plan, sandbox);
+		throw error;
+	}
+}
+
+function validateSandboxRollbackSupport(
+	plan: ApplyPatchPlan,
+	sandbox: Sandbox,
+): void {
+	const needsDeleteForApplyOrRollback = plan.changes.some(
+		(change) => change.nextContent === null || change.previousContent === null,
+	);
+	if (needsDeleteForApplyOrRollback && !sandbox.delete) {
+		throw new Error(
+			"Sandbox does not support deleting files, so apply_patch cannot safely apply add/delete operations",
+		);
+	}
+}
+
+async function rollbackSandboxChanges(
+	plan: ApplyPatchPlan,
+	sandbox: Sandbox,
+): Promise<void> {
+	for (const change of [...plan.changes].reverse()) {
+		try {
+			if (change.previousContent === null) {
+				await sandbox.delete?.(change.path, false);
+				continue;
+			}
+			await sandbox.writeFile(change.path, change.previousContent);
+		} catch {}
+	}
+}
+
+async function captureWriteBaselines(
+	plan: ApplyPatchPlan,
+): Promise<Map<string, DiagnosticBaseline>> {
+	const baselines = new Map<string, DiagnosticBaseline>();
+	for (const change of plan.changes) {
+		if (change.nextContent === null) {
+			continue;
+		}
+		baselines.set(
+			change.absolutePath,
+			await captureDiagnosticBaseline(change.absolutePath),
+		);
+	}
+	return baselines;
+}
+
+async function collectPostWriteDetails(
+	plan: ApplyPatchPlan,
+	baselines: Map<string, DiagnosticBaseline>,
+	throwIfAborted: () => void,
+): Promise<
+	Pick<
+		ApplyPatchToolDetails,
+		"validators" | "diagnosticDelta" | "diagnosticDeltas"
+	>
+> {
+	const writePaths = plan.changes
+		.filter((change) => change.nextContent !== null)
+		.map((change) => change.absolutePath);
+	if (writePaths.length === 0) {
+		return {};
+	}
+	throwIfAborted();
+	const deltaResults = await Promise.all(
+		writePaths.map((writePath) =>
+			collectDiagnosticDelta(baselines.get(writePath)!),
+		),
+	);
+	const deltas = deltaResults.map((result, index) => {
+		const writePath = writePaths[index] ?? "";
+		return buildDiagnosticDeltaToolSummary({
+			file: writePath,
+			displayPath:
+				plan.changes.find((change) => change.absolutePath === writePath)
+					?.path ?? writePath,
+			result,
+		});
+	});
+	const validatorDiagnostics = Object.fromEntries(
+		deltaResults.flatMap((result) =>
+			Object.entries(result.validatorDiagnostics),
+		),
+	);
+	const validatorSummaries = await runValidatorsOnSuccess(
+		writePaths,
+		validatorDiagnostics,
+	);
+	return {
+		validators: validatorSummaries,
+		diagnosticDelta: deltas[0],
+		diagnosticDeltas: deltas,
+	};
+}
+
+async function rollbackFilesystemChanges(plan: ApplyPatchPlan): Promise<void> {
+	for (const change of [...plan.changes].reverse()) {
+		try {
+			if (change.previousContent === null) {
+				await rm(change.absolutePath, { force: true });
+				continue;
+			}
+			await mkdir(dirname(change.absolutePath), { recursive: true });
+			await writeFileAtomically(change.absolutePath, change.previousContent);
+		} catch {}
+	}
+}
+
+async function writeFileAtomically(
+	filePath: string,
+	contents: string,
+): Promise<void> {
+	const tempPath = `${filePath}.${crypto.randomUUID()}.tmp`;
+	await writeFile(tempPath, contents, "utf-8");
+	try {
+		await rename(tempPath, filePath);
+	} catch (error) {
+		await unlink(tempPath).catch(() => {});
+		throw error;
+	}
+}
+
+async function readExistingFile(
+	absolutePath: string,
+	displayPath: string,
+): Promise<string> {
+	try {
+		await access(absolutePath, constants.R_OK | constants.W_OK);
+		return await readFile(absolutePath, "utf-8");
+	} catch {
+		throw new Error(
+			`File not found: ${displayPath}. Use read to verify the path exists.`,
+		);
+	}
+}
+
+async function assertFileDoesNotExist(
+	absolutePath: string,
+	displayPath: string,
+): Promise<void> {
+	try {
+		await access(absolutePath, constants.F_OK);
+		throw new Error(`File already exists: ${displayPath}`);
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			error.message.startsWith("File already exists:")
+		) {
+			throw error;
+		}
+	}
+}
+
+function emptyPlan(): ApplyPatchPlan {
+	return {
+		filesModified: [],
+		filesCreated: [],
+		filesDeleted: [],
+		hunksApplied: 0,
+		hunksFailed: 0,
+		changes: [],
+	};
+}
+
+function addPlannedChange(
+	plan: ApplyPatchPlan,
+	change: PlannedFileChange,
+): void {
+	plan.changes.push(change);
+	plan.hunksApplied += change.hunksApplied;
+	if (change.operation === "add") {
+		plan.filesCreated.push(change.path);
+	} else if (change.operation === "delete") {
+		plan.filesDeleted.push(change.path);
+	} else {
+		plan.filesModified.push(change.path);
+	}
+}
+
+function recordConflicts(
+	plan: ApplyPatchPlan,
+	path: string,
+	conflicts: string[],
+): void {
+	plan.hunksFailed += conflicts.length;
+	plan.conflictDetails ??= [];
+	for (const conflict of conflicts) {
+		plan.conflictDetails.push(`${path}: ${conflict}`);
+	}
+}
+
+function buildDetails(
+	plan: ApplyPatchPlan,
+	mode?: "sandbox",
+): ApplyPatchToolDetails {
+	return {
+		filesModified: plan.filesModified,
+		filesCreated: plan.filesCreated,
+		filesDeleted: plan.filesDeleted,
+		hunksApplied: plan.hunksApplied,
+		hunksFailed: plan.hunksFailed,
+		conflictDetails: plan.conflictDetails,
+		diffs: Object.fromEntries(
+			plan.changes
+				.filter((change) => change.diff !== undefined)
+				.map((change) => [change.path, change.diff ?? ""]),
+		),
+		editGrammar: "apply_patch",
+		mode,
+	};
+}
+
+function detectLineEnding(text: string): LineEnding {
+	if (text.includes("\r\n")) return "\r\n";
+	if (text.includes("\r")) return "\r";
+	return "\n";
+}
+
+function normalizeDocument(content: string): NormalizedDocument {
+	const bom = content.startsWith("\uFEFF") ? "\uFEFF" : "";
+	const withoutBom = bom ? content.slice(1) : content;
+	const lineEnding = detectLineEnding(withoutBom);
+	const normalized = withoutBom.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+	const hadFinalNewline = normalized.endsWith("\n");
+	const trimmed = hadFinalNewline ? normalized.slice(0, -1) : normalized;
+	const lines = trimmed.length === 0 ? [] : trimmed.split("\n");
+	return { original: content, lines, hadFinalNewline, bom, lineEnding };
+}
+
+function restoreDocumentContent(
+	lines: string[],
+	document: NormalizedDocument,
+): string {
+	return `${document.bom}${serializeLines(lines, document.hadFinalNewline).replace(/\n/g, document.lineEnding)}`;
+}
+
+function serializeLines(lines: string[], finalNewline: boolean): string {
+	if (lines.length === 0) {
+		return finalNewline ? "\n" : "";
+	}
+	return `${lines.join("\n")}${finalNewline ? "\n" : ""}`;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -60,6 +60,7 @@ import { codesearchTool } from "./codesearch.js";
 import { diffTool } from "./diff.js";
 
 // File manipulation
+import { applyPatchTool } from "./apply-patch.js";
 import { editTool } from "./edit.js";
 import { extractDocumentTool } from "./extract-document.js";
 import { findTool } from "./find.js";
@@ -119,6 +120,7 @@ export {
 } from "./ask-user.js";
 export { bashTool } from "./bash.js";
 export { backgroundTasksTool } from "./background/tool-handler.js";
+export { applyPatchTool } from "./apply-patch.js";
 export { codesearchTool } from "./codesearch.js";
 export { diffTool } from "./diff.js";
 export { editTool } from "./edit.js";
@@ -171,6 +173,7 @@ export const codingTools = [
 	bashTool,
 	backgroundTasksTool,
 	// File modification
+	applyPatchTool,
 	editTool,
 	writeTool,
 	notebookEditTool,
@@ -211,6 +214,7 @@ export const toolRegistry: Record<string, (typeof codingTools)[number]> = {
 	diff: diffTool,
 	bash: bashTool,
 	background_tasks: backgroundTasksTool,
+	apply_patch: applyPatchTool,
 	edit: editTool,
 	write: writeTool,
 	notebook_edit: notebookEditTool,

--- a/src/tools/parallel-execution.ts
+++ b/src/tools/parallel-execution.ts
@@ -78,6 +78,7 @@ export const READ_ONLY_TOOLS = new Set([
  * operations on the same resources.
  */
 export const WRITE_TOOLS = new Set([
+	"apply_patch",
 	"write",
 	"Write",
 	"edit",

--- a/src/tools/tool-result-cache.ts
+++ b/src/tools/tool-result-cache.ts
@@ -122,6 +122,7 @@ export const DEFAULT_TOOL_CACHE_CONFIGS: Record<string, ToolCacheConfig> = {
 	},
 
 	// Mutating tools - not cacheable
+	apply_patch: { cacheable: false, ttlSeconds: 0, scope: "session" },
 	write: { cacheable: false, ttlSeconds: 0, scope: "session" },
 	edit: { cacheable: false, ttlSeconds: 0, scope: "session" },
 	bash: { cacheable: false, ttlSeconds: 0, scope: "session" },

--- a/test/agent/subagent-specs.test.ts
+++ b/test/agent/subagent-specs.test.ts
@@ -23,6 +23,7 @@ describe("subagent-specs", () => {
 		});
 
 		it("should have write tools", () => {
+			expect(TOOL_CATEGORIES.write).toContain("apply_patch");
 			expect(TOOL_CATEGORIES.write).toContain("edit");
 			expect(TOOL_CATEGORIES.write).toContain("write");
 		});
@@ -55,6 +56,7 @@ describe("subagent-specs", () => {
 		it("coder should have all major tools", () => {
 			const spec = SUBAGENT_SPECS.coder;
 			expect(spec.allowedTools).toContain("read");
+			expect(spec.allowedTools).toContain("apply_patch");
 			expect(spec.allowedTools).toContain("write");
 			expect(spec.allowedTools).toContain("edit");
 			expect(spec.allowedTools).toContain("bash");

--- a/test/packages/core/subagent-specs.test.ts
+++ b/test/packages/core/subagent-specs.test.ts
@@ -53,6 +53,7 @@ describe("SubagentSpecs", () => {
 
 		it("has write category with edit and write", () => {
 			expect(TOOL_CATEGORIES.write).toBeDefined();
+			expect(TOOL_CATEGORIES.write).toContain("apply_patch");
 			expect(TOOL_CATEGORIES.write).toContain("edit");
 			expect(TOOL_CATEGORIES.write).toContain("write");
 		});

--- a/test/safety/action-firewall.test.ts
+++ b/test/safety/action-firewall.test.ts
@@ -99,6 +99,23 @@ function makeEditContext(): ActionApprovalContext {
 	return { toolName: "edit", args: { path: "file.txt" } };
 }
 
+function makeApplyPatchContext(path: string): ActionApprovalContext {
+	return {
+		toolName: "apply_patch",
+		args: {
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${path}`,
+				"@@",
+				" old",
+				"-value",
+				"+updated",
+				"*** End Patch",
+			].join("\n"),
+		},
+	};
+}
+
 function makeReadPathContext(path: string): ActionApprovalContext {
 	return { toolName: "read", args: { path } };
 }
@@ -301,6 +318,14 @@ describe("ActionFirewall", () => {
 			makeMoveFileContext("~/.gnupg/secring.gpg", "./backup.gpg"),
 		);
 		expect(moveVerdict).toMatchObject({
+			action: "require_approval",
+			ruleId: "default-guarded-file",
+		});
+
+		const applyPatchVerdict = await defaultActionFirewall.evaluate(
+			makeApplyPatchContext("~/.ssh/config"),
+		);
+		expect(applyPatchVerdict).toMatchObject({
 			action: "require_approval",
 			ruleId: "default-guarded-file",
 		});
@@ -519,6 +544,11 @@ describe("ActionFirewall", () => {
 				makeEditContext(),
 			);
 			expect(editVerdict.action).toBe("require_approval");
+
+			const applyPatchVerdict = await defaultActionFirewall.evaluate(
+				makeApplyPatchContext("file.txt"),
+			);
+			expect(applyPatchVerdict.action).toBe("require_approval");
 
 			const todoVerdict = await defaultActionFirewall.evaluate(
 				makeTodoContext(),

--- a/test/scripts/check-prepared-public-mirror-tree.test.ts
+++ b/test/scripts/check-prepared-public-mirror-tree.test.ts
@@ -1,0 +1,85 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const fixtures: string[] = [];
+const scriptPath = join(
+	process.cwd(),
+	"scripts/check-prepared-public-mirror-tree.mjs",
+);
+
+function makeFixture() {
+	const root = join(
+		tmpdir(),
+		`maestro-prepared-public-mirror-${process.pid}-${Date.now()}-${fixtures.length}`,
+	);
+	fixtures.push(root);
+	mkdirSync(root, { recursive: true });
+	write(join(root, "package.json"), JSON.stringify({ scripts: {} }, null, 2));
+	write(join(root, "src/cli/args.ts"), "const COMMANDS = new Set([]);\n");
+	write(
+		join(root, "scripts/check-public-surface-boundary.mjs"),
+		[
+			"#!/usr/bin/env node",
+			"import { existsSync } from 'node:fs';",
+			"if (existsSync('src/cli/commands/scenario.ts')) process.exit(1);",
+			"console.log('Public surface boundary check passed.');",
+		].join("\n"),
+	);
+	return root;
+}
+
+function write(path: string, content: string) {
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, content);
+}
+
+function runCheck(target: string) {
+	return spawnSync(process.execPath, [scriptPath, "--target", target], {
+		cwd: process.cwd(),
+		encoding: "utf8",
+	});
+}
+
+describe("check-prepared-public-mirror-tree", () => {
+	afterEach(() => {
+		for (const fixture of fixtures.splice(0)) {
+			rmSync(fixture, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts a prepared public tree that can run its own boundary check", () => {
+		const target = makeFixture();
+
+		const result = runCheck(target);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain(
+			"Prepared public mirror tree smoke passed.",
+		);
+	});
+
+	it("rejects an internal mirror exclude file in the prepared public tree", () => {
+		const target = makeFixture();
+		write(join(target, ".github/public-release-mirror.exclude"), "internal\n");
+
+		const result = runCheck(target);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain(
+			".github/public-release-mirror.exclude must not exist",
+		);
+	});
+
+	it("surfaces public boundary check failures from the prepared tree", () => {
+		const target = makeFixture();
+		write(join(target, "src/cli/commands/scenario.ts"), "export {};\n");
+
+		const result = runCheck(target);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("Public surface boundary smoke failed");
+	});
+});

--- a/test/tools/apply-patch.test.ts
+++ b/test/tools/apply-patch.test.ts
@@ -1,0 +1,516 @@
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentToolResult } from "../../src/agent/types.js";
+import { runValidatorsOnSuccess } from "../../src/safety/safe-mode.js";
+import type { Sandbox } from "../../src/sandbox/types.js";
+import {
+	parseApplyPatch,
+	parseApplyPatchPaths,
+} from "../../src/tools/apply-patch-parser.js";
+import {
+	type ApplyPatchToolDetails,
+	applyPatchTool,
+} from "../../src/tools/apply-patch.js";
+import type { ToolError } from "../../src/tools/tool-dsl.js";
+
+vi.mock("../../src/safety/safe-mode.js", () => ({
+	requirePlanCheck: vi.fn(),
+	runValidatorsOnSuccess: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../src/lsp/index.js", () => ({
+	collectDiagnostics: vi.fn().mockResolvedValue({}),
+}));
+
+function getTextOutput(result: AgentToolResult<unknown>): string {
+	return (
+		result.content
+			?.filter(
+				(c): c is { type: "text"; text: string } =>
+					c.type === "text" && typeof c.text === "string",
+			)
+			.map((c) => c.text)
+			.join("\n") || ""
+	);
+}
+
+function details(result: AgentToolResult<unknown>): ApplyPatchToolDetails {
+	return result.details as ApplyPatchToolDetails;
+}
+
+function createMemorySandbox(
+	files: Record<string, string>,
+	options: { failWritesFor?: Set<string>; delete?: true } = {},
+): Sandbox {
+	const contents = new Map(Object.entries(files));
+	return {
+		async exec() {
+			return { stdout: "", stderr: "", exitCode: 0 };
+		},
+		async readFile(path: string) {
+			const content = contents.get(path);
+			if (content === undefined) {
+				throw new Error(`missing ${path}`);
+			}
+			return content;
+		},
+		async writeFile(path: string, content: string) {
+			if (options.failWritesFor?.has(path)) {
+				throw new Error(`write failed for ${path}`);
+			}
+			contents.set(path, content);
+		},
+		async exists(path: string) {
+			return contents.has(path);
+		},
+		...(options.delete
+			? {
+					async delete(path: string) {
+						contents.delete(path);
+					},
+				}
+			: {}),
+		async dispose() {},
+	};
+}
+
+describe("apply_patch parser", () => {
+	it("parses add, update, and delete operations", () => {
+		const patch = [
+			"*** Begin Patch",
+			"*** Add File: src/new.ts",
+			"+export const answer = 42;",
+			"*** Update File: src/existing.ts",
+			"@@",
+			" export function name() {",
+			"-  return 'old';",
+			"+  return 'new';",
+			" }",
+			"*** Delete File: src/remove.ts",
+			"*** End Patch",
+		].join("\n");
+
+		expect(parseApplyPatchPaths(patch)).toEqual([
+			"src/new.ts",
+			"src/existing.ts",
+			"src/remove.ts",
+		]);
+		expect(parseApplyPatch(patch).operations).toHaveLength(3);
+	});
+
+	it("parses move headers and includes both source and destination paths", () => {
+		const patch = [
+			"*** Begin Patch",
+			"*** Update File: src/old.ts",
+			"*** Move to: src/new.ts",
+			"*** End Patch",
+		].join("\n");
+
+		expect(parseApplyPatchPaths(patch)).toEqual(["src/old.ts", "src/new.ts"]);
+		expect(parseApplyPatch(patch).operations).toEqual([
+			{
+				type: "update",
+				path: "src/old.ts",
+				moveTo: "src/new.ts",
+				hunks: [],
+			},
+		]);
+	});
+});
+
+describe("apply_patch tool", () => {
+	let testDir: string;
+
+	beforeEach(() => {
+		testDir = mkdtempSync(join(tmpdir(), "apply-patch-tool-"));
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("updates an existing file and reports apply_patch details", async () => {
+		const filePath = join(testDir, "example.ts");
+		writeFileSync(filePath, "const value = 1;\nconsole.log(value);\n");
+
+		const result = await applyPatchTool.execute("call-1", {
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${filePath}`,
+				"@@",
+				" const value = 1;",
+				"-console.log(value);",
+				"+console.log(value + 1);",
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(getTextOutput(result)).toContain("Applied patch to 1 file(s)");
+		expect(readFileSync(filePath, "utf-8")).toBe(
+			"const value = 1;\nconsole.log(value + 1);\n",
+		);
+		expect(details(result)).toMatchObject({
+			filesModified: [filePath],
+			filesCreated: [],
+			filesDeleted: [],
+			hunksApplied: 1,
+			hunksFailed: 0,
+			editGrammar: "apply_patch",
+		});
+		expect(runValidatorsOnSuccess).toHaveBeenCalledWith([filePath], {
+			[filePath]: [],
+		});
+	});
+
+	it("adds and deletes files", async () => {
+		const addedPath = join(testDir, "nested", "created.py");
+		const deletedPath = join(testDir, "old.rs");
+		writeFileSync(deletedPath, "fn main() {}\n");
+
+		const result = await applyPatchTool.execute("call-2", {
+			patch: [
+				"*** Begin Patch",
+				`*** Add File: ${addedPath}`,
+				"+def main():",
+				"+    return 1",
+				`*** Delete File: ${deletedPath}`,
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(readFileSync(addedPath, "utf-8")).toBe(
+			"def main():\n    return 1\n",
+		);
+		expect(existsSync(deletedPath)).toBe(false);
+		expect(details(result)).toMatchObject({
+			filesCreated: [addedPath],
+			filesDeleted: [deletedPath],
+			hunksApplied: 2,
+		});
+	});
+
+	it("moves a file while applying update hunks", async () => {
+		const sourcePath = join(testDir, "source.ts");
+		const destinationPath = join(testDir, "destination.ts");
+		writeFileSync(sourcePath, "export const label = 'old';\n");
+
+		const result = await applyPatchTool.execute("call-move", {
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${sourcePath}`,
+				`*** Move to: ${destinationPath}`,
+				"@@",
+				"-export const label = 'old';",
+				"+export const label = 'new';",
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(existsSync(sourcePath)).toBe(false);
+		expect(readFileSync(destinationPath, "utf-8")).toBe(
+			"export const label = 'new';\n",
+		);
+		expect(details(result)).toMatchObject({
+			filesCreated: [destinationPath],
+			filesDeleted: [sourcePath],
+			hunksApplied: 1,
+		});
+	});
+
+	it("appends insertion-only update hunks", async () => {
+		const filePath = join(testDir, "insert-only.txt");
+		writeFileSync(filePath, "first\n");
+
+		await applyPatchTool.execute("call-insert-only", {
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${filePath}`,
+				"@@",
+				"+second",
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(readFileSync(filePath, "utf-8")).toBe("first\nsecond\n");
+	});
+
+	it("rolls back earlier filesystem writes when a later write fails", async () => {
+		const firstPath = join(testDir, "first.txt");
+		const parentFilePath = join(testDir, "parent-file");
+		const blockedPath = join(parentFilePath, "child.txt");
+		writeFileSync(firstPath, "old\n");
+		writeFileSync(parentFilePath, "not a directory\n");
+
+		await expect(
+			applyPatchTool.execute("call-rollback", {
+				patch: [
+					"*** Begin Patch",
+					`*** Update File: ${firstPath}`,
+					"@@",
+					"-old",
+					"+new",
+					`*** Add File: ${blockedPath}`,
+					"+blocked",
+					"*** End Patch",
+				].join("\n"),
+			}),
+		).rejects.toThrow();
+
+		expect(readFileSync(firstPath, "utf-8")).toBe("old\n");
+	});
+
+	it("supports dry runs without writing", async () => {
+		const filePath = join(testDir, "dry-run.md");
+		writeFileSync(filePath, "hello\n");
+
+		const result = await applyPatchTool.execute("call-3", {
+			dryRun: true,
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${filePath}`,
+				"@@",
+				"-hello",
+				"+goodbye",
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(getTextOutput(result)).toContain("Dry run");
+		expect(readFileSync(filePath, "utf-8")).toBe("hello\n");
+		expect(runValidatorsOnSuccess).not.toHaveBeenCalled();
+	});
+
+	it("rolls back earlier writes when a later filesystem write fails", async () => {
+		const firstPath = join(testDir, "first.ts");
+		const blockedDir = join(testDir, "blocked");
+		const blockedPath = join(blockedDir, "created.ts");
+		writeFileSync(firstPath, "export const first = 1;\n");
+		mkdirSync(blockedDir);
+
+		try {
+			chmodSync(blockedDir, 0o500);
+
+			await expect(
+				applyPatchTool.execute("call-rollback", {
+					patch: [
+						"*** Begin Patch",
+						`*** Update File: ${firstPath}`,
+						"@@",
+						"-export const first = 1;",
+						"+export const first = 2;",
+						`*** Add File: ${blockedPath}`,
+						"+export const blocked = true;",
+						"*** End Patch",
+					].join("\n"),
+				}),
+			).rejects.toThrow();
+		} finally {
+			chmodSync(blockedDir, 0o700);
+		}
+
+		expect(readFileSync(firstPath, "utf-8")).toBe("export const first = 1;\n");
+		expect(existsSync(blockedPath)).toBe(false);
+	});
+
+	it("rolls back earlier sandbox writes when a later sandbox write fails", async () => {
+		const sandbox = createMemorySandbox(
+			{
+				"first.ts": "export const first = 1;\n",
+				"second.ts": "export const second = 1;\n",
+			},
+			{ failWritesFor: new Set(["second.ts"]) },
+		);
+
+		await expect(
+			applyPatchTool.execute(
+				"call-sandbox-rollback",
+				{
+					patch: [
+						"*** Begin Patch",
+						"*** Update File: first.ts",
+						"@@",
+						"-export const first = 1;",
+						"+export const first = 2;",
+						"*** Update File: second.ts",
+						"@@",
+						"-export const second = 1;",
+						"+export const second = 2;",
+						"*** End Patch",
+					].join("\n"),
+				},
+				undefined,
+				{ sandbox },
+			),
+		).rejects.toThrow("write failed for second.ts");
+
+		await expect(sandbox.readFile("first.ts")).resolves.toBe(
+			"export const first = 1;\n",
+		);
+		await expect(sandbox.readFile("second.ts")).resolves.toBe(
+			"export const second = 1;\n",
+		);
+	});
+
+	it("prevents unsafe sandbox add or delete patches when rollback deletes are unavailable", async () => {
+		const sandbox = createMemorySandbox({
+			"first.ts": "export const first = 1;\n",
+			"second.ts": "export const second = 1;\n",
+		});
+
+		await expect(
+			applyPatchTool.execute(
+				"call-sandbox-no-delete",
+				{
+					patch: [
+						"*** Begin Patch",
+						"*** Update File: first.ts",
+						"@@",
+						"-export const first = 1;",
+						"+export const first = 2;",
+						"*** Delete File: second.ts",
+						"*** End Patch",
+					].join("\n"),
+				},
+				undefined,
+				{ sandbox },
+			),
+		).rejects.toThrow("cannot safely apply add/delete operations");
+
+		await expect(sandbox.readFile("first.ts")).resolves.toBe(
+			"export const first = 1;\n",
+		);
+		await expect(sandbox.readFile("second.ts")).resolves.toBe(
+			"export const second = 1;\n",
+		);
+	});
+
+	it("throws a retryable ToolError with conflict details for failed hunks", async () => {
+		const filePath = join(testDir, "stale.ts");
+		writeFileSync(filePath, "const fresh = true;\n");
+
+		await expect(
+			applyPatchTool.execute("call-4", {
+				patch: [
+					"*** Begin Patch",
+					`*** Update File: ${filePath}`,
+					"@@",
+					"-const stale = true;",
+					"+const stale = false;",
+					"*** End Patch",
+				].join("\n"),
+			}),
+		).rejects.toMatchObject({
+			name: "ToolError",
+			code: "APPLY_PATCH_CONFLICT",
+			details: {
+				filesModified: [],
+				hunksApplied: 0,
+				hunksFailed: 1,
+				editGrammar: "apply_patch",
+			},
+		} satisfies Partial<ToolError>);
+		expect(readFileSync(filePath, "utf-8")).toBe("const fresh = true;\n");
+	});
+
+	it("applies a 20-case representative patch fixture set", async () => {
+		const cases = [
+			[
+				"alpha.ts",
+				"export const a = 1;\n",
+				"-export const a = 1;",
+				"+export const a = 2;",
+			],
+			[
+				"bravo.tsx",
+				"return <span>old</span>;\n",
+				"-return <span>old</span>;",
+				"+return <span>new</span>;",
+			],
+			[
+				"charlie.js",
+				"module.exports = 1;\n",
+				"-module.exports = 1;",
+				"+module.exports = 2;",
+			],
+			[
+				"delta.mjs",
+				"export default 'old';\n",
+				"-export default 'old';",
+				"+export default 'new';",
+			],
+			["echo.py", "value = 1\n", "-value = 1", "+value = 2"],
+			["foxtrot.py", "print('old')\n", "-print('old')", "+print('new')"],
+			["golf.rs", "let value = 1;\n", "-let value = 1;", "+let value = 2;"],
+			[
+				"hotel.rs",
+				'println!("old");\n',
+				'-println!("old");',
+				'+println!("new");',
+			],
+			["india.go", "value := 1\n", "-value := 1", "+value := 2"],
+			[
+				"juliet.go",
+				'fmt.Println("old")\n',
+				'-fmt.Println("old")',
+				'+fmt.Println("new")',
+			],
+			["kilo.md", "# Old\n", "-# Old", "+# New"],
+			["lima.md", "- old\n", "-- old", "+- new"],
+			[
+				"mike.json",
+				'{"enabled": false}\n',
+				'-{"enabled": false}',
+				'+{"enabled": true}',
+			],
+			[
+				"november.yaml",
+				"enabled: false\n",
+				"-enabled: false",
+				"+enabled: true",
+			],
+			[
+				"oscar.css",
+				".btn { color: red; }\n",
+				"-.btn { color: red; }",
+				"+.btn { color: blue; }",
+			],
+			["papa.scss", "$gap: 4px;\n", "-$gap: 4px;", "+$gap: 8px;"],
+			["quebec.sql", "select 1;\n", "-select 1;", "+select 2;"],
+			["romeo.sh", "echo old\n", "-echo old", "+echo new"],
+			[
+				"sierra.toml",
+				"enabled = false\n",
+				"-enabled = false",
+				"+enabled = true",
+			],
+			["tango.txt", "old\n", "-old", "+new"],
+		] as const;
+
+		for (const [name, before, removeLine, addLine] of cases) {
+			const filePath = join(testDir, name);
+			writeFileSync(filePath, before);
+			const result = await applyPatchTool.execute(`fixture-${name}`, {
+				patch: [
+					"*** Begin Patch",
+					`*** Update File: ${filePath}`,
+					"@@",
+					removeLine,
+					addLine,
+					"*** End Patch",
+				].join("\n"),
+			});
+			expect(details(result).hunksApplied).toBe(1);
+		}
+	});
+});

--- a/test/tools/tools.test.ts
+++ b/test/tools/tools.test.ts
@@ -1703,6 +1703,7 @@ describe("codingTools bundle", () => {
 			"diff",
 			"bash",
 			"background_tasks",
+			"apply_patch",
 			"edit",
 			"write",
 			"notebook_edit",


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `0517c00265f31b1d3a2eeea8826767fa9b05eac4`
- last generated public sync base: `a9e5ae1839115ac784f8412959df75af20b071fc`
- previewed public-tree drift: `24` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (0517c00265f3)`
- public projection: `https://github.com/evalops/maestro@main (a9e5ae183911)`
- files to copy or update: `24`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/THREAT_MODEL.md
- copy/update docs/TOOLS_REFERENCE.md
- copy/update docs/WEB_UI.md
- copy/update docs/opencode-parity.md
- copy/update evals/tools/surface-smoke-cases.json
- copy/update scripts/check-prepared-public-mirror-tree.mjs
- copy/update src/agent/subagent-specs.ts
- copy/update src/agent/transport/tool-safety-pipeline.ts
- copy/update src/safety/action-firewall.ts
- copy/update src/safety/guarded-files.ts
- copy/update src/safety/tool-categorization.ts
- copy/update src/server/handlers/pending-requests.ts
- copy/update src/testing/test-verification-hook.ts
- copy/update src/tools/apply-patch-parser.ts
- copy/update src/tools/apply-patch.ts
- copy/update src/tools/index.ts
- copy/update src/tools/parallel-execution.ts
- copy/update src/tools/tool-result-cache.ts
- copy/update test/agent/subagent-specs.test.ts
- copy/update test/packages/core/subagent-specs.test.ts
- copy/update test/safety/action-firewall.test.ts
- copy/update test/scripts/check-prepared-public-mirror-tree.test.ts
- copy/update test/tools/apply-patch.test.ts
- copy/update test/tools/tools.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/THREAT_MODEL.md
- copy/update docs/TOOLS_REFERENCE.md
- copy/update docs/WEB_UI.md
- copy/update docs/opencode-parity.md
- copy/update evals/tools/surface-smoke-cases.json
- copy/update scripts/check-prepared-public-mirror-tree.mjs
- copy/update src/agent/subagent-specs.ts
- copy/update src/agent/transport/tool-safety-pipeline.ts
- copy/update src/safety/action-firewall.ts
- copy/update src/safety/guarded-files.ts
- copy/update src/safety/tool-categorization.ts
- copy/update src/server/handlers/pending-requests.ts
- copy/update src/testing/test-verification-hook.ts
- copy/update src/tools/apply-patch-parser.ts
- copy/update src/tools/apply-patch.ts
- copy/update src/tools/index.ts
- copy/update src/tools/parallel-execution.ts
- copy/update src/tools/tool-result-cache.ts
- copy/update test/agent/subagent-specs.test.ts
- copy/update test/packages/core/subagent-specs.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #361 to internal source `0517c00265f31b1d3a2eeea8826767fa9b05eac4`