### PR TITLE
fix: clarify pending request source condition

### DIFF
--- a/src/server/handlers/pending-requests.ts
+++ b/src/server/handlers/pending-requests.ts
@@ -306,7 +306,9 @@ function responseFor(
 			sessionId: request.sessionId,
 			resolution,
 			source:
-				request.platform || operation === "ResumeRun" ? "platform" : "local",
+				Boolean(request.platform) || operation === "ResumeRun"
+					? "platform"
+					: "local",
 			platform: request.platform,
 			platformOperation: operation,
 		},


### PR DESCRIPTION
## Summary
- make the pending-request response source condition explicitly boolean before the ternary
- preserve the existing platform/local behavior while removing precedence ambiguity

## Verification
- npx biome check src/server/handlers/pending-requests.ts
- git diff --check

Note: 
> @evalops/maestro@0.10.18 test
> node ./scripts/run-vitest.js --run test/web/pending-request-resume-handler.test.ts could not start in this fresh worktree because dependencies were not installed ( module missing).