### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/safety/action-firewall.ts
+++ b/src/safety/action-firewall.ts
@@ -841,6 +841,7 @@ export class ActionFirewall {
 				"bash",
 				"write",
 				"edit",
+				"apply_patch",
 				"delete_file",
 				"background_tasks",
 			];

--- a/src/safety/attack-patterns.ts
+++ b/src/safety/attack-patterns.ts
@@ -10,6 +10,7 @@
  * @module safety/attack-patterns
  */
 
+import { parseApplyPatchPaths } from "../tools/apply-patch-parser.js";
 import type { SequencePattern } from "./tool-sequence-analyzer.js";
 
 /**
@@ -213,7 +214,34 @@ function pathMatches(args: Record<string, unknown>, pattern: RegExp): boolean {
 		(args.path as string) ||
 		(args.file_path as string) ||
 		(args.target as string);
-	return path ? pattern.test(path) : false;
+	if (path && pattern.test(path)) {
+		return true;
+	}
+	const patch = args.patch;
+	if (typeof patch === "string") {
+		return parseApplyPatchPaths(patch).some((patchPath) =>
+			pattern.test(patchPath),
+		);
+	}
+	return false;
+}
+
+function toolMutatesFiles(currentTool: string): boolean {
+	const normalizedTool = currentTool.toLowerCase();
+	return (
+		normalizedTool === "write" ||
+		normalizedTool === "edit" ||
+		normalizedTool === "apply_patch"
+	);
+}
+
+function mutationContent(args: Record<string, unknown>): string {
+	const content = args.content;
+	if (typeof content === "string") {
+		return content;
+	}
+	const patch = args.patch;
+	return typeof patch === "string" ? patch : "";
 }
 
 /**
@@ -547,10 +575,7 @@ export const PRIVILEGE_ESCALATION_PATTERNS: SequencePattern[] = [
 		windowMs: 60_000,
 		detect: (_records, currentTool, currentArgs) => {
 			const cronPattern = /\/etc\/cron|crontab|\/var\/spool\/cron/i;
-			if (
-				currentTool.toLowerCase() === "write" ||
-				currentTool.toLowerCase() === "edit"
-			) {
+			if (toolMutatesFiles(currentTool)) {
 				if (pathMatches(currentArgs, cronPattern)) {
 					return {
 						matched: true,
@@ -676,10 +701,7 @@ export const PERSISTENCE_PATTERNS: SequencePattern[] = [
 		windowMs: 60_000,
 		detect: (_records, currentTool, currentArgs) => {
 			const sshPattern = /\.ssh\/authorized_keys|\.ssh\/id_/i;
-			if (
-				currentTool.toLowerCase() === "write" ||
-				currentTool.toLowerCase() === "edit"
-			) {
+			if (toolMutatesFiles(currentTool)) {
 				if (pathMatches(currentArgs, sshPattern)) {
 					return {
 						matched: true,
@@ -700,10 +722,7 @@ export const PERSISTENCE_PATTERNS: SequencePattern[] = [
 		detect: (_records, currentTool, currentArgs) => {
 			const profilePattern =
 				/\.bashrc|\.bash_profile|\.zshrc|\.profile|\.bash_login/i;
-			if (
-				currentTool.toLowerCase() === "write" ||
-				currentTool.toLowerCase() === "edit"
-			) {
+			if (toolMutatesFiles(currentTool)) {
 				if (pathMatches(currentArgs, profilePattern)) {
 					return {
 						matched: true,
@@ -723,10 +742,7 @@ export const PERSISTENCE_PATTERNS: SequencePattern[] = [
 		windowMs: 60_000,
 		detect: (_records, currentTool, currentArgs) => {
 			const systemdPattern = /\/etc\/systemd|\.config\/systemd|\.service$/i;
-			if (
-				currentTool.toLowerCase() === "write" ||
-				currentTool.toLowerCase() === "edit"
-			) {
+			if (toolMutatesFiles(currentTool)) {
 				if (pathMatches(currentArgs, systemdPattern)) {
 					return {
 						matched: true,
@@ -749,6 +765,7 @@ export const PERSISTENCE_PATTERNS: SequencePattern[] = [
 			if (
 				currentTool.toLowerCase() === "write" ||
 				currentTool.toLowerCase() === "edit" ||
+				currentTool.toLowerCase() === "apply_patch" ||
 				currentTool.toLowerCase() === "bash"
 			) {
 				// Check for LD_PRELOAD in command or file content
@@ -766,7 +783,7 @@ export const PERSISTENCE_PATTERNS: SequencePattern[] = [
 					}
 				} else if (pathMatches(currentArgs, profilePattern)) {
 					// If writing to profile files, check for LD_PRELOAD in content
-					const content = currentArgs.content as string;
+					const content = mutationContent(currentArgs);
 					if (content && ldPreloadPattern.test(content)) {
 						return {
 							matched: true,
@@ -787,10 +804,7 @@ export const PERSISTENCE_PATTERNS: SequencePattern[] = [
 		windowMs: 60_000,
 		detect: (_records, currentTool, currentArgs) => {
 			const gitHooksPattern = /\.git\/hooks\//i;
-			if (
-				currentTool.toLowerCase() === "write" ||
-				currentTool.toLowerCase() === "edit"
-			) {
+			if (toolMutatesFiles(currentTool)) {
 				if (pathMatches(currentArgs, gitHooksPattern)) {
 					return {
 						matched: true,
@@ -810,10 +824,7 @@ export const PERSISTENCE_PATTERNS: SequencePattern[] = [
 		windowMs: 60_000,
 		detect: (_records, currentTool, currentArgs) => {
 			const pamPattern = /\/etc\/pam\.d\/|\/etc\/pam\.conf|pam_.*\.so/i;
-			if (
-				currentTool.toLowerCase() === "write" ||
-				currentTool.toLowerCase() === "edit"
-			) {
+			if (toolMutatesFiles(currentTool)) {
 				if (pathMatches(currentArgs, pamPattern)) {
 					return {
 						matched: true,

--- a/src/safety/suspicious-patterns.ts
+++ b/src/safety/suspicious-patterns.ts
@@ -7,6 +7,7 @@
  * @module safety/suspicious-patterns
  */
 
+import { parseApplyPatchPaths } from "../tools/apply-patch-parser.js";
 import type { SequencePattern } from "./sequence-analyzer-types.js";
 import { containsSensitivePath, getToolTags } from "./tool-categorization.js";
 
@@ -96,18 +97,25 @@ export const SUSPICIOUS_PATTERNS: SequencePattern[] = [
 				"C:\\Program Files",
 			];
 
-			const targetPath = (currentArgs.path ||
-				currentArgs.file_path ||
-				currentArgs.target) as string | undefined;
+			const targetPaths =
+				currentTool.toLowerCase() === "apply_patch" &&
+				typeof currentArgs.patch === "string"
+					? parseApplyPatchPaths(currentArgs.patch)
+					: [
+							(currentArgs.path ||
+								currentArgs.file_path ||
+								currentArgs.target) as string | undefined,
+						].filter((path): path is string => typeof path === "string");
 
 			if (
-				targetPath &&
 				(currentTags.has("write") || currentTags.has("delete")) &&
-				systemPaths.some((sp) => targetPath.startsWith(sp))
+				targetPaths.some((targetPath) =>
+					systemPaths.some((sp) => targetPath.startsWith(sp)),
+				)
 			) {
 				return {
 					matched: true,
-					reason: `Modification of system path detected: ${targetPath}`,
+					reason: `Modification of system path detected: ${targetPaths.join(", ")}`,
 				};
 			}
 

--- a/src/safety/validators/path-policy-validator.ts
+++ b/src/safety/validators/path-policy-validator.ts
@@ -1,4 +1,5 @@
 import type { ActionApprovalContext } from "../../agent/action-approval.js";
+import { parseApplyPatchPaths } from "../../tools/apply-patch-parser.js";
 import { matchesPathPattern } from "../../utils/path-matcher.js";
 import type { EnterprisePolicy } from "../policy.js";
 
@@ -59,6 +60,13 @@ export function extractPolicyFilePaths(
 	if (!args) return [];
 
 	const paths: string[] = [];
+
+	if (context.toolName === "apply_patch") {
+		const patch = getStringArg(context, "patch");
+		if (patch) {
+			paths.push(...parseApplyPatchPaths(patch));
+		}
+	}
 
 	for (const key of PATH_KEYS) {
 		const value = args[key];

--- a/src/tools/apply-patch-parser.ts
+++ b/src/tools/apply-patch-parser.ts
@@ -1,6 +1,8 @@
 export type ApplyPatchHunk = {
 	oldLines: string[];
 	newLines: string[];
+	oldNoFinalNewline?: boolean;
+	newNoFinalNewline?: boolean;
 };
 
 export type ApplyPatchOperation =
@@ -71,6 +73,9 @@ export function parseApplyPatch(patch: string): ApplyPatchDocument {
 				addLines.push(bodyLine.slice(1));
 				index++;
 			}
+			if (addLines.length === 0) {
+				throw new Error(`Add File ${path} must contain at least one line`);
+			}
 			operations.push({ type: "add", path, lines: addLines });
 			continue;
 		}
@@ -100,6 +105,7 @@ export function parseApplyPatch(patch: string): ApplyPatchDocument {
 					index++;
 				}
 				const hunk: ApplyPatchHunk = { oldLines: [], newLines: [] };
+				let previousPrefix: string | undefined;
 				while (index < endIndex) {
 					const bodyLine = lines[index] ?? "";
 					if (bodyLine.startsWith("@@") || isOperationHeader(bodyLine)) {
@@ -111,6 +117,12 @@ export function parseApplyPatch(patch: string): ApplyPatchDocument {
 						);
 					}
 					if (bodyLine === "\\ No newline at end of file") {
+						if (previousPrefix === "-" || previousPrefix === " ") {
+							hunk.oldNoFinalNewline = true;
+						}
+						if (previousPrefix === "+" || previousPrefix === " ") {
+							hunk.newNoFinalNewline = true;
+						}
 						index++;
 						continue;
 					}
@@ -132,6 +144,7 @@ export function parseApplyPatch(patch: string): ApplyPatchDocument {
 							`Update File ${path} contains an invalid hunk line: ${bodyLine}`,
 						);
 					}
+					previousPrefix = prefix;
 					index++;
 				}
 				if (hunk.oldLines.length === 0 && hunk.newLines.length === 0) {

--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -173,10 +173,7 @@ Use this when a Codex-family model emits its native apply_patch grammar. Use edi
 			}
 		}
 
-		const changedFileCount =
-			plan.filesCreated.length +
-			plan.filesModified.length +
-			plan.filesDeleted.length;
+		const changedFileCount = countChangedFiles(plan);
 		return respond
 			.text(
 				[
@@ -443,11 +440,13 @@ function applyUpdateHunks(
 ): { content: string; hunksApplied: number; conflicts: string[] } {
 	const document = normalizeDocument(previousContent);
 	let lines = [...document.lines];
+	let finalNewline = document.hadFinalNewline;
 	const conflicts: string[] = [];
 	let hunksApplied = 0;
 	for (const [index, hunk] of hunks.entries()) {
 		if (hunk.oldLines.length === 0) {
 			lines = [...lines, ...hunk.newLines];
+			finalNewline = resolveHunkFinalNewline(finalNewline, hunk);
 			hunksApplied++;
 			continue;
 		}
@@ -468,13 +467,27 @@ function applyUpdateHunks(
 			...hunk.newLines,
 			...lines.slice(start + hunk.oldLines.length),
 		];
+		finalNewline = resolveHunkFinalNewline(finalNewline, hunk);
 		hunksApplied++;
 	}
 	return {
-		content: restoreDocumentContent(lines, document),
+		content: restoreDocumentContent(lines, document, finalNewline),
 		hunksApplied,
 		conflicts,
 	};
+}
+
+function resolveHunkFinalNewline(
+	currentFinalNewline: boolean,
+	hunk: ApplyPatchHunk,
+): boolean {
+	if (hunk.newNoFinalNewline === true) {
+		return false;
+	}
+	if (hunk.oldNoFinalNewline === true) {
+		return true;
+	}
+	return currentFinalNewline;
 }
 
 function findLineSequence(lines: string[], needle: string[]): number[] {
@@ -786,6 +799,14 @@ function buildDetails(
 	};
 }
 
+function countChangedFiles(plan: ApplyPatchPlan): number {
+	return new Set([
+		...plan.filesCreated,
+		...plan.filesModified,
+		...plan.filesDeleted,
+	]).size;
+}
+
 function detectLineEnding(text: string): LineEnding {
 	if (text.includes("\r\n")) return "\r\n";
 	if (text.includes("\r")) return "\r";
@@ -806,8 +827,9 @@ function normalizeDocument(content: string): NormalizedDocument {
 function restoreDocumentContent(
 	lines: string[],
 	document: NormalizedDocument,
+	finalNewline = document.hadFinalNewline,
 ): string {
-	return `${document.bom}${serializeLines(lines, document.hadFinalNewline).replace(/\n/g, document.lineEnding)}`;
+	return `${document.bom}${serializeLines(lines, finalNewline).replace(/\n/g, document.lineEnding)}`;
 }
 
 function serializeLines(lines: string[], finalNewline: boolean): string {

--- a/test/safety/action-firewall.test.ts
+++ b/test/safety/action-firewall.test.ts
@@ -7,6 +7,7 @@ import {
 	ActionFirewall,
 	defaultActionFirewall,
 } from "../../src/safety/action-firewall.js";
+import { SemanticJudge } from "../../src/safety/semantic-judge.js";
 
 const withPlanMode = async (fn: () => Promise<void>) => {
 	const prev = process.env.MAESTRO_PLAN_MODE;
@@ -526,6 +527,29 @@ describe("ActionFirewall", () => {
 			makeCustomCommandContext("mkfs.ext4 /dev/sda"),
 		);
 		expect(verdict.action).toBe("require_approval");
+	});
+
+	it("runs semantic judge for apply_patch calls", async () => {
+		const firewall = new ActionFirewall();
+		firewall.setSemanticJudge(
+			new SemanticJudge(async () =>
+				JSON.stringify({
+					safe: false,
+					reason: "Patch edits a file unrelated to the user intent.",
+				}),
+			),
+		);
+
+		const verdict = await firewall.evaluate({
+			...makeApplyPatchContext("file.txt"),
+			userIntent: "Inspect the repository",
+		});
+
+		expect(verdict).toMatchObject({
+			action: "require_approval",
+			ruleId: "semantic-judge",
+			reason: "Patch edits a file unrelated to the user intent.",
+		});
 	});
 
 	it("requires approval for mutating tools when plan mode is on", async () => {

--- a/test/safety/attack-patterns.test.ts
+++ b/test/safety/attack-patterns.test.ts
@@ -155,6 +155,65 @@ describe("attack-patterns", () => {
 		});
 	});
 
+	describe("apply_patch coverage", () => {
+		it("detects persistence paths embedded in apply_patch bodies", () => {
+			const pattern = PERSISTENCE_PATTERNS.find(
+				(p) => p.id === "persist-git-hooks",
+			)!;
+
+			const result = pattern.detect([], "apply_patch", {
+				patch: [
+					"*** Begin Patch",
+					"*** Add File: .git/hooks/pre-commit",
+					"+#!/bin/sh",
+					"+echo pwned",
+					"*** End Patch",
+				].join("\n"),
+			});
+
+			expect(result.matched).toBe(true);
+			expect(result.reason).toContain("Git hooks modification");
+		});
+
+		it("checks apply_patch content when evaluating profile persistence", () => {
+			const pattern = PERSISTENCE_PATTERNS.find(
+				(p) => p.id === "persist-ld-preload",
+			)!;
+
+			const result = pattern.detect([], "apply_patch", {
+				patch: [
+					"*** Begin Patch",
+					"*** Update File: ~/.bashrc",
+					"@@",
+					"+export LD_PRELOAD=/tmp/libshim.so",
+					"*** End Patch",
+				].join("\n"),
+			});
+
+			expect(result.matched).toBe(true);
+			expect(result.reason).toContain("LD_PRELOAD");
+		});
+
+		it("detects systemd persistence paths embedded in apply_patch bodies", () => {
+			const pattern = PERSISTENCE_PATTERNS.find(
+				(p) => p.id === "persist-systemd",
+			)!;
+
+			const result = pattern.detect([], "apply_patch", {
+				patch: [
+					"*** Begin Patch",
+					"*** Add File: /etc/systemd/system/backdoor.service",
+					"+[Service]",
+					"+ExecStart=/tmp/backdoor",
+					"*** End Patch",
+				].join("\n"),
+			});
+
+			expect(result.matched).toBe(true);
+			expect(result.reason).toContain("Systemd");
+		});
+	});
+
 	describe("CREDENTIAL_HARVESTING_PATTERNS", () => {
 		describe("cred-harvest-env-egress", () => {
 			const pattern = CREDENTIAL_HARVESTING_PATTERNS.find(

--- a/test/safety/policy.test.ts
+++ b/test/safety/policy.test.ts
@@ -345,6 +345,26 @@ describe("Enterprise Policy Enforcement", () => {
 			expect(result.allowed).toBe(false);
 		});
 
+		it("extracts file paths from apply_patch bodies", async () => {
+			setupPolicy({ paths: { blocked: ["/etc/**"] } });
+			const result = await checkPolicy({
+				toolName: "apply_patch",
+				args: {
+					patch: [
+						"*** Begin Patch",
+						"*** Update File: /etc/cron.d/backdoor",
+						"@@",
+						"-old",
+						"+new",
+						"*** End Patch",
+					].join("\n"),
+				},
+			} as ActionApprovalContext);
+
+			expect(result.allowed).toBe(false);
+			expect(result.reason).toContain("blocked by enterprise policy");
+		});
+
 		it("checks common path argument keys", async () => {
 			const pathKeys = [
 				"path",

--- a/test/safety/safety-middleware.test.ts
+++ b/test/safety/safety-middleware.test.ts
@@ -159,6 +159,23 @@ describe("safety-middleware", () => {
 			expect(result.requiresApproval).toBe(true);
 			expect(result.triggeredBy).toBe("sequence");
 		});
+
+		it("detects system path escalation inside apply_patch", () => {
+			const result = middleware.preExecution("apply_patch", {
+				patch: [
+					"*** Begin Patch",
+					"*** Update File: /etc/passwd",
+					"@@",
+					"-old",
+					"+new",
+					"*** End Patch",
+				].join("\n"),
+			});
+
+			expect(result.allowed).toBe(false);
+			expect(result.requiresApproval).toBe(true);
+			expect(result.triggeredBy).toBe("sequence");
+		});
 	});
 
 	describe("context firewall integration", () => {

--- a/test/tools/apply-patch.test.ts
+++ b/test/tools/apply-patch.test.ts
@@ -126,6 +126,18 @@ describe("apply_patch parser", () => {
 			},
 		]);
 	});
+
+	it("rejects empty add-file hunks", () => {
+		const patch = [
+			"*** Begin Patch",
+			"*** Add File: src/empty.ts",
+			"*** End Patch",
+		].join("\n");
+
+		expect(() => parseApplyPatch(patch)).toThrow(
+			"Add File src/empty.ts must contain at least one line",
+		);
+	});
 });
 
 describe("apply_patch tool", () => {
@@ -177,7 +189,7 @@ describe("apply_patch tool", () => {
 		const filePath = join(testDir, "repeated.ts");
 		writeFileSync(filePath, "export const a = 1;\nexport const b = 1;\n");
 
-		await applyPatchTool.execute("call-repeated", {
+		const result = await applyPatchTool.execute("call-repeated", {
 			patch: [
 				"*** Begin Patch",
 				`*** Update File: ${filePath}`,
@@ -195,6 +207,45 @@ describe("apply_patch tool", () => {
 		expect(readFileSync(filePath, "utf-8")).toBe(
 			"export const a = 2;\nexport const b = 2;\n",
 		);
+		expect(getTextOutput(result)).toContain("Applied patch to 1 file(s)");
+	});
+
+	it("honors EOF newline markers when adding a final newline", async () => {
+		const filePath = join(testDir, "missing-final-newline.txt");
+		writeFileSync(filePath, "old");
+
+		await applyPatchTool.execute("call-eof-add-newline", {
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${filePath}`,
+				"@@",
+				"-old",
+				"\\ No newline at end of file",
+				"+new",
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(readFileSync(filePath, "utf-8")).toBe("new\n");
+	});
+
+	it("honors EOF newline markers when removing a final newline", async () => {
+		const filePath = join(testDir, "remove-final-newline.txt");
+		writeFileSync(filePath, "old\n");
+
+		await applyPatchTool.execute("call-eof-remove-newline", {
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${filePath}`,
+				"@@",
+				"-old",
+				"+new",
+				"\\ No newline at end of file",
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(readFileSync(filePath, "utf-8")).toBe("new");
 	});
 
 	it("adds and deletes files", async () => {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `e392c7ba2cbf0fa7a6298cd690cd80cb88fecdf6`
- last generated public sync base: `70d73615bc9131c2b4576c12c52b117a89849a96`
- previewed public-tree drift: `11` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (e392c7ba2cbf)`
- public projection: `https://github.com/evalops/maestro@main (70d73615bc91)`
- files to copy or update: `11`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/safety/action-firewall.ts
- copy/update src/safety/attack-patterns.ts
- copy/update src/safety/suspicious-patterns.ts
- copy/update src/safety/validators/path-policy-validator.ts
- copy/update src/tools/apply-patch-parser.ts
- copy/update src/tools/apply-patch.ts
- copy/update test/safety/action-firewall.test.ts
- copy/update test/safety/attack-patterns.test.ts
- copy/update test/safety/policy.test.ts
- copy/update test/safety/safety-middleware.test.ts
- copy/update test/tools/apply-patch.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/safety/action-firewall.ts
- copy/update src/safety/attack-patterns.ts
- copy/update src/safety/suspicious-patterns.ts
- copy/update src/safety/validators/path-policy-validator.ts
- copy/update src/tools/apply-patch-parser.ts
- copy/update src/tools/apply-patch.ts
- copy/update test/safety/action-firewall.test.ts
- copy/update test/safety/attack-patterns.test.ts
- copy/update test/safety/policy.test.ts
- copy/update test/safety/safety-middleware.test.ts
- copy/update test/tools/apply-patch.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode