### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/tools/apply-patch-parser.ts
+++ b/src/tools/apply-patch-parser.ts
@@ -3,6 +3,7 @@ export type ApplyPatchHunk = {
 	newLines: string[];
 	oldNoFinalNewline?: boolean;
 	newNoFinalNewline?: boolean;
+	oldMustEndAtEOF?: boolean;
 };
 
 export type ApplyPatchOperation =
@@ -127,6 +128,7 @@ export function parseApplyPatch(patch: string): ApplyPatchDocument {
 						continue;
 					}
 					if (bodyLine === "*** End of File") {
+						hunk.oldMustEndAtEOF = true;
 						index++;
 						continue;
 					}

--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -450,7 +450,10 @@ function applyUpdateHunks(
 			hunksApplied++;
 			continue;
 		}
-		const matches = findLineSequence(lines, hunk.oldLines);
+		const matches = findLineSequence(lines, hunk.oldLines).filter(
+			(start) =>
+				!hunk.oldMustEndAtEOF || start + hunk.oldLines.length === lines.length,
+		);
 		if (matches.length === 0) {
 			conflicts.push(`hunk ${index + 1}: context not found`);
 			continue;

--- a/test/tools/apply-patch.test.ts
+++ b/test/tools/apply-patch.test.ts
@@ -248,6 +248,48 @@ describe("apply_patch tool", () => {
 		expect(readFileSync(filePath, "utf-8")).toBe("new");
 	});
 
+	it("honors End of File anchors when matching repeated context", async () => {
+		const filePath = join(testDir, "eof-anchor.txt");
+		writeFileSync(filePath, "anchor\nmiddle\nanchor\n");
+
+		await applyPatchTool.execute("call-eof-anchor", {
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${filePath}`,
+				"@@",
+				" anchor",
+				"*** End of File",
+				"+tail",
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(readFileSync(filePath, "utf-8")).toBe(
+			"anchor\nmiddle\nanchor\ntail\n",
+		);
+	});
+
+	it("rejects End of File anchors when context is not at EOF", async () => {
+		const filePath = join(testDir, "bad-eof-anchor.txt");
+		writeFileSync(filePath, "target\ntrailer\n");
+
+		await expect(
+			applyPatchTool.execute("call-bad-eof-anchor", {
+				patch: [
+					"*** Begin Patch",
+					`*** Update File: ${filePath}`,
+					"@@",
+					" target",
+					"*** End of File",
+					"+tail",
+					"*** End Patch",
+				].join("\n"),
+			}),
+		).rejects.toMatchObject({
+			code: "APPLY_PATCH_CONFLICT",
+		});
+	});
+
 	it("adds and deletes files", async () => {
 		const addedPath = join(testDir, "nested", "created.py");
 		const deletedPath = join(testDir, "old.rs");


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `526733d949467eefa8f1decd91e68a598f9b196a`
- last generated public sync base: `0319e7dc5192c0f79c758b135397c04fc708fdd1`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (526733d94946)`
- public projection: `https://github.com/evalops/maestro@main (0319e7dc5192)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/tools/apply-patch-parser.ts
- copy/update src/tools/apply-patch.ts
- copy/update test/tools/apply-patch.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/tools/apply-patch-parser.ts
- copy/update src/tools/apply-patch.ts
- copy/update test/tools/apply-patch.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode