### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -446,7 +446,7 @@ function applyUpdateHunks(
 	for (const [index, hunk] of hunks.entries()) {
 		if (hunk.oldLines.length === 0) {
 			lines = [...lines, ...hunk.newLines];
-			finalNewline = resolveHunkFinalNewline(finalNewline, hunk);
+			finalNewline = resolveHunkFinalNewline(finalNewline, hunk, lines.length);
 			hunksApplied++;
 			continue;
 		}
@@ -470,7 +470,7 @@ function applyUpdateHunks(
 			...hunk.newLines,
 			...lines.slice(start + hunk.oldLines.length),
 		];
-		finalNewline = resolveHunkFinalNewline(finalNewline, hunk);
+		finalNewline = resolveHunkFinalNewline(finalNewline, hunk, lines.length);
 		hunksApplied++;
 	}
 	return {
@@ -483,12 +483,13 @@ function applyUpdateHunks(
 function resolveHunkFinalNewline(
 	currentFinalNewline: boolean,
 	hunk: ApplyPatchHunk,
+	resultLineCount: number,
 ): boolean {
 	if (hunk.newNoFinalNewline === true) {
 		return false;
 	}
 	if (hunk.oldNoFinalNewline === true) {
-		return true;
+		return resultLineCount > 0;
 	}
 	return currentFinalNewline;
 }

--- a/test/tools/apply-patch.test.ts
+++ b/test/tools/apply-patch.test.ts
@@ -290,6 +290,42 @@ describe("apply_patch tool", () => {
 		});
 	});
 
+	it("does not create a newline when deleting the only no-newline line", async () => {
+		const filePath = join(testDir, "delete-only-no-newline.txt");
+		writeFileSync(filePath, "old");
+
+		await applyPatchTool.execute("call-eof-delete-only-line", {
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${filePath}`,
+				"@@",
+				"-old",
+				"\\ No newline at end of file",
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(readFileSync(filePath, "utf-8")).toBe("");
+	});
+
+	it("adds a final newline when deleting the last no-newline line from a non-empty file", async () => {
+		const filePath = join(testDir, "delete-last-no-newline.txt");
+		writeFileSync(filePath, "keep\nold");
+
+		await applyPatchTool.execute("call-eof-delete-last-line", {
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${filePath}`,
+				"@@",
+				"-old",
+				"\\ No newline at end of file",
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(readFileSync(filePath, "utf-8")).toBe("keep\n");
+	});
+
 	it("adds and deletes files", async () => {
 		const addedPath = join(testDir, "nested", "created.py");
 		const deletedPath = join(testDir, "old.rs");


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `7e489012c4dc8a81e8b339e1c16ce3e6e47204a5`
- last generated public sync base: `330fc72f78363d2ae40d6a9de045c2954f7c59c8`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (7e489012c4dc)`
- public projection: `https://github.com/evalops/maestro@main (330fc72f7836)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/tools/apply-patch.ts
- copy/update test/tools/apply-patch.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/tools/apply-patch.ts
- copy/update test/tools/apply-patch.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode