### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -195,11 +195,11 @@ async function planFilesystemPatch(
 	const plan = emptyPlan();
 	const stagedFiles = new Map<string, StagedFileState>();
 	const getState = async (path: string): Promise<StagedFileState> => {
-		const cached = stagedFiles.get(path);
+		const absolutePath = resolvePath(expandUserPath(path));
+		const cached = stagedFiles.get(absolutePath);
 		if (cached) {
 			return cached;
 		}
-		const absolutePath = resolvePath(expandUserPath(path));
 		const exists = await fileExists(absolutePath);
 		const state = {
 			path,
@@ -207,7 +207,7 @@ async function planFilesystemPatch(
 			exists,
 			currentContent: exists ? undefined : null,
 		};
-		stagedFiles.set(path, state);
+		stagedFiles.set(absolutePath, state);
 		return state;
 	};
 
@@ -221,7 +221,7 @@ async function planFilesystemPatch(
 			const nextContent = serializeLines(operation.lines, true);
 			assertTeamMemoryContentSafe(absolutePath, nextContent);
 			addPlannedChange(plan, {
-				path: operation.path,
+				path: state.path,
 				absolutePath,
 				previousContent: null,
 				nextContent,
@@ -237,7 +237,7 @@ async function planFilesystemPatch(
 				operation.path,
 			);
 			addPlannedChange(plan, {
-				path: operation.path,
+				path: state.path,
 				absolutePath,
 				previousContent,
 				nextContent: null,
@@ -268,7 +268,7 @@ async function planFilesystemPatch(
 				}
 				assertTeamMemoryContentSafe(destinationState.absolutePath, nextContent);
 				addPlannedChange(plan, {
-					path: operation.path,
+					path: state.path,
 					absolutePath,
 					previousContent,
 					nextContent: null,
@@ -277,7 +277,7 @@ async function planFilesystemPatch(
 					diff: generateDiffString(previousContent, ""),
 				});
 				addPlannedChange(plan, {
-					path: operation.moveTo,
+					path: destinationState.path,
 					absolutePath: destinationState.absolutePath,
 					previousContent: null,
 					nextContent,
@@ -293,7 +293,7 @@ async function planFilesystemPatch(
 			}
 			assertTeamMemoryContentSafe(absolutePath, nextContent);
 			addPlannedChange(plan, {
-				path: operation.path,
+				path: state.path,
 				absolutePath,
 				previousContent,
 				nextContent,
@@ -315,11 +315,12 @@ async function planSandboxPatch(
 	const plan = emptyPlan();
 	const stagedFiles = new Map<string, StagedFileState>();
 	const getState = async (path: string): Promise<StagedFileState> => {
-		const cached = stagedFiles.get(path);
+		const absolutePath = resolvePath(expandUserPath(path));
+		const cacheKey = normalizeSandboxPathKey(path);
+		const cached = stagedFiles.get(cacheKey);
 		if (cached) {
 			return cached;
 		}
-		const absolutePath = resolvePath(expandUserPath(path));
 		const exists = await sandbox.exists(path);
 		const state = {
 			path,
@@ -327,7 +328,7 @@ async function planSandboxPatch(
 			exists,
 			currentContent: exists ? undefined : null,
 		};
-		stagedFiles.set(path, state);
+		stagedFiles.set(cacheKey, state);
 		return state;
 	};
 
@@ -341,7 +342,7 @@ async function planSandboxPatch(
 			const nextContent = serializeLines(operation.lines, true);
 			assertTeamMemoryContentSafe(absolutePath, nextContent);
 			addPlannedChange(plan, {
-				path: operation.path,
+				path: state.path,
 				absolutePath,
 				previousContent: null,
 				nextContent,
@@ -359,7 +360,7 @@ async function planSandboxPatch(
 				"in sandbox",
 			);
 			addPlannedChange(plan, {
-				path: operation.path,
+				path: state.path,
 				absolutePath,
 				previousContent,
 				nextContent: null,
@@ -394,7 +395,7 @@ async function planSandboxPatch(
 				}
 				assertTeamMemoryContentSafe(destinationState.absolutePath, nextContent);
 				addPlannedChange(plan, {
-					path: operation.path,
+					path: state.path,
 					absolutePath,
 					previousContent,
 					nextContent: null,
@@ -403,7 +404,7 @@ async function planSandboxPatch(
 					diff: generateDiffString(previousContent, ""),
 				});
 				addPlannedChange(plan, {
-					path: operation.moveTo,
+					path: destinationState.path,
 					absolutePath: destinationState.absolutePath,
 					previousContent: null,
 					nextContent,
@@ -419,7 +420,7 @@ async function planSandboxPatch(
 			}
 			assertTeamMemoryContentSafe(absolutePath, nextContent);
 			addPlannedChange(plan, {
-				path: operation.path,
+				path: state.path,
 				absolutePath,
 				previousContent,
 				nextContent,
@@ -692,6 +693,27 @@ async function fileExists(absolutePath: string): Promise<boolean> {
 	} catch {
 		return false;
 	}
+}
+
+function normalizeSandboxPathKey(path: string): string {
+	const isAbsolute = path.startsWith("/");
+	const parts = path.split("/").reduce<string[]>((segments, segment) => {
+		if (segment === "" || segment === ".") {
+			return segments;
+		}
+		if (segment === "..") {
+			if (segments.length > 0 && segments.at(-1) !== "..") {
+				segments.pop();
+			} else if (!isAbsolute) {
+				segments.push(segment);
+			}
+			return segments;
+		}
+		segments.push(segment);
+		return segments;
+	}, []);
+	const normalized = parts.join("/");
+	return isAbsolute ? `/${normalized}` : normalized;
 }
 
 async function readFilesystemStateContent(

--- a/test/tools/apply-patch.test.ts
+++ b/test/tools/apply-patch.test.ts
@@ -8,7 +8,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentToolResult } from "../../src/agent/types.js";
 import { runValidatorsOnSuccess } from "../../src/safety/safe-mode.js";
@@ -326,6 +326,32 @@ describe("apply_patch tool", () => {
 		expect(readFileSync(filePath, "utf-8")).toBe("keep\n");
 	});
 
+	it("normalizes filesystem staged state keys by resolved path", async () => {
+		const filePath = join(testDir, "normalized.ts");
+		const variantPath = `${testDir}${sep}.${sep}normalized.ts`;
+		writeFileSync(filePath, "export const a = 1;\nexport const b = 1;\n");
+		expect(variantPath).not.toBe(filePath);
+
+		await applyPatchTool.execute("call-normalized", {
+			patch: [
+				"*** Begin Patch",
+				`*** Update File: ${filePath}`,
+				"@@",
+				"-export const a = 1;",
+				"+export const a = 2;",
+				`*** Update File: ${variantPath}`,
+				"@@",
+				"-export const b = 1;",
+				"+export const b = 2;",
+				"*** End Patch",
+			].join("\n"),
+		});
+
+		expect(readFileSync(filePath, "utf-8")).toBe(
+			"export const a = 2;\nexport const b = 2;\n",
+		);
+	});
+
 	it("adds and deletes files", async () => {
 		const addedPath = join(testDir, "nested", "created.py");
 		const deletedPath = join(testDir, "old.rs");
@@ -558,6 +584,104 @@ describe("apply_patch tool", () => {
 
 		await expect(sandbox.readFile("repeated.ts")).resolves.toBe(
 			"export const a = 2;\nexport const b = 2;\n",
+		);
+	});
+
+	it("normalizes sandbox staged state keys by resolved path", async () => {
+		const sandbox = createMemorySandbox({
+			"normalized.ts": "export const a = 1;\nexport const b = 1;\n",
+		});
+
+		await applyPatchTool.execute(
+			"call-sandbox-normalized",
+			{
+				patch: [
+					"*** Begin Patch",
+					"*** Update File: normalized.ts",
+					"@@",
+					"-export const a = 1;",
+					"+export const a = 2;",
+					"*** Update File: ./normalized.ts",
+					"@@",
+					"-export const b = 1;",
+					"+export const b = 2;",
+					"*** End Patch",
+				].join("\n"),
+			},
+			undefined,
+			{ sandbox },
+		);
+
+		await expect(sandbox.readFile("normalized.ts")).resolves.toBe(
+			"export const a = 2;\nexport const b = 2;\n",
+		);
+	});
+
+	it("keeps absolute and relative sandbox staged paths distinct", async () => {
+		const sandbox = createMemorySandbox({
+			"/tmp/normalized.ts": "export const absolute = 1;\n",
+			"tmp/normalized.ts": "export const relative = 1;\n",
+		});
+
+		await applyPatchTool.execute(
+			"call-sandbox-absolute-normalized",
+			{
+				patch: [
+					"*** Begin Patch",
+					"*** Update File: tmp/normalized.ts",
+					"@@",
+					"-export const relative = 1;",
+					"+export const relative = 2;",
+					"*** Update File: /tmp/normalized.ts",
+					"@@",
+					"-export const absolute = 1;",
+					"+export const absolute = 2;",
+					"*** End Patch",
+				].join("\n"),
+			},
+			undefined,
+			{ sandbox },
+		);
+
+		await expect(sandbox.readFile("/tmp/normalized.ts")).resolves.toBe(
+			"export const absolute = 2;\n",
+		);
+		await expect(sandbox.readFile("tmp/normalized.ts")).resolves.toBe(
+			"export const relative = 2;\n",
+		);
+	});
+
+	it("keeps backslash and slash sandbox staged paths distinct", async () => {
+		const sandbox = createMemorySandbox({
+			"dir\\normalized.ts": "export const backslash = 1;\n",
+			"dir/normalized.ts": "export const slash = 1;\n",
+		});
+
+		await applyPatchTool.execute(
+			"call-sandbox-backslash-normalized",
+			{
+				patch: [
+					"*** Begin Patch",
+					"*** Update File: dir\\normalized.ts",
+					"@@",
+					"-export const backslash = 1;",
+					"+export const backslash = 2;",
+					"*** Update File: dir/normalized.ts",
+					"@@",
+					"-export const slash = 1;",
+					"+export const slash = 2;",
+					"*** End Patch",
+				].join("\n"),
+			},
+			undefined,
+			{ sandbox },
+		);
+
+		await expect(sandbox.readFile("dir\\normalized.ts")).resolves.toBe(
+			"export const backslash = 2;\n",
+		);
+		await expect(sandbox.readFile("dir/normalized.ts")).resolves.toBe(
+			"export const slash = 2;\n",
 		);
 	});
 


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `d156d8d85618b4926d1e31c912f383928bfcdf0d`
- last generated public sync base: `b1874fb267c690fb0d1e9ccc0e5f208afafe6358`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (d156d8d85618)`
- public projection: `https://github.com/evalops/maestro@main (b1874fb267c6)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/tools/apply-patch.ts
- copy/update test/tools/apply-patch.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/tools/apply-patch.ts
- copy/update test/tools/apply-patch.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode