### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -784,11 +784,17 @@ function addPlannedChange(
 	plan.changes.push(change);
 	plan.hunksApplied += change.hunksApplied;
 	if (change.operation === "add") {
-		plan.filesCreated.push(change.path);
+		pushUnique(plan.filesCreated, change.path);
 	} else if (change.operation === "delete") {
-		plan.filesDeleted.push(change.path);
+		pushUnique(plan.filesDeleted, change.path);
 	} else {
-		plan.filesModified.push(change.path);
+		pushUnique(plan.filesModified, change.path);
+	}
+}
+
+function pushUnique(values: string[], value: string): void {
+	if (!values.includes(value)) {
+		values.push(value);
 	}
 }
 
@@ -815,14 +821,22 @@ function buildDetails(
 		hunksApplied: plan.hunksApplied,
 		hunksFailed: plan.hunksFailed,
 		conflictDetails: plan.conflictDetails,
-		diffs: Object.fromEntries(
-			plan.changes
-				.filter((change) => change.diff !== undefined)
-				.map((change) => [change.path, change.diff ?? ""]),
-		),
+		diffs: buildDiffDetails(plan),
 		editGrammar: "apply_patch",
 		mode,
 	};
+}
+
+function buildDiffDetails(plan: ApplyPatchPlan): Record<string, string> {
+	const diffs: Record<string, string> = {};
+	for (const change of plan.changes) {
+		if (change.diff === undefined) {
+			continue;
+		}
+		const existing = diffs[change.path];
+		diffs[change.path] = existing ? `${existing}\n${change.diff}` : change.diff;
+	}
+	return diffs;
 }
 
 function countChangedFiles(plan: ApplyPatchPlan): number {

--- a/test/tools/apply-patch.test.ts
+++ b/test/tools/apply-patch.test.ts
@@ -208,6 +208,12 @@ describe("apply_patch tool", () => {
 			"export const a = 2;\nexport const b = 2;\n",
 		);
 		expect(getTextOutput(result)).toContain("Applied patch to 1 file(s)");
+		const resultDetails = details(result);
+		expect(resultDetails.filesModified).toEqual([filePath]);
+		expect(resultDetails.diffs?.[filePath]).toContain("-1 export const a = 1;");
+		expect(resultDetails.diffs?.[filePath]).toContain("+1 export const a = 2;");
+		expect(resultDetails.diffs?.[filePath]).toContain("-2 export const b = 1;");
+		expect(resultDetails.diffs?.[filePath]).toContain("+2 export const b = 2;");
 	});
 
 	it("honors EOF newline markers when adding a final newline", async () => {


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `0f6a8d289a5c1dcaa2280270ddd387c3c27fe1a5`
- last generated public sync base: `aa29b8cc6a8bcd9af3dfcab648a8e79270fca51e`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (0f6a8d289a5c)`
- public projection: `https://github.com/evalops/maestro@main (aa29b8cc6a8b)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/tools/apply-patch.ts
- copy/update test/tools/apply-patch.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/tools/apply-patch.ts
- copy/update test/tools/apply-patch.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode