### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/design/HEADLESS_PROTOCOL_VERSIONING.md
+++ b/docs/design/HEADLESS_PROTOCOL_VERSIONING.md
@@ -1,0 +1,45 @@
+# Headless Protocol Versioning
+
+Maestro headless protocol changes should be staged so native and hosted clients
+can recover during a cutover without exposing internal-only commands as public
+CLI surface.
+
+## Runtime Escape Flag
+
+`--legacy-runtime` is a hidden support flag for headless protocol cutovers. It
+is intentionally omitted from default `maestro --help`; support staff can verify
+its presence with:
+
+```bash
+maestro --help --hidden
+```
+
+The flag is only valid with `--headless` or `--mode headless`. When present,
+Maestro selects the previous headless runtime adapter for the cutover window and
+emits one info-level log event:
+
+```text
+runtime_legacy_selected
+```
+
+The event context includes the selected runtime id, the triggering flag, and the
+`headless` surface so cutover usage can be measured without adding a settings
+key or another public command. The selected runtime object is also passed into
+the headless dispatch boundary; while no cutover is active it resolves to the
+current TypeScript adapter, and the next cutover can attach the concrete previous
+adapter behind that same selector.
+
+## Cutover Rules
+
+1. Keep the current and previous headless runtime adapters in the same release
+   during a protocol cutover.
+2. Route `--legacy-runtime` to the previous adapter until clients have upgraded.
+3. Mention the flag in cutover release notes only. Do not add it to default
+   help, onboarding docs, or stable automation examples.
+4. Remove the previous adapter and the escape flag after the cutover window
+   closes.
+
+When no protocol cutover is active, the selected legacy runtime id remains a
+measurement and routing seam for the TypeScript headless adapter. The next
+protocol cutover should register the concrete previous adapter behind the same
+selection path instead of introducing another flag.

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -14,10 +14,14 @@ export interface Args {
 	continue?: boolean;
 	resume?: boolean;
 	help?: boolean;
+	/** Show support-only flags in help output. */
+	hiddenHelp?: boolean;
 	version?: boolean;
 	mode?: Mode;
 	/** Run in headless mode for native TUI communication */
 	headless?: boolean;
+	/** Select the previous headless runtime during a protocol cutover window. */
+	legacyRuntime?: boolean;
 	noSession?: boolean;
 	session?: string;
 	safeMode?: boolean;
@@ -142,6 +146,8 @@ export function parseArgs(args: string[]): Args {
 
 		if (arg === "--help" || arg === "-h") {
 			result.help = true;
+		} else if (arg === "--hidden") {
+			result.hiddenHelp = true;
 		} else if (arg === "--version" || arg === "-v") {
 			result.version = true;
 		} else if (arg?.startsWith("--mode=")) {
@@ -173,6 +179,8 @@ export function parseArgs(args: string[]): Args {
 		} else if (arg === "--headless") {
 			result.headless = true;
 			result.mode = "headless";
+		} else if (arg === "--legacy-runtime") {
+			result.legacyRuntime = true;
 		} else if (arg === "--continue" || arg === "-c") {
 			result.continue = true;
 		} else if (arg === "--resume" || arg === "-r") {

--- a/src/cli/headless-runtime-selection.ts
+++ b/src/cli/headless-runtime-selection.ts
@@ -1,0 +1,51 @@
+import { createLogger } from "../utils/logger.js";
+import type { Args } from "./args.js";
+
+export const LEGACY_HEADLESS_RUNTIME_FLAG = "--legacy-runtime";
+export const LEGACY_HEADLESS_RUNTIME_ID = "typescript-headless-legacy";
+export const LEGACY_HEADLESS_RUNTIME_EVENT = "runtime_legacy_selected";
+
+export type HeadlessRuntimeSelection =
+	| {
+			kind: "current";
+	  }
+	| {
+			kind: "legacy";
+			flag: typeof LEGACY_HEADLESS_RUNTIME_FLAG;
+			runtimeId: typeof LEGACY_HEADLESS_RUNTIME_ID;
+			event: typeof LEGACY_HEADLESS_RUNTIME_EVENT;
+	  };
+
+export interface RuntimeSelectionLogger {
+	info(message: string, context?: Record<string, unknown>): void;
+}
+
+export function selectHeadlessRuntime(
+	args: Pick<Args, "legacyRuntime">,
+): HeadlessRuntimeSelection {
+	if (!args.legacyRuntime) {
+		return { kind: "current" };
+	}
+
+	return {
+		kind: "legacy",
+		flag: LEGACY_HEADLESS_RUNTIME_FLAG,
+		runtimeId: LEGACY_HEADLESS_RUNTIME_ID,
+		event: LEGACY_HEADLESS_RUNTIME_EVENT,
+	};
+}
+
+export function recordHeadlessRuntimeSelection(
+	selection: HeadlessRuntimeSelection,
+	logger: RuntimeSelectionLogger = createLogger("headless-runtime"),
+): void {
+	if (selection.kind !== "legacy") {
+		return;
+	}
+
+	logger.info(selection.event, {
+		flag: selection.flag,
+		runtime: selection.runtimeId,
+		surface: "headless",
+	});
+}

--- a/src/cli/headless.ts
+++ b/src/cli/headless.ts
@@ -43,6 +43,7 @@ import {
 	headlessViewerDisallowedCapability,
 	loadPromptAttachments,
 } from "./headless-protocol.js";
+import type { HeadlessRuntimeSelection } from "./headless-runtime-selection.js";
 
 export {
 	HEADLESS_PROTOCOL_VERSION,
@@ -53,6 +54,10 @@ export {
 };
 
 const LOCAL_HEADLESS_CONNECTION_ID = "local";
+
+export interface RunHeadlessModeOptions {
+	runtimeSelection?: HeadlessRuntimeSelection;
+}
 
 function send(msg: HeadlessFromAgentMessage): void {
 	try {
@@ -94,9 +99,11 @@ export async function runHeadlessMode(
 	sessionManager: SessionManager,
 	approvalService?: ActionApprovalService,
 	toolRetryService?: ToolRetryService,
+	options: RunHeadlessModeOptions = {},
 ): Promise<void> {
 	const translator = new HeadlessProtocolTranslator();
 	const state = createHeadlessRuntimeState();
+	void options.runtimeSelection;
 
 	const shouldFilterOutgoingMessage = (
 		msg: HeadlessFromAgentMessage,

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -43,7 +43,11 @@ import { badge, heading, muted, sectionHeading } from "../style/theme.js";
  * }
  * ```
  */
-export function printHelp(version: string) {
+export interface HelpOptions {
+	hidden?: boolean;
+}
+
+export function printHelp(version: string, options_: HelpOptions = {}) {
 	const header = `${heading("Maestro")} ${muted(
 		`v${version} by EvalOps — AI coding assistant with read, list, search, diff, bash, edit, write, todo tools`,
 	)}`;
@@ -73,6 +77,15 @@ export function printHelp(version: string) {
 	]
 		.map((line) => `  ${muted(line)}`)
 		.join("\n")}`;
+	const hiddenOptions =
+		options_.hidden === true
+			? `${sectionHeading("Hidden Support Flags")}${muted(
+					`  --legacy-runtime       Use the previous headless runtime during a protocol cutover window
+
+  Hidden flags are support and release-note escape hatches. They are intentionally
+  omitted from default help and are not stable automation surfaces.`,
+				)}`
+			: null;
 	const examples = `${sectionHeading("Examples")}${muted(
 		`  # Interactive mode (no messages = interactive TUI)
   maestro
@@ -259,6 +272,7 @@ export function printHelp(version: string) {
 			header,
 			usage,
 			options,
+			hiddenOptions,
 			examples,
 			env,
 			execSection,
@@ -278,6 +292,8 @@ export function printHelp(version: string) {
 			)}`,
 			frameworkSection,
 			tools,
-		].join("\n\n"),
+		]
+			.filter((section): section is string => section !== null)
+			.join("\n\n"),
 	);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,6 +120,10 @@ import {
 	EXEC_SESSION_SUMMARY_PREFIX,
 	runExecCommand,
 } from "./cli/commands/exec.js";
+import {
+	recordHeadlessRuntimeSelection,
+	selectHeadlessRuntime,
+} from "./cli/headless-runtime-selection.js";
 import { runHeadlessMode } from "./cli/headless.js";
 import { printHelp } from "./cli/help.js";
 import {
@@ -485,13 +489,22 @@ export async function main(args: string[]) {
 
 	// Handle --help early exit (before any logging redirection or heavy init)
 	if (parsed.help) {
-		printHelp(VERSION);
+		printHelp(VERSION, { hidden: parsed.hiddenHelp });
 		await waitForStartupTelemetryForImmediateExit(startupTelemetry);
 		process.exit(0);
 	}
 
 	if (parsed.error) {
 		console.error(chalk.red(parsed.error));
+		await waitForStartupTelemetryForImmediateExit(startupTelemetry);
+		process.exit(1);
+	}
+
+	const isHeadlessMode = parsed.headless || parsed.mode === "headless";
+	if (parsed.legacyRuntime && !isHeadlessMode) {
+		console.error(
+			chalk.red("--legacy-runtime can only be used with --headless mode"),
+		);
 		await waitForStartupTelemetryForImmediateExit(startupTelemetry);
 		process.exit(1);
 	}
@@ -584,7 +597,6 @@ export async function main(args: string[]) {
 		!parsed.messages.length &&
 		(parsed.mode === "text" || parsed.mode === undefined) &&
 		parsed.command === undefined;
-	const isHeadlessMode = parsed.headless || parsed.mode === "headless";
 	if (isLikelyInteractiveTui || isHeadlessMode) {
 		const {
 			redirectLoggerToFile,
@@ -599,6 +611,9 @@ export async function main(args: string[]) {
 		}
 		pipeProcessEventsToLogger();
 	}
+
+	const headlessRuntimeSelection = selectHeadlessRuntime(parsed);
+	recordHeadlessRuntimeSelection(headlessRuntimeSelection);
 
 	const runtimeConfig = loadRuntimeConfig(parsed, process.cwd());
 	startupProfiler.checkpoint("config:loaded");
@@ -1531,6 +1546,7 @@ export async function main(args: string[]) {
 				sessionManager,
 				approvalService,
 				toolRetryService,
+				{ runtimeSelection: headlessRuntimeSelection },
 			);
 		} else if (mode === "rpc") {
 			// RPC mode - headless operation

--- a/src/telemetry/cli-startup.ts
+++ b/src/telemetry/cli-startup.ts
@@ -8,6 +8,7 @@ export interface CliStartupArgs {
 	help?: boolean;
 	error?: string;
 	headless?: boolean;
+	legacyRuntime?: boolean;
 	mode?: "text" | "json" | "rpc" | "headless";
 	messages: string[];
 }
@@ -74,6 +75,7 @@ export async function recordCliStartupTelemetry(
 						command,
 						mode,
 						hasPrompt: options.args.messages.length > 0,
+						legacyRuntimeRequested: options.args.legacyRuntime === true,
 						argCount: options.rawArgs?.length ?? 0,
 					},
 				},

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -41,6 +41,18 @@ describe("parseArgs", () => {
 		});
 	});
 
+	it("parses hidden support help and legacy headless runtime flags", () => {
+		expect(parseArgs(["--help", "--hidden"])).toMatchObject({
+			help: true,
+			hiddenHelp: true,
+		});
+		expect(parseArgs(["--headless", "--legacy-runtime"])).toMatchObject({
+			headless: true,
+			mode: "headless",
+			legacyRuntime: true,
+		});
+	});
+
 	it("parses export commands and formats", () => {
 		expect(
 			parseArgs([

--- a/test/cli/cli.integration.test.ts
+++ b/test/cli/cli.integration.test.ts
@@ -749,6 +749,22 @@ describe("CLI integration", () => {
 		exitSpy.mockRestore();
 	});
 
+	it("rejects legacy runtime flag before non-headless command dispatch", async () => {
+		const exitCodes: number[] = [];
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+			exitCodes.push(Number(code ?? 0));
+			throw new Error("exit");
+		});
+
+		await expect(main(["web", "--legacy-runtime"])).rejects.toThrow("exit");
+
+		expect(exitCodes).toEqual([1]);
+		expect(output.join("\n")).toContain(
+			"--legacy-runtime can only be used with --headless mode",
+		);
+		exitSpy.mockRestore();
+	});
+
 	it("prints providers summary for filter", async () => {
 		const originalTelemetry = process.env.MAESTRO_TELEMETRY;
 		const originalBeaconFile = process.env.MAESTRO_BEACON_FILE;

--- a/test/cli/headless-runtime-selection.test.ts
+++ b/test/cli/headless-runtime-selection.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	LEGACY_HEADLESS_RUNTIME_EVENT,
+	LEGACY_HEADLESS_RUNTIME_FLAG,
+	LEGACY_HEADLESS_RUNTIME_ID,
+	recordHeadlessRuntimeSelection,
+	selectHeadlessRuntime,
+} from "../../src/cli/headless-runtime-selection.js";
+
+describe("headless runtime selection", () => {
+	it("uses the current runtime by default", () => {
+		expect(selectHeadlessRuntime({})).toEqual({ kind: "current" });
+	});
+
+	it("selects the legacy runtime for the hidden escape flag", () => {
+		expect(selectHeadlessRuntime({ legacyRuntime: true })).toEqual({
+			kind: "legacy",
+			flag: LEGACY_HEADLESS_RUNTIME_FLAG,
+			runtimeId: LEGACY_HEADLESS_RUNTIME_ID,
+			event: LEGACY_HEADLESS_RUNTIME_EVENT,
+		});
+	});
+
+	it("emits one measurable info event only when legacy runtime is selected", () => {
+		const logger = { info: vi.fn() };
+
+		recordHeadlessRuntimeSelection({ kind: "current" }, logger);
+		expect(logger.info).not.toHaveBeenCalled();
+
+		recordHeadlessRuntimeSelection(
+			selectHeadlessRuntime({ legacyRuntime: true }),
+			logger,
+		);
+
+		expect(logger.info).toHaveBeenCalledOnce();
+		expect(logger.info).toHaveBeenCalledWith(LEGACY_HEADLESS_RUNTIME_EVENT, {
+			flag: LEGACY_HEADLESS_RUNTIME_FLAG,
+			runtime: LEGACY_HEADLESS_RUNTIME_ID,
+			surface: "headless",
+		});
+	});
+});

--- a/test/cli/help.test.ts
+++ b/test/cli/help.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { printHelp } from "../../src/cli/help.js";
+
+describe("printHelp", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("does not show hidden support flags by default", () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		printHelp("0.0.0");
+
+		const output = log.mock.calls.map((call) => call.join(" ")).join("\n");
+		expect(output).not.toContain("--legacy-runtime");
+		expect(output).not.toContain("Hidden Support Flags");
+	});
+
+	it("shows hidden support flags when requested", () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		printHelp("0.0.0", { hidden: true });
+
+		const output = log.mock.calls.map((call) => call.join(" ")).join("\n");
+		expect(output).toContain("Hidden Support Flags");
+		expect(output).toContain("--legacy-runtime");
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `fd3b383e9bf3db0624b8b4851b37f3ef0c564ded`
- last generated public sync base: `504e8dad9df977c872d1c5a56f1a9356981ab08d`
- previewed public-tree drift: `11` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (fd3b383e9bf3)`
- public projection: `https://github.com/evalops/maestro@main (504e8dad9df9)`
- files to copy or update: `11`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/design/HEADLESS_PROTOCOL_VERSIONING.md
- copy/update src/cli/args.ts
- copy/update src/cli/headless-runtime-selection.ts
- copy/update src/cli/headless.ts
- copy/update src/cli/help.ts
- copy/update src/main.ts
- copy/update src/telemetry/cli-startup.ts
- copy/update test/cli/args.test.ts
- copy/update test/cli/cli.integration.test.ts
- copy/update test/cli/headless-runtime-selection.test.ts
- copy/update test/cli/help.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/design/HEADLESS_PROTOCOL_VERSIONING.md
- copy/update src/cli/args.ts
- copy/update src/cli/headless-runtime-selection.ts
- copy/update src/cli/headless.ts
- copy/update src/cli/help.ts
- copy/update src/main.ts
- copy/update src/telemetry/cli-startup.ts
- copy/update test/cli/args.test.ts
- copy/update test/cli/cli.integration.test.ts
- copy/update test/cli/headless-runtime-selection.test.ts
- copy/update test/cli/help.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode