### PR TITLE
ci: retry bun install in shared setup

### DIFF
--- a/.github/actions/setup-bun-nx/action.yml
+++ b/.github/actions/setup-bun-nx/action.yml
@@ -95,4 +95,16 @@ runs:
     - name: Install dependencies
       if: ${{ inputs.install == 'true' }}
       shell: bash
-      run: bun install --frozen-lockfile
+      run: |
+        set -euo pipefail
+        for attempt in 1 2 3; do
+          if bun install --frozen-lockfile; then
+            exit 0
+          fi
+          if [[ "$attempt" -eq 3 ]]; then
+            exit 1
+          fi
+          echo "bun install failed on attempt ${attempt}; clearing Bun download cache before retry."
+          rm -rf "$HOME/.bun/install/cache"
+          sleep $((attempt * 5))
+        done


### PR DESCRIPTION
## Summary
- mirror the shared setup-bun-nx retry behavior from internal
- retry bun install up to three times and clear Bun's download cache between failures
- keep --frozen-lockfile strictness unchanged

## Internal source
- https://github.com/evalops/maestro-internal/pull/1858

## Verification
- git diff --check