### PR TITLE
Harden local smoke assertions

### DIFF
--- a/scripts/run-mock-agent-search-read.js
+++ b/scripts/run-mock-agent-search-read.js
@@ -63,7 +63,7 @@ const transport = new MockToolTransport(
 					.find((line) => line.includes(tempFile));
 				const number = match?.split(":")[1];
 				lineNumber = number ? Number(number) : 1;
-				foundSearchMatch = Number.isFinite(lineNumber) && lineNumber > 0;
+				foundSearchMatch = !!match && Number.isFinite(lineNumber) && lineNumber > 0;
 				readOperation.args.offset = lineNumber;
 			},
 		},

--- a/scripts/run-mock-agent-search-read.js
+++ b/scripts/run-mock-agent-search-read.js
@@ -43,6 +43,7 @@ const mockModel = {
 
 let lineNumber = 1;
 let readContent = "";
+let foundSearchMatch = false;
 const readOperation = {
 	name: "read",
 	args: { path: tempFile, offset: lineNumber },
@@ -62,6 +63,7 @@ const transport = new MockToolTransport(
 					.find((line) => line.includes(tempFile));
 				const number = match?.split(":")[1];
 				lineNumber = number ? Number(number) : 1;
+				foundSearchMatch = Number.isFinite(lineNumber) && lineNumber > 0;
 				readOperation.args.offset = lineNumber;
 			},
 		},
@@ -89,6 +91,11 @@ if (!finalAssistant) {
 }
 
 console.log(finalAssistant.content.find((c) => c.type === "text")?.text ?? "");
+if (!foundSearchMatch) {
+	console.error("mock search/read flow did not find the expected search match");
+	rmSync(tempDir, { recursive: true, force: true });
+	process.exit(1);
+}
 if (!readContent.includes("TODO testing")) {
 	console.error("mock search/read flow did not read the expected search match");
 	rmSync(tempDir, { recursive: true, force: true });

--- a/scripts/run-mock-agent-write-read.js
+++ b/scripts/run-mock-agent-write-read.js
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { rmSync } from "node:fs";
 import { runMockAgentFlow } from "./mock-agent-runner.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "..");
 const targetFile = join(projectRoot, "evals", "mock-agent-flow.txt");
+
+rmSync(targetFile, { force: true });
 
 let readContent = "";
 


### PR DESCRIPTION
## Summary
- fail the mock search/read smoke if the expected search result was never found before reading
- remove the stale mock write target before the write/read smoke so old output cannot mask write failures
- confirmed `smoke:local-e2e` already delegates to `npm run smoke` on current main

## Review feedback addressed
- evalops/maestro#372: validate search success before passing search/read smoke
- evalops/maestro#372: reset mock write target before asserting write/read smoke
- evalops/maestro#372: `smoke:local-e2e` alias is already fixed on current main

## Validation
- `bun install`
- `bun run build`
- `node scripts/run-mock-agent-search-read.js`
- `node scripts/run-mock-agent-write-read.js`
- `npm run smoke:local-e2e`
- `git diff --check`
- commit hook: guardian, `bunx biome check .`, `bun run lint:evals`, generated contract checks, `bun run build`, compiled `dist/maestro-bun`
