### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/design/HEADLESS_PROTOCOL_VERSIONING.md
+++ b/docs/design/HEADLESS_PROTOCOL_VERSIONING.md
@@ -4,25 +4,22 @@ Maestro headless protocol changes should be staged so native and hosted clients
 can recover during a cutover without exposing internal-only commands as public
 CLI surface.
 
-## Runtime Escape Flag
+## Internal Runtime Cutover Gate
 
-`--legacy-runtime` is a hidden support flag for headless protocol cutovers. It
-is intentionally omitted from default `maestro --help`; support staff can verify
-its presence with:
+Legacy runtime selection is an internal deployment control, not a CLI command or
+support flag. Release automation may set the internal runtime gate during a
+cutover window, but user-facing commands must keep the normal headless shape:
+`maestro --headless` or `maestro exec --mode=headless`.
 
-```bash
-maestro --help --hidden
-```
-
-The flag is only valid with `--headless` or `--mode headless`. When present,
-Maestro selects the previous headless runtime adapter for the cutover window and
-emits one info-level log event:
+The internal gate is only honored when Maestro is already dispatching headless
+mode. When present, Maestro selects the previous headless runtime adapter for the
+cutover window and emits one info-level log event:
 
 ```text
 runtime_legacy_selected
 ```
 
-The event context includes the selected runtime id, the triggering flag, and the
+The event context includes the selected runtime id, the internal source, and the
 `headless` surface so cutover usage can be measured without adding a settings
 key or another public command. The selected runtime object is also passed into
 the headless dispatch boundary; while no cutover is active it resolves to the
@@ -33,13 +30,14 @@ adapter behind that same selector.
 
 1. Keep the current and previous headless runtime adapters in the same release
    during a protocol cutover.
-2. Route `--legacy-runtime` to the previous adapter until clients have upgraded.
-3. Mention the flag in cutover release notes only. Do not add it to default
-   help, onboarding docs, or stable automation examples.
-4. Remove the previous adapter and the escape flag after the cutover window
+2. Route the internal runtime gate to the previous adapter until clients have
+   upgraded.
+3. Do not add cutover controls to CLI help, onboarding docs, or stable
+   automation examples.
+4. Remove the previous adapter and the internal gate after the cutover window
    closes.
 
 When no protocol cutover is active, the selected legacy runtime id remains a
 measurement and routing seam for the TypeScript headless adapter. The next
 protocol cutover should register the concrete previous adapter behind the same
-selection path instead of introducing another flag.
+selection path instead of introducing a user-facing switch.

--- a/packages/ai/tsconfig.build.json
+++ b/packages/ai/tsconfig.build.json
@@ -42,6 +42,7 @@
 		"../../src/oauth/**/*.ts",
 		"../../src/platform/**/*.ts",
 		"../../src/sandbox/**/*.ts",
+		"../../src/cli/headless-runtime-selection.ts",
 		"../../src/cli/system-prompt.ts",
 		"../../src/prompts/**/*.ts",
 		"../../src/skills/**/*.ts",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -20,8 +20,8 @@ export interface Args {
 	mode?: Mode;
 	/** Run in headless mode for native TUI communication */
 	headless?: boolean;
-	/** Select the previous headless runtime during a protocol cutover window. */
-	legacyRuntime?: boolean;
+	/** Attempted to use a support-only runtime selector through CLI args. */
+	legacyRuntimeCliRequested?: boolean;
 	noSession?: boolean;
 	session?: string;
 	safeMode?: boolean;
@@ -180,7 +180,9 @@ export function parseArgs(args: string[]): Args {
 			result.headless = true;
 			result.mode = "headless";
 		} else if (arg === "--legacy-runtime") {
-			result.legacyRuntime = true;
+			result.legacyRuntimeCliRequested = true;
+			result.error =
+				"Legacy headless runtime selection is not available from the CLI";
 		} else if (arg === "--continue" || arg === "-c") {
 			result.continue = true;
 		} else if (arg === "--resume" || arg === "-r") {

--- a/src/cli/headless-runtime-selection.ts
+++ b/src/cli/headless-runtime-selection.ts
@@ -1,7 +1,7 @@
 import { createLogger } from "../utils/logger.js";
-import type { Args } from "./args.js";
 
-export const LEGACY_HEADLESS_RUNTIME_FLAG = "--legacy-runtime";
+export const LEGACY_HEADLESS_RUNTIME_ENV = "MAESTRO_INTERNAL_HEADLESS_RUNTIME";
+export const LEGACY_HEADLESS_RUNTIME_ENV_VALUE = "legacy";
 export const LEGACY_HEADLESS_RUNTIME_ID = "typescript-headless-legacy";
 export const LEGACY_HEADLESS_RUNTIME_EVENT = "runtime_legacy_selected";
 
@@ -11,7 +11,7 @@ export type HeadlessRuntimeSelection =
 	  }
 	| {
 			kind: "legacy";
-			flag: typeof LEGACY_HEADLESS_RUNTIME_FLAG;
+			source: typeof LEGACY_HEADLESS_RUNTIME_ENV;
 			runtimeId: typeof LEGACY_HEADLESS_RUNTIME_ID;
 			event: typeof LEGACY_HEADLESS_RUNTIME_EVENT;
 	  };
@@ -20,14 +20,21 @@ export interface RuntimeSelectionLogger {
 	info(message: string, context?: Record<string, unknown>): void;
 }
 
-export function isHeadlessModeRequested(
-	args: Pick<Args, "headless" | "mode">,
-): boolean {
+type HeadlessModeArgs = {
+	headless?: boolean;
+	mode?: string;
+};
+
+type HeadlessDispatchArgs = HeadlessModeArgs & {
+	command?: string;
+};
+
+export function isHeadlessModeRequested(args: HeadlessModeArgs): boolean {
 	return args.headless === true || args.mode === "headless";
 }
 
 export function willDispatchHeadlessRuntime(
-	args: Pick<Args, "command" | "headless" | "mode">,
+	args: HeadlessDispatchArgs,
 ): boolean {
 	return (
 		isHeadlessModeRequested(args) &&
@@ -36,18 +43,24 @@ export function willDispatchHeadlessRuntime(
 }
 
 export function selectHeadlessRuntime(
-	args: Pick<Args, "legacyRuntime">,
+	env: NodeJS.ProcessEnv = process.env,
 ): HeadlessRuntimeSelection {
-	if (!args.legacyRuntime) {
+	if (!isLegacyHeadlessRuntimeRequested(env)) {
 		return { kind: "current" };
 	}
 
 	return {
 		kind: "legacy",
-		flag: LEGACY_HEADLESS_RUNTIME_FLAG,
+		source: LEGACY_HEADLESS_RUNTIME_ENV,
 		runtimeId: LEGACY_HEADLESS_RUNTIME_ID,
 		event: LEGACY_HEADLESS_RUNTIME_EVENT,
 	};
+}
+
+export function isLegacyHeadlessRuntimeRequested(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	return env[LEGACY_HEADLESS_RUNTIME_ENV] === LEGACY_HEADLESS_RUNTIME_ENV_VALUE;
 }
 
 export function recordHeadlessRuntimeSelection(
@@ -59,8 +72,8 @@ export function recordHeadlessRuntimeSelection(
 	}
 
 	logger.info(selection.event, {
-		flag: selection.flag,
 		runtime: selection.runtimeId,
+		source: selection.source,
 		surface: "headless",
 	});
 }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -48,6 +48,7 @@ export interface HelpOptions {
 }
 
 export function printHelp(version: string, options_: HelpOptions = {}) {
+	void options_;
 	const header = `${heading("Maestro")} ${muted(
 		`v${version} by EvalOps — AI coding assistant with read, list, search, diff, bash, edit, write, todo tools`,
 	)}`;
@@ -77,15 +78,6 @@ export function printHelp(version: string, options_: HelpOptions = {}) {
 	]
 		.map((line) => `  ${muted(line)}`)
 		.join("\n")}`;
-	const hiddenOptions =
-		options_.hidden === true
-			? `${sectionHeading("Hidden Support Flags")}${muted(
-					`  --legacy-runtime       Use the previous headless runtime during a protocol cutover window
-
-  Hidden flags are support and release-note escape hatches. They are intentionally
-  omitted from default help and are not stable automation surfaces.`,
-				)}`
-			: null;
 	const examples = `${sectionHeading("Examples")}${muted(
 		`  # Interactive mode (no messages = interactive TUI)
   maestro
@@ -272,7 +264,6 @@ export function printHelp(version: string, options_: HelpOptions = {}) {
 			header,
 			usage,
 			options,
-			hiddenOptions,
 			examples,
 			env,
 			execSection,

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,6 +122,7 @@ import {
 } from "./cli/commands/exec.js";
 import {
 	isHeadlessModeRequested,
+	isLegacyHeadlessRuntimeRequested,
 	recordHeadlessRuntimeSelection,
 	selectHeadlessRuntime,
 	willDispatchHeadlessRuntime,
@@ -504,17 +505,18 @@ export async function main(args: string[]) {
 
 	const isHeadlessMode = isHeadlessModeRequested(parsed);
 	const willDispatchHeadlessMode = willDispatchHeadlessRuntime(parsed);
-	if (parsed.legacyRuntime && !isHeadlessMode) {
+	const legacyHeadlessRuntimeRequested = isLegacyHeadlessRuntimeRequested();
+	if (legacyHeadlessRuntimeRequested && !isHeadlessMode) {
 		console.error(
-			chalk.red("--legacy-runtime can only be used with --headless mode"),
+			chalk.red("Legacy headless runtime selection requires headless mode"),
 		);
 		await waitForStartupTelemetryForImmediateExit(startupTelemetry);
 		process.exit(1);
 	}
-	if (parsed.legacyRuntime && !willDispatchHeadlessMode) {
+	if (legacyHeadlessRuntimeRequested && !willDispatchHeadlessMode) {
 		console.error(
 			chalk.red(
-				"--legacy-runtime can only be used when Maestro dispatches headless mode. Remove the command or use `maestro exec --mode=headless --legacy-runtime`.",
+				"Legacy headless runtime selection requires Maestro-dispatched headless mode",
 			),
 		);
 		await waitForStartupTelemetryForImmediateExit(startupTelemetry);
@@ -624,7 +626,7 @@ export async function main(args: string[]) {
 		pipeProcessEventsToLogger();
 	}
 
-	const headlessRuntimeSelection = selectHeadlessRuntime(parsed);
+	const headlessRuntimeSelection = selectHeadlessRuntime();
 	recordHeadlessRuntimeSelection(headlessRuntimeSelection);
 
 	const runtimeConfig = loadRuntimeConfig(parsed, process.cwd());

--- a/src/telemetry/cli-startup.ts
+++ b/src/telemetry/cli-startup.ts
@@ -1,3 +1,4 @@
+import { isLegacyHeadlessRuntimeRequested } from "../cli/headless-runtime-selection.js";
 import { emitBeacon } from "./beacon.js";
 import { getGlobalCliCommandAggregator } from "./cli-command-aggregator.js";
 
@@ -8,7 +9,6 @@ export interface CliStartupArgs {
 	help?: boolean;
 	error?: string;
 	headless?: boolean;
-	legacyRuntime?: boolean;
 	mode?: "text" | "json" | "rpc" | "headless";
 	messages: string[];
 }
@@ -75,7 +75,7 @@ export async function recordCliStartupTelemetry(
 						command,
 						mode,
 						hasPrompt: options.args.messages.length > 0,
-						legacyRuntimeRequested: options.args.legacyRuntime === true,
+						legacyRuntimeRequested: isLegacyHeadlessRuntimeRequested(env),
 						argCount: options.rawArgs?.length ?? 0,
 					},
 				},

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -41,7 +41,7 @@ describe("parseArgs", () => {
 		});
 	});
 
-	it("parses hidden support help and legacy headless runtime flags", () => {
+	it("parses hidden support help and rejects legacy runtime as a CLI flag", () => {
 		expect(parseArgs(["--help", "--hidden"])).toMatchObject({
 			help: true,
 			hiddenHelp: true,
@@ -49,7 +49,8 @@ describe("parseArgs", () => {
 		expect(parseArgs(["--headless", "--legacy-runtime"])).toMatchObject({
 			headless: true,
 			mode: "headless",
-			legacyRuntime: true,
+			legacyRuntimeCliRequested: true,
+			error: "Legacy headless runtime selection is not available from the CLI",
 		});
 	});
 

--- a/test/cli/cli.integration.test.ts
+++ b/test/cli/cli.integration.test.ts
@@ -749,7 +749,7 @@ describe("CLI integration", () => {
 		exitSpy.mockRestore();
 	});
 
-	it("rejects legacy runtime flag before non-headless command dispatch", async () => {
+	it("rejects legacy runtime as a CLI flag", async () => {
 		const exitCodes: number[] = [];
 		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
 			exitCodes.push(Number(code ?? 0));
@@ -764,10 +764,7 @@ describe("CLI integration", () => {
 		expect(exitCodes).toEqual([1, 1]);
 		const combined = output.join("\n");
 		expect(combined).toContain(
-			"--legacy-runtime can only be used with --headless mode",
-		);
-		expect(combined).toContain(
-			"--legacy-runtime can only be used when Maestro dispatches headless mode",
+			"Legacy headless runtime selection is not available from the CLI",
 		);
 		exitSpy.mockRestore();
 	});

--- a/test/cli/headless-runtime-selection.test.ts
+++ b/test/cli/headless-runtime-selection.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+	LEGACY_HEADLESS_RUNTIME_ENV,
+	LEGACY_HEADLESS_RUNTIME_ENV_VALUE,
 	LEGACY_HEADLESS_RUNTIME_EVENT,
-	LEGACY_HEADLESS_RUNTIME_FLAG,
 	LEGACY_HEADLESS_RUNTIME_ID,
 	isHeadlessModeRequested,
 	recordHeadlessRuntimeSelection,
@@ -14,10 +15,14 @@ describe("headless runtime selection", () => {
 		expect(selectHeadlessRuntime({})).toEqual({ kind: "current" });
 	});
 
-	it("selects the legacy runtime for the hidden escape flag", () => {
-		expect(selectHeadlessRuntime({ legacyRuntime: true })).toEqual({
+	it("selects the legacy runtime for the internal cutover gate", () => {
+		expect(
+			selectHeadlessRuntime({
+				[LEGACY_HEADLESS_RUNTIME_ENV]: LEGACY_HEADLESS_RUNTIME_ENV_VALUE,
+			}),
+		).toEqual({
 			kind: "legacy",
-			flag: LEGACY_HEADLESS_RUNTIME_FLAG,
+			source: LEGACY_HEADLESS_RUNTIME_ENV,
 			runtimeId: LEGACY_HEADLESS_RUNTIME_ID,
 			event: LEGACY_HEADLESS_RUNTIME_EVENT,
 		});
@@ -30,14 +35,16 @@ describe("headless runtime selection", () => {
 		expect(logger.info).not.toHaveBeenCalled();
 
 		recordHeadlessRuntimeSelection(
-			selectHeadlessRuntime({ legacyRuntime: true }),
+			selectHeadlessRuntime({
+				[LEGACY_HEADLESS_RUNTIME_ENV]: LEGACY_HEADLESS_RUNTIME_ENV_VALUE,
+			}),
 			logger,
 		);
 
 		expect(logger.info).toHaveBeenCalledOnce();
 		expect(logger.info).toHaveBeenCalledWith(LEGACY_HEADLESS_RUNTIME_EVENT, {
-			flag: LEGACY_HEADLESS_RUNTIME_FLAG,
 			runtime: LEGACY_HEADLESS_RUNTIME_ID,
+			source: LEGACY_HEADLESS_RUNTIME_ENV,
 			surface: "headless",
 		});
 	});

--- a/test/cli/help.test.ts
+++ b/test/cli/help.test.ts
@@ -16,13 +16,13 @@ describe("printHelp", () => {
 		expect(output).not.toContain("Hidden Support Flags");
 	});
 
-	it("shows hidden support flags when requested", () => {
+	it("does not expose internal cutover controls in hidden help", () => {
 		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
 		printHelp("0.0.0", { hidden: true });
 
 		const output = log.mock.calls.map((call) => call.join(" ")).join("\n");
-		expect(output).toContain("Hidden Support Flags");
-		expect(output).toContain("--legacy-runtime");
+		expect(output).not.toContain("Hidden Support Flags");
+		expect(output).not.toContain("--legacy-runtime");
 	});
 });

--- a/test/telemetry/cli-command-aggregator.test.ts
+++ b/test/telemetry/cli-command-aggregator.test.ts
@@ -393,6 +393,43 @@ describe("CLI command telemetry aggregator", () => {
 		});
 	});
 
+	it("records legacy runtime startup metadata through the canonical selector", async () => {
+		const { LEGACY_HEADLESS_RUNTIME_ENV, LEGACY_HEADLESS_RUNTIME_ENV_VALUE } =
+			await import("../../src/cli/headless-runtime-selection.js");
+		const { recordCliStartupTelemetry } = await import(
+			"../../src/telemetry/cli-startup.js"
+		);
+
+		await recordCliStartupTelemetry({
+			args: {
+				headless: true,
+				messages: [],
+			},
+			clientVersion: "0.10.18",
+			rawArgs: ["--headless"],
+			now: () => now,
+			env: {
+				...process.env,
+				[LEGACY_HEADLESS_RUNTIME_ENV]: LEGACY_HEADLESS_RUNTIME_ENV_VALUE,
+			},
+		});
+
+		const [startupEvent] = JSON.parse(
+			(await readFile(beaconFile, "utf8")).trim(),
+		) as [
+			{
+				parameters?: {
+					metadata?: Record<string, unknown>;
+				};
+			},
+		];
+
+		expect(startupEvent.parameters?.metadata).toMatchObject({
+			command: "headless",
+			legacyRuntimeRequested: true,
+		});
+	});
+
 	it("records default prompt startup mode as text", async () => {
 		const { recordCliStartupTelemetry } = await import(
 			"../../src/telemetry/cli-startup.js"


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `b9b1e09235775d1ad79a697770a65ffabd49af4b`
- last generated public sync base: `7b14e944223430d01a63e09acbbfb706b358e12f`
- previewed public-tree drift: `12` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (b9b1e0923577)`
- public projection: `https://github.com/evalops/maestro@main (7b14e9442234)`
- files to copy or update: `12`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/design/HEADLESS_PROTOCOL_VERSIONING.md
- copy/update packages/ai/tsconfig.build.json
- copy/update src/cli/args.ts
- copy/update src/cli/headless-runtime-selection.ts
- copy/update src/cli/help.ts
- copy/update src/main.ts
- copy/update src/telemetry/cli-startup.ts
- copy/update test/cli/args.test.ts
- copy/update test/cli/cli.integration.test.ts
- copy/update test/cli/headless-runtime-selection.test.ts
- copy/update test/cli/help.test.ts
- copy/update test/telemetry/cli-command-aggregator.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/design/HEADLESS_PROTOCOL_VERSIONING.md
- copy/update packages/ai/tsconfig.build.json
- copy/update src/cli/args.ts
- copy/update src/cli/headless-runtime-selection.ts
- copy/update src/cli/help.ts
- copy/update src/main.ts
- copy/update src/telemetry/cli-startup.ts
- copy/update test/cli/args.test.ts
- copy/update test/cli/cli.integration.test.ts
- copy/update test/cli/headless-runtime-selection.test.ts
- copy/update test/cli/help.test.ts
- copy/update test/telemetry/cli-command-aggregator.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #376 to internal source `b9b1e09235775d1ad79a697770a65ffabd49af4b`