### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/design/HEADLESS_PROTOCOL_VERSIONING.md
+++ b/docs/design/HEADLESS_PROTOCOL_VERSIONING.md
@@ -12,8 +12,10 @@ cutover window, but user-facing commands must keep the normal headless shape:
 `maestro --headless` or `maestro exec --mode=headless`.
 
 The internal gate is only honored when Maestro is already dispatching headless
-mode. When present, Maestro selects the previous headless runtime adapter for the
-cutover window and emits one info-level log event:
+mode. If it is exported broadly, unrelated commands continue to use their normal
+runtime path. When present for a headless dispatch, Maestro selects the previous
+headless runtime adapter for the cutover window and emits one info-level log
+event:
 
 ```text
 runtime_legacy_selected

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -14,8 +14,6 @@ export interface Args {
 	continue?: boolean;
 	resume?: boolean;
 	help?: boolean;
-	/** Show support-only flags in help output. */
-	hiddenHelp?: boolean;
 	version?: boolean;
 	mode?: Mode;
 	/** Run in headless mode for native TUI communication */
@@ -146,8 +144,6 @@ export function parseArgs(args: string[]): Args {
 
 		if (arg === "--help" || arg === "-h") {
 			result.help = true;
-		} else if (arg === "--hidden") {
-			result.hiddenHelp = true;
 		} else if (arg === "--version" || arg === "-v") {
 			result.version = true;
 		} else if (arg?.startsWith("--mode=")) {

--- a/src/cli/headless-runtime-selection.ts
+++ b/src/cli/headless-runtime-selection.ts
@@ -42,10 +42,17 @@ export function willDispatchHeadlessRuntime(
 	);
 }
 
+export function isLegacyHeadlessRuntimeRequested(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	return env[LEGACY_HEADLESS_RUNTIME_ENV] === LEGACY_HEADLESS_RUNTIME_ENV_VALUE;
+}
+
 export function selectHeadlessRuntime(
 	env: NodeJS.ProcessEnv = process.env,
+	options: { allowLegacy?: boolean } = {},
 ): HeadlessRuntimeSelection {
-	if (!isLegacyHeadlessRuntimeRequested(env)) {
+	if (options.allowLegacy !== true || !isLegacyHeadlessRuntimeRequested(env)) {
 		return { kind: "current" };
 	}
 
@@ -55,12 +62,6 @@ export function selectHeadlessRuntime(
 		runtimeId: LEGACY_HEADLESS_RUNTIME_ID,
 		event: LEGACY_HEADLESS_RUNTIME_EVENT,
 	};
-}
-
-export function isLegacyHeadlessRuntimeRequested(
-	env: NodeJS.ProcessEnv = process.env,
-): boolean {
-	return env[LEGACY_HEADLESS_RUNTIME_ENV] === LEGACY_HEADLESS_RUNTIME_ENV_VALUE;
 }
 
 export function recordHeadlessRuntimeSelection(

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -43,12 +43,7 @@ import { badge, heading, muted, sectionHeading } from "../style/theme.js";
  * }
  * ```
  */
-export interface HelpOptions {
-	hidden?: boolean;
-}
-
-export function printHelp(version: string, options_: HelpOptions = {}) {
-	void options_;
+export function printHelp(version: string) {
 	const header = `${heading("Maestro")} ${muted(
 		`v${version} by EvalOps — AI coding assistant with read, list, search, diff, bash, edit, write, todo tools`,
 	)}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,7 +122,6 @@ import {
 } from "./cli/commands/exec.js";
 import {
 	isHeadlessModeRequested,
-	isLegacyHeadlessRuntimeRequested,
 	recordHeadlessRuntimeSelection,
 	selectHeadlessRuntime,
 	willDispatchHeadlessRuntime,
@@ -492,7 +491,7 @@ export async function main(args: string[]) {
 
 	// Handle --help early exit (before any logging redirection or heavy init)
 	if (parsed.help) {
-		printHelp(VERSION, { hidden: parsed.hiddenHelp });
+		printHelp(VERSION);
 		await waitForStartupTelemetryForImmediateExit(startupTelemetry);
 		process.exit(0);
 	}
@@ -505,23 +504,6 @@ export async function main(args: string[]) {
 
 	const isHeadlessMode = isHeadlessModeRequested(parsed);
 	const willDispatchHeadlessMode = willDispatchHeadlessRuntime(parsed);
-	const legacyHeadlessRuntimeRequested = isLegacyHeadlessRuntimeRequested();
-	if (legacyHeadlessRuntimeRequested && !isHeadlessMode) {
-		console.error(
-			chalk.red("Legacy headless runtime selection requires headless mode"),
-		);
-		await waitForStartupTelemetryForImmediateExit(startupTelemetry);
-		process.exit(1);
-	}
-	if (legacyHeadlessRuntimeRequested && !willDispatchHeadlessMode) {
-		console.error(
-			chalk.red(
-				"Legacy headless runtime selection requires Maestro-dispatched headless mode",
-			),
-		);
-		await waitForStartupTelemetryForImmediateExit(startupTelemetry);
-		process.exit(1);
-	}
 
 	const exitWithEarlyStartupError = (error: unknown): never => {
 		const message = error instanceof Error ? error.message : String(error);
@@ -626,7 +608,9 @@ export async function main(args: string[]) {
 		pipeProcessEventsToLogger();
 	}
 
-	const headlessRuntimeSelection = selectHeadlessRuntime();
+	const headlessRuntimeSelection = selectHeadlessRuntime(process.env, {
+		allowLegacy: willDispatchHeadlessMode,
+	});
 	recordHeadlessRuntimeSelection(headlessRuntimeSelection);
 
 	const runtimeConfig = loadRuntimeConfig(parsed, process.cwd());

--- a/src/telemetry/cli-startup.ts
+++ b/src/telemetry/cli-startup.ts
@@ -1,4 +1,7 @@
-import { isLegacyHeadlessRuntimeRequested } from "../cli/headless-runtime-selection.js";
+import {
+	isLegacyHeadlessRuntimeRequested,
+	willDispatchHeadlessRuntime,
+} from "../cli/headless-runtime-selection.js";
 import { emitBeacon } from "./beacon.js";
 import { getGlobalCliCommandAggregator } from "./cli-command-aggregator.js";
 
@@ -75,7 +78,9 @@ export async function recordCliStartupTelemetry(
 						command,
 						mode,
 						hasPrompt: options.args.messages.length > 0,
-						legacyRuntimeRequested: isLegacyHeadlessRuntimeRequested(env),
+						legacyRuntimeRequested:
+							willDispatchHeadlessRuntime(options.args) &&
+							isLegacyHeadlessRuntimeRequested(env),
 						argCount: options.rawArgs?.length ?? 0,
 					},
 				},

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -41,11 +41,7 @@ describe("parseArgs", () => {
 		});
 	});
 
-	it("parses hidden support help and rejects legacy runtime as a CLI flag", () => {
-		expect(parseArgs(["--help", "--hidden"])).toMatchObject({
-			help: true,
-			hiddenHelp: true,
-		});
+	it("rejects legacy runtime as a CLI flag", () => {
 		expect(parseArgs(["--headless", "--legacy-runtime"])).toMatchObject({
 			headless: true,
 			mode: "headless",

--- a/test/cli/cli.integration.test.ts
+++ b/test/cli/cli.integration.test.ts
@@ -774,11 +774,13 @@ describe("CLI integration", () => {
 		const originalBeaconFile = process.env.MAESTRO_BEACON_FILE;
 		const originalBufferFile =
 			process.env.MAESTRO_CLI_COMMAND_BEACON_BUFFER_FILE;
+		const originalLegacyRuntime = process.env.MAESTRO_INTERNAL_HEADLESS_RUNTIME;
 		const beaconFile = join(tempAgentDir, "models-beacon.jsonl");
 		const bufferFile = join(tempAgentDir, "models-command-buffer.json");
 		process.env.MAESTRO_TELEMETRY = "1";
 		process.env.MAESTRO_BEACON_FILE = beaconFile;
 		process.env.MAESTRO_CLI_COMMAND_BEACON_BUFFER_FILE = bufferFile;
+		process.env.MAESTRO_INTERNAL_HEADLESS_RUNTIME = "legacy";
 		const exitCodes: number[] = [];
 		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
 			exitCodes.push(Number(code ?? 0));
@@ -792,13 +794,24 @@ describe("CLI integration", () => {
 			await waitForFile(bufferFile);
 			const [startupEvent] = JSON.parse(
 				readFileSync(beaconFile, "utf8").trim(),
-			) as [{ feature: string; action: string }];
+			) as [
+				{
+					feature: string;
+					action: string;
+					parameters?: { metadata?: Record<string, unknown> };
+				},
+			];
 			const commandBuffer = JSON.parse(readFileSync(bufferFile, "utf8")) as {
 				counts: Record<string, number>;
 			};
 			expect(startupEvent).toMatchObject({
 				feature: "cli.startup",
 				action: "models.providers",
+				parameters: {
+					metadata: {
+						legacyRuntimeRequested: false,
+					},
+				},
 			});
 			expect(commandBuffer.counts).toEqual({
 				"cli.command.models.providers": 1,
@@ -821,6 +834,14 @@ describe("CLI integration", () => {
 				);
 			} else {
 				process.env.MAESTRO_CLI_COMMAND_BEACON_BUFFER_FILE = originalBufferFile;
+			}
+			if (originalLegacyRuntime === undefined) {
+				Reflect.deleteProperty(
+					process.env,
+					"MAESTRO_INTERNAL_HEADLESS_RUNTIME",
+				);
+			} else {
+				process.env.MAESTRO_INTERNAL_HEADLESS_RUNTIME = originalLegacyRuntime;
 			}
 			exitSpy.mockRestore();
 		}

--- a/test/cli/headless-runtime-selection.test.ts
+++ b/test/cli/headless-runtime-selection.test.ts
@@ -17,15 +17,26 @@ describe("headless runtime selection", () => {
 
 	it("selects the legacy runtime for the internal cutover gate", () => {
 		expect(
-			selectHeadlessRuntime({
-				[LEGACY_HEADLESS_RUNTIME_ENV]: LEGACY_HEADLESS_RUNTIME_ENV_VALUE,
-			}),
+			selectHeadlessRuntime(
+				{
+					[LEGACY_HEADLESS_RUNTIME_ENV]: LEGACY_HEADLESS_RUNTIME_ENV_VALUE,
+				},
+				{ allowLegacy: true },
+			),
 		).toEqual({
 			kind: "legacy",
 			source: LEGACY_HEADLESS_RUNTIME_ENV,
 			runtimeId: LEGACY_HEADLESS_RUNTIME_ID,
 			event: LEGACY_HEADLESS_RUNTIME_EVENT,
 		});
+	});
+
+	it("ignores the internal cutover gate until headless dispatch allows it", () => {
+		expect(
+			selectHeadlessRuntime({
+				[LEGACY_HEADLESS_RUNTIME_ENV]: LEGACY_HEADLESS_RUNTIME_ENV_VALUE,
+			}),
+		).toEqual({ kind: "current" });
 	});
 
 	it("emits one measurable info event only when legacy runtime is selected", () => {
@@ -35,9 +46,12 @@ describe("headless runtime selection", () => {
 		expect(logger.info).not.toHaveBeenCalled();
 
 		recordHeadlessRuntimeSelection(
-			selectHeadlessRuntime({
-				[LEGACY_HEADLESS_RUNTIME_ENV]: LEGACY_HEADLESS_RUNTIME_ENV_VALUE,
-			}),
+			selectHeadlessRuntime(
+				{
+					[LEGACY_HEADLESS_RUNTIME_ENV]: LEGACY_HEADLESS_RUNTIME_ENV_VALUE,
+				},
+				{ allowLegacy: true },
+			),
 			logger,
 		);
 

--- a/test/cli/help.test.ts
+++ b/test/cli/help.test.ts
@@ -15,14 +15,4 @@ describe("printHelp", () => {
 		expect(output).not.toContain("--legacy-runtime");
 		expect(output).not.toContain("Hidden Support Flags");
 	});
-
-	it("does not expose internal cutover controls in hidden help", () => {
-		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-
-		printHelp("0.0.0", { hidden: true });
-
-		const output = log.mock.calls.map((call) => call.join(" ")).join("\n");
-		expect(output).not.toContain("Hidden Support Flags");
-		expect(output).not.toContain("--legacy-runtime");
-	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `28b83eb974343553d88924d60b1c80c51a4bb004`
- last generated public sync base: `91f2d3c7d7e0e94240d1da4a44aa0ec1f5504dda`
- previewed public-tree drift: `10` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (28b83eb97434)`
- public projection: `https://github.com/evalops/maestro@main (91f2d3c7d7e0)`
- files to copy or update: `10`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/design/HEADLESS_PROTOCOL_VERSIONING.md
- copy/update src/cli/args.ts
- copy/update src/cli/headless-runtime-selection.ts
- copy/update src/cli/help.ts
- copy/update src/main.ts
- copy/update src/telemetry/cli-startup.ts
- copy/update test/cli/args.test.ts
- copy/update test/cli/cli.integration.test.ts
- copy/update test/cli/headless-runtime-selection.test.ts
- copy/update test/cli/help.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/design/HEADLESS_PROTOCOL_VERSIONING.md
- copy/update src/cli/args.ts
- copy/update src/cli/headless-runtime-selection.ts
- copy/update src/cli/help.ts
- copy/update src/main.ts
- copy/update src/telemetry/cli-startup.ts
- copy/update test/cli/args.test.ts
- copy/update test/cli/cli.integration.test.ts
- copy/update test/cli/headless-runtime-selection.test.ts
- copy/update test/cli/help.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode