### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 - [ ] `make lint` (or `bun run bun:lint`)
 - [ ] `make test` (or `npx nx run maestro:test --skip-nx-cache`)
 - [ ] Built any touched packages (e.g., `make build-all`)
+- [ ] If this PR adds or promotes user-visible behavior, explain the staged-rollout choice (or why staging is unnecessary).
 
 ## Optional
 

--- a/docs/CONVENTIONS/staged-rollout.md
+++ b/docs/CONVENTIONS/staged-rollout.md
@@ -1,0 +1,76 @@
+# Staged Rollout Convention
+
+Maestro changes that add risky behavior should ship in deployable stages:
+
+1. **Enabling primitive**: the protocol field, runtime path, mode catalog entry,
+   config parser, or backend handler exists and can be exercised safely.
+2. **Limited exercise**: internal usage, tenant-scoped feature flags, or
+   controlled automation exercises the primitive before broad exposure.
+3. **User-visible promotion**: help text, docs, UI, and default behavior expose
+   the feature after the primitive has production evidence.
+
+Do not skip directly to user-visible behavior when the change affects protocol
+shape, runtime dispatch, command surface, agent modes, config compatibility, or
+cross-version client behavior.
+
+## Choosing A Gate
+
+Use the smallest gate that matches the blast radius:
+
+- **Internal env/config primitive**: internal cutovers, runtime swaps, protocol
+  escapes, and support-only migration controls. These must not appear in public
+  help, onboarding docs, stable automation examples, or bespoke CLI parser
+  branches.
+- **Tenant/runtime feature flag**: per-org or per-user rollout where the same
+  binary needs different behavior for different customers. Use `flag-control`
+  or the managed rollout snapshot path.
+- **Hidden user command or mode**: only for features we explicitly want power
+  users or support to invoke from the external CLI before promotion. Hidden
+  commands are still external surface area, so they need telemetry, an owner,
+  and a planned promotion or removal date.
+
+Runtime escape switches for headless protocol cutovers use the internal
+env/config primitive path, not a hidden CLI flag. The old runtime can remain
+compiled in, but the selector must only honor the internal gate at the runtime
+dispatch boundary.
+
+## When Staging Is Required
+
+Use staged rollout for:
+
+- Protocol changes or capability negotiation changes.
+- Runtime swaps, compatibility adapters, or fallback paths.
+- Agent mode additions, mode visibility changes, or cross-model dispatch.
+- New CLI commands, new command groups, or behavior-changing flags.
+- Breaking config changes or migrations with user-visible fallout.
+
+Staging is usually unnecessary for:
+
+- Pure bug fixes with no new behavior.
+- Internal refactors that preserve public contracts.
+- Docs-only changes.
+- Single-tenant experiments that are already isolated by a tenant feature flag.
+
+## Promotion Rules
+
+Promotion to visible behavior should be a small PR that flips visibility or
+default selection after the primitive has evidence. Include one paragraph in the
+PR body with the evidence used for promotion: internal usage, telemetry, support
+exercise, CI coverage, or rollout results.
+
+Every long-lived hidden external surface must have an owner and one of:
+
+- a target promotion version,
+- a target removal version, or
+- an `indefinite-internal` label with rationale.
+
+## PR Checklist Prompt
+
+For PRs that add or promote user-visible behavior, answer:
+
+> Did this need staged rollout? If not, why is direct exposure safe?
+
+For PRs that add internal cutover controls, also answer:
+
+> Is the control implemented as an internal env/config primitive rather than an
+> external CLI/help surface?

--- a/scripts/check-drift-prone-surfaces.mjs
+++ b/scripts/check-drift-prone-surfaces.mjs
@@ -95,6 +95,14 @@ if (!slackRuntime.includes("./platform-env.js")) {
 	failures.push("packages/slack-agent/src/platform-runtime.ts must use platform-env.ts");
 }
 
+const mainSource = read("src/main.ts");
+const validateCodexFlagCalls = mainSource.match(/\bvalidateCodexFlags\(/g) ?? [];
+if (validateCodexFlagCalls.length !== 1) {
+	failures.push(
+		`src/main.ts must validate legacy Codex flags once at startup, found ${validateCodexFlagCalls.length} calls`,
+	);
+}
+
 if (failures.length > 0) {
 	console.error("drift-prone surface check failed:");
 	for (const failure of failures) {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -18,8 +18,6 @@ export interface Args {
 	mode?: Mode;
 	/** Run in headless mode for native TUI communication */
 	headless?: boolean;
-	/** Attempted to use a support-only runtime selector through CLI args. */
-	legacyRuntimeCliRequested?: boolean;
 	noSession?: boolean;
 	session?: string;
 	safeMode?: boolean;
@@ -120,6 +118,17 @@ const FLAGS_WITH_VALUES = new Set([
 	"--config",
 ]);
 
+const DEPRECATED_FLAGS_WITH_VALUES = new Set(["--codex-api-key"]);
+const DEPRECATED_FLAG_PREFIXES = ["--auth=chatgpt"];
+
+function isConfigInitPresetFlag(result: Args, arg: string): boolean {
+	return (
+		result.command === "config" &&
+		result.subcommand === "init" &&
+		(arg === "--preset" || arg === "-p")
+	);
+}
+
 function nextNonFlagToken(args: string[], start: number): string | undefined {
 	for (let index = start; index < args.length; index++) {
 		const token = args[index];
@@ -175,10 +184,6 @@ export function parseArgs(args: string[]): Args {
 		} else if (arg === "--headless") {
 			result.headless = true;
 			result.mode = "headless";
-		} else if (arg === "--legacy-runtime") {
-			result.legacyRuntimeCliRequested = true;
-			result.error =
-				"Legacy headless runtime selection is not available from the CLI";
 		} else if (arg === "--continue" || arg === "-c") {
 			result.continue = true;
 		} else if (arg === "--resume" || arg === "-r") {
@@ -296,7 +301,28 @@ export function parseArgs(args: string[]): Args {
 				result.configOverrides = [];
 			}
 			result.configOverrides.push(override);
-		} else if (arg && !arg.startsWith("-")) {
+		} else if (arg && DEPRECATED_FLAGS_WITH_VALUES.has(arg)) {
+			// Preserve the later migration error from validateCodexFlags().
+			const nextArg = args[i + 1];
+			if (nextArg && !nextArg.startsWith("-") && !COMMANDS.has(nextArg)) {
+				i++;
+			}
+		} else if (
+			arg &&
+			(Array.from(DEPRECATED_FLAGS_WITH_VALUES).some((flag) =>
+				arg.startsWith(`${flag}=`),
+			) ||
+				DEPRECATED_FLAG_PREFIXES.some((flag) => arg.startsWith(flag)))
+		) {
+			// Preserve the later migration error from validateCodexFlags().
+		} else if (arg && isConfigInitPresetFlag(result, arg)) {
+			const nextArg = args[i + 1];
+			if (nextArg && !nextArg.startsWith("-")) {
+				i++;
+			}
+		} else if (arg?.startsWith("-")) {
+			result.error = `Unknown option: ${arg}`;
+		} else if (arg) {
 			const nextArg = args[i + 1];
 			const isCommandToken =
 				COMMANDS.has(arg) &&

--- a/src/main.ts
+++ b/src/main.ts
@@ -507,9 +507,26 @@ export async function main(args: string[]) {
 
 	const exitWithEarlyStartupError = (error: unknown): never => {
 		const message = error instanceof Error ? error.message : String(error);
-		console.error(chalk.red(message));
+		if (isHeadlessMode) {
+			process.stdout.write(
+				`${JSON.stringify({
+					type: "error",
+					message: `Headless startup failed: ${message}`,
+					fatal: true,
+					error_type: "fatal",
+				})}\n`,
+			);
+		} else {
+			console.error(chalk.red(message));
+		}
 		process.exit(1);
 	};
+
+	try {
+		validateCodexFlags(args, parsed.help ? "help" : parsed.command);
+	} catch (error) {
+		exitWithEarlyStartupError(error);
+	}
 
 	// Handle `maestro hosted-runner` before importing web-server so hosted
 	// defaults are visible to its module-level runtime profile.
@@ -548,36 +565,18 @@ export async function main(args: string[]) {
 	// progress or diagnostic output on stderr, so route it before config loading
 	// can emit normal CLI startup logs.
 	if (parsed.command === "init") {
-		try {
-			validateCodexFlags(args, parsed.command);
-		} catch (error) {
-			exitWithEarlyStartupError(error);
-		}
-
 		const { handleInitCommand } = await import("./cli/commands/init.js");
 		await handleInitCommand(parsed.commandArgs ?? []);
 		return;
 	}
 
 	if (parsed.command === "status") {
-		try {
-			validateCodexFlags(args, parsed.command);
-		} catch (error) {
-			exitWithEarlyStartupError(error);
-		}
-
 		const { handleStatusCommand } = await import("./cli/commands/status.js");
 		await handleStatusCommand();
 		return;
 	}
 
 	if (parsed.command === "context") {
-		try {
-			validateCodexFlags(args, parsed.command);
-		} catch (error) {
-			exitWithEarlyStartupError(error);
-		}
-
 		const { handleContextCommand } = await import("./cli/commands/context.js");
 		await handleContextCommand(parsed.subcommand, parsed.messages, {
 			json: parsed.execJson,
@@ -719,12 +718,6 @@ export async function main(args: string[]) {
 	// - api-key: Require explicit API key from --api-key or env var
 	// - claude: Force Anthropic OAuth (no API key fallback)
 	const authMode: AuthMode = parsed.authMode ?? "auto";
-
-	try {
-		validateCodexFlags(args, parsed.command);
-	} catch (error) {
-		exitWithStartupError(error);
-	}
 
 	const { requireCredential } = createAuthSetup({
 		authMode,

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -41,13 +41,53 @@ describe("parseArgs", () => {
 		});
 	});
 
-	it("rejects legacy runtime as a CLI flag", () => {
+	it("rejects unknown CLI flags before they become support surfaces", () => {
 		expect(parseArgs(["--headless", "--legacy-runtime"])).toMatchObject({
 			headless: true,
 			mode: "headless",
-			legacyRuntimeCliRequested: true,
-			error: "Legacy headless runtime selection is not available from the CLI",
+			error: "Unknown option: --legacy-runtime",
 		});
+		expect(parseArgs(["--experimental-runtime"]).error).toBe(
+			"Unknown option: --experimental-runtime",
+		);
+	});
+
+	it("does not consume command tokens after deprecated value flags", () => {
+		expect(parseArgs(["--codex-api-key"]).error).toBeUndefined();
+		expect(parseArgs(["--codex-api-key", "--help"])).toMatchObject({
+			help: true,
+		});
+		expect(parseArgs(["--codex-api-key", "config", "show"])).toMatchObject({
+			command: "config",
+			subcommand: "show",
+		});
+	});
+
+	it("preserves config init preset flags for the config handler", () => {
+		const longForm = parseArgs(["config", "init", "--preset", "evalops"]);
+		expect(longForm).toMatchObject({
+			command: "config",
+			subcommand: "init",
+			messages: [],
+		});
+		expect(longForm.error).toBeUndefined();
+
+		const shortForm = parseArgs(["config", "init", "-p", "local"]);
+		expect(shortForm).toMatchObject({
+			command: "config",
+			subcommand: "init",
+			messages: [],
+		});
+		expect(shortForm.error).toBeUndefined();
+	});
+
+	it("still rejects unknown config init flags", () => {
+		expect(parseArgs(["config", "init", "--unknown"]).error).toBe(
+			"Unknown option: --unknown",
+		);
+		expect(parseArgs(["config", "init", "--preset=local"]).error).toBe(
+			"Unknown option: --preset=local",
+		);
 	});
 
 	it("parses export commands and formats", () => {

--- a/test/cli/cli.integration.test.ts
+++ b/test/cli/cli.integration.test.ts
@@ -9,6 +9,8 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { HeadlessErrorMessageSchema } from "@evalops/contracts";
+import { Value } from "@sinclair/typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearRegisteredHooks, registerHook } from "../../src/hooks/index.js";
 import { main } from "../../src/main.js";
@@ -749,7 +751,7 @@ describe("CLI integration", () => {
 		exitSpy.mockRestore();
 	});
 
-	it("rejects legacy runtime as a CLI flag", async () => {
+	it("rejects unknown flags before they become support surfaces", async () => {
 		const exitCodes: number[] = [];
 		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
 			exitCodes.push(Number(code ?? 0));
@@ -763,9 +765,7 @@ describe("CLI integration", () => {
 
 		expect(exitCodes).toEqual([1, 1]);
 		const combined = output.join("\n");
-		expect(combined).toContain(
-			"Legacy headless runtime selection is not available from the CLI",
-		);
+		expect(combined).toContain("Unknown option: --legacy-runtime");
 		exitSpy.mockRestore();
 	});
 
@@ -1088,6 +1088,22 @@ describe("CLI integration", () => {
 		exitSpy.mockRestore();
 	});
 
+	it("rejects equals-form ChatGPT auth flags with migration guidance", async () => {
+		const exitCodes: number[] = [];
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+			exitCodes.push(Number(code ?? 0));
+			throw new Error("exit");
+		});
+		await expect(
+			main(["--provider", "openai", "--model", "gpt-test", "--auth=chatgpt"]),
+		).rejects.toThrow("exit");
+		expect(exitCodes).toEqual([1]);
+		expect(output.join("\n")).toContain(
+			"Legacy Codex/ChatGPT auth flags are no longer supported",
+		);
+		exitSpy.mockRestore();
+	});
+
 	it("rejects Codex subscription tokens", async () => {
 		const exitCodes: number[] = [];
 		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
@@ -1104,6 +1120,57 @@ describe("CLI integration", () => {
 		exitSpy.mockRestore();
 	});
 
+	it("rejects bare Codex subscription token flags with migration guidance", async () => {
+		const exitCodes: number[] = [];
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+			exitCodes.push(Number(code ?? 0));
+			throw new Error("exit");
+		});
+		await expect(main(["--codex-api-key"])).rejects.toThrow("exit");
+		expect(exitCodes).toEqual([1]);
+		expect(output.join("\n")).toContain(
+			"Legacy Codex/ChatGPT auth flags are no longer supported",
+		);
+		exitSpy.mockRestore();
+	});
+
+	it("keeps early headless auth flag errors schema-compatible", async () => {
+		const exitCodes: number[] = [];
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+			exitCodes.push(Number(code ?? 0));
+			throw new Error("exit");
+		});
+		await expect(main(["--headless", "--codex-api-key"])).rejects.toThrow(
+			"exit",
+		);
+		expect(exitCodes).toEqual([1]);
+
+		const payload = JSON.parse(output.join(""));
+		expect(Value.Check(HeadlessErrorMessageSchema, payload)).toBe(true);
+		expect(payload).toMatchObject({
+			type: "error",
+			fatal: true,
+			error_type: "fatal",
+		});
+		expect(payload.message).toContain(
+			"Legacy Codex/ChatGPT auth flags are no longer supported",
+		);
+		expect(payload).not.toHaveProperty("stack");
+		exitSpy.mockRestore();
+	});
+
+	it("does not consume following options as deprecated auth flag values", async () => {
+		const exitCodes: number[] = [];
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+			exitCodes.push(Number(code ?? 0));
+			throw new Error("exit");
+		});
+		await expect(main(["--codex-api-key", "--help"])).rejects.toThrow("exit");
+		expect(exitCodes).toEqual([0]);
+		expect(output.join("\n")).toContain("Maestro");
+		exitSpy.mockRestore();
+	});
+
 	it("rejects legacy auth flags before status early exit", async () => {
 		const exitCodes: number[] = [];
 		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
@@ -1113,6 +1180,36 @@ describe("CLI integration", () => {
 		await expect(
 			main(["--codex-api-key", "codex-token", "status"]),
 		).rejects.toThrow("exit");
+		expect(exitCodes).toEqual([1]);
+		expect(output.join("\n")).toContain(
+			"Legacy Codex/ChatGPT auth flags are no longer supported",
+		);
+		exitSpy.mockRestore();
+	});
+
+	it("rejects legacy auth flags before hosted-runner early exit", async () => {
+		const exitCodes: number[] = [];
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+			exitCodes.push(Number(code ?? 0));
+			throw new Error("exit");
+		});
+		await expect(
+			main(["hosted-runner", "--codex-api-key", "codex-token"]),
+		).rejects.toThrow("exit");
+		expect(exitCodes).toEqual([1]);
+		expect(output.join("\n")).toContain(
+			"Legacy Codex/ChatGPT auth flags are no longer supported",
+		);
+		exitSpy.mockRestore();
+	});
+
+	it("rejects legacy auth flags before web early exit", async () => {
+		const exitCodes: number[] = [];
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+			exitCodes.push(Number(code ?? 0));
+			throw new Error("exit");
+		});
+		await expect(main(["web", "--auth", "chatgpt"])).rejects.toThrow("exit");
 		expect(exitCodes).toEqual([1]);
 		expect(output.join("\n")).toContain(
 			"Legacy Codex/ChatGPT auth flags are no longer supported",


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `b2724591e823f6c01bdb98036ef17c6b9b19598b`
- last generated public sync base: `d4930734a8fa952d4c159ae7d760e87a02b5ee80`
- previewed public-tree drift: `7` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (b2724591e823)`
- public projection: `https://github.com/evalops/maestro@main (d4930734a8fa)`
- files to copy or update: `7`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update .github/pull_request_template.md
- copy/update docs/CONVENTIONS/staged-rollout.md
- copy/update scripts/check-drift-prone-surfaces.mjs
- copy/update src/cli/args.ts
- copy/update src/main.ts
- copy/update test/cli/args.test.ts
- copy/update test/cli/cli.integration.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update .github/pull_request_template.md
- copy/update docs/CONVENTIONS/staged-rollout.md
- copy/update scripts/check-drift-prone-surfaces.mjs
- copy/update src/cli/args.ts
- copy/update src/main.ts
- copy/update test/cli/args.test.ts
- copy/update test/cli/cli.integration.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Supersedes

- updates existing generated public sync PR #378 to internal source `b2724591e823f6c01bdb98036ef17c6b9b19598b`