### PR TITLE
telemetry: emit explicit platform replay scenario ids

### DIFF
--- a/scripts/headless-protocol-codegen.mjs
+++ b/scripts/headless-protocol-codegen.mjs
@@ -44,6 +44,7 @@ const protoToExportKey = {
 	NotificationType: "notificationTypes",
 	ThinkingLevel: "thinkingLevels",
 	ApprovalMode: "approvalModes",
+	ExecutorType: "executorTypes",
 	ErrorType: "errorTypes",
 	UtilityOperation: "utilityOperations",
 	UtilityCommandStream: "utilityCommandStreams",
@@ -195,6 +196,9 @@ export type HeadlessThinkingLevel = (typeof headlessThinkingLevels)[number];
 
 export const headlessApprovalModes = ${toTsConst(protocolSpec.approvalModes)};
 export type HeadlessApprovalMode = (typeof headlessApprovalModes)[number];
+
+export const headlessExecutorTypes = ${toTsConst(protocolSpec.executorTypes)};
+export type HeadlessExecutorType = (typeof headlessExecutorTypes)[number];
 
 export const headlessErrorTypes = ${toTsConst(protocolSpec.errorTypes)};
 export type HeadlessErrorType = (typeof headlessErrorTypes)[number];

--- a/scripts/headless-protocol-codegen.mjs
+++ b/scripts/headless-protocol-codegen.mjs
@@ -44,7 +44,6 @@ const protoToExportKey = {
 	NotificationType: "notificationTypes",
 	ThinkingLevel: "thinkingLevels",
 	ApprovalMode: "approvalModes",
-	ExecutorType: "executorTypes",
 	ErrorType: "errorTypes",
 	UtilityOperation: "utilityOperations",
 	UtilityCommandStream: "utilityCommandStreams",
@@ -196,9 +195,6 @@ export type HeadlessThinkingLevel = (typeof headlessThinkingLevels)[number];
 
 export const headlessApprovalModes = ${toTsConst(protocolSpec.approvalModes)};
 export type HeadlessApprovalMode = (typeof headlessApprovalModes)[number];
-
-export const headlessExecutorTypes = ${toTsConst(protocolSpec.executorTypes)};
-export type HeadlessExecutorType = (typeof headlessExecutorTypes)[number];
 
 export const headlessErrorTypes = ${toTsConst(protocolSpec.errorTypes)};
 export type HeadlessErrorType = (typeof headlessErrorTypes)[number];

--- a/src/telemetry/maestro-platform-replay-fixture.ts
+++ b/src/telemetry/maestro-platform-replay-fixture.ts
@@ -54,6 +54,7 @@ const baseCorrelation: MaestroCorrelation = {
 	conversation_id: "conversation_platform_replay_001",
 	attributes: {
 		fixture: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+		scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
 	},
 };
 
@@ -233,6 +234,7 @@ function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
 				started_at: eventPlan[0].time,
 				metadata: {
 					fixture: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+					scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
 				},
 			},
 			0,
@@ -442,6 +444,7 @@ export function buildCanonicalMaestroPlatformReplayFixture(): MaestroPlatformRep
 			skill_tool_call_id: SKILL_TOOL_CALL_ID,
 			skill_tool_execution_id: SKILL_TOOL_EXECUTION_ID,
 			approval_request_id: APPROVAL_REQUEST_ID,
+			scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
 		},
 		subjects,
 		events,

--- a/src/telemetry/maestro-platform-replay-fixture.ts
+++ b/src/telemetry/maestro-platform-replay-fixture.ts
@@ -461,6 +461,7 @@ export function buildCanonicalMaestroPlatformReplayFixture(): MaestroPlatformRep
 				evaluation_tool_call_id: BASH_TOOL_CALL_ID,
 				evaluation_tool_execution_id: BASH_TOOL_EXECUTION_ID,
 				eval_run_id: "eval_run_platform_replay_001",
+				scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
 				skill_tool_call_id: SKILL_TOOL_CALL_ID,
 				skill_tool_execution_id: SKILL_TOOL_EXECUTION_ID,
 				skill_invocation_id: "invocation_platform_replay_skill_001",

--- a/test/telemetry/maestro-platform-replay-fixture.test.ts
+++ b/test/telemetry/maestro-platform-replay-fixture.test.ts
@@ -267,6 +267,7 @@ describe("canonical Maestro Platform replay fixture", () => {
 				evaluation_tool_call_id: "tool_call_platform_replay_bash_001",
 				evaluation_tool_execution_id: "tool_exec_platform_replay_bash_001",
 				eval_run_id: "eval_run_platform_replay_001",
+				scenario_id: "canonical-maestro-session-platform-replay",
 				skill_tool_call_id: "tool_call_platform_replay_skill_001",
 				skill_tool_execution_id: "tool_exec_platform_replay_skill_001",
 				skill_invocation_id: "invocation_platform_replay_skill_001",

--- a/test/telemetry/maestro-platform-replay-fixture.test.ts
+++ b/test/telemetry/maestro-platform-replay-fixture.test.ts
@@ -29,6 +29,7 @@ describe("canonical Maestro Platform replay fixture", () => {
 				skill_tool_call_id: "tool_call_platform_replay_skill_001",
 				skill_tool_execution_id: "tool_exec_platform_replay_skill_001",
 				approval_request_id: "approval_platform_replay_001",
+				scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
 			},
 		});
 
@@ -74,6 +75,9 @@ describe("canonical Maestro Platform replay fixture", () => {
 						agent_run_id: "agent_run_platform_replay_001",
 						trace_id: "trace_platform_replay_001",
 						request_id: "request_platform_replay_001",
+						attributes: {
+							scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+						},
 					},
 				},
 			});
@@ -96,6 +100,11 @@ describe("canonical Maestro Platform replay fixture", () => {
 		const promptVariantSelected = byType.get(
 			MaestroBusEventType.PromptVariantSelected,
 		)?.data;
+		expect(byType.get(MaestroBusEventType.SessionStarted)?.data).toMatchObject({
+			metadata: {
+				scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+			},
+		});
 		expect(promptVariantSelected).toMatchObject({
 			"@type": "type.googleapis.com/maestro.v1.PromptVariantSelected",
 			prompt_metadata: {


### PR DESCRIPTION
## Summary
- add explicit `scenario_id` to canonical Platform replay fixture correlation attributes
- include the same scenario ID in session metadata and fixture summary correlation
- assert the generated fixture contract in the telemetry fixture test

Source-of-truth: evalops/maestro-internal#1916

## Test plan
- `bunx tsx scripts/generate-maestro-platform-replay-fixture.ts`
- `bun test test/telemetry/maestro-platform-replay-fixture.test.ts`
- `bunx biome check src/telemetry/maestro-platform-replay-fixture.ts test/telemetry/maestro-platform-replay-fixture.test.ts`
- `git diff --check`
- commit hook: Guardian, Biome, eval/proto/session/trajectory/developer-surface checks, build, compiled bun binary