### PR TITLE
mirror: sync pairwise Fermata eval surface

### DIFF
--- a/scripts/headless-protocol-codegen.mjs
+++ b/scripts/headless-protocol-codegen.mjs
@@ -472,9 +472,6 @@ pub const HEADLESS_THINKING_LEVELS: &[&str] = ${toRustArray(
 pub const HEADLESS_APPROVAL_MODES: &[&str] = ${toRustArray(
 		protocolSpec.approvalModes,
 	)};
-pub const HEADLESS_EXECUTOR_TYPES: &[&str] = ${toRustArray(
-		protocolSpec.executorTypes,
-	)};
 pub const HEADLESS_ERROR_TYPES: &[&str] = ${toRustArray(protocolSpec.errorTypes)};
 pub const HEADLESS_UTILITY_OPERATIONS: &[&str] = ${toRustArray(
 		protocolSpec.utilityOperations,


### PR DESCRIPTION
Source-of-truth internal PR: https://github.com/evalops/maestro-internal/pull/1920

## Summary
- sync the public release mirror for the pairwise Fermata eval surface
- keep public headless protocol codegen aligned with the internal source branch

## Staged rollout
Staging is unnecessary for this generated public mirror sync: it does not independently promote new user-visible behavior. It mirrors already-reviewed internal source from evalops/maestro-internal#1920 and preserves the same hidden/enabling eval primitives and CLI/protocol surfaces already guarded by the internal staged-rollout and scenario-suite checks.

## Tests
- node /Users/jonathanhaas/.codex-worktrees/maestro-pairwise-llm-judges-20260512/scripts/sync-release-mirror.mjs --check --source /Users/jonathanhaas/.codex-worktrees/maestro-pairwise-llm-judges-20260512 --target /Users/jonathanhaas/.codex-worktrees/maestro-public-pairwise-llm-judges-20260512
- git diff --check