### PR TITLE
Add Maestro local A2A bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "smoke:local-e2e": "node scripts/smoke-cli.js",
     "smoke:event-bus": "tsx scripts/smoke-maestro-event-bus.ts",
     "smoke:a2a-local": "tsx scripts/smoke-maestro-a2a-local.ts",
+    "a2a:codex-bridge": "python3 scripts/codex-a2a-bridge.py",
     "smoke:headless": "node scripts/smoke-headless.js",
     "headless:responsiveness": "node scripts/headless-responsiveness-harness.js",
     "smoke:pack": "node scripts/smoke-packed-cli.js",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "smoke": "node scripts/smoke-cli.js",
     "smoke:local-e2e": "node scripts/smoke-cli.js",
     "smoke:event-bus": "tsx scripts/smoke-maestro-event-bus.ts",
+    "smoke:a2a-local": "tsx scripts/smoke-maestro-a2a-local.ts",
     "smoke:headless": "node scripts/smoke-headless.js",
     "headless:responsiveness": "node scripts/headless-responsiveness-harness.js",
     "smoke:pack": "node scripts/smoke-packed-cli.js",

--- a/packages/control-plane-rs/src/auth.rs
+++ b/packages/control-plane-rs/src/auth.rs
@@ -185,7 +185,21 @@ pub(crate) fn validate_csrf(head: &RequestHead, config: &Config) -> Result<(), V
 }
 
 pub(crate) fn csrf_applies(head: &RequestHead) -> bool {
-    head.path.starts_with("/api/") && !matches!(head.method.as_str(), "GET" | "HEAD" | "OPTIONS")
+    if matches!(head.method.as_str(), "GET" | "HEAD" | "OPTIONS") {
+        return false;
+    }
+
+    head.path.starts_with("/api/") || csrf_applies_to_a2a_path(&head.path)
+}
+
+fn csrf_applies_to_a2a_path(path: &str) -> bool {
+    path == "/message:send"
+        || path
+            .strip_prefix("/tasks/")
+            .and_then(|value| value.strip_suffix(":cancel"))
+            .is_some_and(|task_id| {
+                !task_id.is_empty() && !task_id.contains('/') && !task_id.contains(':')
+            })
 }
 
 pub(crate) fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {

--- a/packages/control-plane-rs/src/auth.rs
+++ b/packages/control-plane-rs/src/auth.rs
@@ -192,14 +192,13 @@ pub(crate) fn csrf_applies(head: &RequestHead) -> bool {
     head.path.starts_with("/api/") || csrf_applies_to_a2a_path(&head.path)
 }
 
+pub(crate) fn a2a_task_id_from_cancel_path(path: &str) -> Option<&str> {
+    let task_id = path.strip_prefix("/tasks/")?.strip_suffix(":cancel")?;
+    (!task_id.is_empty() && !task_id.contains('/') && !task_id.contains(':')).then_some(task_id)
+}
+
 fn csrf_applies_to_a2a_path(path: &str) -> bool {
-    path == "/message:send"
-        || path
-            .strip_prefix("/tasks/")
-            .and_then(|value| value.strip_suffix(":cancel"))
-            .is_some_and(|task_id| {
-                !task_id.is_empty() && !task_id.contains('/') && !task_id.contains(':')
-            })
+    path == "/message:send" || a2a_task_id_from_cancel_path(path).is_some()
 }
 
 pub(crate) fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {

--- a/packages/control-plane-rs/src/http.rs
+++ b/packages/control-plane-rs/src/http.rs
@@ -11,7 +11,7 @@ tokio::task_local! {
 
 const MAX_HEADER_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 32 * 1024 * 1024;
-const CORS_ALLOW_HEADERS: &str = "authorization,content-type,a2a-version,a2a-extensions,traceparent,tracestate,x-evalops-agent-id,x-evalops-actor-id,x-evalops-session-id,x-evalops-workspace-id,x-composer-artifact-access,x-composer-api-key,x-composer-approval-mode,x-composer-client,x-composer-client-tools,x-composer-csrf,x-composer-agent-id,x-composer-slim-events,x-composer-workspace,x-composer-workspace-id,x-maestro-artifact-access,x-maestro-api-key,x-maestro-approval-mode,x-maestro-agent-id,x-maestro-client,x-maestro-client-tools,x-maestro-csrf,x-maestro-slim-events,x-maestro-workspace,x-maestro-workspace-id,x-csrf-token,x-xsrf-token";
+const CORS_ALLOW_HEADERS: &str = "authorization,content-type,a2a-version,a2a-extensions,traceparent,tracestate,x-organization-id,x-evalops-agent-id,x-evalops-actor-id,x-evalops-session-id,x-evalops-workspace-id,x-composer-artifact-access,x-composer-api-key,x-composer-approval-mode,x-composer-client,x-composer-client-tools,x-composer-csrf,x-composer-agent-id,x-composer-slim-events,x-composer-workspace,x-composer-workspace-id,x-maestro-artifact-access,x-maestro-api-key,x-maestro-approval-mode,x-maestro-agent-id,x-maestro-client,x-maestro-client-tools,x-maestro-csrf,x-maestro-slim-events,x-maestro-workspace,x-maestro-workspace-id,x-csrf-token,x-xsrf-token";
 
 #[derive(Debug)]
 pub(crate) struct RequestHead {

--- a/packages/control-plane-rs/src/http.rs
+++ b/packages/control-plane-rs/src/http.rs
@@ -11,7 +11,7 @@ tokio::task_local! {
 
 const MAX_HEADER_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 32 * 1024 * 1024;
-const CORS_ALLOW_HEADERS: &str = "authorization,content-type,x-composer-artifact-access,x-composer-api-key,x-composer-approval-mode,x-composer-client,x-composer-client-tools,x-composer-csrf,x-composer-agent-id,x-composer-slim-events,x-composer-workspace,x-composer-workspace-id,x-maestro-artifact-access,x-maestro-api-key,x-maestro-approval-mode,x-maestro-agent-id,x-maestro-client,x-maestro-client-tools,x-maestro-csrf,x-maestro-slim-events,x-maestro-workspace,x-maestro-workspace-id,x-csrf-token,x-xsrf-token";
+const CORS_ALLOW_HEADERS: &str = "authorization,content-type,a2a-version,a2a-extensions,traceparent,tracestate,x-evalops-agent-id,x-evalops-actor-id,x-evalops-session-id,x-evalops-workspace-id,x-composer-artifact-access,x-composer-api-key,x-composer-approval-mode,x-composer-client,x-composer-client-tools,x-composer-csrf,x-composer-agent-id,x-composer-slim-events,x-composer-workspace,x-composer-workspace-id,x-maestro-artifact-access,x-maestro-api-key,x-maestro-approval-mode,x-maestro-agent-id,x-maestro-client,x-maestro-client-tools,x-maestro-csrf,x-maestro-slim-events,x-maestro-workspace,x-maestro-workspace-id,x-csrf-token,x-xsrf-token";
 
 #[derive(Debug)]
 pub(crate) struct RequestHead {

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1377,11 +1377,13 @@ fn a2a_task_metadata(
 }
 
 fn a2a_return_immediately(request: &A2ASendMessageRequest) -> Result<bool, &'static str> {
-    let Some(return_immediately) = request
-        .configuration
-        .as_ref()
-        .and_then(|configuration| configuration.get("returnImmediately"))
-    else {
+    let Some(configuration) = request.configuration.as_ref() else {
+        return Ok(false);
+    };
+    let Some(configuration) = configuration.as_object() else {
+        return Err("A2A configuration must be an object");
+    };
+    let Some(return_immediately) = configuration.get("returnImmediately") else {
         return Ok(false);
     };
     return_immediately
@@ -7455,6 +7457,29 @@ mod tests {
         assert_eq!(
             response["error"]["message"],
             "A2A configuration returnImmediately must be a boolean"
+        );
+        assert!(state.a2a_tasks.lock().await.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_rejects_non_object_configuration() {
+        let body = r#"{"message":{"messageId":"msg-1","contextId":"ctx-1","role":"ROLE_USER","parts":[{"text":"hello","mediaType":"text/plain"}]},"configuration":"oops"}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert_eq!(response["error"]["code"], "INVALID_REQUEST");
+        assert_eq!(
+            response["error"]["message"],
+            "A2A configuration must be an object"
         );
         assert!(state.a2a_tasks.lock().await.is_empty());
     }

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -51,6 +51,7 @@ const MAX_EXTRACT_INPUT_BYTES: usize = 50 * 1024 * 1024;
 const MAX_PROJECT_ONBOARDING_IMPRESSIONS: u8 = 4;
 const A2A_PROTOCOL_VERSION: &str = "1.0";
 const A2A_DEFAULT_TURN_TIMEOUT_MS: u64 = 180_000;
+const A2A_DEFAULT_RESPONSE_END_SETTLE_MS: u64 = 250;
 static ATTACHMENT_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
 type PendingToolResponseSender = mpsc::UnboundedSender<(String, bool, Option<ToolResult>)>;
@@ -1124,9 +1125,10 @@ fn a2a_user_message_value(message: &A2AMessageBody, context_id: &str) -> Value {
         object
             .entry("messageId")
             .or_insert_with(|| Value::String(generate_a2a_id("maestro-message")));
-        object
-            .entry("contextId")
-            .or_insert_with(|| Value::String(context_id.to_string()));
+        object.insert(
+            "contextId".to_string(),
+            Value::String(context_id.to_string()),
+        );
         object
             .entry("role")
             .or_insert_with(|| Value::String("ROLE_USER".to_string()));
@@ -1279,14 +1281,29 @@ async fn run_a2a_native_turn(
     let mut output = A2ATurnOutput::default();
     let mut last_error: Option<String> = None;
     let mut response_ended = false;
+    let response_end_settle = Duration::from_millis(env_u64(
+        "MAESTRO_A2A_RESPONSE_END_SETTLE_MS",
+        A2A_DEFAULT_RESPONSE_END_SETTLE_MS,
+    ));
+    let mut response_end_deadline: Option<tokio::time::Instant> = None;
     let turn_timeout = tokio::time::sleep(timeout);
     tokio::pin!(turn_timeout);
 
     loop {
+        let response_end_wait = async {
+            if let Some(deadline) = response_end_deadline {
+                tokio::time::sleep_until(deadline).await;
+            } else {
+                std::future::pending::<()>().await;
+            }
+        };
         let event = tokio::select! {
             _ = &mut turn_timeout => {
                 agent.cancel();
                 return Err("A2A native TUI turn timed out".to_string());
+            }
+            _ = response_end_wait => {
+                break;
             }
             changed = cancel_rx.changed() => {
                 if changed.is_ok() && *cancel_rx.borrow() {
@@ -1301,11 +1318,15 @@ async fn run_a2a_native_turn(
             },
         };
         match event {
+            FromAgent::ResponseStart { .. } => {
+                response_end_deadline = None;
+            }
             FromAgent::ResponseChunk {
                 content,
                 is_thinking,
                 ..
             } => {
+                response_end_deadline = None;
                 if is_thinking {
                     output.thinking_text.push_str(&content);
                 } else {
@@ -1315,7 +1336,7 @@ async fn run_a2a_native_turn(
             FromAgent::ResponseEnd { usage, .. } => {
                 output.usage = usage;
                 response_ended = true;
-                break;
+                response_end_deadline = Some(tokio::time::Instant::now() + response_end_settle);
             }
             FromAgent::ToolCall {
                 call_id,
@@ -1323,6 +1344,7 @@ async fn run_a2a_native_turn(
                 args,
                 requires_approval,
             } => {
+                response_end_deadline = None;
                 record_tool_call_metadata(&mut output.tools, &call_id, &tool, args);
                 if requires_approval {
                     let _ = agent.tool_response_sender().send((
@@ -1338,6 +1360,7 @@ async fn run_a2a_native_turn(
             FromAgent::ToolEnd {
                 call_id, success, ..
             } => {
+                response_end_deadline = None;
                 finish_tool_metadata(&mut output.tools, &call_id, success);
             }
             FromAgent::HookBlocked {
@@ -1345,6 +1368,7 @@ async fn run_a2a_native_turn(
                 tool,
                 reason,
             } => {
+                response_end_deadline = None;
                 if !output
                     .tools
                     .iter()
@@ -6987,6 +7011,31 @@ mod tests {
         };
 
         assert!(a2a_return_immediately(&request));
+    }
+
+    #[test]
+    fn a2a_user_message_value_replaces_empty_context_id() {
+        let message = A2AMessageBody {
+            message_id: Some("msg-1".to_string()),
+            context_id: Some("   ".to_string()),
+            task_id: None,
+            role: Some("ROLE_USER".to_string()),
+            parts: vec![A2APartBody {
+                text: Some("hello".to_string()),
+                url: None,
+                data: None,
+                metadata: None,
+                filename: None,
+                media_type: Some("text/plain".to_string()),
+            }],
+            metadata: None,
+            extensions: None,
+            reference_task_ids: None,
+        };
+
+        let value = a2a_user_message_value(&message, "ctx-1");
+
+        assert_eq!(value["contextId"], "ctx-1");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1006,6 +1006,10 @@ async fn handle_a2a_message_send(
             "A2A message must contain at least one text part",
         );
     };
+    let return_immediately = match a2a_return_immediately(&request) {
+        Ok(value) => value,
+        Err(error) => return a2a_error_response(400, "INVALID_REQUEST", error),
+    };
 
     let metadata = a2a_task_metadata(head, &request, auth);
     let target = match claim_a2a_send_task(state, &request, head, auth, metadata).await {
@@ -1027,7 +1031,7 @@ async fn handle_a2a_message_send(
         state.a2a_cancel_senders.lock().await.remove(&task_id);
         return json_response(200, &serde_json::json!({ "task": task }));
     }
-    if a2a_return_immediately(&request) {
+    if return_immediately {
         let accepted_message = a2a_agent_message(&context_id, "Maestro accepted the A2A task.");
         let mut accepted_history = history.clone();
         accepted_history.push(accepted_message.clone());
@@ -1373,13 +1377,17 @@ fn a2a_task_metadata(
     Value::Object(metadata)
 }
 
-fn a2a_return_immediately(request: &A2ASendMessageRequest) -> bool {
-    request
+fn a2a_return_immediately(request: &A2ASendMessageRequest) -> Result<bool, &'static str> {
+    let Some(return_immediately) = request
         .configuration
         .as_ref()
         .and_then(|configuration| configuration.get("returnImmediately"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
+    else {
+        return Ok(false);
+    };
+    return_immediately
+        .as_bool()
+        .ok_or("A2A configuration returnImmediately must be a boolean")
 }
 
 async fn run_a2a_native_turn(
@@ -7282,7 +7290,7 @@ mod tests {
             metadata: None,
         };
 
-        assert!(a2a_return_immediately(&request));
+        assert!(a2a_return_immediately(&request).expect("configuration should be valid"));
     }
 
     #[test]
@@ -7375,6 +7383,29 @@ mod tests {
         } else {
             env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_rejects_non_boolean_return_immediately() {
+        let body = r#"{"message":{"messageId":"msg-1","contextId":"ctx-1","role":"ROLE_USER","parts":[{"text":"hello","mediaType":"text/plain"}]},"configuration":{"returnImmediately":"true"}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert_eq!(response["error"]["code"], "INVALID_REQUEST");
+        assert_eq!(
+            response["error"]["message"],
+            "A2A configuration returnImmediately must be a boolean"
+        );
+        assert!(state.a2a_tasks.lock().await.is_empty());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -52,6 +52,7 @@ const MAX_PROJECT_ONBOARDING_IMPRESSIONS: u8 = 4;
 const A2A_PROTOCOL_VERSION: &str = "1.0";
 const A2A_DEFAULT_TURN_TIMEOUT_MS: u64 = 180_000;
 const A2A_DEFAULT_RESPONSE_END_SETTLE_MS: u64 = 250;
+const A2A_TERMINAL_TASK_STORE_LIMIT: usize = 128;
 static ATTACHMENT_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
 type PendingToolResponseSender = mpsc::UnboundedSender<(String, bool, Option<ToolResult>)>;
@@ -699,6 +700,7 @@ async fn cancel_a2a_task(state: &AppState, task_id: &str) -> Result<Value, Vec<u
         "timestamp": now_rfc3339()
     });
     let task = task.clone();
+    prune_a2a_terminal_tasks(&mut tasks);
     drop(tasks);
 
     if let Some(sender) = state.a2a_cancel_senders.lock().await.remove(task_id) {
@@ -711,6 +713,12 @@ async fn cancel_a2a_task(state: &AppState, task_id: &str) -> Result<Value, Vec<u
 fn a2a_task_status_state(task: &Value) -> Option<&str> {
     task.get("status")
         .and_then(|status| status.get("state"))
+        .and_then(Value::as_str)
+}
+
+fn a2a_task_status_timestamp(task: &Value) -> Option<&str> {
+    task.get("status")
+        .and_then(|status| status.get("timestamp"))
         .and_then(Value::as_str)
 }
 
@@ -824,7 +832,35 @@ async fn store_a2a_task_unless_canceled(state: &AppState, task_id: &str, task: V
         }
     }
     tasks.insert(task_id.to_string(), task.clone());
+    prune_a2a_terminal_tasks(&mut tasks);
     task
+}
+
+fn prune_a2a_terminal_tasks(tasks: &mut HashMap<String, Value>) {
+    let mut terminal_tasks = tasks
+        .iter()
+        .filter(|(_, task)| a2a_task_is_terminal(task))
+        .map(|(task_id, task)| {
+            (
+                task_id.clone(),
+                a2a_task_status_timestamp(task)
+                    .unwrap_or_default()
+                    .to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    if terminal_tasks.len() <= A2A_TERMINAL_TASK_STORE_LIMIT {
+        return;
+    }
+    terminal_tasks.sort_by(|(left_id, left_timestamp), (right_id, right_timestamp)| {
+        left_timestamp
+            .cmp(right_timestamp)
+            .then_with(|| left_id.cmp(right_id))
+    });
+    let overflow = terminal_tasks.len() - A2A_TERMINAL_TASK_STORE_LIMIT;
+    for (task_id, _) in terminal_tasks.into_iter().take(overflow) {
+        tasks.remove(&task_id);
+    }
 }
 
 async fn register_a2a_cancel_sender(
@@ -901,11 +937,7 @@ async fn handle_a2a_message_send(
             Vec::new(),
             metadata.clone(),
         );
-        state
-            .a2a_tasks
-            .lock()
-            .await
-            .insert(task_id.clone(), task.clone());
+        let task = store_a2a_task_unless_canceled(state, &task_id, task).await;
         let state = state.clone();
         tokio::spawn(async move {
             let _ = complete_a2a_task(
@@ -7429,6 +7461,55 @@ mod tests {
         } else {
             env::remove_var("MAESTRO_A2A_FAKE_RESPONSE_DELAY_MS");
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_task_store_evicts_old_terminal_tasks() {
+        let state = test_app_state_with_sessions(HashMap::new());
+        let working_task = a2a_task_value(
+            "working-task",
+            "ctx-1",
+            "TASK_STATE_WORKING",
+            a2a_agent_message("ctx-1", "still running"),
+            Vec::new(),
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        store_a2a_task_unless_canceled(&state, "working-task", working_task).await;
+
+        for index in 0..=A2A_TERMINAL_TASK_STORE_LIMIT {
+            let task_id = format!("terminal-task-{index}");
+            let mut task = a2a_task_value(
+                &task_id,
+                "ctx-1",
+                "TASK_STATE_COMPLETED",
+                a2a_agent_message("ctx-1", "done"),
+                Vec::new(),
+                Vec::new(),
+                serde_json::json!({}),
+            );
+            task["status"]["timestamp"] = Value::String(format!(
+                "2026-05-15T00:{:02}:{:02}Z",
+                index / 60,
+                index % 60
+            ));
+            store_a2a_task_unless_canceled(&state, &task_id, task).await;
+        }
+
+        let newest_terminal_task_id = format!("terminal-task-{A2A_TERMINAL_TASK_STORE_LIMIT}");
+        let stored = state.a2a_tasks.lock().await;
+
+        assert_eq!(stored.len(), A2A_TERMINAL_TASK_STORE_LIMIT + 1);
+        assert!(stored.contains_key("working-task"));
+        assert!(!stored.contains_key("terminal-task-0"));
+        assert!(stored.contains_key(&newest_terminal_task_id));
+        assert_eq!(
+            stored
+                .values()
+                .filter(|task| a2a_task_is_terminal(task))
+                .count(),
+            A2A_TERMINAL_TASK_STORE_LIMIT
+        );
     }
 
     #[test]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -595,6 +595,7 @@ struct A2ASendTarget {
     context_id: String,
     history: Vec<Value>,
     previous_task: Option<Value>,
+    metadata: Value,
 }
 
 fn is_a2a_endpoint(head: &RequestHead) -> bool {
@@ -797,71 +798,78 @@ async fn claim_a2a_send_task(
         .map(str::to_string);
 
     let mut tasks = state.a2a_tasks.lock().await;
-    let (task_id, context_id, mut history, previous_task) = if let Some(task_id) = requested_task_id
-    {
-        let Some(task) = tasks.get(task_id) else {
-            return Err(a2a_error_response(
-                404,
-                "TASK_NOT_FOUND",
-                "A2A task not found",
-            ));
-        };
-        if !a2a_task_visible_to_auth(task, auth) {
-            return Err(a2a_error_response(
-                404,
-                "TASK_NOT_FOUND",
-                "A2A task not found",
-            ));
-        }
-        if a2a_task_is_terminal(task) {
-            return Err(a2a_error_response(
-                400,
-                "UNSUPPORTED_OPERATION",
-                "A2A terminal tasks cannot accept more messages",
-            ));
-        }
-        if !a2a_task_accepts_message(task) {
-            return Err(a2a_error_response(
-                409,
-                "UNSUPPORTED_OPERATION",
-                "A2A task is not ready to accept another message",
-            ));
-        }
-
-        let task_context_id = task
-            .get("contextId")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|context_id| !context_id.is_empty())
-            .map(str::to_string);
-        if let (Some(message_context_id), Some(task_context_id)) =
-            (explicit_context_id.as_deref(), task_context_id.as_deref())
-        {
-            if message_context_id != task_context_id {
+    let (task_id, context_id, mut history, previous_task, task_metadata) =
+        if let Some(task_id) = requested_task_id {
+            let Some(task) = tasks.get(task_id) else {
                 return Err(a2a_error_response(
-                    400,
-                    "INVALID_REQUEST",
-                    "A2A message contextId must match the referenced task",
+                    404,
+                    "TASK_NOT_FOUND",
+                    "A2A task not found",
+                ));
+            };
+            if !a2a_task_visible_to_auth(task, auth) {
+                return Err(a2a_error_response(
+                    404,
+                    "TASK_NOT_FOUND",
+                    "A2A task not found",
                 ));
             }
-        }
-        let context_id = explicit_context_id
-            .or(task_context_id)
-            .unwrap_or_else(|| a2a_context_id(request, head));
-        let history = task
-            .get("history")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        (task_id.to_string(), context_id, history, Some(task.clone()))
-    } else {
-        (
-            generate_a2a_id("maestro-task"),
-            explicit_context_id.unwrap_or_else(|| a2a_context_id(request, head)),
-            Vec::new(),
-            None,
-        )
-    };
+            if a2a_task_is_terminal(task) {
+                return Err(a2a_error_response(
+                    400,
+                    "UNSUPPORTED_OPERATION",
+                    "A2A terminal tasks cannot accept more messages",
+                ));
+            }
+            if !a2a_task_accepts_message(task) {
+                return Err(a2a_error_response(
+                    409,
+                    "UNSUPPORTED_OPERATION",
+                    "A2A task is not ready to accept another message",
+                ));
+            }
+
+            let task_context_id = task
+                .get("contextId")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|context_id| !context_id.is_empty())
+                .map(str::to_string);
+            if let (Some(message_context_id), Some(task_context_id)) =
+                (explicit_context_id.as_deref(), task_context_id.as_deref())
+            {
+                if message_context_id != task_context_id {
+                    return Err(a2a_error_response(
+                        400,
+                        "INVALID_REQUEST",
+                        "A2A message contextId must match the referenced task",
+                    ));
+                }
+            }
+            let context_id = explicit_context_id
+                .or(task_context_id)
+                .unwrap_or_else(|| a2a_context_id(request, head));
+            let history = task
+                .get("history")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            (
+                task_id.to_string(),
+                context_id,
+                history,
+                Some(task.clone()),
+                a2a_merge_task_metadata(task, metadata),
+            )
+        } else {
+            (
+                generate_a2a_id("maestro-task"),
+                explicit_context_id.unwrap_or_else(|| a2a_context_id(request, head)),
+                Vec::new(),
+                None,
+                metadata,
+            )
+        };
     history.push(a2a_user_message_value(&request.message, &context_id));
     let working_message = a2a_agent_message(&context_id, "Maestro is working on the A2A task.");
     let task = a2a_task_value(
@@ -871,7 +879,7 @@ async fn claim_a2a_send_task(
         working_message,
         history.clone(),
         Vec::new(),
-        metadata,
+        task_metadata.clone(),
     );
     tasks.insert(task_id.clone(), task);
     prune_a2a_terminal_tasks(&mut tasks);
@@ -880,7 +888,22 @@ async fn claim_a2a_send_task(
         context_id,
         history,
         previous_task,
+        metadata: task_metadata,
     })
+}
+
+fn a2a_merge_task_metadata(existing_task: &Value, metadata: Value) -> Value {
+    let mut merged = existing_task
+        .get("metadata")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if let Value::Object(metadata) = metadata {
+        for (key, value) in metadata {
+            merged.insert(key, value);
+        }
+    }
+    Value::Object(merged)
 }
 
 async fn rollback_a2a_send_claim(state: &AppState, task_id: &str, previous_task: Option<Value>) {
@@ -985,7 +1008,7 @@ async fn handle_a2a_message_send(
     };
 
     let metadata = a2a_task_metadata(head, &request, auth);
-    let target = match claim_a2a_send_task(state, &request, head, auth, metadata.clone()).await {
+    let target = match claim_a2a_send_task(state, &request, head, auth, metadata).await {
         Ok(target) => target,
         Err(response) => return response,
     };
@@ -993,6 +1016,7 @@ async fn handle_a2a_message_send(
     let context_id = target.context_id;
     let history = target.history;
     let previous_task = target.previous_task;
+    let metadata = target.metadata;
 
     let (cancel_tx, cancel_rx) = watch::channel(false);
     if let Err(response) = register_a2a_cancel_sender(state, &task_id, cancel_tx).await {
@@ -1173,12 +1197,22 @@ fn a2a_public_base_url(_head: &RequestHead, config: &Config) -> String {
     {
         return url.trim_end_matches('/').to_string();
     }
-    let host = if config.listen_host == "0.0.0.0" || config.listen_host == "::" {
-        "127.0.0.1"
+    let host = if let Some(host) = trimmed_env("MAESTRO_A2A_PUBLIC_HOST")
+        .or_else(|| trimmed_env("MAESTRO_CONTROL_PUBLIC_HOST"))
+    {
+        host
+    } else if config.listen_host == "0.0.0.0" || config.listen_host == "::" {
+        trimmed_env("HOSTNAME")
+            .or_else(|| trimmed_env("COMPUTERNAME"))
+            .unwrap_or_else(|| "127.0.0.1".to_string())
     } else {
-        config.listen_host.as_str()
+        config.listen_host.clone()
     };
-    format!("http://{host}:{}", config.listen_port)
+    if host.contains(':') {
+        format!("http://{host}")
+    } else {
+        format!("http://{host}:{}", config.listen_port)
+    }
 }
 
 fn a2a_message_text(message: &A2AMessageBody) -> Option<String> {
@@ -7094,9 +7128,13 @@ mod tests {
     fn a2a_agent_card_advertises_http_json_interface() {
         let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
         let previous_a2a_url = env::var_os("MAESTRO_A2A_PUBLIC_URL");
+        let previous_a2a_host = env::var_os("MAESTRO_A2A_PUBLIC_HOST");
         let previous_control_url = env::var_os("MAESTRO_CONTROL_PUBLIC_URL");
+        let previous_control_host = env::var_os("MAESTRO_CONTROL_PUBLIC_HOST");
         env::remove_var("MAESTRO_A2A_PUBLIC_URL");
+        env::remove_var("MAESTRO_A2A_PUBLIC_HOST");
         env::remove_var("MAESTRO_CONTROL_PUBLIC_URL");
+        env::remove_var("MAESTRO_CONTROL_PUBLIC_HOST");
         let head = parse_request_head(
             b"GET /.well-known/agent-card.json HTTP/1.1\r\nHost: attacker.test\r\nx-forwarded-proto: https\r\n\r\n",
         )
@@ -7111,6 +7149,57 @@ mod tests {
             "HTTP+JSON"
         );
         assert_eq!(card["skills"][0]["id"], "maestro-tui-turn");
+        if let Some(previous_a2a_url) = previous_a2a_url {
+            env::set_var("MAESTRO_A2A_PUBLIC_URL", previous_a2a_url);
+        } else {
+            env::remove_var("MAESTRO_A2A_PUBLIC_URL");
+        }
+        if let Some(previous_a2a_host) = previous_a2a_host {
+            env::set_var("MAESTRO_A2A_PUBLIC_HOST", previous_a2a_host);
+        } else {
+            env::remove_var("MAESTRO_A2A_PUBLIC_HOST");
+        }
+        if let Some(previous_control_url) = previous_control_url {
+            env::set_var("MAESTRO_CONTROL_PUBLIC_URL", previous_control_url);
+        } else {
+            env::remove_var("MAESTRO_CONTROL_PUBLIC_URL");
+        }
+        if let Some(previous_control_host) = previous_control_host {
+            env::set_var("MAESTRO_CONTROL_PUBLIC_HOST", previous_control_host);
+        } else {
+            env::remove_var("MAESTRO_CONTROL_PUBLIC_HOST");
+        }
+    }
+
+    #[test]
+    fn a2a_agent_card_uses_configured_public_host_for_wildcard_binds() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_a2a_host = env::var_os("MAESTRO_A2A_PUBLIC_HOST");
+        let previous_a2a_url = env::var_os("MAESTRO_A2A_PUBLIC_URL");
+        let previous_control_url = env::var_os("MAESTRO_CONTROL_PUBLIC_URL");
+        env::set_var("MAESTRO_A2A_PUBLIC_HOST", "mini.example.test");
+        env::remove_var("MAESTRO_A2A_PUBLIC_URL");
+        env::remove_var("MAESTRO_CONTROL_PUBLIC_URL");
+        let mut config = auth_test_config();
+        config.listen_host = "0.0.0.0".to_string();
+        config.listen_port = 18787;
+        let head = parse_request_head(
+            b"GET /.well-known/agent-card.json HTTP/1.1\r\nHost: attacker.test\r\n\r\n",
+        )
+        .expect("request should parse");
+        let card = a2a_agent_card(&head, &config);
+
+        assert_eq!(card["url"], "http://mini.example.test:18787");
+        assert_eq!(
+            card["supportedInterfaces"][0]["url"],
+            "http://mini.example.test:18787"
+        );
+
+        if let Some(previous_a2a_host) = previous_a2a_host {
+            env::set_var("MAESTRO_A2A_PUBLIC_HOST", previous_a2a_host);
+        } else {
+            env::remove_var("MAESTRO_A2A_PUBLIC_HOST");
+        }
         if let Some(previous_a2a_url) = previous_a2a_url {
             env::set_var("MAESTRO_A2A_PUBLIC_URL", previous_a2a_url);
         } else {
@@ -7266,7 +7355,11 @@ mod tests {
                 Vec::new(),
                 Value::Object(metadata),
             );
-            state.a2a_tasks.lock().await.insert(task_id.to_string(), task);
+            state
+                .a2a_tasks
+                .lock()
+                .await
+                .insert(task_id.to_string(), task);
         }
         let token = shared_secret_bearer_token(b"shared-secret", "user-123");
         let request = format!(
@@ -7278,7 +7371,9 @@ mod tests {
 
         let response =
             response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
-        let tasks = response["tasks"].as_array().expect("tasks should be an array");
+        let tasks = response["tasks"]
+            .as_array()
+            .expect("tasks should be an array");
 
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0]["id"], "owned-task");
@@ -7337,6 +7432,58 @@ mod tests {
         } else {
             env::remove_var("MAESTRO_AUTH_SHARED_SECRET");
         }
+        if let Some(previous_fake) = previous_fake {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_preserves_owner_metadata_on_unrestricted_follow_up() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "follow-up response");
+        let state = test_app_state_with_sessions(HashMap::new());
+        let existing_message = a2a_agent_message("ctx-1", "Need more input");
+        let task = a2a_task_value(
+            "owned-task",
+            "ctx-1",
+            "TASK_STATE_INPUT_REQUIRED",
+            existing_message.clone(),
+            vec![existing_message],
+            Vec::new(),
+            serde_json::json!({
+                "ownerSubject": "user-123",
+                "workspaceId": "ws-old"
+            }),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("owned-task".to_string(), task);
+        let body = r#"{"message":{"messageId":"msg-2","contextId":"ctx-1","taskId":"owned-task","role":"ROLE_USER","parts":[{"text":"follow up","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nx-evalops-workspace-id: ws-new\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let task = &response["task"];
+
+        assert_eq!(task["id"], "owned-task");
+        assert_eq!(task["metadata"]["ownerSubject"], "user-123");
+        assert_eq!(task["metadata"]["workspaceId"], "ws-new");
+        assert_eq!(
+            state.a2a_tasks.lock().await["owned-task"]["metadata"]["ownerSubject"],
+            "user-123"
+        );
+
         if let Some(previous_fake) = previous_fake {
             env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
         } else {

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1211,19 +1211,57 @@ fn a2a_public_base_url(_head: &RequestHead, config: &Config) -> String {
     } else {
         config.listen_host.clone()
     };
-    if host.starts_with('[') {
-        if host.contains("]:") {
-            format!("http://{host}")
+    format!(
+        "http://{}",
+        a2a_public_host_authority(&host, config.listen_port)
+    )
+}
+
+fn a2a_public_host_authority(host: &str, port: u16) -> String {
+    if let Some(rest) = host.strip_prefix('[') {
+        if let Some(end) = rest.find(']') {
+            let literal = &rest[..end];
+            let suffix = &rest[end + 1..];
+            let authority = format!("[{}]{suffix}", a2a_uri_host(literal));
+            if suffix.starts_with(':') {
+                authority
+            } else {
+                format!("{authority}:{port}")
+            }
         } else {
-            format!("http://{host}:{}", config.listen_port)
+            format!("[{}]:{port}", a2a_uri_host(rest))
         }
     } else if host.matches(':').count() > 1 {
-        format!("http://[{host}]:{}", config.listen_port)
+        format!("[{}]:{port}", a2a_uri_host(host))
     } else if host.contains(':') {
-        format!("http://{host}")
+        host.to_string()
     } else {
-        format!("http://{host}:{}", config.listen_port)
+        format!("{host}:{port}")
     }
+}
+
+fn a2a_uri_host(host: &str) -> String {
+    let mut normalized = String::with_capacity(host.len());
+    let mut chars = host.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '%' {
+            let mut lookahead = chars.clone();
+            let already_encoded = lookahead
+                .next()
+                .is_some_and(|next| next.is_ascii_hexdigit())
+                && lookahead
+                    .next()
+                    .is_some_and(|next| next.is_ascii_hexdigit());
+            if already_encoded {
+                normalized.push(ch);
+            } else {
+                normalized.push_str("%25");
+            }
+        } else {
+            normalized.push(ch);
+        }
+    }
+    normalized
 }
 
 fn a2a_message_text(message: &A2AMessageBody) -> Option<String> {
@@ -7275,6 +7313,47 @@ mod tests {
 
         assert_eq!(card["url"], "http://[::1]:18787");
         assert_eq!(card["supportedInterfaces"][0]["url"], "http://[::1]:18787");
+
+        if let Some(previous_a2a_host) = previous_a2a_host {
+            env::set_var("MAESTRO_A2A_PUBLIC_HOST", previous_a2a_host);
+        } else {
+            env::remove_var("MAESTRO_A2A_PUBLIC_HOST");
+        }
+        if let Some(previous_a2a_url) = previous_a2a_url {
+            env::set_var("MAESTRO_A2A_PUBLIC_URL", previous_a2a_url);
+        } else {
+            env::remove_var("MAESTRO_A2A_PUBLIC_URL");
+        }
+        if let Some(previous_control_url) = previous_control_url {
+            env::set_var("MAESTRO_CONTROL_PUBLIC_URL", previous_control_url);
+        } else {
+            env::remove_var("MAESTRO_CONTROL_PUBLIC_URL");
+        }
+    }
+
+    #[test]
+    fn a2a_agent_card_percent_encodes_scoped_ipv6_public_host() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_a2a_host = env::var_os("MAESTRO_A2A_PUBLIC_HOST");
+        let previous_a2a_url = env::var_os("MAESTRO_A2A_PUBLIC_URL");
+        let previous_control_url = env::var_os("MAESTRO_CONTROL_PUBLIC_URL");
+        env::set_var("MAESTRO_A2A_PUBLIC_HOST", "fe80::1%en0");
+        env::remove_var("MAESTRO_A2A_PUBLIC_URL");
+        env::remove_var("MAESTRO_CONTROL_PUBLIC_URL");
+        let mut config = auth_test_config();
+        config.listen_host = "::".to_string();
+        config.listen_port = 18787;
+        let head = parse_request_head(
+            b"GET /.well-known/agent-card.json HTTP/1.1\r\nHost: attacker.test\r\n\r\n",
+        )
+        .expect("request should parse");
+        let card = a2a_agent_card(&head, &config);
+
+        assert_eq!(card["url"], "http://[fe80::1%25en0]:18787");
+        assert_eq!(
+            card["supportedInterfaces"][0]["url"],
+            "http://[fe80::1%25en0]:18787"
+        );
 
         if let Some(previous_a2a_host) = previous_a2a_host {
             env::set_var("MAESTRO_A2A_PUBLIC_HOST", previous_a2a_host);

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -751,11 +751,7 @@ async fn complete_a2a_task(
                 Vec::new(),
                 metadata,
             );
-            state
-                .a2a_tasks
-                .lock()
-                .await
-                .insert(task_id.clone(), task.clone());
+            insert_a2a_task_if_not_canceled(state, &task_id, task.clone()).await;
             return task;
         }
     };
@@ -794,12 +790,21 @@ async fn complete_a2a_task(
         })],
         metadata,
     );
-    state
-        .a2a_tasks
-        .lock()
-        .await
-        .insert(task_id.clone(), task.clone());
+    insert_a2a_task_if_not_canceled(state, &task_id, task.clone()).await;
     task
+}
+
+async fn insert_a2a_task_if_not_canceled(state: &AppState, task_id: &str, task: Value) {
+    let mut tasks = state.a2a_tasks.lock().await;
+    let is_canceled = tasks
+        .get(task_id)
+        .and_then(|existing| existing.get("status"))
+        .and_then(|status| status.get("state"))
+        .and_then(Value::as_str)
+        == Some("TASK_STATE_CANCELED");
+    if !is_canceled {
+        tasks.insert(task_id.to_string(), task);
+    }
 }
 
 fn a2a_agent_card(head: &RequestHead, config: &Config) -> Value {
@@ -6767,6 +6772,51 @@ mod tests {
         );
         assert_eq!(task["metadata"]["workspaceId"], "ws-1");
         assert_eq!(state.a2a_tasks.lock().await.len(), 1);
+
+        if let Some(previous_fake) = previous_fake {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn complete_a2a_task_does_not_overwrite_canceled_task() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "hello from fake native turn");
+
+        let state = test_app_state_with_sessions(HashMap::new());
+        let task_id = "task-1".to_string();
+        let context_id = "ctx-1".to_string();
+        state.a2a_tasks.lock().await.insert(
+            task_id.clone(),
+            a2a_task_value(
+                &task_id,
+                &context_id,
+                "TASK_STATE_CANCELED",
+                a2a_agent_message(&context_id, "Task canceled"),
+                Vec::new(),
+                Vec::new(),
+                serde_json::json!({}),
+            ),
+        );
+
+        let task = complete_a2a_task(
+            &state,
+            "hello".to_string(),
+            task_id.clone(),
+            context_id,
+            serde_json::json!({}),
+            serde_json::json!({}),
+        )
+        .await;
+
+        assert_eq!(task["status"]["state"], "TASK_STATE_COMPLETED");
+        assert_eq!(
+            state.a2a_tasks.lock().await[&task_id]["status"]["state"],
+            "TASK_STATE_CANCELED"
+        );
 
         if let Some(previous_fake) = previous_fake {
             env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -635,9 +635,9 @@ async fn handle_a2a_endpoint(
         return json_response(200, &a2a_agent_card(&head, &state.config));
     }
 
-    if let Err(response) = authorize(&head, &state.config) {
-        return response;
-    }
+    let Some(auth) = auth_context(&head, &state.config) else {
+        return json_response(401, &serde_json::json!({ "error": "Unauthorized" }));
+    };
 
     if head.method == "GET" && head.path == "/tasks" {
         let tasks = state
@@ -645,6 +645,7 @@ async fn handle_a2a_endpoint(
             .lock()
             .await
             .values()
+            .filter(|task| a2a_task_visible_to_auth(task, &auth))
             .cloned()
             .collect::<Vec<_>>();
         return json_response(200, &serde_json::json!({ "tasks": tasks }));
@@ -655,14 +656,20 @@ async fn handle_a2a_endpoint(
             let tasks = state.a2a_tasks.lock().await;
             return tasks.get(task_id).map_or_else(
                 || a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found"),
-                |task| json_response(200, task),
+                |task| {
+                    if a2a_task_visible_to_auth(task, &auth) {
+                        json_response(200, task)
+                    } else {
+                        a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found")
+                    }
+                },
             );
         }
     }
 
     if head.method == "POST" {
         if let Some(task_id) = a2a_task_id_from_cancel_path(&head.path) {
-            return match cancel_a2a_task(state, task_id).await {
+            return match cancel_a2a_task(state, task_id, &auth).await {
                 Ok(task) => json_response(200, &task),
                 Err(response) => response,
             };
@@ -670,13 +677,17 @@ async fn handle_a2a_endpoint(
     }
 
     if head.method == "POST" && head.path == "/message:send" {
-        return handle_a2a_message_send(stream, initial, &head, state).await;
+        return handle_a2a_message_send(stream, initial, &head, state, &auth).await;
     }
 
     a2a_error_response(404, "NOT_FOUND", "A2A endpoint not found")
 }
 
-async fn cancel_a2a_task(state: &AppState, task_id: &str) -> Result<Value, Vec<u8>> {
+async fn cancel_a2a_task(
+    state: &AppState,
+    task_id: &str,
+    auth: &AuthContext,
+) -> Result<Value, Vec<u8>> {
     let mut tasks = state.a2a_tasks.lock().await;
     let Some(task) = tasks.get_mut(task_id) else {
         return Err(a2a_error_response(
@@ -685,6 +696,13 @@ async fn cancel_a2a_task(state: &AppState, task_id: &str) -> Result<Value, Vec<u
             "A2A task not found",
         ));
     };
+    if !a2a_task_visible_to_auth(task, auth) {
+        return Err(a2a_error_response(
+            404,
+            "TASK_NOT_FOUND",
+            "A2A task not found",
+        ));
+    }
     if a2a_task_is_terminal(task) {
         return Err(a2a_error_response(
             400,
@@ -742,10 +760,26 @@ fn a2a_task_accepts_message(task: &Value) -> bool {
     a2a_task_status_state(task) == Some("TASK_STATE_INPUT_REQUIRED")
 }
 
+fn a2a_task_owner_subject(task: &Value) -> Option<&str> {
+    task.get("metadata")
+        .and_then(|metadata| metadata.get("ownerSubject"))
+        .and_then(Value::as_str)
+}
+
+fn a2a_task_visible_to_auth(task: &Value, auth: &AuthContext) -> bool {
+    if auth.unrestricted {
+        return true;
+    }
+    auth.subject
+        .as_deref()
+        .is_some_and(|subject| a2a_task_owner_subject(task) == Some(subject))
+}
+
 async fn claim_a2a_send_task(
     state: &AppState,
     request: &A2ASendMessageRequest,
     head: &RequestHead,
+    auth: &AuthContext,
     metadata: Value,
 ) -> Result<A2ASendTarget, Vec<u8>> {
     let requested_task_id = request
@@ -772,6 +806,13 @@ async fn claim_a2a_send_task(
                 "A2A task not found",
             ));
         };
+        if !a2a_task_visible_to_auth(task, auth) {
+            return Err(a2a_error_response(
+                404,
+                "TASK_NOT_FOUND",
+                "A2A task not found",
+            ));
+        }
         if a2a_task_is_terminal(task) {
             return Err(a2a_error_response(
                 400,
@@ -918,6 +959,7 @@ async fn handle_a2a_message_send(
     initial: &mut Vec<u8>,
     head: &RequestHead,
     state: &AppState,
+    auth: &AuthContext,
 ) -> Vec<u8> {
     let body = match read_request_body(stream, initial, head).await {
         Ok(body) => body,
@@ -942,8 +984,8 @@ async fn handle_a2a_message_send(
         );
     };
 
-    let metadata = a2a_task_metadata(head, &request);
-    let target = match claim_a2a_send_task(state, &request, head, metadata.clone()).await {
+    let metadata = a2a_task_metadata(head, &request, auth);
+    let target = match claim_a2a_send_task(state, &request, head, auth, metadata.clone()).await {
         Ok(target) => target,
         Err(response) => return response,
     };
@@ -1236,7 +1278,11 @@ fn a2a_task_value(
     })
 }
 
-fn a2a_task_metadata(head: &RequestHead, request: &A2ASendMessageRequest) -> Value {
+fn a2a_task_metadata(
+    head: &RequestHead,
+    request: &A2ASendMessageRequest,
+    auth: &AuthContext,
+) -> Value {
     let mut metadata = Map::new();
     metadata.insert(
         "runtime".to_string(),
@@ -1247,6 +1293,12 @@ fn a2a_task_metadata(head: &RequestHead, request: &A2ASendMessageRequest) -> Val
         "a2aProtocolVersion".to_string(),
         Value::String(A2A_PROTOCOL_VERSION.to_string()),
     );
+    if let Some(subject) = auth.subject.as_deref() {
+        metadata.insert(
+            "ownerSubject".to_string(),
+            Value::String(subject.to_string()),
+        );
+    }
     for (field, header) in [
         ("workspaceId", "x-evalops-workspace-id"),
         ("agentId", "x-evalops-agent-id"),
@@ -6720,6 +6772,11 @@ mod tests {
         }
     }
 
+    fn shared_secret_bearer_token(secret: &[u8], user_id: &str) -> String {
+        let signature = hmac_sha256_hex(secret, user_id.as_bytes());
+        format!("{}.{}", URL_SAFE_NO_PAD.encode(user_id), signature)
+    }
+
     fn csrf_head(method: &str, token: Option<&str>) -> RequestHead {
         let mut headers = HashMap::new();
         if let Some(token) = token {
@@ -7186,6 +7243,108 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn a2a_tasks_list_only_returns_tasks_owned_by_subject() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_secret = env::var_os("MAESTRO_AUTH_SHARED_SECRET");
+        env::set_var("MAESTRO_AUTH_SHARED_SECRET", "shared-secret");
+        let state = test_app_state_with_sessions(HashMap::new());
+        for (task_id, owner) in [
+            ("owned-task", Some("user-123")),
+            ("other-task", Some("user-456")),
+            ("unowned-task", None),
+        ] {
+            let mut metadata = Map::new();
+            if let Some(owner) = owner {
+                metadata.insert("ownerSubject".to_string(), Value::String(owner.to_string()));
+            }
+            let task = a2a_task_value(
+                task_id,
+                "ctx-1",
+                "TASK_STATE_COMPLETED",
+                a2a_agent_message("ctx-1", "done"),
+                Vec::new(),
+                Vec::new(),
+                Value::Object(metadata),
+            );
+            state.a2a_tasks.lock().await.insert(task_id.to_string(), task);
+        }
+        let token = shared_secret_bearer_token(b"shared-secret", "user-123");
+        let request = format!(
+            "GET /tasks HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {token}\r\n\r\n"
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let tasks = response["tasks"].as_array().expect("tasks should be an array");
+
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0]["id"], "owned-task");
+
+        if let Some(previous_secret) = previous_secret {
+            env::set_var("MAESTRO_AUTH_SHARED_SECRET", previous_secret);
+        } else {
+            env::remove_var("MAESTRO_AUTH_SHARED_SECRET");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_rejects_task_follow_up_from_other_subject() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_secret = env::var_os("MAESTRO_AUTH_SHARED_SECRET");
+        let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
+        env::set_var("MAESTRO_AUTH_SHARED_SECRET", "shared-secret");
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "should not run");
+        let state = test_app_state_with_sessions(HashMap::new());
+        let existing_message = a2a_agent_message("ctx-1", "Need more input");
+        let task = a2a_task_value(
+            "owned-task",
+            "ctx-1",
+            "TASK_STATE_INPUT_REQUIRED",
+            existing_message.clone(),
+            vec![existing_message],
+            Vec::new(),
+            serde_json::json!({ "ownerSubject": "user-123" }),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("owned-task".to_string(), task);
+        let token = shared_secret_bearer_token(b"shared-secret", "user-456");
+        let body = r#"{"message":{"messageId":"msg-2","contextId":"ctx-1","taskId":"owned-task","role":"ROLE_USER","parts":[{"text":"follow up","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {token}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert_eq!(response["error"]["code"], "TASK_NOT_FOUND");
+        assert_eq!(
+            state.a2a_tasks.lock().await["owned-task"]["status"]["state"],
+            "TASK_STATE_INPUT_REQUIRED"
+        );
+
+        if let Some(previous_secret) = previous_secret {
+            env::set_var("MAESTRO_AUTH_SHARED_SECRET", previous_secret);
+        } else {
+            env::remove_var("MAESTRO_AUTH_SHARED_SECRET");
+        }
+        if let Some(previous_fake) = previous_fake {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn a2a_message_send_rejects_unknown_task_id() {
         let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
         let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
@@ -7384,11 +7543,16 @@ mod tests {
             configuration: None,
             metadata: None,
         };
+        let auth = AuthContext {
+            subject: None,
+            unrestricted: true,
+        };
 
         let claimed = claim_a2a_send_task(
             &state,
             &request,
             &head,
+            &auth,
             serde_json::json!({ "test": "metadata" }),
         )
         .await
@@ -7405,7 +7569,7 @@ mod tests {
         drop(stored);
 
         let response = response_json(
-            claim_a2a_send_task(&state, &request, &head, serde_json::json!({}))
+            claim_a2a_send_task(&state, &request, &head, &auth, serde_json::json!({}))
                 .await
                 .expect_err("already-claimed task should reject overlap"),
         );

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1208,7 +1208,15 @@ fn a2a_public_base_url(_head: &RequestHead, config: &Config) -> String {
     } else {
         config.listen_host.clone()
     };
-    if host.contains(':') {
+    if host.starts_with('[') {
+        if host.contains("]:") {
+            format!("http://{host}")
+        } else {
+            format!("http://{host}:{}", config.listen_port)
+        }
+    } else if host.matches(':').count() > 1 {
+        format!("http://[{host}]:{}", config.listen_port)
+    } else if host.contains(':') {
         format!("http://{host}")
     } else {
         format!("http://{host}:{}", config.listen_port)
@@ -7194,6 +7202,44 @@ mod tests {
             card["supportedInterfaces"][0]["url"],
             "http://mini.example.test:18787"
         );
+
+        if let Some(previous_a2a_host) = previous_a2a_host {
+            env::set_var("MAESTRO_A2A_PUBLIC_HOST", previous_a2a_host);
+        } else {
+            env::remove_var("MAESTRO_A2A_PUBLIC_HOST");
+        }
+        if let Some(previous_a2a_url) = previous_a2a_url {
+            env::set_var("MAESTRO_A2A_PUBLIC_URL", previous_a2a_url);
+        } else {
+            env::remove_var("MAESTRO_A2A_PUBLIC_URL");
+        }
+        if let Some(previous_control_url) = previous_control_url {
+            env::set_var("MAESTRO_CONTROL_PUBLIC_URL", previous_control_url);
+        } else {
+            env::remove_var("MAESTRO_CONTROL_PUBLIC_URL");
+        }
+    }
+
+    #[test]
+    fn a2a_agent_card_brackets_ipv6_public_host_and_preserves_port() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_a2a_host = env::var_os("MAESTRO_A2A_PUBLIC_HOST");
+        let previous_a2a_url = env::var_os("MAESTRO_A2A_PUBLIC_URL");
+        let previous_control_url = env::var_os("MAESTRO_CONTROL_PUBLIC_URL");
+        env::set_var("MAESTRO_A2A_PUBLIC_HOST", "::1");
+        env::remove_var("MAESTRO_A2A_PUBLIC_URL");
+        env::remove_var("MAESTRO_CONTROL_PUBLIC_URL");
+        let mut config = auth_test_config();
+        config.listen_host = "::".to_string();
+        config.listen_port = 18787;
+        let head = parse_request_head(
+            b"GET /.well-known/agent-card.json HTTP/1.1\r\nHost: attacker.test\r\n\r\n",
+        )
+        .expect("request should parse");
+        let card = a2a_agent_card(&head, &config);
+
+        assert_eq!(card["url"], "http://[::1]:18787");
+        assert_eq!(card["supportedInterfaces"][0]["url"], "http://[::1]:18787");
 
         if let Some(previous_a2a_host) = previous_a2a_host {
             env::set_var("MAESTRO_A2A_PUBLIC_HOST", previous_a2a_host);

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1229,9 +1229,15 @@ async fn run_a2a_native_turn(
     let mut output = A2ATurnOutput::default();
     let mut last_error: Option<String> = None;
     let mut response_ended = false;
+    let turn_timeout = tokio::time::sleep(timeout);
+    tokio::pin!(turn_timeout);
 
     loop {
         let event = tokio::select! {
+            _ = &mut turn_timeout => {
+                agent.cancel();
+                return Err("A2A native TUI turn timed out".to_string());
+            }
             changed = cancel_rx.changed() => {
                 if changed.is_ok() && *cancel_rx.borrow() {
                     agent.cancel();
@@ -1239,13 +1245,9 @@ async fn run_a2a_native_turn(
                 }
                 continue;
             }
-            event = tokio::time::timeout(timeout, events.recv()) => match event {
-                Ok(Some(event)) => event,
-                Ok(None) => break,
-                Err(_) => {
-                    agent.cancel();
-                    return Err("A2A native TUI turn timed out".to_string());
-                }
+            event = events.recv() => match event {
+                Some(event) => event,
+                None => break,
             },
         };
         match event {

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1099,23 +1099,35 @@ fn a2a_message_text(message: &A2AMessageBody) -> Option<String> {
     (!text.is_empty()).then_some(text)
 }
 
+fn trimmed_non_empty_string(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
 fn a2a_context_id(request: &A2ASendMessageRequest, head: &RequestHead) -> String {
     request
         .message
         .context_id
         .as_deref()
+        .and_then(trimmed_non_empty_string)
         .or_else(|| {
             request
                 .message
                 .metadata
                 .as_ref()
                 .and_then(|metadata| metadata.get("sessionId").and_then(Value::as_str))
+                .and_then(trimmed_non_empty_string)
         })
-        .or_else(|| head.headers.get("x-evalops-session-id").map(String::as_str))
-        .or_else(|| head.headers.get("x-maestro-session-id").map(String::as_str))
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
+        .or_else(|| {
+            head.headers
+                .get("x-evalops-session-id")
+                .and_then(|value| trimmed_non_empty_string(value))
+        })
+        .or_else(|| {
+            head.headers
+                .get("x-maestro-session-id")
+                .and_then(|value| trimmed_non_empty_string(value))
+        })
         .unwrap_or_else(|| generate_a2a_id("maestro-context"))
 }
 
@@ -7036,6 +7048,37 @@ mod tests {
         let value = a2a_user_message_value(&message, "ctx-1");
 
         assert_eq!(value["contextId"], "ctx-1");
+    }
+
+    #[test]
+    fn a2a_context_id_falls_back_when_message_context_is_blank() {
+        let request = A2ASendMessageRequest {
+            message: A2AMessageBody {
+                message_id: Some("msg-1".to_string()),
+                context_id: Some("   ".to_string()),
+                task_id: None,
+                role: Some("ROLE_USER".to_string()),
+                parts: vec![A2APartBody {
+                    text: Some("hello".to_string()),
+                    url: None,
+                    data: None,
+                    metadata: Some(serde_json::json!({ "sessionId": " metadata-ctx " })),
+                    filename: None,
+                    media_type: Some("text/plain".to_string()),
+                }],
+                metadata: Some(serde_json::json!({ "sessionId": " metadata-ctx " })),
+                extensions: None,
+                reference_task_ids: None,
+            },
+            configuration: None,
+            metadata: None,
+        };
+        let head = parse_request_head(
+            b"POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-evalops-session-id: header-ctx\r\n\r\n",
+        )
+        .expect("request should parse");
+
+        assert_eq!(a2a_context_id(&request, &head), "metadata-ctx");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1125,35 +1125,18 @@ fn a2a_agent_card(head: &RequestHead, config: &Config) -> Value {
     })
 }
 
-fn a2a_public_base_url(head: &RequestHead, config: &Config) -> String {
+fn a2a_public_base_url(_head: &RequestHead, config: &Config) -> String {
     if let Some(url) =
         trimmed_env("MAESTRO_A2A_PUBLIC_URL").or_else(|| trimmed_env("MAESTRO_CONTROL_PUBLIC_URL"))
     {
         return url.trim_end_matches('/').to_string();
     }
-    let proto = head
-        .headers
-        .get("x-forwarded-proto")
-        .and_then(|value| value.split(',').next())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("http");
-    let host = head
-        .headers
-        .get("host")
-        .map(String::as_str)
-        .filter(|host| !host.trim().is_empty())
-        .map(str::trim)
-        .map(str::to_string)
-        .unwrap_or_else(|| {
-            let host = if config.listen_host == "0.0.0.0" || config.listen_host == "::" {
-                "127.0.0.1"
-            } else {
-                config.listen_host.as_str()
-            };
-            format!("{host}:{}", config.listen_port)
-        });
-    format!("{proto}://{host}")
+    let host = if config.listen_host == "0.0.0.0" || config.listen_host == "::" {
+        "127.0.0.1"
+    } else {
+        config.listen_host.as_str()
+    };
+    format!("http://{host}:{}", config.listen_port)
 }
 
 fn a2a_message_text(message: &A2AMessageBody) -> Option<String> {
@@ -7052,19 +7035,35 @@ mod tests {
 
     #[test]
     fn a2a_agent_card_advertises_http_json_interface() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_a2a_url = env::var_os("MAESTRO_A2A_PUBLIC_URL");
+        let previous_control_url = env::var_os("MAESTRO_CONTROL_PUBLIC_URL");
+        env::remove_var("MAESTRO_A2A_PUBLIC_URL");
+        env::remove_var("MAESTRO_CONTROL_PUBLIC_URL");
         let head = parse_request_head(
-            b"GET /.well-known/agent-card.json HTTP/1.1\r\nHost: mini.local:8080\r\n\r\n",
+            b"GET /.well-known/agent-card.json HTTP/1.1\r\nHost: attacker.test\r\nx-forwarded-proto: https\r\n\r\n",
         )
         .expect("request should parse");
         let card = a2a_agent_card(&head, &auth_test_config());
 
         assert_eq!(card["protocolVersion"], A2A_PROTOCOL_VERSION);
-        assert_eq!(card["url"], "http://mini.local:8080");
+        assert_eq!(card["url"], "http://127.0.0.1:0");
+        assert_eq!(card["supportedInterfaces"][0]["url"], "http://127.0.0.1:0");
         assert_eq!(
             card["supportedInterfaces"][0]["protocolBinding"],
             "HTTP+JSON"
         );
         assert_eq!(card["skills"][0]["id"], "maestro-tui-turn");
+        if let Some(previous_a2a_url) = previous_a2a_url {
+            env::set_var("MAESTRO_A2A_PUBLIC_URL", previous_a2a_url);
+        } else {
+            env::remove_var("MAESTRO_A2A_PUBLIC_URL");
+        }
+        if let Some(previous_control_url) = previous_control_url {
+            env::set_var("MAESTRO_CONTROL_PUBLIC_URL", previous_control_url);
+        } else {
+            env::remove_var("MAESTRO_CONTROL_PUBLIC_URL");
+        }
     }
 
     #[test]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -587,6 +587,11 @@ enum A2ATurnResult {
     Canceled,
 }
 
+struct A2ASendTarget {
+    task_id: String,
+    context_id: String,
+}
+
 fn is_a2a_endpoint(head: &RequestHead) -> bool {
     if head.method == "OPTIONS" {
         return head.path == "/.well-known/agent-card.json"
@@ -720,10 +725,15 @@ fn a2a_task_is_terminal(task: &Value) -> bool {
     )
 }
 
-async fn a2a_resolve_send_task_id(
+fn a2a_task_accepts_message(task: &Value) -> bool {
+    a2a_task_status_state(task) == Some("TASK_STATE_INPUT_REQUIRED")
+}
+
+async fn a2a_resolve_send_target(
     state: &AppState,
     request: &A2ASendMessageRequest,
-) -> Result<String, Vec<u8>> {
+    head: &RequestHead,
+) -> Result<A2ASendTarget, Vec<u8>> {
     let Some(task_id) = request
         .message
         .task_id
@@ -731,7 +741,10 @@ async fn a2a_resolve_send_task_id(
         .map(str::trim)
         .filter(|task_id| !task_id.is_empty())
     else {
-        return Ok(generate_a2a_id("maestro-task"));
+        return Ok(A2ASendTarget {
+            task_id: generate_a2a_id("maestro-task"),
+            context_id: a2a_context_id(request, head),
+        });
     };
 
     let tasks = state.a2a_tasks.lock().await;
@@ -749,24 +762,45 @@ async fn a2a_resolve_send_task_id(
             "A2A terminal tasks cannot accept more messages",
         ));
     }
-    if let Some(message_context_id) = request
+    if !a2a_task_accepts_message(task) {
+        return Err(a2a_error_response(
+            409,
+            "UNSUPPORTED_OPERATION",
+            "A2A task is not ready to accept another message",
+        ));
+    }
+
+    let explicit_context_id = request
         .message
         .context_id
         .as_deref()
         .map(str::trim)
         .filter(|context_id| !context_id.is_empty())
+        .map(str::to_string);
+    let task_context_id = task
+        .get("contextId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|context_id| !context_id.is_empty())
+        .map(str::to_string);
+    if let (Some(message_context_id), Some(task_context_id)) =
+        (explicit_context_id.as_deref(), task_context_id.as_deref())
     {
-        if let Some(task_context_id) = task.get("contextId").and_then(Value::as_str) {
-            if message_context_id != task_context_id {
-                return Err(a2a_error_response(
-                    400,
-                    "INVALID_REQUEST",
-                    "A2A message contextId must match the referenced task",
-                ));
-            }
+        if message_context_id != task_context_id {
+            return Err(a2a_error_response(
+                400,
+                "INVALID_REQUEST",
+                "A2A message contextId must match the referenced task",
+            ));
         }
     }
-    Ok(task_id.to_string())
+    let context_id = explicit_context_id
+        .or(task_context_id)
+        .unwrap_or_else(|| a2a_context_id(request, head));
+    Ok(A2ASendTarget {
+        task_id: task_id.to_string(),
+        context_id,
+    })
 }
 
 async fn a2a_existing_task_history(state: &AppState, task_id: &str) -> Vec<Value> {
@@ -790,6 +824,23 @@ async fn store_a2a_task_unless_canceled(state: &AppState, task_id: &str, task: V
     }
     tasks.insert(task_id.to_string(), task.clone());
     task
+}
+
+async fn register_a2a_cancel_sender(
+    state: &AppState,
+    task_id: &str,
+    cancel_tx: A2ACancelSender,
+) -> Result<(), Vec<u8>> {
+    let mut senders = state.a2a_cancel_senders.lock().await;
+    if senders.contains_key(task_id) {
+        return Err(a2a_error_response(
+            409,
+            "UNSUPPORTED_OPERATION",
+            "A2A task is already running",
+        ));
+    }
+    senders.insert(task_id.to_string(), cancel_tx);
+    Ok(())
 }
 
 async fn handle_a2a_message_send(
@@ -821,22 +872,21 @@ async fn handle_a2a_message_send(
         );
     };
 
-    let context_id = a2a_context_id(&request, head);
-    let task_id = match a2a_resolve_send_task_id(state, &request).await {
-        Ok(task_id) => task_id,
+    let target = match a2a_resolve_send_target(state, &request, head).await {
+        Ok(target) => target,
         Err(response) => return response,
     };
+    let task_id = target.task_id;
+    let context_id = target.context_id;
     let user_message = a2a_user_message_value(&request.message, &context_id);
     let mut history = a2a_existing_task_history(state, &task_id).await;
     history.push(user_message.clone());
 
     let metadata = a2a_task_metadata(head, &request);
     let (cancel_tx, cancel_rx) = watch::channel(false);
-    state
-        .a2a_cancel_senders
-        .lock()
-        .await
-        .insert(task_id.clone(), cancel_tx);
+    if let Err(response) = register_a2a_cancel_sender(state, &task_id, cancel_tx).await {
+        return response;
+    }
     if a2a_return_immediately(&request) {
         let accepted_message = a2a_agent_message(&context_id, "Maestro accepted the A2A task.");
         let mut accepted_history = history.clone();
@@ -7010,9 +7060,9 @@ mod tests {
         let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
         env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "follow-up response");
 
-        let body = r#"{"message":{"messageId":"msg-2","contextId":"ctx-1","taskId":"maestro-task-1","role":"ROLE_USER","parts":[{"text":"follow up","mediaType":"text/plain"}]}}"#;
+        let body = r#"{"message":{"messageId":"msg-2","taskId":"maestro-task-1","role":"ROLE_USER","parts":[{"text":"follow up","mediaType":"text/plain"}]}}"#;
         let request = format!(
-            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nx-evalops-session-id: header-ctx\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
             body.len()
         );
         let mut initial = request.into_bytes();
@@ -7040,8 +7090,10 @@ mod tests {
         let task = &response["task"];
 
         assert_eq!(task["id"], "maestro-task-1");
+        assert_eq!(task["contextId"], "ctx-1");
         assert_eq!(task["status"]["state"], "TASK_STATE_COMPLETED");
         assert_eq!(task["history"].as_array().unwrap().len(), 3);
+        assert_eq!(task["history"][1]["contextId"], "ctx-1");
         assert_eq!(task["history"][2]["parts"][0]["text"], "follow-up response");
 
         if let Some(previous_fake) = previous_fake {
@@ -7081,6 +7133,50 @@ mod tests {
             response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
 
         assert_eq!(response["error"]["code"], "UNSUPPORTED_OPERATION");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_rejects_active_task_id() {
+        let body = r#"{"message":{"messageId":"msg-2","contextId":"ctx-1","taskId":"maestro-task-1","role":"ROLE_USER","parts":[{"text":"follow up","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+        let task = a2a_task_value(
+            "maestro-task-1",
+            "ctx-1",
+            "TASK_STATE_WORKING",
+            a2a_agent_message("ctx-1", "working"),
+            Vec::new(),
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-1".to_string(), task);
+        let (cancel_tx, _cancel_rx) = watch::channel(false);
+        state
+            .a2a_cancel_senders
+            .lock()
+            .await
+            .insert("maestro-task-1".to_string(), cancel_tx);
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let stored = state.a2a_tasks.lock().await;
+
+        assert_eq!(response["error"]["code"], "UNSUPPORTED_OPERATION");
+        assert_eq!(
+            stored["maestro-task-1"]["status"]["state"],
+            "TASK_STATE_WORKING"
+        );
+        assert_eq!(state.a2a_cancel_senders.lock().await.len(), 1);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -617,11 +617,6 @@ fn a2a_task_id_from_get_path(path: &str) -> Option<&str> {
     (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
 }
 
-fn a2a_task_id_from_cancel_path(path: &str) -> Option<&str> {
-    let id = path.strip_prefix("/tasks/")?.strip_suffix(":cancel")?;
-    (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
-}
-
 async fn handle_a2a_endpoint(
     stream: &mut TcpStream,
     initial: &mut Vec<u8>,

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -632,6 +632,10 @@ async fn handle_a2a_endpoint(
         return response(204, "text/plain; charset=utf-8", &[]);
     }
 
+    if let Err(response) = validate_csrf(&head, &state.config) {
+        return response;
+    }
+
     if head.method == "GET" && head.path == "/.well-known/agent-card.json" {
         return json_response(200, &a2a_agent_card(&head, &state.config));
     }
@@ -1522,6 +1526,10 @@ async fn run_a2a_native_turn(
                         finish_tool_metadata(&mut output.tools, &call_id, false);
                     }
                 }
+            }
+            FromAgent::ToolStart { call_id } => {
+                response_end_deadline = None;
+                update_tool_metadata_status(&mut output.tools, &call_id, "running");
             }
             FromAgent::ToolEnd {
                 call_id, success, ..
@@ -6828,13 +6836,17 @@ mod tests {
     }
 
     fn csrf_head(method: &str, token: Option<&str>) -> RequestHead {
+        csrf_head_for_path(method, "/api/status", token)
+    }
+
+    fn csrf_head_for_path(method: &str, path: &str, token: Option<&str>) -> RequestHead {
         let mut headers = HashMap::new();
         if let Some(token) = token {
             headers.insert("x-maestro-csrf".to_string(), token.to_string());
         }
         RequestHead {
             method: method.to_string(),
-            path: "/api/status".to_string(),
+            path: path.to_string(),
             query: HashMap::new(),
             headers,
         }
@@ -7022,7 +7034,7 @@ mod tests {
     }
 
     #[test]
-    fn csrf_validation_requires_matching_token_for_mutating_api_requests() {
+    fn csrf_validation_requires_matching_token_for_mutating_api_and_a2a_requests() {
         let mut config = auth_test_config();
         config.require_csrf = true;
         config.csrf_token = Some("csrf-token".to_string());
@@ -7030,6 +7042,24 @@ mod tests {
         assert!(validate_csrf(&csrf_head("POST", Some("csrf-token")), &config).is_ok());
         assert!(validate_csrf(&csrf_head("POST", Some("wrong-token")), &config).is_err());
         assert!(validate_csrf(&csrf_head("POST", None), &config).is_err());
+        assert!(validate_csrf(
+            &csrf_head_for_path("POST", "/message:send", Some("csrf-token")),
+            &config,
+        )
+        .is_ok());
+        assert!(
+            validate_csrf(&csrf_head_for_path("POST", "/message:send", None), &config).is_err()
+        );
+        assert!(validate_csrf(
+            &csrf_head_for_path("POST", "/tasks/maestro-task-1:cancel", Some("csrf-token")),
+            &config,
+        )
+        .is_ok());
+        assert!(validate_csrf(
+            &csrf_head_for_path("POST", "/tasks/maestro-task-1:cancel", None),
+            &config
+        )
+        .is_err());
         assert!(validate_csrf(&csrf_head("GET", None), &config).is_ok());
     }
 
@@ -7383,6 +7413,32 @@ mod tests {
         } else {
             env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_requires_csrf_token_when_enabled() {
+        let body = r#"{"message":{"messageId":"msg-1","contextId":"ctx-1","role":"ROLE_USER","parts":[{"text":"hello","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let base_state = test_app_state_with_sessions(HashMap::new());
+        let mut config = auth_test_config();
+        config.require_csrf = true;
+        config.csrf_token = Some("csrf-token".to_string());
+        let state = AppState {
+            config: Arc::new(config),
+            ..base_state
+        };
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert_eq!(response["error"], "Forbidden: invalid CSRF token");
+        assert!(state.a2a_tasks.lock().await.is_empty());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -8055,6 +8111,44 @@ mod tests {
         } else {
             env::remove_var("MAESTRO_A2A_FAKE_RESPONSE_DELAY_MS");
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_cancel_requires_csrf_token_when_enabled() {
+        let base_state = test_app_state_with_sessions(HashMap::new());
+        let mut config = auth_test_config();
+        config.require_csrf = true;
+        config.csrf_token = Some("csrf-token".to_string());
+        let state = AppState {
+            config: Arc::new(config),
+            ..base_state
+        };
+        state.a2a_tasks.lock().await.insert(
+            "maestro-task-1".to_string(),
+            a2a_task_value(
+                "maestro-task-1",
+                "ctx-1",
+                "TASK_STATE_WORKING",
+                a2a_agent_message("ctx-1", "working"),
+                Vec::new(),
+                Vec::new(),
+                serde_json::json!({ "workspaceId": "ws-1" }),
+            ),
+        );
+
+        let request = "POST /tasks/maestro-task-1:cancel HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n";
+        let mut initial = request.as_bytes().to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert_eq!(response["error"], "Forbidden: invalid CSRF token");
+        assert_eq!(
+            state.a2a_tasks.lock().await["maestro-task-1"]["status"]["state"],
+            "TASK_STATE_WORKING"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -594,6 +594,7 @@ struct A2ASendTarget {
     task_id: String,
     context_id: String,
     history: Vec<Value>,
+    previous_task: Option<Value>,
 }
 
 fn is_a2a_endpoint(head: &RequestHead) -> bool {
@@ -762,7 +763,8 @@ async fn claim_a2a_send_task(
         .map(str::to_string);
 
     let mut tasks = state.a2a_tasks.lock().await;
-    let (task_id, context_id, mut history) = if let Some(task_id) = requested_task_id {
+    let (task_id, context_id, mut history, previous_task) = if let Some(task_id) = requested_task_id
+    {
         let Some(task) = tasks.get(task_id) else {
             return Err(a2a_error_response(
                 404,
@@ -810,12 +812,13 @@ async fn claim_a2a_send_task(
             .and_then(Value::as_array)
             .cloned()
             .unwrap_or_default();
-        (task_id.to_string(), context_id, history)
+        (task_id.to_string(), context_id, history, Some(task.clone()))
     } else {
         (
             generate_a2a_id("maestro-task"),
             explicit_context_id.unwrap_or_else(|| a2a_context_id(request, head)),
             Vec::new(),
+            None,
         )
     };
     history.push(a2a_user_message_value(&request.message, &context_id));
@@ -835,7 +838,17 @@ async fn claim_a2a_send_task(
         task_id,
         context_id,
         history,
+        previous_task,
     })
+}
+
+async fn rollback_a2a_send_claim(state: &AppState, task_id: &str, previous_task: Option<Value>) {
+    let mut tasks = state.a2a_tasks.lock().await;
+    if let Some(previous_task) = previous_task {
+        tasks.insert(task_id.to_string(), previous_task);
+    } else {
+        tasks.remove(task_id);
+    }
 }
 
 async fn a2a_canceled_task(state: &AppState, task_id: &str) -> Option<Value> {
@@ -937,9 +950,11 @@ async fn handle_a2a_message_send(
     let task_id = target.task_id;
     let context_id = target.context_id;
     let history = target.history;
+    let previous_task = target.previous_task;
 
     let (cancel_tx, cancel_rx) = watch::channel(false);
     if let Err(response) = register_a2a_cancel_sender(state, &task_id, cancel_tx).await {
+        rollback_a2a_send_claim(state, &task_id, previous_task).await;
         return response;
     }
     if let Some(task) = a2a_canceled_task(state, &task_id).await {
@@ -7396,6 +7411,57 @@ mod tests {
                 .expect_err("already-claimed task should reject overlap"),
         );
         assert_eq!(response["error"]["code"], "UNSUPPORTED_OPERATION");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_restores_claim_when_cancel_sender_registration_fails() {
+        let body = r#"{"message":{"messageId":"msg-2","contextId":"ctx-1","taskId":"maestro-task-1","role":"ROLE_USER","parts":[{"text":"follow up","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+        let existing_message = a2a_agent_message("ctx-1", "Need more input");
+        let task = a2a_task_value(
+            "maestro-task-1",
+            "ctx-1",
+            "TASK_STATE_INPUT_REQUIRED",
+            existing_message.clone(),
+            vec![existing_message],
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-1".to_string(), task);
+        let (cancel_tx, _cancel_rx) = watch::channel(false);
+        state
+            .a2a_cancel_senders
+            .lock()
+            .await
+            .insert("maestro-task-1".to_string(), cancel_tx);
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let stored = state.a2a_tasks.lock().await;
+
+        assert_eq!(response["error"]["code"], "UNSUPPORTED_OPERATION");
+        assert_eq!(
+            stored["maestro-task-1"]["status"]["state"],
+            "TASK_STATE_INPUT_REQUIRED"
+        );
+        assert_eq!(
+            stored["maestro-task-1"]["history"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -617,6 +617,34 @@ fn a2a_task_id_from_get_path(path: &str) -> Option<&str> {
     (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
 }
 
+fn validate_a2a_protocol_version(head: &RequestHead) -> Result<(), Vec<u8>> {
+    let Some(version) = a2a_requested_protocol_version(head) else {
+        return Ok(());
+    };
+    let version = version.trim();
+    if version == A2A_PROTOCOL_VERSION {
+        Ok(())
+    } else {
+        let message =
+            format!("Unsupported A2A protocol version {version}; expected {A2A_PROTOCOL_VERSION}");
+        Err(a2a_error_response(400, "UNSUPPORTED_VERSION", &message))
+    }
+}
+
+fn a2a_requested_protocol_version(head: &RequestHead) -> Option<&str> {
+    head.headers
+        .get("a2a-version")
+        .and_then(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .find(|part| !part.is_empty())
+        })
+        .or_else(|| head.query.get("a2a-version").map(String::as_str))
+        .or_else(|| head.query.get("A2A-Version").map(String::as_str))
+        .or_else(|| head.query.get("a2aVersion").map(String::as_str))
+}
+
 async fn handle_a2a_endpoint(
     stream: &mut TcpStream,
     initial: &mut Vec<u8>,
@@ -625,6 +653,10 @@ async fn handle_a2a_endpoint(
 ) -> Vec<u8> {
     if head.method == "OPTIONS" {
         return response(204, "text/plain; charset=utf-8", &[]);
+    }
+
+    if let Err(response) = validate_a2a_protocol_version(&head) {
+        return response;
     }
 
     if let Err(response) = validate_csrf(&head, &state.config) {
@@ -7559,6 +7591,29 @@ mod tests {
         assert_eq!(
             response["error"]["message"],
             "A2A configuration must be an object"
+        );
+        assert!(state.a2a_tasks.lock().await.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_rejects_incompatible_protocol_version() {
+        let body = r#"{"message":{"messageId":"msg-1","contextId":"ctx-1","role":"ROLE_USER","parts":[{"text":"hello","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:send?a2a-version=2.0 HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert_eq!(response["error"]["code"], "UNSUPPORTED_VERSION");
+        assert_eq!(
+            response["error"]["message"],
+            "Unsupported A2A protocol version 2.0; expected 1.0"
         );
         assert!(state.a2a_tasks.lock().await.is_empty());
     }

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -701,6 +701,7 @@ async fn cancel_a2a_task(state: &AppState, task_id: &str) -> Result<Value, Vec<u
         "message": a2a_agent_message(&context_id, "Task canceled"),
         "timestamp": now_rfc3339()
     });
+    task["artifacts"] = serde_json::json!([]);
     let task = task.clone();
     prune_a2a_terminal_tasks(&mut tasks);
     drop(tasks);
@@ -7428,6 +7429,52 @@ mod tests {
         assert_eq!(
             stored["maestro-task-1"]["status"]["state"],
             "TASK_STATE_COMPLETED"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_cancel_clears_existing_artifacts() {
+        let (_client, mut server) = tcp_stream_pair().await;
+        let mut initial =
+            b"POST /tasks/maestro-task-1:cancel HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n"
+                .to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let state = test_app_state_with_sessions(HashMap::new());
+        let task = a2a_task_value(
+            "maestro-task-1",
+            "ctx-1",
+            "TASK_STATE_INPUT_REQUIRED",
+            a2a_agent_message("ctx-1", "Need more input"),
+            Vec::new(),
+            vec![serde_json::json!({
+                "artifactId": "artifact-1",
+                "name": "assistant-response",
+                "parts": [{ "text": "stale", "mediaType": "text/plain" }]
+            })],
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-1".to_string(), task);
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let stored = state.a2a_tasks.lock().await;
+
+        assert_eq!(response["status"]["state"], "TASK_STATE_CANCELED");
+        assert_eq!(response["artifacts"].as_array().unwrap().len(), 0);
+        assert_eq!(
+            stored["maestro-task-1"]["status"]["state"],
+            "TASK_STATE_CANCELED"
+        );
+        assert_eq!(
+            stored["maestro-task-1"]["artifacts"]
+                .as_array()
+                .unwrap()
+                .len(),
+            0
         );
     }
 

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -589,9 +589,11 @@ enum A2ATurnResult {
     Canceled,
 }
 
+#[derive(Debug)]
 struct A2ASendTarget {
     task_id: String,
     context_id: String,
+    history: Vec<Value>,
 }
 
 fn is_a2a_endpoint(head: &RequestHead) -> bool {
@@ -738,47 +740,18 @@ fn a2a_task_accepts_message(task: &Value) -> bool {
     a2a_task_status_state(task) == Some("TASK_STATE_INPUT_REQUIRED")
 }
 
-async fn a2a_resolve_send_target(
+async fn claim_a2a_send_task(
     state: &AppState,
     request: &A2ASendMessageRequest,
     head: &RequestHead,
+    metadata: Value,
 ) -> Result<A2ASendTarget, Vec<u8>> {
-    let Some(task_id) = request
+    let requested_task_id = request
         .message
         .task_id
         .as_deref()
         .map(str::trim)
-        .filter(|task_id| !task_id.is_empty())
-    else {
-        return Ok(A2ASendTarget {
-            task_id: generate_a2a_id("maestro-task"),
-            context_id: a2a_context_id(request, head),
-        });
-    };
-
-    let tasks = state.a2a_tasks.lock().await;
-    let Some(task) = tasks.get(task_id) else {
-        return Err(a2a_error_response(
-            404,
-            "TASK_NOT_FOUND",
-            "A2A task not found",
-        ));
-    };
-    if a2a_task_is_terminal(task) {
-        return Err(a2a_error_response(
-            400,
-            "UNSUPPORTED_OPERATION",
-            "A2A terminal tasks cannot accept more messages",
-        ));
-    }
-    if !a2a_task_accepts_message(task) {
-        return Err(a2a_error_response(
-            409,
-            "UNSUPPORTED_OPERATION",
-            "A2A task is not ready to accept another message",
-        ));
-    }
-
+        .filter(|task_id| !task_id.is_empty());
     let explicit_context_id = request
         .message
         .context_id
@@ -786,42 +759,88 @@ async fn a2a_resolve_send_target(
         .map(str::trim)
         .filter(|context_id| !context_id.is_empty())
         .map(str::to_string);
-    let task_context_id = task
-        .get("contextId")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|context_id| !context_id.is_empty())
-        .map(str::to_string);
-    if let (Some(message_context_id), Some(task_context_id)) =
-        (explicit_context_id.as_deref(), task_context_id.as_deref())
-    {
-        if message_context_id != task_context_id {
+
+    let mut tasks = state.a2a_tasks.lock().await;
+    let (task_id, context_id, mut history) = if let Some(task_id) = requested_task_id {
+        let Some(task) = tasks.get(task_id) else {
+            return Err(a2a_error_response(
+                404,
+                "TASK_NOT_FOUND",
+                "A2A task not found",
+            ));
+        };
+        if a2a_task_is_terminal(task) {
             return Err(a2a_error_response(
                 400,
-                "INVALID_REQUEST",
-                "A2A message contextId must match the referenced task",
+                "UNSUPPORTED_OPERATION",
+                "A2A terminal tasks cannot accept more messages",
             ));
         }
-    }
-    let context_id = explicit_context_id
-        .or(task_context_id)
-        .unwrap_or_else(|| a2a_context_id(request, head));
+        if !a2a_task_accepts_message(task) {
+            return Err(a2a_error_response(
+                409,
+                "UNSUPPORTED_OPERATION",
+                "A2A task is not ready to accept another message",
+            ));
+        }
+
+        let task_context_id = task
+            .get("contextId")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|context_id| !context_id.is_empty())
+            .map(str::to_string);
+        if let (Some(message_context_id), Some(task_context_id)) =
+            (explicit_context_id.as_deref(), task_context_id.as_deref())
+        {
+            if message_context_id != task_context_id {
+                return Err(a2a_error_response(
+                    400,
+                    "INVALID_REQUEST",
+                    "A2A message contextId must match the referenced task",
+                ));
+            }
+        }
+        let context_id = explicit_context_id
+            .or(task_context_id)
+            .unwrap_or_else(|| a2a_context_id(request, head));
+        let history = task
+            .get("history")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        (task_id.to_string(), context_id, history)
+    } else {
+        (
+            generate_a2a_id("maestro-task"),
+            explicit_context_id.unwrap_or_else(|| a2a_context_id(request, head)),
+            Vec::new(),
+        )
+    };
+    history.push(a2a_user_message_value(&request.message, &context_id));
+    let working_message = a2a_agent_message(&context_id, "Maestro is working on the A2A task.");
+    let task = a2a_task_value(
+        &task_id,
+        &context_id,
+        "TASK_STATE_WORKING",
+        working_message,
+        history.clone(),
+        Vec::new(),
+        metadata,
+    );
+    tasks.insert(task_id.clone(), task);
+    prune_a2a_terminal_tasks(&mut tasks);
     Ok(A2ASendTarget {
-        task_id: task_id.to_string(),
+        task_id,
         context_id,
+        history,
     })
 }
 
-async fn a2a_existing_task_history(state: &AppState, task_id: &str) -> Vec<Value> {
-    state
-        .a2a_tasks
-        .lock()
-        .await
-        .get(task_id)
-        .and_then(|task| task.get("history"))
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default()
+async fn a2a_canceled_task(state: &AppState, task_id: &str) -> Option<Value> {
+    state.a2a_tasks.lock().await.get(task_id).and_then(|task| {
+        (a2a_task_status_state(task) == Some("TASK_STATE_CANCELED")).then(|| task.clone())
+    })
 }
 
 async fn store_a2a_task_unless_canceled(state: &AppState, task_id: &str, task: Value) -> Value {
@@ -909,20 +928,22 @@ async fn handle_a2a_message_send(
         );
     };
 
-    let target = match a2a_resolve_send_target(state, &request, head).await {
+    let metadata = a2a_task_metadata(head, &request);
+    let target = match claim_a2a_send_task(state, &request, head, metadata.clone()).await {
         Ok(target) => target,
         Err(response) => return response,
     };
     let task_id = target.task_id;
     let context_id = target.context_id;
-    let user_message = a2a_user_message_value(&request.message, &context_id);
-    let mut history = a2a_existing_task_history(state, &task_id).await;
-    history.push(user_message.clone());
+    let history = target.history;
 
-    let metadata = a2a_task_metadata(head, &request);
     let (cancel_tx, cancel_rx) = watch::channel(false);
     if let Err(response) = register_a2a_cancel_sender(state, &task_id, cancel_tx).await {
         return response;
+    }
+    if let Some(task) = a2a_canceled_task(state, &task_id).await {
+        state.a2a_cancel_senders.lock().await.remove(&task_id);
+        return json_response(200, &serde_json::json!({ "task": task }));
     }
     if a2a_return_immediately(&request) {
         let accepted_message = a2a_agent_message(&context_id, "Maestro accepted the A2A task.");
@@ -7301,6 +7322,79 @@ mod tests {
             "TASK_STATE_WORKING"
         );
         assert_eq!(state.a2a_cancel_senders.lock().await.len(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_claims_input_task_before_launch() {
+        let state = test_app_state_with_sessions(HashMap::new());
+        let existing_message = a2a_agent_message("ctx-1", "Need more input");
+        let task = a2a_task_value(
+            "maestro-task-1",
+            "ctx-1",
+            "TASK_STATE_INPUT_REQUIRED",
+            existing_message.clone(),
+            vec![existing_message],
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-1".to_string(), task);
+        let head = RequestHead {
+            method: "POST".to_string(),
+            path: "/message:send".to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+        };
+        let request = A2ASendMessageRequest {
+            message: A2AMessageBody {
+                message_id: Some("msg-2".to_string()),
+                context_id: None,
+                task_id: Some("maestro-task-1".to_string()),
+                role: Some("ROLE_USER".to_string()),
+                parts: vec![A2APartBody {
+                    text: Some("follow up".to_string()),
+                    url: None,
+                    data: None,
+                    metadata: None,
+                    filename: None,
+                    media_type: Some("text/plain".to_string()),
+                }],
+                metadata: None,
+                extensions: None,
+                reference_task_ids: None,
+            },
+            configuration: None,
+            metadata: None,
+        };
+
+        let claimed = claim_a2a_send_task(
+            &state,
+            &request,
+            &head,
+            serde_json::json!({ "test": "metadata" }),
+        )
+        .await
+        .expect("input-required task should be claimed");
+        let stored = state.a2a_tasks.lock().await;
+
+        assert_eq!(claimed.task_id, "maestro-task-1");
+        assert_eq!(claimed.context_id, "ctx-1");
+        assert_eq!(claimed.history.len(), 2);
+        assert_eq!(
+            stored["maestro-task-1"]["status"]["state"],
+            "TASK_STATE_WORKING"
+        );
+        drop(stored);
+
+        let response = response_json(
+            claim_a2a_send_task(&state, &request, &head, serde_json::json!({}))
+                .await
+                .expect_err("already-claimed task should reject overlap"),
+        );
+        assert_eq!(response["error"]["code"], "UNSUPPORTED_OPERATION");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -49,6 +49,8 @@ const MAX_EXTRACT_JSON_BODY_BYTES: usize = 72 * 1024 * 1024;
 const DEFAULT_EXTRACT_MAX_CHARS: usize = 200_000;
 const MAX_EXTRACT_INPUT_BYTES: usize = 50 * 1024 * 1024;
 const MAX_PROJECT_ONBOARDING_IMPRESSIONS: u8 = 4;
+const A2A_PROTOCOL_VERSION: &str = "1.0";
+const A2A_DEFAULT_TURN_TIMEOUT_MS: u64 = 180_000;
 static ATTACHMENT_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
 type PendingToolResponseSender = mpsc::UnboundedSender<(String, bool, Option<ToolResult>)>;
@@ -151,6 +153,7 @@ struct AppState {
     shared_sessions: Arc<Mutex<HashMap<String, SharedSessionGrant>>>,
     approval_modes: Arc<Mutex<HashMap<String, String>>>,
     pending_tool_responses: Arc<Mutex<HashMap<String, PendingToolResponseSender>>>,
+    a2a_tasks: Arc<Mutex<HashMap<String, Value>>>,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -295,6 +298,7 @@ async fn main() -> anyhow::Result<()> {
         shared_sessions: Arc::new(Mutex::new(shared_sessions)),
         approval_modes: Arc::new(Mutex::new(HashMap::new())),
         pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
+        a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
     };
 
     loop {
@@ -327,6 +331,16 @@ async fn handle_connection(mut stream: TcpStream, state: AppState) -> Result<(),
 
         if is_chat_endpoint(&head) {
             return handle_chat_endpoint(stream, initial, head, state).await;
+        }
+
+        if is_a2a_endpoint(&head) {
+            let response = handle_a2a_endpoint(&mut stream, &mut initial, head, &state).await;
+            stream
+                .write_all(&response)
+                .await
+                .map_err(|error| error.to_string())?;
+            let _ = stream.shutdown().await;
+            return Ok(());
         }
 
         if is_local_endpoint(&head) {
@@ -506,6 +520,637 @@ fn pending_request_id_from_resume_path(path: &str) -> Option<&str> {
         return None;
     }
     Some(request_id)
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct A2APartBody {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    metadata: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    filename: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    media_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct A2AMessageBody {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    message_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    context_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    role: Option<String>,
+    #[serde(default)]
+    parts: Vec<A2APartBody>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    metadata: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    extensions: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reference_task_ids: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct A2ASendMessageRequest {
+    message: A2AMessageBody,
+    #[serde(default)]
+    configuration: Option<Value>,
+    #[serde(default)]
+    metadata: Option<Value>,
+}
+
+#[derive(Debug, Default)]
+struct A2ATurnOutput {
+    assistant_text: String,
+    thinking_text: String,
+    usage: Option<TokenUsage>,
+    tools: Vec<Value>,
+}
+
+fn is_a2a_endpoint(head: &RequestHead) -> bool {
+    if head.method == "OPTIONS" {
+        return head.path == "/.well-known/agent-card.json"
+            || head.path == "/message:send"
+            || head.path == "/tasks"
+            || head.path.starts_with("/tasks/");
+    }
+    matches!(
+        (head.method.as_str(), head.path.as_str()),
+        ("GET", "/.well-known/agent-card.json") | ("POST", "/message:send") | ("GET", "/tasks")
+    ) || (head.method == "GET" && a2a_task_id_from_get_path(&head.path).is_some())
+        || (head.method == "POST" && a2a_task_id_from_cancel_path(&head.path).is_some())
+}
+
+fn a2a_task_id_from_get_path(path: &str) -> Option<&str> {
+    let id = path.strip_prefix("/tasks/")?;
+    (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
+}
+
+fn a2a_task_id_from_cancel_path(path: &str) -> Option<&str> {
+    let id = path.strip_prefix("/tasks/")?.strip_suffix(":cancel")?;
+    (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
+}
+
+async fn handle_a2a_endpoint(
+    stream: &mut TcpStream,
+    initial: &mut Vec<u8>,
+    head: RequestHead,
+    state: &AppState,
+) -> Vec<u8> {
+    if head.method == "OPTIONS" {
+        return response(204, "text/plain; charset=utf-8", &[]);
+    }
+
+    if head.method == "GET" && head.path == "/.well-known/agent-card.json" {
+        return json_response(200, &a2a_agent_card(&head, &state.config));
+    }
+
+    if let Err(response) = authorize(&head, &state.config) {
+        return response;
+    }
+
+    if head.method == "GET" && head.path == "/tasks" {
+        let tasks = state
+            .a2a_tasks
+            .lock()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        return json_response(200, &serde_json::json!({ "tasks": tasks }));
+    }
+
+    if head.method == "GET" {
+        if let Some(task_id) = a2a_task_id_from_get_path(&head.path) {
+            let tasks = state.a2a_tasks.lock().await;
+            return tasks.get(task_id).map_or_else(
+                || a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found"),
+                |task| json_response(200, task),
+            );
+        }
+    }
+
+    if head.method == "POST" {
+        if let Some(task_id) = a2a_task_id_from_cancel_path(&head.path) {
+            let mut tasks = state.a2a_tasks.lock().await;
+            let Some(task) = tasks.get_mut(task_id) else {
+                return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");
+            };
+            let context_id = task
+                .get("contextId")
+                .and_then(Value::as_str)
+                .unwrap_or("a2a")
+                .to_string();
+            task["status"] = serde_json::json!({
+                "state": "TASK_STATE_CANCELED",
+                "message": a2a_agent_message(&context_id, "Task canceled"),
+                "timestamp": now_rfc3339()
+            });
+            return json_response(200, task);
+        }
+    }
+
+    if head.method == "POST" && head.path == "/message:send" {
+        return handle_a2a_message_send(stream, initial, &head, state).await;
+    }
+
+    a2a_error_response(404, "NOT_FOUND", "A2A endpoint not found")
+}
+
+async fn handle_a2a_message_send(
+    stream: &mut TcpStream,
+    initial: &mut Vec<u8>,
+    head: &RequestHead,
+    state: &AppState,
+) -> Vec<u8> {
+    let body = match read_request_body(stream, initial, head).await {
+        Ok(body) => body,
+        Err(error) => return a2a_error_response(400, "INVALID_REQUEST", &error),
+    };
+    let request: A2ASendMessageRequest = match serde_json::from_slice(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            return a2a_error_response(
+                400,
+                "INVALID_REQUEST",
+                &format!("invalid A2A message request: {error}"),
+            );
+        }
+    };
+
+    let Some(prompt) = a2a_message_text(&request.message) else {
+        return a2a_error_response(
+            400,
+            "INVALID_REQUEST",
+            "A2A message must contain at least one text part",
+        );
+    };
+
+    let context_id = a2a_context_id(&request, head);
+    let task_id = generate_a2a_id("maestro-task");
+    let user_message = a2a_user_message_value(&request.message, &context_id);
+
+    let metadata = a2a_task_metadata(head, &request);
+    if a2a_return_immediately(&request) {
+        let accepted_message = a2a_agent_message(&context_id, "Maestro accepted the A2A task.");
+        let task = a2a_task_value(
+            &task_id,
+            &context_id,
+            "TASK_STATE_WORKING",
+            accepted_message.clone(),
+            vec![user_message.clone(), accepted_message],
+            Vec::new(),
+            metadata.clone(),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert(task_id.clone(), task.clone());
+        let state = state.clone();
+        tokio::spawn(async move {
+            let _ = complete_a2a_task(&state, prompt, task_id, context_id, user_message, metadata)
+                .await;
+        });
+        return json_response(200, &serde_json::json!({ "task": task }));
+    }
+
+    let task = complete_a2a_task(state, prompt, task_id, context_id, user_message, metadata).await;
+    json_response(200, &serde_json::json!({ "task": task }))
+}
+
+async fn complete_a2a_task(
+    state: &AppState,
+    prompt: String,
+    task_id: String,
+    context_id: String,
+    user_message: Value,
+    mut metadata: Value,
+) -> Value {
+    let turn = match run_a2a_native_turn(state, prompt).await {
+        Ok(turn) => turn,
+        Err(error) => {
+            let message = a2a_agent_message(&context_id, &error);
+            let task = a2a_task_value(
+                &task_id,
+                &context_id,
+                "TASK_STATE_FAILED",
+                message.clone(),
+                vec![user_message, message],
+                Vec::new(),
+                metadata,
+            );
+            state
+                .a2a_tasks
+                .lock()
+                .await
+                .insert(task_id.clone(), task.clone());
+            return task;
+        }
+    };
+
+    let assistant_text = if turn.assistant_text.trim().is_empty() {
+        "Maestro completed the A2A task without a text response.".to_string()
+    } else {
+        turn.assistant_text
+    };
+    let agent_message = a2a_agent_message(&context_id, &assistant_text);
+    if !turn.thinking_text.trim().is_empty() {
+        metadata["thinking"] = Value::String(turn.thinking_text);
+    }
+    if !turn.tools.is_empty() {
+        metadata["tools"] = Value::Array(turn.tools);
+    }
+    if let Some(usage) = turn.usage {
+        metadata["usage"] = serde_json::json!({
+            "input": usage.input_tokens,
+            "output": usage.output_tokens,
+            "cacheRead": usage.cache_read_tokens,
+            "cacheWrite": usage.cache_write_tokens,
+            "cost": usage.cost.unwrap_or(0.0)
+        });
+    }
+    let task = a2a_task_value(
+        &task_id,
+        &context_id,
+        "TASK_STATE_COMPLETED",
+        agent_message.clone(),
+        vec![user_message, agent_message],
+        vec![serde_json::json!({
+            "artifactId": format!("{task_id}-assistant-response"),
+            "name": "assistant-response",
+            "parts": [{ "text": assistant_text, "mediaType": "text/plain" }]
+        })],
+        metadata,
+    );
+    state
+        .a2a_tasks
+        .lock()
+        .await
+        .insert(task_id.clone(), task.clone());
+    task
+}
+
+fn a2a_agent_card(head: &RequestHead, config: &Config) -> Value {
+    let base_url = a2a_public_base_url(head, config);
+    serde_json::json!({
+        "protocolVersion": A2A_PROTOCOL_VERSION,
+        "name": trimmed_env("MAESTRO_A2A_AGENT_NAME")
+            .unwrap_or_else(|| "Maestro Desktop Agent".to_string()),
+        "description": "Local Maestro Rust/TS TUI agent endpoint for A2A task delegation.",
+        "url": base_url,
+        "preferredTransport": "HTTP+JSON",
+        "supportedInterfaces": [{
+            "url": base_url,
+            "protocolBinding": "HTTP+JSON",
+            "protocolVersion": A2A_PROTOCOL_VERSION
+        }],
+        "provider": {
+            "organization": "EvalOps",
+            "url": "https://evalops.com"
+        },
+        "version": env!("CARGO_PKG_VERSION"),
+        "capabilities": {
+            "streaming": false,
+            "pushNotifications": false,
+            "extendedAgentCard": false
+        },
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain", "application/json"],
+        "skills": [{
+            "id": "maestro-tui-turn",
+            "name": "Maestro TUI turn",
+            "description": "Run a prompt through the local Maestro native TUI agent runner.",
+            "tags": ["maestro", "tui", "codex", "a2a"],
+            "examples": [
+                "Review the current workspace and summarize the next highest leverage action."
+            ],
+            "inputModes": ["text/plain"],
+            "outputModes": ["text/plain", "application/json"]
+        }]
+    })
+}
+
+fn a2a_public_base_url(head: &RequestHead, config: &Config) -> String {
+    if let Some(url) =
+        trimmed_env("MAESTRO_A2A_PUBLIC_URL").or_else(|| trimmed_env("MAESTRO_CONTROL_PUBLIC_URL"))
+    {
+        return url.trim_end_matches('/').to_string();
+    }
+    let proto = head
+        .headers
+        .get("x-forwarded-proto")
+        .and_then(|value| value.split(',').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("http");
+    let host = head
+        .headers
+        .get("host")
+        .map(String::as_str)
+        .filter(|host| !host.trim().is_empty())
+        .map(str::trim)
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            let host = if config.listen_host == "0.0.0.0" || config.listen_host == "::" {
+                "127.0.0.1"
+            } else {
+                config.listen_host.as_str()
+            };
+            format!("{host}:{}", config.listen_port)
+        });
+    format!("{proto}://{host}")
+}
+
+fn a2a_message_text(message: &A2AMessageBody) -> Option<String> {
+    let text = message
+        .parts
+        .iter()
+        .filter_map(|part| part.text.as_deref())
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    (!text.is_empty()).then_some(text)
+}
+
+fn a2a_context_id(request: &A2ASendMessageRequest, head: &RequestHead) -> String {
+    request
+        .message
+        .context_id
+        .as_deref()
+        .or_else(|| {
+            request
+                .message
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("sessionId").and_then(Value::as_str))
+        })
+        .or_else(|| head.headers.get("x-evalops-session-id").map(String::as_str))
+        .or_else(|| head.headers.get("x-maestro-session-id").map(String::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| generate_a2a_id("maestro-context"))
+}
+
+fn a2a_user_message_value(message: &A2AMessageBody, context_id: &str) -> Value {
+    let mut value = serde_json::to_value(message).unwrap_or_else(|_| serde_json::json!({}));
+    if let Value::Object(object) = &mut value {
+        object
+            .entry("messageId")
+            .or_insert_with(|| Value::String(generate_a2a_id("maestro-message")));
+        object
+            .entry("contextId")
+            .or_insert_with(|| Value::String(context_id.to_string()));
+        object
+            .entry("role")
+            .or_insert_with(|| Value::String("ROLE_USER".to_string()));
+    }
+    value
+}
+
+fn a2a_agent_message(context_id: &str, text: &str) -> Value {
+    serde_json::json!({
+        "messageId": generate_a2a_id("maestro-message"),
+        "contextId": context_id,
+        "role": "ROLE_AGENT",
+        "parts": [{ "text": text, "mediaType": "text/plain" }],
+        "metadata": {
+            "runtime": "maestro-rust-control-plane",
+            "surface": "rust-tui"
+        }
+    })
+}
+
+fn a2a_task_value(
+    task_id: &str,
+    context_id: &str,
+    state: &str,
+    status_message: Value,
+    history: Vec<Value>,
+    artifacts: Vec<Value>,
+    metadata: Value,
+) -> Value {
+    serde_json::json!({
+        "id": task_id,
+        "contextId": context_id,
+        "status": {
+            "state": state,
+            "message": status_message,
+            "timestamp": now_rfc3339()
+        },
+        "history": history,
+        "artifacts": artifacts,
+        "metadata": metadata
+    })
+}
+
+fn a2a_task_metadata(head: &RequestHead, request: &A2ASendMessageRequest) -> Value {
+    let mut metadata = Map::new();
+    metadata.insert(
+        "runtime".to_string(),
+        Value::String("maestro-rust-control-plane".to_string()),
+    );
+    metadata.insert("surface".to_string(), Value::String("rust-tui".to_string()));
+    metadata.insert(
+        "a2aProtocolVersion".to_string(),
+        Value::String(A2A_PROTOCOL_VERSION.to_string()),
+    );
+    for (field, header) in [
+        ("workspaceId", "x-evalops-workspace-id"),
+        ("agentId", "x-evalops-agent-id"),
+        ("sessionId", "x-evalops-session-id"),
+        ("actorId", "x-evalops-actor-id"),
+        ("traceparent", "traceparent"),
+        ("tracestate", "tracestate"),
+    ] {
+        if let Some(value) = head.headers.get(header).map(String::as_str) {
+            if !value.trim().is_empty() {
+                metadata.insert(field.to_string(), Value::String(value.trim().to_string()));
+            }
+        }
+    }
+    if let Some(Value::Object(request_metadata)) = request.metadata.as_ref() {
+        for (key, value) in request_metadata {
+            metadata.entry(key.clone()).or_insert_with(|| value.clone());
+        }
+    }
+    if let Some(configuration) = request.configuration.as_ref() {
+        metadata
+            .entry("configuration".to_string())
+            .or_insert_with(|| configuration.clone());
+    }
+    if let Some(Value::Object(message_metadata)) = request.message.metadata.as_ref() {
+        for (key, value) in message_metadata {
+            metadata.entry(key.clone()).or_insert_with(|| value.clone());
+        }
+    }
+    Value::Object(metadata)
+}
+
+fn a2a_return_immediately(request: &A2ASendMessageRequest) -> bool {
+    request
+        .configuration
+        .as_ref()
+        .and_then(|configuration| configuration.get("returnImmediately"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+async fn run_a2a_native_turn(state: &AppState, prompt: String) -> Result<A2ATurnOutput, String> {
+    if let Some(response) = trimmed_env("MAESTRO_A2A_FAKE_RESPONSE") {
+        return Ok(A2ATurnOutput {
+            assistant_text: response,
+            ..Default::default()
+        });
+    }
+
+    let model = if let Some(model) = trimmed_env("MAESTRO_A2A_MODEL") {
+        model
+    } else {
+        let selected = state.selected_model.lock().await;
+        format!("{}/{}", selected.provider, selected.id)
+    };
+    let config = NativeAgentConfig {
+        model,
+        cwd: state.config.cwd.to_string_lossy().to_string(),
+        system_prompt: Some(
+            trimmed_env("MAESTRO_A2A_SYSTEM_PROMPT").unwrap_or_else(|| {
+                "You are the local Maestro Desktop A2A agent. Complete delegated work from peer agents clearly and concisely.".to_string()
+            }),
+        ),
+        thinking_enabled: truthy_env("MAESTRO_A2A_THINKING"),
+        thinking_budget: env::var("MAESTRO_A2A_THINKING_BUDGET")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(10_000),
+        ..NativeAgentConfig::default()
+    };
+    let (agent, mut events) = NativeAgent::new(config).map_err(|error| error.to_string())?;
+    agent
+        .prompt(prompt, Vec::new())
+        .await
+        .map_err(|error| error.to_string())?;
+
+    let timeout = Duration::from_millis(env_u64(
+        "MAESTRO_A2A_TURN_TIMEOUT_MS",
+        A2A_DEFAULT_TURN_TIMEOUT_MS,
+    ));
+    let approval_mode = trimmed_env("MAESTRO_A2A_TOOL_APPROVAL")
+        .unwrap_or_else(|| "fail".to_string())
+        .to_ascii_lowercase();
+    let auto_approve_tools = matches!(approval_mode.as_str(), "auto" | "approve" | "approved");
+    let mut output = A2ATurnOutput::default();
+    let mut last_error: Option<String> = None;
+    let mut response_ended = false;
+
+    loop {
+        let event = match tokio::time::timeout(timeout, events.recv()).await {
+            Ok(Some(event)) => event,
+            Ok(None) => break,
+            Err(_) => {
+                agent.cancel();
+                return Err("A2A native TUI turn timed out".to_string());
+            }
+        };
+        match event {
+            FromAgent::ResponseChunk {
+                content,
+                is_thinking,
+                ..
+            } => {
+                if is_thinking {
+                    output.thinking_text.push_str(&content);
+                } else {
+                    output.assistant_text.push_str(&content);
+                }
+            }
+            FromAgent::ResponseEnd { usage, .. } => {
+                output.usage = usage;
+                response_ended = true;
+                break;
+            }
+            FromAgent::ToolCall {
+                call_id,
+                tool,
+                args,
+                requires_approval,
+            } => {
+                record_tool_call_metadata(&mut output.tools, &call_id, &tool, args);
+                if requires_approval {
+                    let _ = agent.tool_response_sender().send((
+                        call_id.clone(),
+                        auto_approve_tools,
+                        None,
+                    ));
+                    if !auto_approve_tools {
+                        finish_tool_metadata(&mut output.tools, &call_id, false);
+                    }
+                }
+            }
+            FromAgent::ToolEnd {
+                call_id, success, ..
+            } => {
+                finish_tool_metadata(&mut output.tools, &call_id, success);
+            }
+            FromAgent::HookBlocked {
+                call_id,
+                tool,
+                reason,
+            } => {
+                if !output
+                    .tools
+                    .iter()
+                    .any(|entry| entry.get("id").and_then(Value::as_str) == Some(&call_id))
+                {
+                    record_tool_call_metadata(&mut output.tools, &call_id, &tool, Value::Null);
+                }
+                finish_tool_metadata(&mut output.tools, &call_id, false);
+                last_error = Some(reason);
+            }
+            FromAgent::Error { message, fatal } => {
+                last_error = Some(message);
+                if fatal {
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if response_ended {
+        Ok(output)
+    } else {
+        Err(last_error
+            .unwrap_or_else(|| "A2A native TUI turn ended before response_end".to_string()))
+    }
+}
+
+fn generate_a2a_id(prefix: &str) -> String {
+    let mut bytes = [0_u8; 16];
+    if getrandom::fill(&mut bytes).is_ok() {
+        return format!("{prefix}-{}", URL_SAFE_NO_PAD.encode(bytes));
+    }
+    format!("{prefix}-{}-{}", now_millis(), process::id())
+}
+
+fn a2a_error_response(status: u16, code: &str, message: &str) -> Vec<u8> {
+    json_response(
+        status,
+        &serde_json::json!({ "error": { "code": code, "message": message } }),
+    )
 }
 
 async fn handle_local_endpoint(
@@ -5655,6 +6300,13 @@ fn env_u16(name: &str, default: u16) -> u16 {
         .unwrap_or(default)
 }
 
+fn env_u64(name: &str, default: u64) -> u64 {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
 fn trimmed_env(name: &str) -> Option<String> {
     env::var(name)
         .ok()
@@ -5779,6 +6431,7 @@ mod tests {
             shared_sessions: Arc::new(Mutex::new(HashMap::new())),
             approval_modes: Arc::new(Mutex::new(HashMap::new())),
             pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
+            a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -6025,6 +6678,101 @@ mod tests {
         let head = parse_request_head(request).expect("request should parse");
 
         assert!(is_local_endpoint(&head));
+    }
+
+    #[test]
+    fn detects_a2a_control_plane_routes() {
+        for request in [
+            "GET /.well-known/agent-card.json HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "GET /tasks/maestro-task-1 HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "GET /tasks HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "POST /tasks/maestro-task-1:cancel HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "OPTIONS /message:send HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        ] {
+            let head = parse_request_head(request.as_bytes()).expect("request should parse");
+            assert!(is_a2a_endpoint(&head), "{request} should be A2A");
+        }
+    }
+
+    #[test]
+    fn a2a_agent_card_advertises_http_json_interface() {
+        let head = parse_request_head(
+            b"GET /.well-known/agent-card.json HTTP/1.1\r\nHost: mini.local:8080\r\n\r\n",
+        )
+        .expect("request should parse");
+        let card = a2a_agent_card(&head, &auth_test_config());
+
+        assert_eq!(card["protocolVersion"], A2A_PROTOCOL_VERSION);
+        assert_eq!(card["url"], "http://mini.local:8080");
+        assert_eq!(
+            card["supportedInterfaces"][0]["protocolBinding"],
+            "HTTP+JSON"
+        );
+        assert_eq!(card["skills"][0]["id"], "maestro-tui-turn");
+    }
+
+    #[test]
+    fn a2a_send_message_honors_return_immediately_configuration() {
+        let request = A2ASendMessageRequest {
+            message: A2AMessageBody {
+                message_id: Some("msg-1".to_string()),
+                context_id: Some("ctx-1".to_string()),
+                task_id: None,
+                role: Some("ROLE_USER".to_string()),
+                parts: vec![A2APartBody {
+                    text: Some("hello".to_string()),
+                    url: None,
+                    data: None,
+                    metadata: None,
+                    filename: None,
+                    media_type: Some("text/plain".to_string()),
+                }],
+                metadata: None,
+                extensions: None,
+                reference_task_ids: None,
+            },
+            configuration: Some(serde_json::json!({ "returnImmediately": true })),
+            metadata: None,
+        };
+
+        assert!(a2a_return_immediately(&request));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_runs_fake_turn_and_records_task() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "hello from fake native turn");
+
+        let body = r#"{"message":{"messageId":"msg-1","contextId":"ctx-1","role":"ROLE_USER","parts":[{"text":"hello","mediaType":"text/plain"}],"metadata":{"agentId":"ts-tui"}}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nx-evalops-workspace-id: ws-1\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let task = &response["task"];
+
+        assert_eq!(task["contextId"], "ctx-1");
+        assert_eq!(task["status"]["state"], "TASK_STATE_COMPLETED");
+        assert_eq!(
+            task["artifacts"][0]["parts"][0]["text"],
+            "hello from fake native turn"
+        );
+        assert_eq!(task["metadata"]["workspaceId"], "ws-1");
+        assert_eq!(state.a2a_tasks.lock().await.len(), 1);
+
+        if let Some(previous_fake) = previous_fake {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
     }
 
     #[test]
@@ -8078,6 +8826,7 @@ mod tests {
             shared_sessions: Arc::new(Mutex::new(HashMap::new())),
             approval_modes: Arc::new(Mutex::new(HashMap::new())),
             pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
+            a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
         };
         let (_client, mut server) = tcp_stream_pair().await;
         let head = RequestHead {
@@ -8153,6 +8902,7 @@ mod tests {
             shared_sessions: Arc::new(Mutex::new(HashMap::new())),
             approval_modes: Arc::new(Mutex::new(HashMap::new())),
             pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
+            a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
         };
 
         persist_session_store(&state).await;

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::process::Command;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, watch, Mutex};
 
 mod auth;
 mod http;
@@ -54,6 +54,8 @@ const A2A_DEFAULT_TURN_TIMEOUT_MS: u64 = 180_000;
 static ATTACHMENT_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
 type PendingToolResponseSender = mpsc::UnboundedSender<(String, bool, Option<ToolResult>)>;
+type A2ACancelSender = watch::Sender<bool>;
+type A2ACancelReceiver = watch::Receiver<bool>;
 #[derive(Debug, Clone)]
 struct Config {
     listen_host: String,
@@ -154,6 +156,7 @@ struct AppState {
     approval_modes: Arc<Mutex<HashMap<String, String>>>,
     pending_tool_responses: Arc<Mutex<HashMap<String, PendingToolResponseSender>>>,
     a2a_tasks: Arc<Mutex<HashMap<String, Value>>>,
+    a2a_cancel_senders: Arc<Mutex<HashMap<String, A2ACancelSender>>>,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -299,6 +302,7 @@ async fn main() -> anyhow::Result<()> {
         approval_modes: Arc::new(Mutex::new(HashMap::new())),
         pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
         a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
+        a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
     };
 
     loop {
@@ -578,6 +582,11 @@ struct A2ATurnOutput {
     tools: Vec<Value>,
 }
 
+enum A2ATurnResult {
+    Completed(A2ATurnOutput),
+    Canceled,
+}
+
 fn is_a2a_endpoint(head: &RequestHead) -> bool {
     if head.method == "OPTIONS" {
         return head.path == "/.well-known/agent-card.json"
@@ -643,21 +652,10 @@ async fn handle_a2a_endpoint(
 
     if head.method == "POST" {
         if let Some(task_id) = a2a_task_id_from_cancel_path(&head.path) {
-            let mut tasks = state.a2a_tasks.lock().await;
-            let Some(task) = tasks.get_mut(task_id) else {
-                return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");
+            return match cancel_a2a_task(state, task_id).await {
+                Ok(task) => json_response(200, &task),
+                Err(response) => response,
             };
-            let context_id = task
-                .get("contextId")
-                .and_then(Value::as_str)
-                .unwrap_or("a2a")
-                .to_string();
-            task["status"] = serde_json::json!({
-                "state": "TASK_STATE_CANCELED",
-                "message": a2a_agent_message(&context_id, "Task canceled"),
-                "timestamp": now_rfc3339()
-            });
-            return json_response(200, task);
         }
     }
 
@@ -666,6 +664,132 @@ async fn handle_a2a_endpoint(
     }
 
     a2a_error_response(404, "NOT_FOUND", "A2A endpoint not found")
+}
+
+async fn cancel_a2a_task(state: &AppState, task_id: &str) -> Result<Value, Vec<u8>> {
+    let mut tasks = state.a2a_tasks.lock().await;
+    let Some(task) = tasks.get_mut(task_id) else {
+        return Err(a2a_error_response(
+            404,
+            "TASK_NOT_FOUND",
+            "A2A task not found",
+        ));
+    };
+    if a2a_task_is_terminal(task) {
+        return Err(a2a_error_response(
+            400,
+            "TASK_NOT_CANCELABLE",
+            "A2A task cannot be canceled from its current state",
+        ));
+    }
+    let context_id = task
+        .get("contextId")
+        .and_then(Value::as_str)
+        .unwrap_or("a2a")
+        .to_string();
+    task["status"] = serde_json::json!({
+        "state": "TASK_STATE_CANCELED",
+        "message": a2a_agent_message(&context_id, "Task canceled"),
+        "timestamp": now_rfc3339()
+    });
+    let task = task.clone();
+    drop(tasks);
+
+    if let Some(sender) = state.a2a_cancel_senders.lock().await.remove(task_id) {
+        let _ = sender.send(true);
+    }
+
+    Ok(task)
+}
+
+fn a2a_task_status_state(task: &Value) -> Option<&str> {
+    task.get("status")
+        .and_then(|status| status.get("state"))
+        .and_then(Value::as_str)
+}
+
+fn a2a_task_is_terminal(task: &Value) -> bool {
+    matches!(
+        a2a_task_status_state(task),
+        Some(
+            "TASK_STATE_COMPLETED"
+                | "TASK_STATE_FAILED"
+                | "TASK_STATE_CANCELED"
+                | "TASK_STATE_REJECTED"
+        )
+    )
+}
+
+async fn a2a_resolve_send_task_id(
+    state: &AppState,
+    request: &A2ASendMessageRequest,
+) -> Result<String, Vec<u8>> {
+    let Some(task_id) = request
+        .message
+        .task_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|task_id| !task_id.is_empty())
+    else {
+        return Ok(generate_a2a_id("maestro-task"));
+    };
+
+    let tasks = state.a2a_tasks.lock().await;
+    let Some(task) = tasks.get(task_id) else {
+        return Err(a2a_error_response(
+            404,
+            "TASK_NOT_FOUND",
+            "A2A task not found",
+        ));
+    };
+    if a2a_task_is_terminal(task) {
+        return Err(a2a_error_response(
+            400,
+            "UNSUPPORTED_OPERATION",
+            "A2A terminal tasks cannot accept more messages",
+        ));
+    }
+    if let Some(message_context_id) = request
+        .message
+        .context_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|context_id| !context_id.is_empty())
+    {
+        if let Some(task_context_id) = task.get("contextId").and_then(Value::as_str) {
+            if message_context_id != task_context_id {
+                return Err(a2a_error_response(
+                    400,
+                    "INVALID_REQUEST",
+                    "A2A message contextId must match the referenced task",
+                ));
+            }
+        }
+    }
+    Ok(task_id.to_string())
+}
+
+async fn a2a_existing_task_history(state: &AppState, task_id: &str) -> Vec<Value> {
+    state
+        .a2a_tasks
+        .lock()
+        .await
+        .get(task_id)
+        .and_then(|task| task.get("history"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+async fn store_a2a_task_unless_canceled(state: &AppState, task_id: &str, task: Value) -> Value {
+    let mut tasks = state.a2a_tasks.lock().await;
+    if let Some(existing) = tasks.get(task_id) {
+        if a2a_task_status_state(existing) == Some("TASK_STATE_CANCELED") {
+            return existing.clone();
+        }
+    }
+    tasks.insert(task_id.to_string(), task.clone());
+    task
 }
 
 async fn handle_a2a_message_send(
@@ -698,18 +822,31 @@ async fn handle_a2a_message_send(
     };
 
     let context_id = a2a_context_id(&request, head);
-    let task_id = generate_a2a_id("maestro-task");
+    let task_id = match a2a_resolve_send_task_id(state, &request).await {
+        Ok(task_id) => task_id,
+        Err(response) => return response,
+    };
     let user_message = a2a_user_message_value(&request.message, &context_id);
+    let mut history = a2a_existing_task_history(state, &task_id).await;
+    history.push(user_message.clone());
 
     let metadata = a2a_task_metadata(head, &request);
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+    state
+        .a2a_cancel_senders
+        .lock()
+        .await
+        .insert(task_id.clone(), cancel_tx);
     if a2a_return_immediately(&request) {
         let accepted_message = a2a_agent_message(&context_id, "Maestro accepted the A2A task.");
+        let mut accepted_history = history.clone();
+        accepted_history.push(accepted_message.clone());
         let task = a2a_task_value(
             &task_id,
             &context_id,
             "TASK_STATE_WORKING",
             accepted_message.clone(),
-            vec![user_message.clone(), accepted_message],
+            accepted_history.clone(),
             Vec::new(),
             metadata.clone(),
         );
@@ -720,13 +857,24 @@ async fn handle_a2a_message_send(
             .insert(task_id.clone(), task.clone());
         let state = state.clone();
         tokio::spawn(async move {
-            let _ = complete_a2a_task(&state, prompt, task_id, context_id, user_message, metadata)
-                .await;
+            let _ = complete_a2a_task(
+                &state,
+                prompt,
+                task_id,
+                context_id,
+                accepted_history,
+                metadata,
+                cancel_rx,
+            )
+            .await;
         });
         return json_response(200, &serde_json::json!({ "task": task }));
     }
 
-    let task = complete_a2a_task(state, prompt, task_id, context_id, user_message, metadata).await;
+    let task = complete_a2a_task(
+        state, prompt, task_id, context_id, history, metadata, cancel_rx,
+    )
+    .await;
     json_response(200, &serde_json::json!({ "task": task }))
 }
 
@@ -735,23 +883,42 @@ async fn complete_a2a_task(
     prompt: String,
     task_id: String,
     context_id: String,
-    user_message: Value,
+    mut history: Vec<Value>,
     mut metadata: Value,
+    cancel_rx: A2ACancelReceiver,
 ) -> Value {
-    let turn = match run_a2a_native_turn(state, prompt).await {
-        Ok(turn) => turn,
+    let turn = match run_a2a_native_turn(state, prompt, cancel_rx).await {
+        Ok(A2ATurnResult::Completed(turn)) => turn,
+        Ok(A2ATurnResult::Canceled) => {
+            let message = a2a_agent_message(&context_id, "Task canceled");
+            history.push(message.clone());
+            let task = a2a_task_value(
+                &task_id,
+                &context_id,
+                "TASK_STATE_CANCELED",
+                message,
+                history,
+                Vec::new(),
+                metadata,
+            );
+            let task = store_a2a_task_unless_canceled(state, &task_id, task).await;
+            state.a2a_cancel_senders.lock().await.remove(&task_id);
+            return task;
+        }
         Err(error) => {
             let message = a2a_agent_message(&context_id, &error);
+            history.push(message.clone());
             let task = a2a_task_value(
                 &task_id,
                 &context_id,
                 "TASK_STATE_FAILED",
                 message.clone(),
-                vec![user_message, message],
+                history,
                 Vec::new(),
                 metadata,
             );
-            insert_a2a_task_if_not_canceled(state, &task_id, task.clone()).await;
+            let task = store_a2a_task_unless_canceled(state, &task_id, task).await;
+            state.a2a_cancel_senders.lock().await.remove(&task_id);
             return task;
         }
     };
@@ -782,7 +949,10 @@ async fn complete_a2a_task(
         &context_id,
         "TASK_STATE_COMPLETED",
         agent_message.clone(),
-        vec![user_message, agent_message],
+        {
+            history.push(agent_message);
+            history
+        },
         vec![serde_json::json!({
             "artifactId": format!("{task_id}-assistant-response"),
             "name": "assistant-response",
@@ -790,21 +960,9 @@ async fn complete_a2a_task(
         })],
         metadata,
     );
-    insert_a2a_task_if_not_canceled(state, &task_id, task.clone()).await;
+    let task = store_a2a_task_unless_canceled(state, &task_id, task).await;
+    state.a2a_cancel_senders.lock().await.remove(&task_id);
     task
-}
-
-async fn insert_a2a_task_if_not_canceled(state: &AppState, task_id: &str, task: Value) {
-    let mut tasks = state.a2a_tasks.lock().await;
-    let is_canceled = tasks
-        .get(task_id)
-        .and_then(|existing| existing.get("status"))
-        .and_then(|status| status.get("state"))
-        .and_then(Value::as_str)
-        == Some("TASK_STATE_CANCELED");
-    if !is_canceled {
-        tasks.insert(task_id.to_string(), task);
-    }
 }
 
 fn a2a_agent_card(head: &RequestHead, config: &Config) -> Value {
@@ -1014,12 +1172,23 @@ fn a2a_return_immediately(request: &A2ASendMessageRequest) -> bool {
         .unwrap_or(false)
 }
 
-async fn run_a2a_native_turn(state: &AppState, prompt: String) -> Result<A2ATurnOutput, String> {
+async fn run_a2a_native_turn(
+    state: &AppState,
+    prompt: String,
+    mut cancel_rx: A2ACancelReceiver,
+) -> Result<A2ATurnResult, String> {
+    if *cancel_rx.borrow() {
+        return Ok(A2ATurnResult::Canceled);
+    }
+
     if let Some(response) = trimmed_env("MAESTRO_A2A_FAKE_RESPONSE") {
-        return Ok(A2ATurnOutput {
+        if a2a_wait_for_fake_response_delay(&mut cancel_rx).await {
+            return Ok(A2ATurnResult::Canceled);
+        }
+        return Ok(A2ATurnResult::Completed(A2ATurnOutput {
             assistant_text: response,
             ..Default::default()
-        });
+        }));
     }
 
     let model = if let Some(model) = trimmed_env("MAESTRO_A2A_MODEL") {
@@ -1062,13 +1231,22 @@ async fn run_a2a_native_turn(state: &AppState, prompt: String) -> Result<A2ATurn
     let mut response_ended = false;
 
     loop {
-        let event = match tokio::time::timeout(timeout, events.recv()).await {
-            Ok(Some(event)) => event,
-            Ok(None) => break,
-            Err(_) => {
-                agent.cancel();
-                return Err("A2A native TUI turn timed out".to_string());
+        let event = tokio::select! {
+            changed = cancel_rx.changed() => {
+                if changed.is_ok() && *cancel_rx.borrow() {
+                    agent.cancel();
+                    return Ok(A2ATurnResult::Canceled);
+                }
+                continue;
             }
+            event = tokio::time::timeout(timeout, events.recv()) => match event {
+                Ok(Some(event)) => event,
+                Ok(None) => break,
+                Err(_) => {
+                    agent.cancel();
+                    return Err("A2A native TUI turn timed out".to_string());
+                }
+            },
         };
         match event {
             FromAgent::ResponseChunk {
@@ -1136,10 +1314,24 @@ async fn run_a2a_native_turn(state: &AppState, prompt: String) -> Result<A2ATurn
     }
 
     if response_ended {
-        Ok(output)
+        Ok(A2ATurnResult::Completed(output))
     } else {
         Err(last_error
             .unwrap_or_else(|| "A2A native TUI turn ended before response_end".to_string()))
+    }
+}
+
+async fn a2a_wait_for_fake_response_delay(cancel_rx: &mut A2ACancelReceiver) -> bool {
+    let delay_ms = env_u64("MAESTRO_A2A_FAKE_RESPONSE_DELAY_MS", 0);
+    if delay_ms == 0 {
+        return *cancel_rx.borrow();
+    }
+
+    let delay = tokio::time::sleep(Duration::from_millis(delay_ms));
+    tokio::pin!(delay);
+    tokio::select! {
+        _ = &mut delay => *cancel_rx.borrow(),
+        changed = cancel_rx.changed() => changed.is_ok() && *cancel_rx.borrow(),
     }
 }
 
@@ -6437,6 +6629,7 @@ mod tests {
             approval_modes: Arc::new(Mutex::new(HashMap::new())),
             pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
             a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
+            a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -6781,40 +6974,205 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn complete_a2a_task_does_not_overwrite_canceled_task() {
+    async fn a2a_message_send_rejects_unknown_task_id() {
         let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
         let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
-        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "hello from fake native turn");
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "should not run");
+
+        let body = r#"{"message":{"messageId":"msg-1","contextId":"ctx-1","taskId":"missing-task","role":"ROLE_USER","parts":[{"text":"hello","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert_eq!(response["error"]["code"], "TASK_NOT_FOUND");
+        assert!(state.a2a_tasks.lock().await.is_empty());
+
+        if let Some(previous_fake) = previous_fake {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_reuses_existing_task_id_and_history() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "follow-up response");
+
+        let body = r#"{"message":{"messageId":"msg-2","contextId":"ctx-1","taskId":"maestro-task-1","role":"ROLE_USER","parts":[{"text":"follow up","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+        let existing_message = a2a_agent_message("ctx-1", "Need more input");
+        let task = a2a_task_value(
+            "maestro-task-1",
+            "ctx-1",
+            "TASK_STATE_INPUT_REQUIRED",
+            existing_message.clone(),
+            vec![existing_message],
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-1".to_string(), task);
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let task = &response["task"];
+
+        assert_eq!(task["id"], "maestro-task-1");
+        assert_eq!(task["status"]["state"], "TASK_STATE_COMPLETED");
+        assert_eq!(task["history"].as_array().unwrap().len(), 3);
+        assert_eq!(task["history"][2]["parts"][0]["text"], "follow-up response");
+
+        if let Some(previous_fake) = previous_fake {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_rejects_terminal_task_id() {
+        let body = r#"{"message":{"messageId":"msg-2","contextId":"ctx-1","taskId":"maestro-task-1","role":"ROLE_USER","parts":[{"text":"follow up","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+        let task = a2a_task_value(
+            "maestro-task-1",
+            "ctx-1",
+            "TASK_STATE_COMPLETED",
+            a2a_agent_message("ctx-1", "complete"),
+            Vec::new(),
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-1".to_string(), task);
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert_eq!(response["error"]["code"], "UNSUPPORTED_OPERATION");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_cancel_rejects_terminal_tasks() {
+        let (_client, mut server) = tcp_stream_pair().await;
+        let mut initial =
+            b"POST /tasks/maestro-task-1:cancel HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n"
+                .to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let state = test_app_state_with_sessions(HashMap::new());
+        let task = a2a_task_value(
+            "maestro-task-1",
+            "ctx-1",
+            "TASK_STATE_COMPLETED",
+            a2a_agent_message("ctx-1", "complete"),
+            Vec::new(),
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-1".to_string(), task);
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let stored = state.a2a_tasks.lock().await;
+
+        assert_eq!(response["error"]["code"], "TASK_NOT_CANCELABLE");
+        assert_eq!(
+            stored["maestro-task-1"]["status"]["state"],
+            "TASK_STATE_COMPLETED"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_async_completion_preserves_canceled_task_state() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "late response");
 
         let state = test_app_state_with_sessions(HashMap::new());
-        let task_id = "task-1".to_string();
-        let context_id = "ctx-1".to_string();
-        state.a2a_tasks.lock().await.insert(
-            task_id.clone(),
-            a2a_task_value(
-                &task_id,
-                &context_id,
-                "TASK_STATE_CANCELED",
-                a2a_agent_message(&context_id, "Task canceled"),
-                Vec::new(),
-                Vec::new(),
-                serde_json::json!({}),
-            ),
+        let task = a2a_task_value(
+            "maestro-task-1",
+            "ctx-1",
+            "TASK_STATE_CANCELED",
+            a2a_agent_message("ctx-1", "Task canceled"),
+            Vec::new(),
+            Vec::new(),
+            serde_json::json!({}),
         );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-1".to_string(), task);
 
+        let user_message = a2a_user_message_value(
+            &A2AMessageBody {
+                message_id: Some("msg-1".to_string()),
+                context_id: Some("ctx-1".to_string()),
+                task_id: Some("maestro-task-1".to_string()),
+                role: Some("ROLE_USER".to_string()),
+                parts: vec![A2APartBody {
+                    text: Some("hello".to_string()),
+                    url: None,
+                    data: None,
+                    metadata: None,
+                    filename: None,
+                    media_type: Some("text/plain".to_string()),
+                }],
+                metadata: None,
+                extensions: None,
+                reference_task_ids: None,
+            },
+            "ctx-1",
+        );
+        let (_cancel_tx, cancel_rx) = watch::channel(false);
         let task = complete_a2a_task(
             &state,
             "hello".to_string(),
-            task_id.clone(),
-            context_id,
+            "maestro-task-1".to_string(),
+            "ctx-1".to_string(),
+            vec![user_message],
             serde_json::json!({}),
-            serde_json::json!({}),
+            cancel_rx,
         )
         .await;
+        let stored = state.a2a_tasks.lock().await;
 
-        assert_eq!(task["status"]["state"], "TASK_STATE_COMPLETED");
+        assert_eq!(task["status"]["state"], "TASK_STATE_CANCELED");
         assert_eq!(
-            state.a2a_tasks.lock().await[&task_id]["status"]["state"],
+            stored["maestro-task-1"]["status"]["state"],
             "TASK_STATE_CANCELED"
         );
 
@@ -6822,6 +7180,64 @@ mod tests {
             env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
         } else {
             env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_cancel_signals_return_immediately_worker() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
+        let previous_delay = env::var("MAESTRO_A2A_FAKE_RESPONSE_DELAY_MS").ok();
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "late response");
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE_DELAY_MS", "500");
+
+        let body = r#"{"message":{"messageId":"msg-1","contextId":"ctx-1","role":"ROLE_USER","parts":[{"text":"hello","mediaType":"text/plain"}]},"configuration":{"returnImmediately":true}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let task_id = response["task"]["id"]
+            .as_str()
+            .expect("task id should be present")
+            .to_string();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            state.a2a_tasks.lock().await[&task_id]["status"]["state"],
+            "TASK_STATE_WORKING"
+        );
+
+        let cancel_request = format!(
+            "POST /tasks/{task_id}:cancel HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n"
+        );
+        let mut cancel_initial = cancel_request.into_bytes();
+        let cancel_head = parse_request_head(&cancel_initial).expect("request should parse");
+        let (_client, mut cancel_server) = tcp_stream_pair().await;
+        let cancel_response = response_json(
+            handle_a2a_endpoint(&mut cancel_server, &mut cancel_initial, cancel_head, &state).await,
+        );
+        assert_eq!(cancel_response["status"]["state"], "TASK_STATE_CANCELED");
+
+        tokio::time::sleep(Duration::from_millis(600)).await;
+        let stored = state.a2a_tasks.lock().await;
+        assert_eq!(stored[&task_id]["status"]["state"], "TASK_STATE_CANCELED");
+        assert_eq!(stored[&task_id]["artifacts"].as_array().unwrap().len(), 0);
+
+        if let Some(previous_fake) = previous_fake {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+        if let Some(previous_delay) = previous_delay {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE_DELAY_MS", previous_delay);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE_DELAY_MS");
         }
     }
 
@@ -7533,6 +7949,17 @@ mod tests {
 
         assert!(response.contains("Access-Control-Allow-Origin: http://localhost:3000\r\n"));
         assert!(!response.contains("Access-Control-Allow-Origin: http://localhost:4173\r\n"));
+    }
+
+    #[tokio::test]
+    async fn cors_response_allows_platform_organization_header() {
+        let response = with_response_cors_origin("http://localhost:3000".to_string(), async {
+            response(204, "text/plain; charset=utf-8", &[])
+        })
+        .await;
+        let response = String::from_utf8(response).expect("response should be utf-8");
+
+        assert!(response.contains("x-organization-id"));
     }
 
     #[test]
@@ -8877,6 +9304,7 @@ mod tests {
             approval_modes: Arc::new(Mutex::new(HashMap::new())),
             pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
             a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
+            a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
         };
         let (_client, mut server) = tcp_stream_pair().await;
         let head = RequestHead {
@@ -8953,6 +9381,7 @@ mod tests {
             approval_modes: Arc::new(Mutex::new(HashMap::new())),
             pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
             a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
+            a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
         };
 
         persist_session_store(&state).await;

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -168,14 +168,26 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
 
     process: subprocess.Popen[str] | None = None
     try:
+        with LOCK:
+            current = TASKS.get(task_id)
+            if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
+                return
         process = subprocess.Popen(
             codex_command(prompt, output_path),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
         )
+        terminate_before_wait = False
         with LOCK:
-            PROCESSES[task_id] = process
+            current = TASKS.get(task_id)
+            if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
+                terminate_before_wait = True
+            else:
+                PROCESSES[task_id] = process
+        if terminate_before_wait:
+            terminate_process(process)
+            return
         stdout, stderr = process.communicate(timeout=timeout)
         with LOCK:
             PROCESSES.pop(task_id, None)
@@ -382,6 +394,7 @@ class Handler(BaseHTTPRequestHandler):
                 return
             requested_task_id = str(message.get("taskId") or "").strip()
             requested_context_id = str(message.get("contextId") or "").strip()
+            immediate = bool((body.get("configuration") or {}).get("returnImmediately"))
             with LOCK:
                 if requested_task_id:
                     existing = TASKS.get(requested_task_id)
@@ -424,28 +437,31 @@ class Handler(BaseHTTPRequestHandler):
                     context_id = requested_context_id or new_id("codex-a2a-context")
                     task_id = new_id("codex-a2a-task")
                     history = []
-            history.append(user_message(message, context_id))
-            immediate = bool((body.get("configuration") or {}).get("returnImmediately"))
-            if immediate:
-                accepted = agent_message(context_id, "Codex accepted the A2A task.")
+                history.append(user_message(message, context_id))
+                if immediate:
+                    status_message = agent_message(context_id, "Codex accepted the A2A task.")
+                    launch_history = [*history, status_message]
+                else:
+                    status_message = agent_message(context_id, "Codex is working on the A2A task.")
+                    launch_history = list(history)
                 task = task_value(
                     task_id,
                     context_id,
                     "TASK_STATE_WORKING",
-                    accepted,
-                    [*history, accepted],
+                    status_message,
+                    launch_history,
                     metadata={"backend": "codex-exec"},
                 )
-                with LOCK:
-                    TASKS[task_id] = task
+                TASKS[task_id] = task
+            if immediate:
                 threading.Thread(
                     target=complete_task,
-                    args=(task_id, context_id, prompt, [*history, accepted]),
+                    args=(task_id, context_id, prompt, launch_history),
                     daemon=True,
                 ).start()
                 self.send_json(200, {"task": task})
                 return
-            complete_task(task_id, context_id, prompt, history)
+            complete_task(task_id, context_id, prompt, launch_history)
             with LOCK:
                 task = TASKS[task_id]
             self.send_json(200, {"task": task})

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -10,6 +10,7 @@ Codex authentication.
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import shlex
@@ -355,7 +356,7 @@ class Handler(BaseHTTPRequestHandler):
     def authorized(self) -> bool:
         token = os.environ.get("CODEX_A2A_TOKEN", "").strip()
         if not token:
-            return True
+            return False
         return (
             self.headers.get("Authorization", "") == f"Bearer {token}"
             or self.headers.get("x-maestro-api-key", "") == token
@@ -553,13 +554,16 @@ class Handler(BaseHTTPRequestHandler):
                 else:
                     context_id = str(task.get("contextId") or "codex-a2a")
                     canceled = agent_message(context_id, "Task canceled")
-                    task["status"] = {
-                        "state": "TASK_STATE_CANCELED",
-                        "message": canceled,
-                        "timestamp": now_iso(),
-                    }
-                    task["artifacts"] = []
-                    task = dict(task)
+                    task = task_value(
+                        task_id,
+                        context_id,
+                        "TASK_STATE_CANCELED",
+                        canceled,
+                        copy.deepcopy(task.get("history") or []),
+                        artifacts=[],
+                        metadata=copy.deepcopy(task.get("metadata") or {}),
+                    )
+                    TASKS[task_id] = task
                     process = PROCESSES.pop(task_id, None)
             if error is not None:
                 self.error_json(*error)

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -421,7 +421,8 @@ class Handler(BaseHTTPRequestHandler):
             return
         if path == "/tasks":
             with LOCK:
-                self.send_json(200, {"tasks": list(TASKS.values())})
+                tasks = list(TASKS.values())
+            self.send_json(200, {"tasks": tasks})
             return
         if path.startswith("/tasks/"):
             task_id = path.removeprefix("/tasks/")
@@ -456,64 +457,68 @@ class Handler(BaseHTTPRequestHandler):
                 self.error_json(400, "INVALID_REQUEST", "A2A configuration must be an object")
                 return
             immediate = bool((configuration or {}).get("returnImmediately"))
+            error: tuple[int, str, str] | None = None
             with LOCK:
                 if requested_task_id:
                     existing = TASKS.get(requested_task_id)
                     if not existing:
-                        self.error_json(404, "TASK_NOT_FOUND", "A2A task not found")
-                        return
-                    if terminal(existing.get("status", {}).get("state")):
-                        self.error_json(
+                        error = (404, "TASK_NOT_FOUND", "A2A task not found")
+                    elif terminal(existing.get("status", {}).get("state")):
+                        error = (
                             400,
                             "UNSUPPORTED_OPERATION",
                             "A2A terminal tasks cannot accept more messages",
                         )
-                        return
-                    existing_state = existing.get("status", {}).get("state")
-                    if not accepts_message(existing_state):
-                        self.error_json(
+                    elif not accepts_message(existing.get("status", {}).get("state")):
+                        error = (
                             409,
                             "UNSUPPORTED_OPERATION",
                             "A2A task is not ready to accept another message",
                         )
-                        return
-                    existing_context_id = str(existing.get("contextId") or "").strip()
-                    if (
-                        requested_context_id
-                        and existing_context_id
-                        and requested_context_id != existing_context_id
-                    ):
-                        self.error_json(
-                            400,
-                            "INVALID_REQUEST",
-                            "A2A message contextId must match the referenced task",
-                        )
-                        return
-                    context_id = requested_context_id or existing_context_id or new_id(
-                        "codex-a2a-context"
-                    )
-                    task_id = requested_task_id
-                    history = list(existing.get("history") or [])
+                    else:
+                        existing_context_id = str(existing.get("contextId") or "").strip()
+                        if (
+                            requested_context_id
+                            and existing_context_id
+                            and requested_context_id != existing_context_id
+                        ):
+                            error = (
+                                400,
+                                "INVALID_REQUEST",
+                                "A2A message contextId must match the referenced task",
+                            )
+                        else:
+                            context_id = requested_context_id or existing_context_id or new_id(
+                                "codex-a2a-context"
+                            )
+                            task_id = requested_task_id
+                            history = list(existing.get("history") or [])
                 else:
                     context_id = requested_context_id or new_id("codex-a2a-context")
                     task_id = new_id("codex-a2a-task")
                     history = []
-                history.append(user_message(message, context_id))
-                if immediate:
-                    status_message = agent_message(context_id, "Codex accepted the A2A task.")
-                    launch_history = [*history, status_message]
-                else:
-                    status_message = agent_message(context_id, "Codex is working on the A2A task.")
-                    launch_history = list(history)
-                task = task_value(
-                    task_id,
-                    context_id,
-                    "TASK_STATE_WORKING",
-                    status_message,
-                    launch_history,
-                    metadata={"backend": "codex-exec"},
-                )
-                TASKS[task_id] = task
+                if error is None:
+                    history.append(user_message(message, context_id))
+                    if immediate:
+                        status_message = agent_message(context_id, "Codex accepted the A2A task.")
+                        launch_history = [*history, status_message]
+                    else:
+                        status_message = agent_message(
+                            context_id, "Codex is working on the A2A task."
+                        )
+                        launch_history = list(history)
+                    task = task_value(
+                        task_id,
+                        context_id,
+                        "TASK_STATE_WORKING",
+                        status_message,
+                        launch_history,
+                        metadata={"backend": "codex-exec"},
+                    )
+                    TASKS[task_id] = task
+            if error is not None:
+                self.error_json(*error)
+                return
             if immediate:
                 threading.Thread(
                     target=complete_task,
@@ -529,27 +534,33 @@ class Handler(BaseHTTPRequestHandler):
             return
         if path.startswith("/tasks/") and path.endswith(":cancel"):
             task_id = path.removeprefix("/tasks/").removesuffix(":cancel")
+            error: tuple[int, str, str] | None = None
+            process: subprocess.Popen[str] | None = None
+            task: dict[str, Any] | None = None
             with LOCK:
                 task = TASKS.get(task_id)
                 if not task:
-                    self.error_json(404, "TASK_NOT_FOUND", "A2A task not found")
-                    return
-                if terminal(task.get("status", {}).get("state")):
-                    self.error_json(
+                    error = (404, "TASK_NOT_FOUND", "A2A task not found")
+                elif terminal(task.get("status", {}).get("state")):
+                    error = (
                         400,
                         "TASK_NOT_CANCELABLE",
                         "A2A task cannot be canceled from its current state",
                     )
-                    return
-                context_id = str(task.get("contextId") or "codex-a2a")
-                canceled = agent_message(context_id, "Task canceled")
-                task["status"] = {
-                    "state": "TASK_STATE_CANCELED",
-                    "message": canceled,
-                    "timestamp": now_iso(),
-                }
-                task["artifacts"] = []
-                process = PROCESSES.pop(task_id, None)
+                else:
+                    context_id = str(task.get("contextId") or "codex-a2a")
+                    canceled = agent_message(context_id, "Task canceled")
+                    task["status"] = {
+                        "state": "TASK_STATE_CANCELED",
+                        "message": canceled,
+                        "timestamp": now_iso(),
+                    }
+                    task["artifacts"] = []
+                    task = dict(task)
+                    process = PROCESSES.pop(task_id, None)
+            if error is not None:
+                self.error_json(*error)
+                return
             if process is not None:
                 terminate_process(process)
             self.send_json(200, task)

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -231,6 +231,22 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
             if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
                 return
             TASKS[task_id] = next_task
+    except OSError as error:
+        metadata["error"] = str(error)
+        message = agent_message(context_id, f"codex exec failed to start: {error}")
+        with LOCK:
+            PROCESSES.pop(task_id, None)
+            current = TASKS.get(task_id)
+            if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
+                return
+            TASKS[task_id] = task_value(
+                task_id,
+                context_id,
+                "TASK_STATE_FAILED",
+                message,
+                [*history, message],
+                metadata=metadata,
+            )
     except subprocess.TimeoutExpired:
         if process is not None:
             terminate_process(process)

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -29,6 +29,7 @@ from urllib.parse import urlparse
 TASKS: dict[str, dict[str, Any]] = {}
 PROCESSES: dict[str, subprocess.Popen[str]] = {}
 LOCK = threading.Lock()
+MAX_REQUEST_BODY_BYTES = 1024 * 1024
 
 
 def env(name: str, default: str) -> str:
@@ -364,6 +365,8 @@ class Handler(BaseHTTPRequestHandler):
     def read_body(self) -> dict[str, Any] | None:
         try:
             length = int(self.headers.get("Content-Length", "0"))
+            if length < 0 or length > MAX_REQUEST_BODY_BYTES:
+                return None
             raw = self.rfile.read(length) if length else b"{}"
             value = json.loads(raw.decode("utf-8"))
             return value if isinstance(value, dict) else None

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -614,7 +614,10 @@ class Handler(BaseHTTPRequestHandler):
                 return
             complete_task(task_id, context_id, prompt, launch_history)
             with LOCK:
-                task = TASKS[task_id]
+                task = TASKS.get(task_id)
+            if task is None:
+                self.error_json(410, "TASK_EXPIRED", "A2A task was pruned after completion")
+                return
             self.send_json(200, {"task": task})
             return
         task_id = task_id_from_cancel_path(path)

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -48,6 +48,23 @@ def default_public_host() -> str:
     return bind_host
 
 
+def url_authority_host(host: str) -> str:
+    if host.startswith("[") and host.endswith("]"):
+        return host
+    if ":" in host:
+        return f"[{host.replace('%', '%25')}]"
+    return host
+
+
+def default_public_url() -> str:
+    public_url = os.environ.get("CODEX_A2A_PUBLIC_URL", "").strip()
+    if public_url:
+        return public_url
+    host = url_authority_host(default_public_host())
+    port = env("CODEX_A2A_PORT", "18787")
+    return f"http://{host}:{port}"
+
+
 def now_ms() -> int:
     return int(time.time() * 1000)
 
@@ -434,10 +451,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_json(200, {"ok": True})
             return
         if path == "/.well-known/agent-card.json":
-            base_url = env(
-                "CODEX_A2A_PUBLIC_URL",
-                f"http://{default_public_host()}:{env('CODEX_A2A_PORT', '18787')}",
-            ).rstrip("/")
+            base_url = default_public_url().rstrip("/")
             self.send_json(
                 200,
                 {

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -82,6 +82,27 @@ def message_text(message: dict[str, Any]) -> str | None:
     return joined or None
 
 
+def task_id_from_get_path(path: str) -> str | None:
+    prefix = "/tasks/"
+    if not path.startswith(prefix):
+        return None
+    task_id = path[len(prefix) :]
+    if not task_id or "/" in task_id or ":" in task_id:
+        return None
+    return task_id
+
+
+def task_id_from_cancel_path(path: str) -> str | None:
+    prefix = "/tasks/"
+    suffix = ":cancel"
+    if not path.startswith(prefix) or not path.endswith(suffix):
+        return None
+    task_id = path[len(prefix) : -len(suffix)]
+    if not task_id or "/" in task_id or ":" in task_id:
+        return None
+    return task_id
+
+
 def agent_message(context_id: str, text: str) -> dict[str, Any]:
     return {
         "messageId": new_id("codex-a2a-message"),
@@ -428,8 +449,8 @@ class Handler(BaseHTTPRequestHandler):
                 tasks = list(TASKS.values())
             self.send_json(200, {"tasks": tasks})
             return
-        if path.startswith("/tasks/"):
-            task_id = path.removeprefix("/tasks/")
+        task_id = task_id_from_get_path(path)
+        if task_id is not None:
             with LOCK:
                 task = TASKS.get(task_id)
             if not task:
@@ -460,7 +481,15 @@ class Handler(BaseHTTPRequestHandler):
             if configuration is not None and not isinstance(configuration, dict):
                 self.error_json(400, "INVALID_REQUEST", "A2A configuration must be an object")
                 return
-            immediate = bool((configuration or {}).get("returnImmediately"))
+            return_immediately = (configuration or {}).get("returnImmediately")
+            if return_immediately is not None and not isinstance(return_immediately, bool):
+                self.error_json(
+                    400,
+                    "INVALID_REQUEST",
+                    "A2A configuration returnImmediately must be a boolean",
+                )
+                return
+            immediate = return_immediately is True
             error: tuple[int, str, str] | None = None
             with LOCK:
                 if requested_task_id:
@@ -536,8 +565,8 @@ class Handler(BaseHTTPRequestHandler):
                 task = TASKS[task_id]
             self.send_json(200, {"task": task})
             return
-        if path.startswith("/tasks/") and path.endswith(":cancel"):
-            task_id = path.removeprefix("/tasks/").removesuffix(":cancel")
+        task_id = task_id_from_cancel_path(path)
+        if task_id is not None:
             error: tuple[int, str, str] | None = None
             process: subprocess.Popen[str] | None = None
             task: dict[str, Any] | None = None

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -56,6 +56,10 @@ def terminal(state: str | None) -> bool:
     }
 
 
+def accepts_message(state: str | None) -> bool:
+    return state == "TASK_STATE_INPUT_REQUIRED"
+
+
 def message_text(message: dict[str, Any]) -> str | None:
     parts = message.get("parts")
     if not isinstance(parts, list):
@@ -361,8 +365,8 @@ class Handler(BaseHTTPRequestHandler):
             if not prompt:
                 self.error_json(400, "INVALID_REQUEST", "A2A text part is required")
                 return
-            context_id = str(message.get("contextId") or new_id("codex-a2a-context"))
             requested_task_id = str(message.get("taskId") or "").strip()
+            requested_context_id = str(message.get("contextId") or "").strip()
             with LOCK:
                 if requested_task_id:
                     existing = TASKS.get(requested_task_id)
@@ -376,9 +380,33 @@ class Handler(BaseHTTPRequestHandler):
                             "A2A terminal tasks cannot accept more messages",
                         )
                         return
+                    existing_state = existing.get("status", {}).get("state")
+                    if not accepts_message(existing_state):
+                        self.error_json(
+                            409,
+                            "UNSUPPORTED_OPERATION",
+                            "A2A task is not ready to accept another message",
+                        )
+                        return
+                    existing_context_id = str(existing.get("contextId") or "").strip()
+                    if (
+                        requested_context_id
+                        and existing_context_id
+                        and requested_context_id != existing_context_id
+                    ):
+                        self.error_json(
+                            400,
+                            "INVALID_REQUEST",
+                            "A2A message contextId must match the referenced task",
+                        )
+                        return
+                    context_id = requested_context_id or existing_context_id or new_id(
+                        "codex-a2a-context"
+                    )
                     task_id = requested_task_id
                     history = list(existing.get("history") or [])
                 else:
+                    context_id = requested_context_id or new_id("codex-a2a-context")
                     task_id = new_id("codex-a2a-task")
                     history = []
             history.append(user_message(message, context_id))

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -258,7 +258,22 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header(
             "Access-Control-Allow-Headers",
-            "authorization,content-type,x-organization-id,x-evalops-workspace-id,x-maestro-api-key",
+            ",".join(
+                [
+                    "authorization",
+                    "content-type",
+                    "traceparent",
+                    "tracestate",
+                    "x-codex-a2a-token",
+                    "x-evalops-actor-id",
+                    "x-evalops-agent-id",
+                    "x-evalops-session-id",
+                    "x-evalops-workspace-id",
+                    "x-maestro-api-key",
+                    "x-maestro-session-id",
+                    "x-organization-id",
+                ]
+            ),
         )
         self.send_header("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
         self.end_headers()

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -14,7 +14,6 @@ import copy
 import json
 import os
 import shlex
-import signal
 import socket
 import subprocess
 import tempfile
@@ -607,8 +606,6 @@ class Handler(BaseHTTPRequestHandler):
 def main() -> None:
     host = env("CODEX_A2A_BIND", "127.0.0.1")
     port = int(env("CODEX_A2A_PORT", "18787"))
-    if hasattr(signal, "SIGPIPE"):
-        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
     server = ThreadingHTTPServer((host, port), Handler)
     print(f"codex-a2a bridge listening on http://{host}:{port}", flush=True)
     server.serve_forever()

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -388,6 +388,8 @@ class Handler(BaseHTTPRequestHandler):
                 [
                     "authorization",
                     "content-type",
+                    "a2a-version",
+                    "a2a-extensions",
                     "traceparent",
                     "tracestate",
                     "x-codex-a2a-token",

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Expose a small A2A HTTP/JSON bridge backed by `codex exec`.
+
+This is intentionally dependency-free so it can run on fleet machines that have
+only Python and Codex installed. It is useful as a local peer-agent endpoint for
+Maestro/Codex fleet experiments: A2A clients discover an Agent Card, send a
+message, and the bridge executes a real Codex turn through the host's existing
+Codex authentication.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import signal
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+TASKS: dict[str, dict[str, Any]] = {}
+PROCESSES: dict[str, subprocess.Popen[str]] = {}
+LOCK = threading.Lock()
+
+
+def env(name: str, default: str) -> str:
+    value = os.environ.get(name)
+    return value.strip() if value and value.strip() else default
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def new_id(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex}"
+
+
+def terminal(state: str | None) -> bool:
+    return state in {
+        "TASK_STATE_COMPLETED",
+        "TASK_STATE_FAILED",
+        "TASK_STATE_CANCELED",
+        "TASK_STATE_REJECTED",
+    }
+
+
+def message_text(message: dict[str, Any]) -> str | None:
+    parts = message.get("parts")
+    if not isinstance(parts, list):
+        return None
+    texts = [part.get("text") for part in parts if isinstance(part, dict)]
+    joined = "\n".join(text.strip() for text in texts if isinstance(text, str) and text.strip())
+    return joined or None
+
+
+def agent_message(context_id: str, text: str) -> dict[str, Any]:
+    return {
+        "messageId": new_id("codex-a2a-message"),
+        "contextId": context_id,
+        "role": "ROLE_AGENT",
+        "parts": [{"text": text, "mediaType": "text/plain"}],
+    }
+
+
+def user_message(message: dict[str, Any], context_id: str) -> dict[str, Any]:
+    copied = dict(message)
+    copied["contextId"] = context_id
+    copied.setdefault("messageId", new_id("codex-a2a-message"))
+    copied.setdefault("role", "ROLE_USER")
+    return copied
+
+
+def task_value(
+    task_id: str,
+    context_id: str,
+    state: str,
+    status_message: dict[str, Any],
+    history: list[dict[str, Any]],
+    artifacts: list[dict[str, Any]] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": task_id,
+        "contextId": context_id,
+        "status": {
+            "state": state,
+            "message": status_message,
+            "timestamp": now_iso(),
+        },
+        "history": history,
+        "artifacts": artifacts or [],
+        "metadata": metadata or {},
+    }
+
+
+def json_bytes(value: Any) -> bytes:
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def codex_command(prompt: str, output_path: Path) -> list[str]:
+    command = [
+        env("CODEX_A2A_CODEX_BIN", "codex"),
+        "exec",
+        "--skip-git-repo-check",
+        "-C",
+        env("CODEX_A2A_WORKDIR", str(Path.home())),
+        "--sandbox",
+        env("CODEX_A2A_SANDBOX", "read-only"),
+        "--output-last-message",
+        str(output_path),
+    ]
+    model = os.environ.get("CODEX_A2A_MODEL", "").strip()
+    if model:
+        command.extend(["-m", model])
+    profile = os.environ.get("CODEX_A2A_PROFILE", "").strip()
+    if profile:
+        command.extend(["-p", profile])
+    extra_args = os.environ.get("CODEX_A2A_EXTRA_ARGS", "").strip()
+    if extra_args:
+        command.extend(shlex.split(extra_args))
+    command.append(prompt)
+    return command
+
+
+def terminate_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        process.terminate()
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+    except ProcessLookupError:
+        pass
+
+
+def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict[str, Any]]) -> None:
+    metadata: dict[str, Any] = {
+        "backend": "codex-exec",
+        "host": env("CODEX_A2A_AGENT_NAME", env("HOSTNAME", "codex-a2a")),
+    }
+    timeout = int(env("CODEX_A2A_TURN_TIMEOUT_MS", "600000")) / 1000
+    runtime_dir = Path(env("CODEX_A2A_RUNTIME_DIR", str(Path.home() / ".codex" / "a2a")))
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        prefix=f"{task_id}-",
+        suffix=".txt",
+        dir=runtime_dir,
+        delete=False,
+    ) as output_file:
+        output_path = Path(output_file.name)
+
+    process: subprocess.Popen[str] | None = None
+    try:
+        process = subprocess.Popen(
+            codex_command(prompt, output_path),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        with LOCK:
+            PROCESSES[task_id] = process
+        stdout, stderr = process.communicate(timeout=timeout)
+        with LOCK:
+            PROCESSES.pop(task_id, None)
+            current = TASKS.get(task_id)
+            if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
+                return
+        output = output_path.read_text(encoding="utf-8").strip() if output_path.exists() else ""
+        if process.returncode != 0:
+            metadata["exitCode"] = process.returncode
+            if stderr.strip():
+                metadata["stderrTail"] = stderr.strip()[-2000:]
+            message = agent_message(context_id, f"codex exec exited {process.returncode}")
+            next_task = task_value(
+                task_id,
+                context_id,
+                "TASK_STATE_FAILED",
+                message,
+                [*history, message],
+                metadata=metadata,
+            )
+        else:
+            text = output or stdout.strip() or "Codex completed without a text response."
+            message = agent_message(context_id, text)
+            next_task = task_value(
+                task_id,
+                context_id,
+                "TASK_STATE_COMPLETED",
+                message,
+                [*history, message],
+                artifacts=[
+                    {
+                        "artifactId": f"{task_id}-codex-response",
+                        "name": "codex-response",
+                        "parts": [{"text": text, "mediaType": "text/plain"}],
+                    }
+                ],
+                metadata=metadata,
+            )
+        with LOCK:
+            current = TASKS.get(task_id)
+            if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
+                return
+            TASKS[task_id] = next_task
+    except subprocess.TimeoutExpired:
+        if process is not None:
+            terminate_process(process)
+        message = agent_message(context_id, "codex exec timed out")
+        with LOCK:
+            PROCESSES.pop(task_id, None)
+            current = TASKS.get(task_id)
+            if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
+                return
+            TASKS[task_id] = task_value(
+                task_id,
+                context_id,
+                "TASK_STATE_FAILED",
+                message,
+                [*history, message],
+                metadata=metadata,
+            )
+    finally:
+        try:
+            output_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "codex-a2a-bridge/0.1"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        if env("CODEX_A2A_ACCESS_LOG", "0") == "1":
+            super().log_message(fmt, *args)
+
+    def send_json(self, status: int, value: Any) -> None:
+        body = json_bytes(value)
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header(
+            "Access-Control-Allow-Headers",
+            "authorization,content-type,x-organization-id,x-evalops-workspace-id,x-maestro-api-key",
+        )
+        self.send_header("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def error_json(self, status: int, code: str, message: str) -> None:
+        self.send_json(status, {"error": {"code": code, "message": message}})
+
+    def authorized(self) -> bool:
+        token = os.environ.get("CODEX_A2A_TOKEN", "").strip()
+        if not token:
+            return True
+        return (
+            self.headers.get("Authorization", "") == f"Bearer {token}"
+            or self.headers.get("x-maestro-api-key", "") == token
+            or self.headers.get("x-codex-a2a-token", "") == token
+        )
+
+    def read_body(self) -> dict[str, Any] | None:
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length) if length else b"{}"
+            value = json.loads(raw.decode("utf-8"))
+            return value if isinstance(value, dict) else None
+        except Exception:
+            return None
+
+    def do_OPTIONS(self) -> None:
+        self.send_json(204, {})
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path
+        if path == "/healthz":
+            self.send_json(200, {"ok": True})
+            return
+        if path == "/.well-known/agent-card.json":
+            base_url = env(
+                "CODEX_A2A_PUBLIC_URL",
+                f"http://{env('CODEX_A2A_HOST', '127.0.0.1')}:{env('CODEX_A2A_PORT', '18787')}",
+            ).rstrip("/")
+            self.send_json(
+                200,
+                {
+                    "protocolVersion": "1.0",
+                    "name": env("CODEX_A2A_AGENT_NAME", "Codex A2A Agent"),
+                    "description": "A2A peer backed by codex exec on this host.",
+                    "url": base_url,
+                    "preferredTransport": "HTTP+JSON",
+                    "supportedInterfaces": [
+                        {
+                            "url": base_url,
+                            "protocolBinding": "HTTP+JSON",
+                            "protocolVersion": "1.0",
+                        }
+                    ],
+                    "provider": {"organization": "EvalOps", "url": "https://evalops.com"},
+                    "version": "0.1",
+                    "capabilities": {"streaming": False, "pushNotifications": False},
+                    "defaultInputModes": ["text/plain"],
+                    "defaultOutputModes": ["text/plain"],
+                    "skills": [
+                        {
+                            "id": "codex-exec-turn",
+                            "name": "Codex exec turn",
+                            "description": "Run a prompt through the authenticated Codex CLI.",
+                            "tags": ["codex", "a2a", "fleet"],
+                            "inputModes": ["text/plain"],
+                            "outputModes": ["text/plain"],
+                        }
+                    ],
+                },
+            )
+            return
+        if not self.authorized():
+            self.error_json(401, "UNAUTHORIZED", "A2A token is required")
+            return
+        if path == "/tasks":
+            with LOCK:
+                self.send_json(200, {"tasks": list(TASKS.values())})
+            return
+        if path.startswith("/tasks/"):
+            task_id = path.removeprefix("/tasks/")
+            with LOCK:
+                task = TASKS.get(task_id)
+            if not task:
+                self.error_json(404, "TASK_NOT_FOUND", "A2A task not found")
+                return
+            self.send_json(200, task)
+            return
+        self.error_json(404, "NOT_FOUND", "A2A endpoint not found")
+
+    def do_POST(self) -> None:
+        path = urlparse(self.path).path
+        if not self.authorized():
+            self.error_json(401, "UNAUTHORIZED", "A2A token is required")
+            return
+        if path == "/message:send":
+            body = self.read_body()
+            if not body or not isinstance(body.get("message"), dict):
+                self.error_json(400, "INVALID_REQUEST", "A2A message is required")
+                return
+            message = body["message"]
+            prompt = message_text(message)
+            if not prompt:
+                self.error_json(400, "INVALID_REQUEST", "A2A text part is required")
+                return
+            context_id = str(message.get("contextId") or new_id("codex-a2a-context"))
+            requested_task_id = str(message.get("taskId") or "").strip()
+            with LOCK:
+                if requested_task_id:
+                    existing = TASKS.get(requested_task_id)
+                    if not existing:
+                        self.error_json(404, "TASK_NOT_FOUND", "A2A task not found")
+                        return
+                    if terminal(existing.get("status", {}).get("state")):
+                        self.error_json(
+                            400,
+                            "UNSUPPORTED_OPERATION",
+                            "A2A terminal tasks cannot accept more messages",
+                        )
+                        return
+                    task_id = requested_task_id
+                    history = list(existing.get("history") or [])
+                else:
+                    task_id = new_id("codex-a2a-task")
+                    history = []
+            history.append(user_message(message, context_id))
+            immediate = bool((body.get("configuration") or {}).get("returnImmediately"))
+            if immediate:
+                accepted = agent_message(context_id, "Codex accepted the A2A task.")
+                task = task_value(
+                    task_id,
+                    context_id,
+                    "TASK_STATE_WORKING",
+                    accepted,
+                    [*history, accepted],
+                    metadata={"backend": "codex-exec"},
+                )
+                with LOCK:
+                    TASKS[task_id] = task
+                threading.Thread(
+                    target=complete_task,
+                    args=(task_id, context_id, prompt, [*history, accepted]),
+                    daemon=True,
+                ).start()
+                self.send_json(200, {"task": task})
+                return
+            complete_task(task_id, context_id, prompt, history)
+            with LOCK:
+                task = TASKS[task_id]
+            self.send_json(200, {"task": task})
+            return
+        if path.startswith("/tasks/") and path.endswith(":cancel"):
+            task_id = path.removeprefix("/tasks/").removesuffix(":cancel")
+            with LOCK:
+                task = TASKS.get(task_id)
+                if not task:
+                    self.error_json(404, "TASK_NOT_FOUND", "A2A task not found")
+                    return
+                if terminal(task.get("status", {}).get("state")):
+                    self.error_json(
+                        400,
+                        "TASK_NOT_CANCELABLE",
+                        "A2A task cannot be canceled from its current state",
+                    )
+                    return
+                context_id = str(task.get("contextId") or "codex-a2a")
+                canceled = agent_message(context_id, "Task canceled")
+                task["status"] = {
+                    "state": "TASK_STATE_CANCELED",
+                    "message": canceled,
+                    "timestamp": now_iso(),
+                }
+                task["artifacts"] = []
+                process = PROCESSES.pop(task_id, None)
+            if process is not None:
+                terminate_process(process)
+            self.send_json(200, task)
+            return
+        self.error_json(404, "NOT_FOUND", "A2A endpoint not found")
+
+
+def main() -> None:
+    host = env("CODEX_A2A_BIND", "127.0.0.1")
+    port = int(env("CODEX_A2A_PORT", "18787"))
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    server = ThreadingHTTPServer((host, port), Handler)
+    print(f"codex-a2a bridge listening on http://{host}:{port}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -30,6 +30,7 @@ TASKS: dict[str, dict[str, Any]] = {}
 PROCESSES: dict[str, subprocess.Popen[str]] = {}
 LOCK = threading.Lock()
 MAX_REQUEST_BODY_BYTES = 1024 * 1024
+TERMINAL_TASK_STORE_LIMIT = 128
 
 
 def env(name: str, default: str) -> str:
@@ -66,6 +67,27 @@ def terminal(state: str | None) -> bool:
         "TASK_STATE_CANCELED",
         "TASK_STATE_REJECTED",
     }
+
+
+def prune_terminal_tasks_locked() -> None:
+    terminal_tasks = sorted(
+        (
+            str(task.get("status", {}).get("timestamp") or ""),
+            task_id,
+        )
+        for task_id, task in TASKS.items()
+        if terminal(task.get("status", {}).get("state"))
+    )
+    overflow = len(terminal_tasks) - TERMINAL_TASK_STORE_LIMIT
+    if overflow <= 0:
+        return
+    for _, task_id in terminal_tasks[:overflow]:
+        TASKS.pop(task_id, None)
+
+
+def store_task_locked(task_id: str, task: dict[str, Any]) -> None:
+    TASKS[task_id] = task
+    prune_terminal_tasks_locked()
 
 
 def accepts_message(state: str | None) -> bool:
@@ -267,7 +289,7 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
             current = TASKS.get(task_id)
             if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
                 return
-            TASKS[task_id] = next_task
+            store_task_locked(task_id, next_task)
     except ValueError as error:
         metadata["error"] = str(error)
         message = agent_message(context_id, f"invalid Codex A2A timeout: {error}")
@@ -276,13 +298,16 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
             current = TASKS.get(task_id)
             if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
                 return
-            TASKS[task_id] = task_value(
+            store_task_locked(
                 task_id,
-                context_id,
-                "TASK_STATE_FAILED",
-                message,
-                [*history, message],
-                metadata=metadata,
+                task_value(
+                    task_id,
+                    context_id,
+                    "TASK_STATE_FAILED",
+                    message,
+                    [*history, message],
+                    metadata=metadata,
+                ),
             )
     except OSError as error:
         metadata["error"] = str(error)
@@ -292,13 +317,16 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
             current = TASKS.get(task_id)
             if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
                 return
-            TASKS[task_id] = task_value(
+            store_task_locked(
                 task_id,
-                context_id,
-                "TASK_STATE_FAILED",
-                message,
-                [*history, message],
-                metadata=metadata,
+                task_value(
+                    task_id,
+                    context_id,
+                    "TASK_STATE_FAILED",
+                    message,
+                    [*history, message],
+                    metadata=metadata,
+                ),
             )
     except subprocess.TimeoutExpired:
         if process is not None:
@@ -309,13 +337,16 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
             current = TASKS.get(task_id)
             if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
                 return
-            TASKS[task_id] = task_value(
+            store_task_locked(
                 task_id,
-                context_id,
-                "TASK_STATE_FAILED",
-                message,
-                [*history, message],
-                metadata=metadata,
+                task_value(
+                    task_id,
+                    context_id,
+                    "TASK_STATE_FAILED",
+                    message,
+                    [*history, message],
+                    metadata=metadata,
+                ),
             )
     finally:
         if output_path is not None:
@@ -547,7 +578,7 @@ class Handler(BaseHTTPRequestHandler):
                         launch_history,
                         metadata={"backend": "codex-exec"},
                     )
-                    TASKS[task_id] = task
+                    store_task_locked(task_id, task)
             if error is not None:
                 self.error_json(*error)
                 return
@@ -591,7 +622,7 @@ class Handler(BaseHTTPRequestHandler):
                         artifacts=[],
                         metadata=copy.deepcopy(task.get("metadata") or {}),
                     )
-                    TASKS[task_id] = task
+                    store_task_locked(task_id, task)
                     process = PROCESSES.pop(task_id, None)
             if error is not None:
                 self.error_json(*error)

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -155,7 +155,6 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
         "backend": "codex-exec",
         "host": env("CODEX_A2A_AGENT_NAME", env("HOSTNAME", "codex-a2a")),
     }
-    timeout = int(env("CODEX_A2A_TURN_TIMEOUT_MS", "600000")) / 1000
     runtime_dir = Path(env("CODEX_A2A_RUNTIME_DIR", str(Path.home() / ".codex" / "a2a")))
     runtime_dir.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile(
@@ -168,6 +167,11 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
 
     process: subprocess.Popen[str] | None = None
     try:
+        timeout_raw = env("CODEX_A2A_TURN_TIMEOUT_MS", "600000")
+        timeout_ms = int(timeout_raw)
+        if timeout_ms <= 0:
+            raise ValueError("CODEX_A2A_TURN_TIMEOUT_MS must be positive")
+        timeout = timeout_ms / 1000
         with LOCK:
             current = TASKS.get(task_id)
             if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
@@ -231,6 +235,22 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
             if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
                 return
             TASKS[task_id] = next_task
+    except ValueError as error:
+        metadata["error"] = str(error)
+        message = agent_message(context_id, f"invalid Codex A2A timeout: {error}")
+        with LOCK:
+            PROCESSES.pop(task_id, None)
+            current = TASKS.get(task_id)
+            if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
+                return
+            TASKS[task_id] = task_value(
+                task_id,
+                context_id,
+                "TASK_STATE_FAILED",
+                message,
+                [*history, message],
+                metadata=metadata,
+            )
     except OSError as error:
         metadata["error"] = str(error)
         message = agent_message(context_id, f"codex exec failed to start: {error}")
@@ -410,7 +430,11 @@ class Handler(BaseHTTPRequestHandler):
                 return
             requested_task_id = str(message.get("taskId") or "").strip()
             requested_context_id = str(message.get("contextId") or "").strip()
-            immediate = bool((body.get("configuration") or {}).get("returnImmediately"))
+            configuration = body.get("configuration")
+            if configuration is not None and not isinstance(configuration, dict):
+                self.error_json(400, "INVALID_REQUEST", "A2A configuration must be an object")
+                return
+            immediate = bool((configuration or {}).get("returnImmediately"))
             with LOCK:
                 if requested_task_id:
                     existing = TASKS.get(requested_task_id)

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -50,9 +50,10 @@ def default_public_host() -> str:
 
 def url_authority_host(host: str) -> str:
     if host.startswith("[") and host.endswith("]"):
-        return host
+        inner = host[1:-1].replace("%25", "%").replace("%", "%25")
+        return f"[{inner}]"
     if ":" in host:
-        return f"[{host.replace('%', '%25')}]"
+        return f"[{host.replace('%25', '%').replace('%', '%25')}]"
     return host
 
 
@@ -86,7 +87,7 @@ def terminal(state: str | None) -> bool:
     }
 
 
-def prune_terminal_tasks_locked() -> None:
+def prune_terminal_tasks_locked(protected_task_id: str | None = None) -> None:
     terminal_tasks = sorted(
         (
             str(task.get("status", {}).get("timestamp") or ""),
@@ -98,13 +99,18 @@ def prune_terminal_tasks_locked() -> None:
     overflow = len(terminal_tasks) - TERMINAL_TASK_STORE_LIMIT
     if overflow <= 0:
         return
-    for _, task_id in terminal_tasks[:overflow]:
+    for _, task_id in terminal_tasks:
+        if overflow <= 0:
+            break
+        if task_id == protected_task_id:
+            continue
         TASKS.pop(task_id, None)
+        overflow -= 1
 
 
 def store_task_locked(task_id: str, task: dict[str, Any]) -> None:
     TASKS[task_id] = task
-    prune_terminal_tasks_locked()
+    prune_terminal_tasks_locked(protected_task_id=task_id)
 
 
 def accepts_message(state: str | None) -> bool:

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -14,6 +14,7 @@ import json
 import os
 import shlex
 import signal
+import socket
 import subprocess
 import tempfile
 import threading
@@ -33,6 +34,16 @@ LOCK = threading.Lock()
 def env(name: str, default: str) -> str:
     value = os.environ.get(name)
     return value.strip() if value and value.strip() else default
+
+
+def default_public_host() -> str:
+    configured_host = env("CODEX_A2A_HOST", "")
+    if configured_host:
+        return configured_host
+    bind_host = env("CODEX_A2A_BIND", "127.0.0.1")
+    if bind_host in {"0.0.0.0", "::"}:
+        return socket.getfqdn() or socket.gethostname() or "127.0.0.1"
+    return bind_host
 
 
 def now_ms() -> int:
@@ -155,23 +166,23 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
         "backend": "codex-exec",
         "host": env("CODEX_A2A_AGENT_NAME", env("HOSTNAME", "codex-a2a")),
     }
-    runtime_dir = Path(env("CODEX_A2A_RUNTIME_DIR", str(Path.home() / ".codex" / "a2a")))
-    runtime_dir.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        prefix=f"{task_id}-",
-        suffix=".txt",
-        dir=runtime_dir,
-        delete=False,
-    ) as output_file:
-        output_path = Path(output_file.name)
-
     process: subprocess.Popen[str] | None = None
+    output_path: Path | None = None
     try:
         timeout_raw = env("CODEX_A2A_TURN_TIMEOUT_MS", "600000")
         timeout_ms = int(timeout_raw)
         if timeout_ms <= 0:
             raise ValueError("CODEX_A2A_TURN_TIMEOUT_MS must be positive")
         timeout = timeout_ms / 1000
+        runtime_dir = Path(env("CODEX_A2A_RUNTIME_DIR", str(Path.home() / ".codex" / "a2a")))
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            prefix=f"{task_id}-",
+            suffix=".txt",
+            dir=runtime_dir,
+            delete=False,
+        ) as output_file:
+            output_path = Path(output_file.name)
         with LOCK:
             current = TASKS.get(task_id)
             if current and current.get("status", {}).get("state") == "TASK_STATE_CANCELED":
@@ -285,10 +296,11 @@ def complete_task(task_id: str, context_id: str, prompt: str, history: list[dict
                 metadata=metadata,
             )
     finally:
-        try:
-            output_path.unlink(missing_ok=True)
-        except OSError:
-            pass
+        if output_path is not None:
+            try:
+                output_path.unlink(missing_ok=True)
+            except OSError:
+                pass
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -298,11 +310,7 @@ class Handler(BaseHTTPRequestHandler):
         if env("CODEX_A2A_ACCESS_LOG", "0") == "1":
             super().log_message(fmt, *args)
 
-    def send_json(self, status: int, value: Any) -> None:
-        body = json_bytes(value)
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
+    def send_cors_headers(self) -> None:
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header(
             "Access-Control-Allow-Headers",
@@ -324,8 +332,21 @@ class Handler(BaseHTTPRequestHandler):
             ),
         )
         self.send_header("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
+
+    def send_json(self, status: int, value: Any) -> None:
+        body = json_bytes(value)
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_cors_headers()
         self.end_headers()
         self.wfile.write(body)
+
+    def send_empty(self, status: int) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.send_cors_headers()
+        self.end_headers()
 
     def error_json(self, status: int, code: str, message: str) -> None:
         self.send_json(status, {"error": {"code": code, "message": message}})
@@ -350,7 +371,7 @@ class Handler(BaseHTTPRequestHandler):
             return None
 
     def do_OPTIONS(self) -> None:
-        self.send_json(204, {})
+        self.send_empty(204)
 
     def do_GET(self) -> None:
         path = urlparse(self.path).path
@@ -360,7 +381,7 @@ class Handler(BaseHTTPRequestHandler):
         if path == "/.well-known/agent-card.json":
             base_url = env(
                 "CODEX_A2A_PUBLIC_URL",
-                f"http://{env('CODEX_A2A_HOST', '127.0.0.1')}:{env('CODEX_A2A_PORT', '18787')}",
+                f"http://{default_public_host()}:{env('CODEX_A2A_PORT', '18787')}",
             ).rstrip("/")
             self.send_json(
                 200,

--- a/scripts/smoke-maestro-a2a-local.ts
+++ b/scripts/smoke-maestro-a2a-local.ts
@@ -34,7 +34,9 @@ async function openPort(): Promise<number> {
 }
 
 async function waitForHealth(baseUrl: string, stderr: () => string): Promise<void> {
-	for (let attempt = 0; attempt < 80; attempt++) {
+	const timeoutMs = Number.parseInt(process.env.MAESTRO_A2A_SMOKE_READY_TIMEOUT_MS ?? "120000", 10);
+	const deadline = Date.now() + (Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 120000);
+	while (Date.now() < deadline) {
 		try {
 			const response = await fetch(`${baseUrl}/healthz`);
 			if (response.ok) {
@@ -43,7 +45,7 @@ async function waitForHealth(baseUrl: string, stderr: () => string): Promise<voi
 		} catch {
 			// The Rust server may still be compiling or binding the port.
 		}
-		await delay(100);
+		await delay(250);
 	}
 	throw new Error(`Rust control-plane did not become ready:\n${stderr()}`);
 }

--- a/scripts/smoke-maestro-a2a-local.ts
+++ b/scripts/smoke-maestro-a2a-local.ts
@@ -1,0 +1,156 @@
+import { once } from "node:events";
+import net from "node:net";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+	buildA2AUserMessage,
+	discoverA2AAgentCard,
+	getA2ATask,
+	resolveA2AServiceConfig,
+	sendA2AMessage,
+} from "../src/platform/a2a-client.js";
+
+const SMOKE_RESPONSE = "A2A smoke response from Maestro Rust TUI agent";
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function openPort(): Promise<number> {
+	const server = net.createServer();
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	if (address === null || typeof address === "string") {
+		server.close();
+		throw new Error("failed to allocate a local TCP port");
+	}
+	const port = address.port;
+	await new Promise<void>((resolve, reject) => {
+		server.close((error) => (error ? reject(error) : resolve()));
+	});
+	return port;
+}
+
+async function waitForHealth(baseUrl: string, stderr: () => string): Promise<void> {
+	for (let attempt = 0; attempt < 80; attempt++) {
+		try {
+			const response = await fetch(`${baseUrl}/healthz`);
+			if (response.ok) {
+				return;
+			}
+		} catch {
+			// The Rust server may still be compiling or binding the port.
+		}
+		await delay(100);
+	}
+	throw new Error(`Rust control-plane did not become ready:\n${stderr()}`);
+}
+
+async function stopProcess(child: ChildProcessWithoutNullStreams): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return;
+	}
+	child.kill("SIGTERM");
+	await Promise.race([once(child, "exit"), delay(2_000)]);
+	if (child.exitCode === null && child.signalCode === null) {
+		child.kill("SIGKILL");
+	}
+}
+
+async function main(): Promise<void> {
+	const port = await openPort();
+	const baseUrl = `http://127.0.0.1:${port}`;
+	let stderr = "";
+	const controlPlane = spawn(
+		"cargo",
+		[
+			"run",
+			"--quiet",
+			"--manifest-path",
+			"packages/control-plane-rs/Cargo.toml",
+			"--bin",
+			"maestro-control-plane",
+		],
+		{
+			env: {
+				...process.env,
+				MAESTRO_A2A_AGENT_NAME: "Maestro Rust TUI Smoke Agent",
+				MAESTRO_A2A_FAKE_RESPONSE: SMOKE_RESPONSE,
+				MAESTRO_CONTROL_HOST: "127.0.0.1",
+				MAESTRO_WEB_REQUIRE_KEY: "0",
+				PORT: String(port),
+			},
+			stdio: ["ignore", "ignore", "pipe"],
+		},
+	);
+	controlPlane.stderr.on("data", (chunk: Buffer) => {
+		stderr += chunk.toString("utf8");
+	});
+
+	try {
+		await waitForHealth(baseUrl, () => stderr);
+		const config = await resolveA2AServiceConfig({
+			baseUrl,
+			workspaceId: "local-a2a-smoke",
+			agentId: "maestro-ts-tui-smoke",
+			sessionId: "a2a-smoke-session",
+			actorId: "maestro-ts-tui",
+			timeoutMs: 1_500,
+			maxAttempts: 1,
+		});
+		if (!config) {
+			throw new Error("failed to resolve local A2A config");
+		}
+
+		const card = await discoverA2AAgentCard(config);
+		if (card.name !== "Maestro Rust TUI Smoke Agent") {
+			throw new Error(`unexpected A2A agent card name: ${card.name}`);
+		}
+
+		const sent = await sendA2AMessage(config, {
+			message: buildA2AUserMessage({
+				text: "Reply with the deterministic A2A smoke response.",
+				messageId: `ts-to-rust-${Date.now()}`,
+				contextId: "a2a-smoke-session",
+			}),
+			configuration: {
+				acceptedOutputModes: ["text/plain"],
+				returnImmediately: false,
+			},
+		});
+		const task = await getA2ATask(config, sent.task.id);
+		const artifactText = task.artifacts
+			?.flatMap((artifact) => artifact.parts.map((part) => part.text ?? ""))
+			.join("\n")
+			.trim();
+		if (task.status.state !== "TASK_STATE_COMPLETED") {
+			throw new Error(`unexpected A2A task state: ${task.status.state}`);
+		}
+		if (artifactText !== SMOKE_RESPONSE) {
+			throw new Error(`unexpected A2A artifact text: ${artifactText ?? "<empty>"}`);
+		}
+
+		console.log(
+			JSON.stringify(
+				{
+					ok: true,
+					card: card.name,
+					taskId: task.id,
+					contextId: task.contextId,
+					state: task.status.state,
+				},
+				null,
+				2,
+			),
+		);
+	} finally {
+		await stopProcess(controlPlane);
+	}
+}
+
+main().catch((error: unknown) => {
+	console.error(error instanceof Error ? error.stack : String(error));
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- expose the Rust control-plane as an A2A HTTP+JSON agent with Agent Card discovery, message send, task lookup/list, and cancel routes
- route incoming A2A messages through the native Rust TUI agent runner, including task history/artifacts/metadata and bounded tool approval handling
- add a TS smoke harness that discovers the Rust A2A Agent Card, sends an A2A message with the existing TS client, and fetches the completed task

## Source of truth
- evalops/maestro-internal#1927

## Test Plan
- `cd packages/control-plane-rs && cargo check --bin maestro-control-plane`
- `cd packages/control-plane-rs && cargo test --bin maestro-control-plane a2a`
- `bun run smoke:a2a-local`
- commit hook: guardian + `bunx biome check . && bun run lint:evals` + build/binary compile

## Notes
- The smoke uses `MAESTRO_A2A_FAKE_RESPONSE` so CI/local checks prove the A2A wire path without spending model tokens. Without that env var, `/message:send` invokes the native Maestro agent runner.