### PR TITLE
Add Codex A2A peer relay CLI

### DIFF
--- a/docs/protocols/codex-a2a-peer-relay.md
+++ b/docs/protocols/codex-a2a-peer-relay.md
@@ -1,0 +1,39 @@
+# Codex A2A Peer Relay
+
+`scripts/codex-a2a-peer.py` lets a fleet host initiate A2A handoffs to other
+Codex bridge peers without an operator brokering each `message:send` call.
+
+Create a local registry at `~/.codex/fleet/peers.json`:
+
+```json
+{
+  "defaultPeer": "mac-mini",
+  "timeoutMs": 600000,
+  "peers": {
+    "dev-desktop": {
+      "url": "http://192.168.4.113:18787",
+      "tokenFile": "~/.codex/fleet/dev-desktop.token"
+    },
+    "mac-mini": {
+      "url": "http://192.168.4.53:18787",
+      "tokenFile": "~/.codex/fleet/mac-mini.token"
+    }
+  }
+}
+```
+
+Use token files or `tokenEnv`; avoid committing inline `token` values. The relay
+sends `Authorization: Bearer ...` and `A2A-Version: 1.0` on every request.
+
+Common commands:
+
+```sh
+python3 scripts/codex-a2a-peer.py list
+python3 scripts/codex-a2a-peer.py card mac-mini
+python3 scripts/codex-a2a-peer.py send --from dev-desktop mac-mini "Validate the desktop sign-in flow on macOS"
+python3 scripts/codex-a2a-peer.py relay dev-desktop --stdin < handoff.md
+python3 scripts/codex-a2a-peer.py task mac-mini codex-a2a-task-123
+```
+
+For async work, pass `--async`; the command prints the task id and current state,
+which can be polled later with `task`.

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "smoke:event-bus": "tsx scripts/smoke-maestro-event-bus.ts",
     "smoke:a2a-local": "tsx scripts/smoke-maestro-a2a-local.ts",
     "a2a:codex-bridge": "python3 scripts/codex-a2a-bridge.py",
+    "a2a:peer": "python3 scripts/codex-a2a-peer.py",
     "smoke:headless": "node scripts/smoke-headless.js",
     "headless:responsiveness": "node scripts/headless-responsiveness-harness.js",
     "smoke:pack": "node scripts/smoke-packed-cli.js",

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -241,6 +241,18 @@ def prompt_from_args(args: argparse.Namespace) -> str:
     return text
 
 
+def apply_default_peer_message_fallback(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    if not args.peer:
+        return
+    if args.peer in registry_peers(registry):
+        return
+    default_peer = registry.get("defaultPeer")
+    if not isinstance(default_peer, str) or not default_peer.strip():
+        return
+    args.message = [args.peer, *args.message]
+    args.peer = None
+
+
 def cmd_list(registry: dict[str, Any], args: argparse.Namespace) -> None:
     peers = registry_peers(registry)
     if args.json:
@@ -270,6 +282,7 @@ def cmd_card(registry: dict[str, Any], args: argparse.Namespace) -> None:
 
 
 def cmd_send(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    apply_default_peer_message_fallback(registry, args)
     peer_name, peer = resolve_peer(registry, args.peer)
     text = prompt_from_args(args)
     metadata = {

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -35,6 +35,8 @@ def load_json(path: Path) -> dict[str, Any]:
             value = json.load(handle)
     except FileNotFoundError as error:
         raise PeerError(f"peer registry not found: {path}") from error
+    except OSError as error:
+        raise PeerError(f"cannot read peer registry: {path}: {error.strerror or error}") from error
     except json.JSONDecodeError as error:
         raise PeerError(f"peer registry is not valid JSON: {path}: {error}") from error
     if not isinstance(value, dict):
@@ -94,6 +96,8 @@ def read_token_from_file(path_value: str) -> str | None:
         token = path.read_text(encoding="utf-8").strip()
     except FileNotFoundError as error:
         raise PeerError(f"token file not found: {path}") from error
+    except OSError as error:
+        raise PeerError(f"cannot read token file: {path}: {error.strerror or error}") from error
     return token or None
 
 

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -167,7 +167,10 @@ def request_json(
     timeout = timeout_seconds
     if timeout is None:
         timeout_ms = peer.get("timeoutMs", registry.get("timeoutMs", 600_000))
-        timeout = float(timeout_ms) / 1000.0
+        try:
+            timeout = float(timeout_ms) / 1000.0
+        except (TypeError, ValueError) as error:
+            raise PeerError("timeoutMs must be numeric") from error
     request = Request(
         f"{peer['url']}{path}",
         data=data,
@@ -244,16 +247,16 @@ def prompt_from_args(args: argparse.Namespace) -> str:
     return text
 
 
-def apply_default_peer_message_fallback(registry: dict[str, Any], args: argparse.Namespace) -> None:
-    if not args.peer:
+def normalize_send_args(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    if args.peer:
         return
-    if args.peer in registry_peers(registry):
+    if not args.message:
         return
-    default_peer = registry.get("defaultPeer")
-    if not isinstance(default_peer, str) or not default_peer.strip():
-        return
-    args.message = [args.peer, *args.message]
-    args.peer = None
+    peers = registry_peers(registry)
+    first_token = args.message[0]
+    if first_token in peers:
+        args.peer = first_token
+        args.message = args.message[1:]
 
 
 def cmd_list(registry: dict[str, Any], args: argparse.Namespace) -> None:
@@ -285,7 +288,7 @@ def cmd_card(registry: dict[str, Any], args: argparse.Namespace) -> None:
 
 
 def cmd_send(registry: dict[str, Any], args: argparse.Namespace) -> None:
-    apply_default_peer_message_fallback(registry, args)
+    normalize_send_args(registry, args)
     peer_name, peer = resolve_peer(registry, args.peer)
     text = prompt_from_args(args)
     metadata = {
@@ -348,7 +351,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     for name in ("send", "relay"):
         send_parser = subcommands.add_parser(name, help="send a message to a peer")
-        send_parser.add_argument("peer", nargs="?", help="peer name")
+        send_parser.add_argument("--peer", help="peer name")
         send_parser.add_argument("message", nargs="*", help="message text, or '-' for stdin")
         send_parser.add_argument("--async", dest="return_immediately", action="store_true", help="return immediately with a working task")
         send_parser.add_argument("--context-id", help="A2A context id")

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Send A2A handoffs to peers from a local registry.
+
+This companion to ``codex-a2a-bridge.py`` is intentionally dependency-free so a
+fleet host can initiate handoffs with only Python installed. Peers are read from
+``$CODEX_A2A_PEERS_FILE`` or ``~/.codex/fleet/peers.json`` by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+DEFAULT_CONFIG_PATH = "~/.codex/fleet/peers.json"
+A2A_VERSION = "1.0"
+
+
+class PeerError(Exception):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except FileNotFoundError as error:
+        raise PeerError(f"peer registry not found: {path}") from error
+    except json.JSONDecodeError as error:
+        raise PeerError(f"peer registry is not valid JSON: {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise PeerError("peer registry must be a JSON object")
+    return value
+
+
+def config_path(cli_path: str | None) -> Path:
+    configured = cli_path or os.environ.get("CODEX_A2A_PEERS_FILE") or DEFAULT_CONFIG_PATH
+    return Path(configured).expanduser()
+
+
+def registry_peers(registry: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    peers = registry.get("peers")
+    if not isinstance(peers, dict):
+        raise PeerError('peer registry must contain an object at "peers"')
+    normalized: dict[str, dict[str, Any]] = {}
+    for name, peer in peers.items():
+        if not isinstance(name, str) or not name.strip():
+            raise PeerError("peer names must be non-empty strings")
+        if not isinstance(peer, dict):
+            raise PeerError(f"peer {name!r} must be an object")
+        normalized[name.strip()] = peer
+    return normalized
+
+
+def normalize_base_url(url: str) -> str:
+    normalized = url.strip().rstrip("/")
+    for suffix in (
+        "/.well-known/agent-card.json",
+        "/message:send",
+        "/message:stream",
+    ):
+        if normalized.endswith(suffix):
+            normalized = normalized[: -len(suffix)].rstrip("/")
+    return normalized
+
+
+def resolve_peer(registry: dict[str, Any], name: str | None) -> tuple[str, dict[str, Any]]:
+    peers = registry_peers(registry)
+    peer_name = (name or registry.get("defaultPeer") or "").strip()
+    if not peer_name:
+        raise PeerError("peer name is required; no defaultPeer is configured")
+    peer = peers.get(peer_name)
+    if peer is None:
+        choices = ", ".join(sorted(peers)) or "none"
+        raise PeerError(f"unknown peer {peer_name!r}; available peers: {choices}")
+    url = peer.get("url")
+    if not isinstance(url, str) or not url.strip():
+        raise PeerError(f"peer {peer_name!r} must configure a url")
+    return peer_name, {**peer, "url": normalize_base_url(url)}
+
+
+def read_token_from_file(path_value: str) -> str | None:
+    path = Path(path_value).expanduser()
+    try:
+        token = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as error:
+        raise PeerError(f"token file not found: {path}") from error
+    return token or None
+
+
+def resolve_token(registry: dict[str, Any], peer: dict[str, Any]) -> tuple[str | None, str]:
+    for source in (peer, registry):
+        token_env = source.get("tokenEnv")
+        if isinstance(token_env, str) and token_env.strip():
+            value = os.environ.get(token_env.strip(), "").strip()
+            if value:
+                return value, f"env:{token_env.strip()}"
+        token_file = source.get("tokenFile")
+        if isinstance(token_file, str) and token_file.strip():
+            token = read_token_from_file(token_file.strip())
+            if token:
+                return token, f"file:{Path(token_file).expanduser()}"
+        token = source.get("token")
+        if isinstance(token, str) and token.strip():
+            return token.strip(), "inline"
+    return None, "missing"
+
+
+def token_source_hint(registry: dict[str, Any], peer: dict[str, Any]) -> str:
+    for source in (peer, registry):
+        token_env = source.get("tokenEnv")
+        if isinstance(token_env, str) and token_env.strip():
+            return f"env:{token_env.strip()}"
+        token_file = source.get("tokenFile")
+        if isinstance(token_file, str) and token_file.strip():
+            return f"file:{Path(token_file).expanduser()}"
+        token = source.get("token")
+        if isinstance(token, str) and token.strip():
+            return "inline"
+    return "missing"
+
+
+def peer_headers(registry: dict[str, Any], peer: dict[str, Any]) -> tuple[dict[str, str], str]:
+    headers = {
+        "Accept": "application/json",
+        "A2A-Version": A2A_VERSION,
+    }
+    configured_headers = peer.get("headers")
+    if configured_headers is not None:
+        if not isinstance(configured_headers, dict):
+            raise PeerError("peer headers must be an object")
+        for key, value in configured_headers.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise PeerError("peer header keys and values must be strings")
+            headers[key] = value
+    token, token_source = resolve_token(registry, peer)
+    auth_required = peer.get("authRequired", registry.get("authRequired", True))
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    elif auth_required is not False:
+        raise PeerError("peer token is required; configure tokenEnv or tokenFile")
+    return headers, token_source
+
+
+def request_json(
+    registry: dict[str, Any],
+    peer: dict[str, Any],
+    method: str,
+    path: str,
+    body: dict[str, Any] | None = None,
+    timeout_seconds: float | None = None,
+) -> dict[str, Any]:
+    headers, _ = peer_headers(registry, peer)
+    data = None
+    if body is not None:
+        data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    timeout = timeout_seconds
+    if timeout is None:
+        timeout_ms = peer.get("timeoutMs", registry.get("timeoutMs", 600_000))
+        timeout = float(timeout_ms) / 1000.0
+    request = Request(
+        f"{peer['url']}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            payload = response.read()
+    except HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace").strip()
+        raise PeerError(f"{method} {path} failed with HTTP {error.code}: {detail}") from error
+    except URLError as error:
+        raise PeerError(f"{method} {path} failed: {error}") from error
+    if not payload:
+        return {}
+    value = json.loads(payload.decode("utf-8"))
+    if not isinstance(value, dict):
+        raise PeerError(f"{method} {path} returned non-object JSON")
+    return value
+
+
+def task_text(task: dict[str, Any]) -> str:
+    status = task.get("status") if isinstance(task.get("status"), dict) else {}
+    message = status.get("message") if isinstance(status.get("message"), dict) else {}
+    parts = message.get("parts") if isinstance(message.get("parts"), list) else []
+    texts = [
+        str(part.get("text"))
+        for part in parts
+        if isinstance(part, dict) and isinstance(part.get("text"), str)
+    ]
+    if texts:
+        return "\n".join(texts).strip()
+    artifacts = task.get("artifacts") if isinstance(task.get("artifacts"), list) else []
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        for part in artifact.get("parts") or []:
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                return part["text"].strip()
+    return ""
+
+
+def print_task(payload: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    task = payload.get("task") if isinstance(payload.get("task"), dict) else payload
+    status = task.get("status") if isinstance(task.get("status"), dict) else {}
+    print(f"task: {task.get('id', '')}")
+    print(f"state: {status.get('state', '')}")
+    context_id = task.get("contextId")
+    if context_id:
+        print(f"context: {context_id}")
+    text = task_text(task)
+    if text:
+        print()
+        print(text)
+
+
+def prompt_from_args(args: argparse.Namespace) -> str:
+    if args.stdin:
+        return sys.stdin.read().strip()
+    if args.message == ["-"]:
+        return sys.stdin.read().strip()
+    text = " ".join(args.message).strip()
+    if not text and not sys.stdin.isatty():
+        text = sys.stdin.read().strip()
+    if not text:
+        raise PeerError("message text is required")
+    return text
+
+
+def cmd_list(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    peers = registry_peers(registry)
+    if args.json:
+        safe = {"peers": {}}
+        for name, peer in peers.items():
+            safe["peers"][name] = {
+                "url": normalize_base_url(str(peer.get("url", ""))),
+                "tokenSource": token_source_hint(registry, peer),
+            }
+        print(json.dumps(safe, indent=2, sort_keys=True))
+        return
+    for name in sorted(peers):
+        peer = peers[name]
+        token_source = token_source_hint(registry, peer)
+        print(f"{name}\t{normalize_base_url(str(peer.get('url', '')))}\tauth={token_source}")
+
+
+def cmd_card(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    _, peer = resolve_peer(registry, args.peer)
+    payload = request_json(registry, peer, "GET", "/.well-known/agent-card.json", timeout_seconds=args.timeout)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(f"name: {payload.get('name', '')}")
+    print(f"url: {payload.get('url', '')}")
+    print(f"version: {payload.get('protocolVersion', payload.get('version', ''))}")
+
+
+def cmd_send(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    peer_name, peer = resolve_peer(registry, args.peer)
+    text = prompt_from_args(args)
+    metadata = {
+        "relayPeer": peer_name,
+        "relaySentAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    if args.from_agent:
+        metadata["handoffFrom"] = args.from_agent
+    body = {
+        "message": {
+            "messageId": args.message_id or f"codex-a2a-peer-{uuid.uuid4().hex}",
+            "role": "ROLE_USER",
+            "parts": [{"text": text, "mediaType": "text/plain"}],
+            "metadata": metadata,
+        },
+        "configuration": {"returnImmediately": bool(args.return_immediately)},
+    }
+    if args.context_id:
+        body["message"]["contextId"] = args.context_id
+    if args.task_id:
+        body["message"]["taskId"] = args.task_id
+    payload = request_json(registry, peer, "POST", "/message:send", body, timeout_seconds=args.timeout)
+    print_task(payload, args.json)
+
+
+def cmd_task(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    _, peer = resolve_peer(registry, args.peer)
+    payload = request_json(registry, peer, "GET", f"/tasks/{quote(args.task_id, safe='')}", timeout_seconds=args.timeout)
+    print_task(payload, args.json)
+
+
+def cmd_tasks(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    _, peer = resolve_peer(registry, args.peer)
+    payload = request_json(registry, peer, "GET", "/tasks", timeout_seconds=args.timeout)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    tasks = payload.get("tasks") if isinstance(payload.get("tasks"), list) else []
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        status = task.get("status") if isinstance(task.get("status"), dict) else {}
+        print(f"{task.get('id', '')}\t{status.get('state', '')}\t{task.get('contextId', '')}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Send A2A handoffs to configured peers")
+    parser.add_argument("--config", help=f"peer registry path (default: {DEFAULT_CONFIG_PATH})")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subcommands.add_parser("list", help="list configured peers")
+    list_parser.add_argument("--json", action="store_true", help="print JSON")
+    list_parser.set_defaults(handler=cmd_list)
+
+    card_parser = subcommands.add_parser("card", help="fetch a peer Agent Card")
+    card_parser.add_argument("peer", nargs="?", help="peer name")
+    card_parser.add_argument("--json", action="store_true", help="print JSON")
+    card_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
+    card_parser.set_defaults(handler=cmd_card)
+
+    for name in ("send", "relay"):
+        send_parser = subcommands.add_parser(name, help="send a message to a peer")
+        send_parser.add_argument("peer", nargs="?", help="peer name")
+        send_parser.add_argument("message", nargs="*", help="message text, or '-' for stdin")
+        send_parser.add_argument("--async", dest="return_immediately", action="store_true", help="return immediately with a working task")
+        send_parser.add_argument("--context-id", help="A2A context id")
+        send_parser.add_argument("--task-id", help="A2A task id for follow-up messages")
+        send_parser.add_argument("--message-id", help="A2A message id")
+        send_parser.add_argument("--from", dest="from_agent", help="originating agent name for handoff metadata")
+        send_parser.add_argument("--stdin", action="store_true", help="read message text from stdin")
+        send_parser.add_argument("--json", action="store_true", help="print JSON")
+        send_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
+        send_parser.set_defaults(handler=cmd_send)
+
+    task_parser = subcommands.add_parser("task", help="fetch a task from a peer")
+    task_parser.add_argument("peer", nargs="?", help="peer name")
+    task_parser.add_argument("task_id", help="task id")
+    task_parser.add_argument("--json", action="store_true", help="print JSON")
+    task_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
+    task_parser.set_defaults(handler=cmd_task)
+
+    tasks_parser = subcommands.add_parser("tasks", help="list retained tasks from a peer")
+    tasks_parser.add_argument("peer", nargs="?", help="peer name")
+    tasks_parser.add_argument("--json", action="store_true", help="print JSON")
+    tasks_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
+    tasks_parser.set_defaults(handler=cmd_tasks)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        registry = load_json(config_path(args.config))
+        args.handler(registry, args)
+    except PeerError as error:
+        print(f"codex-a2a-peer: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -184,7 +184,10 @@ def request_json(
         raise PeerError(f"{method} {path} failed: {error}") from error
     if not payload:
         return {}
-    value = json.loads(payload.decode("utf-8"))
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError as error:
+        raise PeerError(f"{method} {path} returned invalid JSON: {error}") from error
     if not isinstance(value, dict):
         raise PeerError(f"{method} {path} returned non-object JSON")
     return value

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -175,6 +175,8 @@ def request_json(
             timeout = float(timeout_ms) / 1000.0
         except (TypeError, ValueError) as error:
             raise PeerError("timeoutMs must be numeric") from error
+    if timeout <= 0:
+        raise PeerError("timeoutMs must be positive")
     request = Request(
         f"{peer['url']}{path}",
         data=data,
@@ -193,7 +195,7 @@ def request_json(
         return {}
     try:
         value = json.loads(payload.decode("utf-8"))
-    except json.JSONDecodeError as error:
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise PeerError(f"{method} {path} returned invalid JSON: {error}") from error
     if not isinstance(value, dict):
         raise PeerError(f"{method} {path} returned non-object JSON")

--- a/scripts/codex-a2a-peers.example.json
+++ b/scripts/codex-a2a-peers.example.json
@@ -1,0 +1,14 @@
+{
+  "defaultPeer": "mac-mini",
+  "timeoutMs": 600000,
+  "peers": {
+    "dev-desktop": {
+      "url": "http://192.168.4.113:18787",
+      "tokenFile": "~/.codex/fleet/dev-desktop.token"
+    },
+    "mac-mini": {
+      "url": "http://192.168.4.53:18787",
+      "tokenFile": "~/.codex/fleet/mac-mini.token"
+    }
+  }
+}

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -84,6 +84,10 @@ describe("codex-a2a-peer", () => {
 				);
 				return;
 			}
+			if (request.url === "/bad-json/.well-known/agent-card.json") {
+				response.end("{not json");
+				return;
+			}
 			if (request.url === "/message:send") {
 				response.end(
 					JSON.stringify({
@@ -173,6 +177,25 @@ describe("codex-a2a-peer", () => {
 			"Bearer super-secret-token",
 		);
 		expect(requests[0]?.headers["a2a-version"]).toBe("1.0");
+	});
+
+	it("reports malformed JSON responses without a traceback", async () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				defaultPeer: "bad",
+				authRequired: false,
+				peers: {
+					bad: {
+						url: `${baseUrl}/bad-json`,
+					},
+				},
+			}),
+		);
+
+		await expect(runPeer(configPath, ["card"], {})).rejects.toMatchObject({
+			stderr: expect.stringContaining("returned invalid JSON"),
+		});
 	});
 
 	it("sends a synchronous handoff through message:send", async () => {

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -163,6 +163,23 @@ describe("codex-a2a-peer", () => {
 		expect(output).not.toContain("super-secret-token");
 	});
 
+	it("reports unreadable registry paths without a traceback", async () => {
+		const registryDirectory = mkdtempSync(
+			join(tmpdir(), "codex-a2a-peer-registry-dir-"),
+		);
+
+		await expect(
+			runPeer(registryDirectory, ["list"], {}),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("cannot read peer registry"),
+		});
+		await expect(
+			runPeer(registryDirectory, ["list"], {}),
+		).rejects.not.toMatchObject({
+			stderr: expect.stringContaining("Traceback"),
+		});
+	});
+
 	it("fetches a peer Agent Card with A2A headers", async () => {
 		const output = await runPeer(configPath, ["card", "mock"], {
 			TEST_A2A_PEER_TOKEN: "super-secret-token",
@@ -177,6 +194,35 @@ describe("codex-a2a-peer", () => {
 			"Bearer super-secret-token",
 		);
 		expect(requests[0]?.headers["a2a-version"]).toBe("1.0");
+	});
+
+	it("reports unreadable token files without a traceback", async () => {
+		const tokenDirectory = mkdtempSync(
+			join(tmpdir(), "codex-a2a-peer-token-dir-"),
+		);
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				peers: {
+					mock: {
+						url: `${baseUrl}/message:send`,
+						tokenFile: tokenDirectory,
+					},
+				},
+			}),
+		);
+
+		await expect(
+			runPeer(configPath, ["card", "mock"], {}),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("cannot read token file"),
+		});
+		await expect(
+			runPeer(configPath, ["card", "mock"], {}),
+		).rejects.not.toMatchObject({
+			stderr: expect.stringContaining("Traceback"),
+		});
+		expect(requests).toHaveLength(0);
 	});
 
 	it("reports malformed JSON responses without a traceback", async () => {

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -1,0 +1,210 @@
+import { execFile } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { type IncomingMessage, type Server, createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+type CapturedRequest = {
+	body: string;
+	headers: IncomingMessage["headers"];
+	method?: string;
+	url?: string;
+};
+
+const scriptPath = resolve(process.cwd(), "scripts/codex-a2a-peer.py");
+const execFileAsync = promisify(execFile);
+
+function readBody(request: IncomingMessage): Promise<string> {
+	return new Promise((resolveBody, reject) => {
+		let body = "";
+		request.setEncoding("utf8");
+		request.on("data", (chunk) => {
+			body += chunk;
+		});
+		request.on("end", () => resolveBody(body));
+		request.on("error", reject);
+	});
+}
+
+async function runPeer(
+	configPath: string,
+	args: string[],
+	env: NodeJS.ProcessEnv = {},
+) {
+	const { stdout } = await execFileAsync(
+		"python3",
+		[scriptPath, "--config", configPath, ...args],
+		{
+			encoding: "utf8",
+			env: { ...process.env, ...env },
+		},
+	);
+	return stdout;
+}
+
+describe("codex-a2a-peer", () => {
+	let server: Server;
+	let baseUrl: string;
+	let configPath: string;
+	let requests: CapturedRequest[];
+
+	beforeEach(async () => {
+		requests = [];
+		server = createServer(async (request, response) => {
+			const body = await readBody(request);
+			requests.push({
+				body,
+				headers: request.headers,
+				method: request.method,
+				url: request.url,
+			});
+
+			response.setHeader("Content-Type", "application/json");
+			if (request.url === "/.well-known/agent-card.json") {
+				response.end(
+					JSON.stringify({
+						protocolVersion: "1.0",
+						name: "Mock Codex Peer",
+						url: baseUrl,
+						version: "test",
+						capabilities: { streaming: false },
+						defaultInputModes: ["text/plain"],
+						defaultOutputModes: ["text/plain"],
+						supportedInterfaces: [
+							{
+								url: baseUrl,
+								protocolBinding: "HTTP+JSON",
+								protocolVersion: "1.0",
+							},
+						],
+						skills: [],
+					}),
+				);
+				return;
+			}
+			if (request.url === "/message:send") {
+				response.end(
+					JSON.stringify({
+						task: {
+							id: "task-1",
+							contextId: "ctx-1",
+							status: {
+								state: "TASK_STATE_COMPLETED",
+								message: {
+									role: "ROLE_AGENT",
+									parts: [{ text: "hello from peer", mediaType: "text/plain" }],
+								},
+							},
+							artifacts: [],
+							history: [],
+							metadata: {},
+						},
+					}),
+				);
+				return;
+			}
+			if (request.url === "/tasks/task-1") {
+				response.end(
+					JSON.stringify({
+						id: "task-1",
+						contextId: "ctx-1",
+						status: { state: "TASK_STATE_COMPLETED" },
+					}),
+				);
+				return;
+			}
+			response.statusCode = 404;
+			response.end(JSON.stringify({ error: { code: "NOT_FOUND" } }));
+		});
+		await new Promise<void>((resolveListen) => {
+			server.listen(0, "127.0.0.1", resolveListen);
+		});
+		const address = server.address();
+		if (!address || typeof address === "string") {
+			throw new Error("mock server did not bind to a TCP port");
+		}
+		baseUrl = `http://127.0.0.1:${address.port}`;
+		const directory = mkdtempSync(join(tmpdir(), "codex-a2a-peer-"));
+		configPath = join(directory, "peers.json");
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				defaultPeer: "mock",
+				peers: {
+					mock: {
+						url: `${baseUrl}/message:send`,
+						tokenEnv: "TEST_A2A_PEER_TOKEN",
+					},
+				},
+			}),
+		);
+	});
+
+	afterEach(async () => {
+		await new Promise<void>((resolveClose) => {
+			server.close(() => resolveClose());
+		});
+	});
+
+	it("lists peers without printing token values", async () => {
+		const output = await runPeer(configPath, ["list"], {
+			TEST_A2A_PEER_TOKEN: "super-secret-token",
+		});
+
+		expect(output).toContain("mock");
+		expect(output).toContain(baseUrl);
+		expect(output).toContain("auth=env:TEST_A2A_PEER_TOKEN");
+		expect(output).not.toContain("super-secret-token");
+	});
+
+	it("fetches a peer Agent Card with A2A headers", async () => {
+		const output = await runPeer(configPath, ["card", "mock"], {
+			TEST_A2A_PEER_TOKEN: "super-secret-token",
+		});
+
+		expect(output).toContain("name: Mock Codex Peer");
+		expect(requests[0]).toMatchObject({
+			method: "GET",
+			url: "/.well-known/agent-card.json",
+		});
+		expect(requests[0]?.headers.authorization).toBe(
+			"Bearer super-secret-token",
+		);
+		expect(requests[0]?.headers["a2a-version"]).toBe("1.0");
+	});
+
+	it("sends a synchronous handoff through message:send", async () => {
+		const output = await runPeer(
+			configPath,
+			["send", "--from", "dev-desktop", "mock", "hello", "fleet"],
+			{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+		);
+
+		expect(output).toContain("task: task-1");
+		expect(output).toContain("state: TASK_STATE_COMPLETED");
+		expect(output).toContain("hello from peer");
+		const request = requests.find((item) => item.url === "/message:send");
+		expect(request?.headers.authorization).toBe("Bearer super-secret-token");
+		expect(request?.headers["a2a-version"]).toBe("1.0");
+		const body = JSON.parse(request?.body ?? "{}");
+		expect(body).toMatchObject({
+			configuration: { returnImmediately: false },
+			message: {
+				role: "ROLE_USER",
+				parts: [{ text: "hello fleet", mediaType: "text/plain" }],
+				metadata: { handoffFrom: "dev-desktop", relayPeer: "mock" },
+			},
+		});
+	});
+
+	it("fails closed when the peer token is missing", async () => {
+		await expect(
+			runPeer(configPath, ["send", "mock", "hello"], {}),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("peer token is required"),
+		});
+		expect(requests).toHaveLength(0);
+	});
+});

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -88,6 +88,10 @@ describe("codex-a2a-peer", () => {
 				response.end("{not json");
 				return;
 			}
+			if (request.url === "/bad-utf8/.well-known/agent-card.json") {
+				response.end(Buffer.from([0xff]));
+				return;
+			}
 			if (request.url === "/message:send") {
 				response.end(
 					JSON.stringify({
@@ -247,6 +251,28 @@ describe("codex-a2a-peer", () => {
 		});
 	});
 
+	it("reports invalid UTF-8 responses without a traceback", async () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				defaultPeer: "bad",
+				authRequired: false,
+				peers: {
+					bad: {
+						url: `${baseUrl}/bad-utf8`,
+					},
+				},
+			}),
+		);
+
+		await expect(runPeer(configPath, ["card"], {})).rejects.toMatchObject({
+			stderr: expect.stringContaining("returned invalid JSON"),
+		});
+		await expect(runPeer(configPath, ["card"], {})).rejects.not.toMatchObject({
+			stderr: expect.stringContaining("Traceback"),
+		});
+	});
+
 	it("sends a synchronous handoff through message:send", async () => {
 		const output = await runPeer(
 			configPath,
@@ -318,6 +344,30 @@ describe("codex-a2a-peer", () => {
 		await expect(runPeer(configPath, ["card"], {})).rejects.not.toMatchObject({
 			stderr: expect.stringContaining("Traceback"),
 		});
+	});
+
+	it("reports non-positive configured timeoutMs without a traceback", async () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				defaultPeer: "mock",
+				authRequired: false,
+				timeoutMs: -1,
+				peers: {
+					mock: {
+						url: baseUrl,
+					},
+				},
+			}),
+		);
+
+		await expect(runPeer(configPath, ["card"], {})).rejects.toMatchObject({
+			stderr: expect.stringContaining("timeoutMs must be positive"),
+		});
+		await expect(runPeer(configPath, ["card"], {})).rejects.not.toMatchObject({
+			stderr: expect.stringContaining("Traceback"),
+		});
+		expect(requests).toHaveLength(0);
 	});
 
 	it("fails closed when the peer token is missing", async () => {

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -199,6 +199,21 @@ describe("codex-a2a-peer", () => {
 		});
 	});
 
+	it("uses defaultPeer for inline send messages without an explicit peer", async () => {
+		await runPeer(configPath, ["send", "hello", "fleet"], {
+			TEST_A2A_PEER_TOKEN: "super-secret-token",
+		});
+
+		const request = requests.find((item) => item.url === "/message:send");
+		const body = JSON.parse(request?.body ?? "{}");
+		expect(body).toMatchObject({
+			message: {
+				parts: [{ text: "hello fleet", mediaType: "text/plain" }],
+				metadata: { relayPeer: "mock" },
+			},
+		});
+	});
+
 	it("fails closed when the peer token is missing", async () => {
 		await expect(
 			runPeer(configPath, ["send", "mock", "hello"], {}),

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -196,6 +196,9 @@ describe("codex-a2a-peer", () => {
 		await expect(runPeer(configPath, ["card"], {})).rejects.toMatchObject({
 			stderr: expect.stringContaining("returned invalid JSON"),
 		});
+		await expect(runPeer(configPath, ["card"], {})).rejects.not.toMatchObject({
+			stderr: expect.stringContaining("Traceback"),
+		});
 	});
 
 	it("sends a synchronous handoff through message:send", async () => {
@@ -234,6 +237,40 @@ describe("codex-a2a-peer", () => {
 				parts: [{ text: "hello fleet", mediaType: "text/plain" }],
 				metadata: { relayPeer: "mock" },
 			},
+		});
+	});
+
+	it("fails unknown explicit peers before sending", async () => {
+		await expect(
+			runPeer(configPath, ["send", "--peer", "mok", "hello"], {
+				TEST_A2A_PEER_TOKEN: "super-secret-token",
+			}),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("unknown peer 'mok'"),
+		});
+		expect(requests).toHaveLength(0);
+	});
+
+	it("reports invalid configured timeoutMs without a traceback", async () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				defaultPeer: "mock",
+				authRequired: false,
+				timeoutMs: "slow",
+				peers: {
+					mock: {
+						url: baseUrl,
+					},
+				},
+			}),
+		);
+
+		await expect(runPeer(configPath, ["card"], {})).rejects.toMatchObject({
+			stderr: expect.stringContaining("timeoutMs must be numeric"),
+		});
+		await expect(runPeer(configPath, ["card"], {})).rejects.not.toMatchObject({
+			stderr: expect.stringContaining("Traceback"),
 		});
 	});
 


### PR DESCRIPTION
## Summary
- add a dependency-free `scripts/codex-a2a-peer.py` CLI for registry-backed A2A handoffs between Codex bridge peers
- add an example peer registry and operator docs for token-file based local fleet setup
- cover peer listing, Agent Card discovery, synchronous `message:send`, token redaction, and fail-closed auth behavior with a mock A2A server

Internal PR: https://github.com/evalops/maestro-internal/pull/1945

## Test plan
- `python3 -m py_compile scripts/codex-a2a-peer.py`
- `node ./scripts/run-vitest.js --run test/scripts/codex-a2a-peer.test.ts`
- commit hook: Guardian, `bunx biome check .`, lint/eval contract checks, build/compile path
- live fleet smoke: installed the peer CLI and local registries on dev-desktop and Mac mini; verified dev-desktop -> mac-mini and mac-mini -> dev-desktop relay handoffs complete over A2A
