### PR TITLE
[maestro] add Agent Core skill package surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ maestro web
 - Keys and config: `~/.maestro/keys.json`, `~/.maestro/config.json`
 - MCP servers: `~/.maestro/mcp.json` or `.maestro/mcp.json`
 - Hooks: `~/.maestro/hooks.json` or `.maestro/hooks.json`
+- Skills: `maestro skill new <name>`, `maestro skill lint .maestro/skills`
 - Agent instructions: `AGENT.md`, `.maestro/APPEND_SYSTEM.md`, `~/.maestro/agent/AGENT.md`
 
 ## Safety Model
@@ -96,6 +97,7 @@ See [Safety](docs/SAFETY.md) and the [Threat Model](docs/THREAT_MODEL.md) for th
 | Understand approvals and sandboxing | [Safety](docs/SAFETY.md) |
 | Run the browser interface | [Web UI Guide](docs/WEB_UI.md) |
 | Set up MCP servers | [MCP Guide](docs/MCP_GUIDE.md) |
+| Package reusable skills | [Skill Cookbook](docs/cookbook/skills/README.md) |
 | Work on the repo as a contributor | [Contributor Runbook](docs/CONTRIBUTOR_RUNBOOK.md) |
 | Integrate Maestro headlessly | [Headless protocol](docs/protocols/headless.md) |
 | Bring any coding agent into EvalOps | [Any-Agent Control Plane](docs/design/ANY_AGENT_CONTROL_PLANE.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Use this index to jump to the right guide quickly and see how the pieces connect
 - [Sessions](SESSIONS.md) — session formats, storage locations, and management commands.
 - [Prompt Queue](PROMPT_QUEUE.md) — queue lifecycle, prioritization, and diagnostics hooks.
 - [MCP Guide](MCP_GUIDE.md) — Model Context Protocol setup and usage.
+- [Skill Cookbook](cookbook/skills/README.md) — progressive skill package authoring, linting, bundled MCP, and toolbox examples.
 - [Headless Protocol Reference](protocols/headless.md) — versioned JSON-over-stdio contract for Chat, TUIs, and other embedders.
 - [Codex Parity Conformance](protocols/codex-parity-conformance.md) — compact anchors for Codex-inspired auth, patching, MCP, queue, and hosted-runtime surfaces.
 - [Hosted Runner Contract](protocols/hosted-runner-contract.md) — provider-neutral runtime contract for account-scoped remote Maestro sessions.
@@ -41,6 +42,7 @@ Use this index to jump to the right guide quickly and see how the pieces connect
   - [Any-Agent EvalOps Control Plane](design/ANY_AGENT_CONTROL_PLANE.md) - agent-neutral control-plane, registry, shim, trace, evidence, and memory integration strategy.
   - [Platform AgentRuntime Session Bridge](design/PLATFORM_AGENT_RUNTIME_SESSION_BRIDGE.md) — hosted-session trigger projection, A2A fallback, trace context, and boundary normalization.
   - [AgentRuntime Task Mapping](design/AGENT_RUNTIME_TASK_MAPPING.md) — next-phase todo/background/swarm projection into Platform AgentRuntime.
+  - [EvalOps Agent Core Parity](design/EVALOPS_AGENT_CORE_PARITY.md) — Hermes-class local-first distribution target and skill package spec.
   - Core Systems: Tool System, Agent State Machine, Context Management, Session Persistence
   - User Interface: TUI Rendering, Web UI Architecture
   - Safety & Security: Safety Firewall, Enterprise RBAC, OAuth Authentication

--- a/docs/cookbook/skills/README.md
+++ b/docs/cookbook/skills/README.md
@@ -1,0 +1,68 @@
+# Skill Cookbook
+
+## Minimal Skill
+
+```bash
+maestro skill new reviewing-prs --description "Review pull requests. Use when the user asks for PR review."
+maestro skill lint .maestro/skills/reviewing-prs
+```
+
+The generated package includes:
+
+```text
+reviewing-prs/
+  SKILL.md
+  reference/overview.md
+  scripts/README.md
+  toolbox/README.md
+  mcp.json.example
+```
+
+## Bundled MCP Server
+
+Copy `mcp.json.example` to `mcp.json` and keep the exposed tools filtered:
+
+```json
+{
+  "github": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github"],
+    "includeTools": ["get_pull_request", "list_pull_request_files"]
+  }
+}
+```
+
+`maestro skill lint` fails packages that omit `includeTools`.
+
+## Reference Files
+
+Put long examples and troubleshooting notes under `reference/`. Keep `SKILL.md`
+short enough for the agent to load quickly; references are Level 3 context and
+should be read only when the task needs them.
+
+## Toolbox Executables
+
+Put executable tool commands under `toolbox/`. A toolbox command should describe
+itself when `MAESTRO_TOOLBOX_ACTION=describe` is set:
+
+```bash
+MAESTRO_TOOLBOX_ACTION=describe .maestro/skills/reviewing-prs/toolbox/list-pr-files
+```
+
+Run strict validation with:
+
+```bash
+maestro skill lint .maestro/skills/reviewing-prs --describe-toolbox
+```
+
+## Model And Mode Hints
+
+Skills can declare model and mode preferences:
+
+```yaml
+model: gpt-5.5
+mode: review
+isolatedContext: true
+```
+
+These fields are advisory until the runtime can enforce skill-scoped dispatch.

--- a/docs/design/EVALOPS_AGENT_CORE_PARITY.md
+++ b/docs/design/EVALOPS_AGENT_CORE_PARITY.md
@@ -27,7 +27,7 @@ EvalOps Agent Core must feel local-first on day one and cloud-governed when atta
 
 | Hermes capability | EvalOps parity surface | First durable slice |
 | --- | --- | --- |
-| One installable OSS agent | `@evalops/maestro` public package | Keep Agent Core in Maestro, not a new repo |
+| One installable OSS agent | public Maestro package | Keep Agent Core in Maestro, not a new repo |
 | Progressive skills | `skills/`, `.maestro/skills`, `maestro skill` | Skill package linter/scaffolder |
 | Bundled MCP/tool plugins | Skill `mcp.json` and `toolbox/` | Require `includeTools` for all bundled MCP servers |
 | Local sessions and recall | Maestro sessions, run inspection, trajectories | Promote into a local AgentRuntime ledger |

--- a/docs/design/EVALOPS_AGENT_CORE_PARITY.md
+++ b/docs/design/EVALOPS_AGENT_CORE_PARITY.md
@@ -1,0 +1,122 @@
+# EvalOps Agent Core Parity Spec
+
+## Goal
+
+Ship a Hermes-class public agent distribution without copying Hermes as a monolith. Maestro is the local agent core, Platform is the governed durable control plane, and Ensemble is the Slack/channel product layer.
+
+The distribution target is:
+
+```text
+maestro                    # local coding agent
+maestro skill ...          # extension package authoring and validation
+maestro run inspect ...    # durable run and evidence inspection
+maestro init               # optional Platform attach
+maestro remote ...         # hosted runtime attach
+```
+
+## Product Contract
+
+EvalOps Agent Core must feel local-first on day one and cloud-governed when attached:
+
+- A developer can install the public package and use Maestro without Platform credentials.
+- A team can attach the same agent to Platform for identity, approvals, memory, audit, meter, traces, and hosted execution.
+- Slack and other channels render Platform runtime events through Ensemble; they do not own durable execution state.
+- Extension authors get one package format for instructions, references, scripts, toolbox executables, and MCP servers.
+
+## Hermes Parity Map
+
+| Hermes capability | EvalOps parity surface | First durable slice |
+| --- | --- | --- |
+| One installable OSS agent | `@evalops/maestro` public package | Keep Agent Core in Maestro, not a new repo |
+| Progressive skills | `skills/`, `.maestro/skills`, `maestro skill` | Skill package linter/scaffolder |
+| Bundled MCP/tool plugins | Skill `mcp.json` and `toolbox/` | Require `includeTools` for all bundled MCP servers |
+| Local sessions and recall | Maestro sessions, run inspection, trajectories | Promote into a local AgentRuntime ledger |
+| Durable goals/workboard | Platform Objectives and AgentRuns | Expose a local workboard that maps to Platform when attached |
+| Gateway/channels | Ensemble adapters plus Maestro Slack/GitHub agents | Keep Slack deep before broad platform count |
+| Governance and evidence | Platform approvals, audit, traces, VFS | Preserve evidence in runtime artifacts, not chat prose |
+
+## Skill Package Format
+
+A skill package is a directory:
+
+```text
+<skill-name>/
+  SKILL.md
+  reference/
+  scripts/
+  toolbox/
+  mcp.json
+```
+
+`SKILL.md` is the progressive disclosure entry point. Startup loads only `name` and `description`; the full body is loaded only when the skill is relevant. Reference files remain Level 3 resources and should be read only on demand.
+
+Frontmatter:
+
+```yaml
+---
+name: reviewing-prs
+description: "Review pull requests. Use when the user asks for PR review."
+license: Apache-2.0
+compatibility: "Requires gh CLI"
+allowed-tools:
+  - github.get_pull_request
+builtin-tools:
+  - read
+  - search
+argument-hint: "<owner/repo#number>"
+model: gpt-5.5
+mode: review
+isolatedContext: true
+metadata:
+  owner: evalops
+---
+```
+
+`mcp.json` is optional, but every server must be filtered:
+
+```json
+{
+  "github": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github"],
+    "includeTools": ["get_pull_request", "list_pull_request_files"]
+  }
+}
+```
+
+Unfiltered MCP servers are rejected because they inflate prompt/tool surface and make governance unclear.
+
+`toolbox/` is optional. Executables in that directory are expected to support `MAESTRO_TOOLBOX_ACTION=describe` so Maestro can register them as typed tools when the skill is active.
+
+## CLI Contract
+
+`maestro skill` is the public authoring surface:
+
+```bash
+maestro skill list
+maestro skill inspect reviewing-prs --json
+maestro skill new reviewing-prs --description "Review pull requests. Use when the user asks for PR review."
+maestro skill lint .maestro/skills
+maestro skill lint .maestro/skills --describe-toolbox
+```
+
+Lint rules:
+
+- `SKILL.md` exists and has valid YAML frontmatter.
+- `name` is lowercase, hyphenated, <= 64 chars, and matches the directory.
+- `description` exists, is <= 1024 chars, and says when to use the skill.
+- The body stays under 500 lines and about 5k tokens.
+- `allowed-tools` and `builtin-tools` are strings or lists of strings.
+- `isolatedContext` is boolean when present.
+- `mcp.json` is valid JSON.
+- Every MCP server has `command` and non-empty `includeTools`.
+- Toolbox files are executable; optional strict mode runs their describe action.
+
+## Next Slices
+
+1. Local AgentRuntime ledger: one SQLite store for runs, tool calls, waits, summaries, checkpoints, and session search.
+2. `maestro goal`: persistent objective loop backed by the local ledger, promotable to Platform Objectives.
+3. `maestro workboard`: local multi-agent board mapped to Platform AgentRuns when attached.
+4. Skill-bundled MCP lifecycle: start servers only when the skill triggers, stop them on cooldown/session end.
+5. Skill-bundled toolbox registration: expose described toolbox commands as governed tools while the skill is active.
+6. Public cookbook and conformance fixtures for third-party skill authors.

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -78,6 +78,7 @@ const COMMANDS = new Set([
 	"openai",
 	"codex",
 	"hooks",
+	"skill",
 	"memory",
 	"remote",
 	"export",
@@ -97,6 +98,7 @@ const SUBCOMMAND_COMMANDS = new Set([
 	"openai",
 	"codex",
 	"hooks",
+	"skill",
 	"memory",
 	"remote",
 	"scenario",
@@ -379,7 +381,8 @@ export function parseArgs(args: string[]): Args {
 					arg === "remote" ||
 					arg === "hosted-runner" ||
 					arg === "init" ||
-					arg === "evalops"
+					arg === "evalops" ||
+					arg === "skill"
 				) {
 					result.commandArgs = args.slice(i + 1);
 					break;

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { inspect } from "node:util";
 import chalk from "chalk";
 import { PATHS } from "../../config/constants.js";
 import {
@@ -137,6 +138,7 @@ async function handleList(workspaceDir: string, options: SkillCommandOptions) {
 async function handleInspect(
 	workspaceDir: string,
 	name: string | undefined,
+	options: SkillCommandOptions,
 ) {
 	if (!name) {
 		throw new Error("maestro skill inspect requires a skill name");
@@ -153,7 +155,17 @@ async function handleInspect(
 		resources: skill.resources,
 		resourceDirs: skill.resourceDirs,
 	};
-	console.log(JSON.stringify(payload, null, 2));
+	if (options.json) {
+		console.log(JSON.stringify(payload, null, 2));
+		return;
+	}
+	console.log(
+		inspect(payload, {
+			colors: process.stdout.isTTY,
+			compact: false,
+			depth: null,
+		}),
+	);
 }
 
 async function handleLint(
@@ -225,7 +237,7 @@ export async function handleSkillCommand(
 			await handleList(workspaceDir, parsedOptions);
 			return;
 		case "inspect":
-			await handleInspect(workspaceDir, positionals[0]);
+			await handleInspect(workspaceDir, positionals[0], parsedOptions);
 			return;
 		case "lint":
 			await handleLint(workspaceDir, positionals, parsedOptions);

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -137,7 +137,6 @@ async function handleList(workspaceDir: string, options: SkillCommandOptions) {
 async function handleInspect(
 	workspaceDir: string,
 	name: string | undefined,
-	options: SkillCommandOptions,
 ) {
 	if (!name) {
 		throw new Error("maestro skill inspect requires a skill name");
@@ -154,10 +153,6 @@ async function handleInspect(
 		resources: skill.resources,
 		resourceDirs: skill.resourceDirs,
 	};
-	if (options.json) {
-		console.log(JSON.stringify(payload, null, 2));
-		return;
-	}
 	console.log(JSON.stringify(payload, null, 2));
 }
 
@@ -230,7 +225,7 @@ export async function handleSkillCommand(
 			await handleList(workspaceDir, parsedOptions);
 			return;
 		case "inspect":
-			await handleInspect(workspaceDir, positionals[0], parsedOptions);
+			await handleInspect(workspaceDir, positionals[0]);
 			return;
 		case "lint":
 			await handleLint(workspaceDir, positionals, parsedOptions);

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -123,6 +123,11 @@ async function handleList(workspaceDir: string, options: SkillCommandOptions) {
 
 	if (result.skills.length === 0) {
 		console.log(chalk.dim("No skills found."));
+		if (result.errors.length > 0) {
+			console.error(
+				chalk.yellow(`\n${result.errors.length} skill load warning(s).`),
+			);
+		}
 		return;
 	}
 	for (const skill of result.skills) {

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -1,0 +1,244 @@
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import chalk from "chalk";
+import { PATHS } from "../../config/constants.js";
+import {
+	findSkill,
+	formatSkillListItem,
+	hasSkillLintErrors,
+	lintSkillPaths,
+	loadSkills,
+	scaffoldSkill,
+	skillToDict,
+} from "../../skills/index.js";
+import { formatSkillLintText } from "../../skills/linter.js";
+
+interface SkillCommandOptions {
+	json?: boolean;
+	dir?: string;
+	description?: string;
+	force?: boolean;
+	describeToolbox?: boolean;
+}
+
+function formatSkillHelp(): string {
+	return `maestro skill <command> [options]
+
+Commands:
+  list                         List available system, user, and project skills
+  inspect <name>               Print one skill package manifest
+  lint [path...]               Validate skill packages
+  new <name>                   Scaffold a skill package
+
+Options:
+  --json                       Emit machine-readable JSON
+  --dir <path>                 Base directory for 'new' (default: .maestro/skills)
+  --description <text>         Description for 'new'
+  --force                      Allow 'new' to overwrite an existing directory
+  --describe-toolbox           Run Toolbox describe checks during lint
+  --help, -h                   Show this help`;
+}
+
+function readValue(args: string[], index: number, flag: string): string {
+	const value = args[index + 1];
+	if (!value || value.startsWith("-")) {
+		throw new Error(`${flag} requires a value`);
+	}
+	return value;
+}
+
+function parseOptions(args: string[]): {
+	options: SkillCommandOptions;
+	positionals: string[];
+} {
+	const options: SkillCommandOptions = {};
+	const positionals: string[] = [];
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		switch (arg) {
+			case "--json":
+				options.json = true;
+				break;
+			case "--dir":
+				options.dir = readValue(args, i, arg);
+				i++;
+				break;
+			case "--description":
+				options.description = readValue(args, i, arg);
+				i++;
+				break;
+			case "--force":
+				options.force = true;
+				break;
+			case "--describe-toolbox":
+				options.describeToolbox = true;
+				break;
+			case "--help":
+			case "-h":
+				positionals.push(arg);
+				break;
+			default:
+				if (arg?.startsWith("-")) {
+					throw new Error(`Unknown maestro skill option: ${arg}`);
+				}
+				if (arg) positionals.push(arg);
+		}
+	}
+	return { options, positionals };
+}
+
+function defaultLintPaths(workspaceDir: string): string[] {
+	const candidates = [
+		join(workspaceDir, "skills"),
+		join(workspaceDir, ".maestro", "skills"),
+		join(PATHS.MAESTRO_HOME, "skills"),
+	].filter((path) => existsSync(path));
+	return candidates.length > 0 ? candidates : [join(workspaceDir, "skills")];
+}
+
+async function handleList(workspaceDir: string, options: SkillCommandOptions) {
+	const result = loadSkills(workspaceDir);
+	if (options.json) {
+		console.log(
+			JSON.stringify(
+				{
+					skills: result.skills.map((skill) => ({
+						...skillToDict(skill),
+						sourceType: skill.sourceType,
+						sourcePath: skill.sourcePath,
+					})),
+					errors: result.errors.map((error) => ({
+						code: error.code,
+						message: error.message,
+						path: error.path,
+					})),
+				},
+				null,
+				2,
+			),
+		);
+		return;
+	}
+
+	if (result.skills.length === 0) {
+		console.log(chalk.dim("No skills found."));
+		return;
+	}
+	for (const skill of result.skills) {
+		console.log(formatSkillListItem(skill));
+	}
+	if (result.errors.length > 0) {
+		console.error(
+			chalk.yellow(`\n${result.errors.length} skill load warning(s).`),
+		);
+	}
+}
+
+async function handleInspect(
+	workspaceDir: string,
+	name: string | undefined,
+	options: SkillCommandOptions,
+) {
+	if (!name) {
+		throw new Error("maestro skill inspect requires a skill name");
+	}
+	const result = loadSkills(workspaceDir);
+	const skill = findSkill(result.skills, name);
+	if (!skill) {
+		throw new Error(`Skill '${name}' not found`);
+	}
+	const payload = {
+		...skillToDict(skill),
+		sourceType: skill.sourceType,
+		sourcePath: skill.sourcePath,
+		resources: skill.resources,
+		resourceDirs: skill.resourceDirs,
+	};
+	if (options.json) {
+		console.log(JSON.stringify(payload, null, 2));
+		return;
+	}
+	console.log(JSON.stringify(payload, null, 2));
+}
+
+async function handleLint(
+	workspaceDir: string,
+	paths: string[],
+	options: SkillCommandOptions,
+) {
+	const lintPaths = paths.length > 0 ? paths : defaultLintPaths(workspaceDir);
+	const results = await lintSkillPaths(lintPaths, {
+		describeToolbox: options.describeToolbox,
+	});
+	if (options.json) {
+		console.log(JSON.stringify({ results }, null, 2));
+	} else {
+		console.log(formatSkillLintText(results));
+	}
+	if (hasSkillLintErrors(results)) {
+		process.exitCode = 1;
+	}
+}
+
+async function handleNew(
+	workspaceDir: string,
+	name: string | undefined,
+	options: SkillCommandOptions,
+) {
+	if (!name) {
+		throw new Error("maestro skill new requires a skill name");
+	}
+	const baseDir = resolve(
+		workspaceDir,
+		options.dir ?? join(".maestro", "skills"),
+	);
+	const result = scaffoldSkill(baseDir, name, {
+		description: options.description,
+		force: options.force,
+	});
+	if (options.json) {
+		console.log(JSON.stringify(result, null, 2));
+		return;
+	}
+	console.log(chalk.green(`Created skill ${result.name}`));
+	console.log(chalk.dim(result.directory));
+	for (const file of result.files) {
+		console.log(`  ${file}`);
+	}
+}
+
+export async function handleSkillCommand(
+	subcommand: string | undefined,
+	args: string[] = [],
+	options: { workspaceDir?: string } = {},
+): Promise<void> {
+	if (
+		!subcommand ||
+		subcommand === "help" ||
+		args.includes("--help") ||
+		args.includes("-h")
+	) {
+		console.log(formatSkillHelp());
+		return;
+	}
+
+	const { options: parsedOptions, positionals } = parseOptions(args);
+	const workspaceDir = options.workspaceDir ?? process.cwd();
+
+	switch (subcommand) {
+		case "list":
+			await handleList(workspaceDir, parsedOptions);
+			return;
+		case "inspect":
+			await handleInspect(workspaceDir, positionals[0], parsedOptions);
+			return;
+		case "lint":
+			await handleLint(workspaceDir, positionals, parsedOptions);
+			return;
+		case "new":
+			await handleNew(workspaceDir, positionals[0], parsedOptions);
+			return;
+		default:
+			throw new Error(`Unknown maestro skill command: ${subcommand}`);
+	}
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -174,6 +174,10 @@ export function printHelp(
   # Import a portable session log into this workspace
   maestro import ./session.json
 
+  # Scaffold and validate progressive skill packages
+  maestro skill new processing-incidents --description "Process incident reports. Use when the user asks for incident triage."
+  maestro skill lint .maestro/skills
+
   # Start a hosted EvalOps runner session and wait for attach readiness
   maestro remote start --workspace ws_123 --repo evalops/foo --branch main --ttl 90m --wait --verify
 
@@ -261,6 +265,12 @@ export function printHelp(
   maestro memory export <id>      Export metrics log as JSONL
   maestro memory watch [id] [ms]  Poll status/metrics continuously`,
 	)}`;
+	const skillSection = `${sectionHeading("maestro skill")}${muted(
+		`  maestro skill list                 List available progressive skills
+  maestro skill inspect <name>       Print one skill package manifest
+  maestro skill new <name>           Scaffold SKILL.md, reference/, scripts/, toolbox/, and mcp.json.example
+  maestro skill lint [path...]       Validate frontmatter, budget, mcp.json includeTools, and toolbox shape`,
+	)}`;
 	const remoteSection = `${sectionHeading("maestro remote")}${muted(
 		`  maestro remote start --workspace <id> --repo <repo> --branch <branch> [--ttl 90m] [--wait] [--verify]
   maestro remote list --workspace <id> [--state running]
@@ -333,6 +343,7 @@ export function printHelp(
 			webSection,
 			portabilitySection,
 			memorySection,
+			skillSection,
 			initSection,
 			runSection,
 			remoteSection,

--- a/src/main.ts
+++ b/src/main.ts
@@ -662,6 +662,12 @@ export async function main(args: string[]) {
 		return;
 	}
 
+	if (parsed.command === "skill") {
+		const { handleSkillCommand } = await import("./cli/commands/skill.js");
+		await handleSkillCommand(parsed.subcommand, parsed.commandArgs ?? []);
+		return;
+	}
+
 	// If we're about to enter interactive TUI mode (no prompt messages and not RPC/exec),
 	// or headless mode (stdout is JSON-only), redirect all logging/console output to a file.
 	// This must run before config/model loading to catch any early warnings.

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -35,13 +35,31 @@ export {
 	type SkillDefinition,
 	type SkillResource,
 	findSkill,
+	findSkillMd,
 	formatSkillForInjection,
 	formatSkillListItem,
 	formatSkillMetadataOnly,
 	formatSkillsForSystemPrompt,
 	getSkillsSummary,
 	loadSkills,
+	parseFrontmatter,
 	searchSkills,
+	skillToDict,
+	skillToJson,
+	skillsToPrompt,
+	stringArrayValue,
 } from "./loader.js";
 
 export { createSkillTool, invalidateSkillCache } from "./tool.js";
+export {
+	type SkillLintIssue,
+	type SkillLintResult,
+	type SkillScaffoldOptions,
+	SKILL_BODY_MAX_CHARS,
+	SKILL_BODY_MAX_LINES,
+	formatSkillLintText,
+	hasSkillLintErrors,
+	lintSkillDirectory,
+	lintSkillPaths,
+	scaffoldSkill,
+} from "./linter.js";

--- a/src/skills/linter.ts
+++ b/src/skills/linter.ts
@@ -1,0 +1,630 @@
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { constants, access } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import {
+	SKILL_FRONTMATTER_FIELDS,
+	findSkillMd,
+	parseFrontmatter,
+	stringArrayValue,
+} from "./loader.js";
+
+export type SkillLintSeverity = "error" | "warning";
+
+export interface SkillLintIssue {
+	code: string;
+	severity: SkillLintSeverity;
+	message: string;
+	path: string;
+}
+
+export interface SkillLintResult {
+	path: string;
+	issues: SkillLintIssue[];
+}
+
+export interface SkillScaffoldOptions {
+	description?: string;
+	force?: boolean;
+}
+
+export interface SkillScaffoldResult {
+	name: string;
+	directory: string;
+	files: string[];
+}
+
+export const SKILL_BODY_MAX_LINES = 500;
+export const SKILL_BODY_MAX_CHARS = 20_000;
+
+const FIELD_SET = new Set<string>(SKILL_FRONTMATTER_FIELDS);
+const SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function issue(
+	code: string,
+	severity: SkillLintSeverity,
+	path: string,
+	message: string,
+): SkillLintIssue {
+	return { code, severity, path, message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateSkillName(
+	value: unknown,
+	dirName: string,
+	path: string,
+): SkillLintIssue[] {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		return [
+			issue("missing_name", "error", path, "Skill frontmatter requires name."),
+		];
+	}
+
+	const issues: SkillLintIssue[] = [];
+	if (value.length > 64) {
+		issues.push(
+			issue("name_too_long", "error", path, "Skill name must be <= 64 chars."),
+		);
+	}
+	if (!SKILL_NAME_PATTERN.test(value)) {
+		issues.push(
+			issue(
+				"invalid_name",
+				"error",
+				path,
+				"Skill name must use lowercase letters, numbers, and single hyphens.",
+			),
+		);
+	}
+	if (dirName !== "skills" && value !== dirName) {
+		issues.push(
+			issue(
+				"name_mismatch",
+				"error",
+				path,
+				`Skill name '${value}' must match directory '${dirName}'.`,
+			),
+		);
+	}
+	return issues;
+}
+
+function validateDescription(value: unknown, path: string): SkillLintIssue[] {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		return [
+			issue(
+				"missing_description",
+				"error",
+				path,
+				"Skill frontmatter requires description.",
+			),
+		];
+	}
+
+	const issues: SkillLintIssue[] = [];
+	if (value.length > 1024) {
+		issues.push(
+			issue(
+				"description_too_long",
+				"error",
+				path,
+				"Skill description must be <= 1024 chars.",
+			),
+		);
+	}
+	if (!/\b(use|when)\b/i.test(value)) {
+		issues.push(
+			issue(
+				"description_missing_when",
+				"warning",
+				path,
+				'Description should include when to use the skill, for example "Use when ...".',
+			),
+		);
+	}
+	return issues;
+}
+
+function validateStringArrayField(
+	frontmatter: Record<string, unknown>,
+	field: string,
+	path: string,
+): SkillLintIssue[] {
+	const value = frontmatter[field];
+	if (value === undefined) return [];
+	const normalized = stringArrayValue(value);
+	if (!normalized || normalized.length === 0) {
+		return [
+			issue(
+				"invalid_string_list",
+				"error",
+				path,
+				`${field} must be a non-empty string or list of strings.`,
+			),
+		];
+	}
+	return [];
+}
+
+function validateBody(body: string, path: string): SkillLintIssue[] {
+	const issues: SkillLintIssue[] = [];
+	const lines = body.split("\n").length;
+	if (lines > SKILL_BODY_MAX_LINES) {
+		issues.push(
+			issue(
+				"skill_oversize",
+				"error",
+				path,
+				`SKILL.md body has ${lines} lines; maximum is ${SKILL_BODY_MAX_LINES}.`,
+			),
+		);
+	}
+	if (body.length > SKILL_BODY_MAX_CHARS) {
+		issues.push(
+			issue(
+				"skill_oversize",
+				"error",
+				path,
+				`SKILL.md body has ${body.length} chars; maximum is ${SKILL_BODY_MAX_CHARS}.`,
+			),
+		);
+	}
+	return issues;
+}
+
+function validateMcpJson(skillDir: string): SkillLintIssue[] {
+	const path = join(skillDir, "mcp.json");
+	if (!existsSync(path)) return [];
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(readFileSync(path, "utf8"));
+	} catch (error) {
+		return [
+			issue(
+				"invalid_mcp_json",
+				"error",
+				path,
+				`mcp.json must be valid JSON: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			),
+		];
+	}
+
+	if (!isRecord(parsed)) {
+		return [
+			issue(
+				"invalid_mcp_json",
+				"error",
+				path,
+				"mcp.json must be an object keyed by server name.",
+			),
+		];
+	}
+
+	const issues: SkillLintIssue[] = [];
+	for (const [serverName, server] of Object.entries(parsed)) {
+		const serverPath = `${path}#${serverName}`;
+		if (!isRecord(server)) {
+			issues.push(
+				issue(
+					"invalid_mcp_server",
+					"error",
+					serverPath,
+					"MCP server config must be an object.",
+				),
+			);
+			continue;
+		}
+		if (typeof server.command !== "string" || server.command.trim() === "") {
+			issues.push(
+				issue(
+					"invalid_mcp_command",
+					"error",
+					serverPath,
+					"MCP server requires a non-empty command.",
+				),
+			);
+		}
+		if (
+			!Array.isArray(server.includeTools) ||
+			server.includeTools.length === 0
+		) {
+			issues.push(
+				issue(
+					"mcp_tools_unfiltered",
+					"error",
+					serverPath,
+					"MCP server must declare includeTools with at least one tool.",
+				),
+			);
+		} else if (
+			server.includeTools.some(
+				(tool) => typeof tool !== "string" || tool.trim() === "",
+			)
+		) {
+			issues.push(
+				issue(
+					"invalid_mcp_include_tools",
+					"error",
+					serverPath,
+					"includeTools entries must be non-empty strings.",
+				),
+			);
+		}
+		if (
+			server.args !== undefined &&
+			(!Array.isArray(server.args) ||
+				server.args.some((arg) => typeof arg !== "string"))
+		) {
+			issues.push(
+				issue(
+					"invalid_mcp_args",
+					"error",
+					serverPath,
+					"MCP args must be a list of strings.",
+				),
+			);
+		}
+		if (server.env !== undefined && !isRecord(server.env)) {
+			issues.push(
+				issue(
+					"invalid_mcp_env",
+					"error",
+					serverPath,
+					"MCP env must be an object of string values.",
+				),
+			);
+		}
+		if (
+			isRecord(server.env) &&
+			Object.values(server.env).some((value) => typeof value !== "string")
+		) {
+			issues.push(
+				issue(
+					"invalid_mcp_env",
+					"error",
+					serverPath,
+					"MCP env values must be strings.",
+				),
+			);
+		}
+	}
+	return issues;
+}
+
+async function isExecutable(path: string): Promise<boolean> {
+	try {
+		await access(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function validateToolbox(
+	skillDir: string,
+	options: { describeToolbox?: boolean } = {},
+): Promise<SkillLintIssue[]> {
+	const toolboxDir = join(skillDir, "toolbox");
+	if (!existsSync(toolboxDir) || !statSync(toolboxDir).isDirectory()) return [];
+
+	const issues: SkillLintIssue[] = [];
+	for (const entry of readdirSync(toolboxDir)) {
+		if (entry.startsWith(".") || entry.toLowerCase() === "readme.md") continue;
+		const path = join(toolboxDir, entry);
+		if (!statSync(path).isFile()) continue;
+		if (!(await isExecutable(path))) {
+			issues.push(
+				issue(
+					"toolbox_not_executable",
+					"error",
+					path,
+					"Toolbox entries must be executable files.",
+				),
+			);
+			continue;
+		}
+		if (options.describeToolbox) {
+			const result = spawnSync(path, {
+				env: { ...process.env, MAESTRO_TOOLBOX_ACTION: "describe" },
+				encoding: "utf8",
+				timeout: 5000,
+			});
+			if (result.status !== 0) {
+				issues.push(
+					issue(
+						"toolbox_describe_failed",
+						"error",
+						path,
+						`Toolbox describe failed: ${result.stderr || result.stdout || "non-zero exit"}`,
+					),
+				);
+			}
+		}
+	}
+	return issues;
+}
+
+export async function lintSkillDirectory(
+	skillDir: string,
+	options: { describeToolbox?: boolean } = {},
+): Promise<SkillLintResult> {
+	const resolvedDir = resolve(skillDir);
+	const skillFile = findSkillMd(resolvedDir);
+	const issues: SkillLintIssue[] = [];
+	if (!skillFile) {
+		return {
+			path: resolvedDir,
+			issues: [
+				issue(
+					"missing_skill_md",
+					"error",
+					resolvedDir,
+					"Skill package requires SKILL.md.",
+				),
+			],
+		};
+	}
+
+	try {
+		const { frontmatter, body } = parseFrontmatter(
+			readFileSync(skillFile, "utf8"),
+		);
+		for (const key of Object.keys(frontmatter)) {
+			if (!FIELD_SET.has(key)) {
+				issues.push(
+					issue(
+						"unexpected_field",
+						"error",
+						skillFile,
+						`Unexpected frontmatter field '${key}'.`,
+					),
+				);
+			}
+		}
+		issues.push(
+			...validateSkillName(frontmatter.name, basename(resolvedDir), skillFile),
+		);
+		issues.push(...validateDescription(frontmatter.description, skillFile));
+		for (const field of ["allowed-tools", "builtin-tools"]) {
+			issues.push(...validateStringArrayField(frontmatter, field, skillFile));
+		}
+		if (
+			frontmatter.compatibility !== undefined &&
+			typeof frontmatter.compatibility !== "string"
+		) {
+			issues.push(
+				issue(
+					"invalid_compatibility",
+					"error",
+					skillFile,
+					"compatibility must be a string.",
+				),
+			);
+		}
+		if (
+			frontmatter.isolatedContext !== undefined &&
+			typeof frontmatter.isolatedContext !== "boolean"
+		) {
+			issues.push(
+				issue(
+					"invalid_isolated_context",
+					"error",
+					skillFile,
+					"isolatedContext must be a boolean.",
+				),
+			);
+		}
+		issues.push(...validateBody(body, skillFile));
+	} catch (error) {
+		issues.push(
+			issue(
+				"invalid_skill_md",
+				"error",
+				skillFile,
+				error instanceof Error ? error.message : String(error),
+			),
+		);
+	}
+
+	if (
+		existsSync(join(resolvedDir, "reference")) &&
+		existsSync(join(resolvedDir, "references"))
+	) {
+		issues.push(
+			issue(
+				"duplicate_reference_dirs",
+				"warning",
+				resolvedDir,
+				"Use either reference/ or references/; reference/ is preferred.",
+			),
+		);
+	}
+	issues.push(...validateMcpJson(resolvedDir));
+	issues.push(...(await validateToolbox(resolvedDir, options)));
+	return { path: resolvedDir, issues };
+}
+
+export async function lintSkillPaths(
+	paths: string[],
+	options: { describeToolbox?: boolean } = {},
+): Promise<SkillLintResult[]> {
+	const results: SkillLintResult[] = [];
+	for (const path of paths) {
+		const resolved = resolve(path);
+		if (!existsSync(resolved)) {
+			results.push({
+				path: resolved,
+				issues: [
+					issue(
+						"missing_path",
+						"error",
+						resolved,
+						"Skill path does not exist.",
+					),
+				],
+			});
+			continue;
+		}
+		const stat = statSync(resolved);
+		if (!stat.isDirectory()) {
+			results.push({
+				path: resolved,
+				issues: [
+					issue(
+						"invalid_path",
+						"error",
+						resolved,
+						"Skill path must be a directory.",
+					),
+				],
+			});
+			continue;
+		}
+		if (findSkillMd(resolved)) {
+			results.push(await lintSkillDirectory(resolved, options));
+			continue;
+		}
+		for (const entry of readdirSync(resolved)) {
+			const child = join(resolved, entry);
+			if (statSync(child).isDirectory()) {
+				results.push(await lintSkillDirectory(child, options));
+			}
+		}
+	}
+	return results;
+}
+
+export function formatSkillLintText(results: SkillLintResult[]): string {
+	const lines: string[] = [];
+	let errorCount = 0;
+	let warningCount = 0;
+	for (const result of results) {
+		const issues = result.issues;
+		if (issues.length === 0) {
+			lines.push(`OK ${result.path}`);
+			continue;
+		}
+		lines.push(result.path);
+		for (const item of issues) {
+			if (item.severity === "error") errorCount++;
+			if (item.severity === "warning") warningCount++;
+			lines.push(
+				`  ${item.severity.toUpperCase()} ${item.code}: ${item.message}`,
+			);
+			if (item.path !== result.path) {
+				lines.push(`    ${item.path}`);
+			}
+		}
+	}
+	lines.push("");
+	lines.push(
+		`${errorCount} error${errorCount === 1 ? "" : "s"}, ${warningCount} warning${
+			warningCount === 1 ? "" : "s"
+		}`,
+	);
+	return lines.join("\n");
+}
+
+export function hasSkillLintErrors(results: SkillLintResult[]): boolean {
+	return results.some((result) =>
+		result.issues.some((item) => item.severity === "error"),
+	);
+}
+
+export function scaffoldSkill(
+	baseDir: string,
+	name: string,
+	options: SkillScaffoldOptions = {},
+): SkillScaffoldResult {
+	if (!SKILL_NAME_PATTERN.test(name) || name.length > 64) {
+		throw new Error(
+			"Skill name must use lowercase letters, numbers, and single hyphens.",
+		);
+	}
+	const directory = resolve(baseDir, name);
+	if (existsSync(directory) && !options.force) {
+		throw new Error(`Skill already exists at ${directory}`);
+	}
+
+	const description =
+		options.description ??
+		`${name.replace(/-/g, " ")}. Use when a task needs this packaged workflow.`;
+	const files: string[] = [];
+	mkdirSync(join(directory, "reference"), { recursive: true });
+	mkdirSync(join(directory, "scripts"), { recursive: true });
+	mkdirSync(join(directory, "toolbox"), { recursive: true });
+
+	const skillMd = join(directory, "SKILL.md");
+	const escapedDescription = description.replace(/"/g, '\\"');
+	writeFileSync(
+		skillMd,
+		[
+			"---",
+			`name: ${name}`,
+			`description: "${escapedDescription}"`,
+			"allowed-tools:",
+			"  - read",
+			"builtin-tools:",
+			"  - read",
+			"---",
+			"",
+			`# ${name}`,
+			"",
+			"## Workflow",
+			"",
+			"1. State the task-specific outcome.",
+			"2. Load only the reference files needed for the request.",
+			"3. Use bundled scripts or toolbox executables when they are more reliable than retyping long commands.",
+			"",
+			"## References",
+			"",
+			"- Read `reference/overview.md` when the user asks for implementation detail.",
+			"",
+		].join("\n"),
+	);
+	files.push(skillMd);
+
+	const reference = join(directory, "reference", "overview.md");
+	writeFileSync(
+		reference,
+		`# ${name} Reference\n\nAdd deeper examples, protocol notes, and troubleshooting details here. Keep this out of SKILL.md until needed.\n`,
+	);
+	files.push(reference);
+
+	const scriptsReadme = join(directory, "scripts", "README.md");
+	writeFileSync(
+		scriptsReadme,
+		"# Scripts\n\nPut deterministic helper scripts here. Agents should run these instead of retyping long workflows.\n",
+	);
+	files.push(scriptsReadme);
+
+	const toolboxReadme = join(directory, "toolbox", "README.md");
+	writeFileSync(
+		toolboxReadme,
+		"# Toolbox\n\nPut executable Toolbox protocol commands here. Each executable should support `MAESTRO_TOOLBOX_ACTION=describe`.\n",
+	);
+	files.push(toolboxReadme);
+
+	const mcpJson = join(directory, "mcp.json.example");
+	writeFileSync(
+		mcpJson,
+		'{\n  "example-server": {\n    "command": "npx",\n    "args": ["-y", "example-mcp-server"],\n    "includeTools": ["example_tool"]\n  }\n}\n',
+	);
+	files.push(mcpJson);
+
+	return { name, directory, files };
+}

--- a/src/skills/linter.ts
+++ b/src/skills/linter.ts
@@ -569,7 +569,9 @@ export function scaffoldSkill(
 	mkdirSync(join(directory, "toolbox"), { recursive: true });
 
 	const skillMd = join(directory, "SKILL.md");
-	const escapedDescription = description.replace(/"/g, '\\"');
+	const escapedDescription = description
+		.replace(/\\/g, "\\\\")
+		.replace(/"/g, '\\"');
 	writeFileSync(
 		skillMd,
 		[

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -191,6 +191,30 @@ function booleanValue(value: unknown): boolean | undefined {
 	return undefined;
 }
 
+function metadataRecordValue(
+	value: unknown,
+): Record<string, string> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+
+	const metadata: Record<string, string> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (
+			typeof entry !== "string" &&
+			typeof entry !== "number" &&
+			typeof entry !== "boolean"
+		) {
+			continue;
+		}
+		const normalized = String(entry).trim();
+		if (normalized.length > 0) {
+			metadata[key] = normalized;
+		}
+	}
+	return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
 /**
  * Validate skill name per Agent Skills spec.
  */
@@ -477,7 +501,7 @@ function loadSkillFromDirectory(
 			model: stringValue(frontmatter.model),
 			mode: stringValue(frontmatter.mode),
 			isolatedContext: booleanValue(frontmatter.isolatedContext),
-			metadata: frontmatter.metadata as Record<string, string> | undefined,
+			metadata: metadataRecordValue(frontmatter.metadata),
 			// Legacy fields for backwards compatibility
 			tags: Array.isArray(frontmatter.tags)
 				? (frontmatter.tags as string[])

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -20,6 +20,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { load as loadYaml } from "js-yaml";
 import { PATHS } from "../config/constants.js";
 import { loadConfiguredPackageResources } from "../packages/runtime.js";
 import { createLogger } from "../utils/logger.js";
@@ -33,19 +34,27 @@ const MAX_DESCRIPTION_LENGTH = 1024;
 const MAX_COMPATIBILITY_LENGTH = 500;
 
 /** Allowed frontmatter fields per Agent Skills spec */
-const ALLOWED_FIELDS = new Set([
+export const SKILL_FRONTMATTER_FIELDS = [
 	"name",
 	"description",
 	"license",
 	"compatibility",
 	"allowed-tools",
+	"argument-hint",
+	"builtin-tools",
+	"model",
+	"mode",
+	"isolatedContext",
 	"metadata",
 	// Legacy fields (deprecated but supported for backwards compatibility)
 	"tags",
 	"author",
 	"version",
 	"triggers",
-]);
+] as const;
+
+/** Allowed frontmatter fields per Agent Skills spec plus Maestro package hints. */
+const ALLOWED_FIELDS = new Set<string>(SKILL_FRONTMATTER_FIELDS);
 
 /**
  * Skill definition from SKILL.md frontmatter (per Agent Skills spec).
@@ -59,8 +68,18 @@ export interface SkillDefinition {
 	license?: string;
 	/** Compatibility/environment requirements (max 500 chars) */
 	compatibility?: string;
-	/** Space-delimited list of pre-approved tools */
-	allowedTools?: string;
+	/** Pre-approved MCP/toolbox tools this skill can use */
+	allowedTools?: string[];
+	/** Built-in Maestro tools this skill needs */
+	builtinTools?: string[];
+	/** Argument hint shown by authoring surfaces */
+	argumentHint?: string;
+	/** Preferred model while this skill is active */
+	model?: string;
+	/** Preferred agent mode while this skill is active */
+	mode?: string;
+	/** Whether the skill should run in isolated context when supported */
+	isolatedContext?: boolean;
 	/** Additional key-value metadata */
 	metadata?: Record<string, string>;
 	/** @deprecated Use metadata instead */
@@ -95,10 +114,16 @@ export interface LoadedSkill extends SkillDefinition {
 export interface SkillResourceDirs {
 	/** Path to scripts directory if it exists */
 	scriptsDir?: string;
-	/** Path to references directory if it exists */
+	/** Path to Sourcegraph/Amp-style singular reference directory if it exists */
+	referenceDir?: string;
+	/** Path to legacy/plural references directory if it exists */
 	referencesDir?: string;
 	/** Path to assets directory if it exists */
 	assetsDir?: string;
+	/** Path to toolbox executable directory if it exists */
+	toolboxDir?: string;
+	/** Path to bundled MCP config if it exists */
+	mcpJsonPath?: string;
 }
 
 /**
@@ -133,6 +158,37 @@ export class SkillLoadError extends Error {
 		super(message);
 		this.name = "SkillLoadError";
 	}
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+export function stringArrayValue(value: unknown): string[] | undefined {
+	if (Array.isArray(value)) {
+		const values = value
+			.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+			.filter((entry) => entry.length > 0);
+		return values.length > 0 ? values : undefined;
+	}
+	if (typeof value === "string") {
+		const values = value
+			.split(/[,\s]+/)
+			.map((entry) => entry.trim())
+			.filter((entry) => entry.length > 0);
+		return values.length > 0 ? values : undefined;
+	}
+	return undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "string") {
+		const normalized = value.toLowerCase();
+		if (normalized === "true") return true;
+		if (normalized === "false") return false;
+	}
+	return undefined;
 }
 
 /**
@@ -219,7 +275,7 @@ function validateFields(frontmatter: Record<string, unknown>): string[] {
 /**
  * Find SKILL.md file (case-insensitive per spec).
  */
-function findSkillMd(dir: string): string | null {
+export function findSkillMd(dir: string): string | null {
 	// Prefer uppercase
 	const uppercase = join(dir, "SKILL.md");
 	if (existsSync(uppercase)) {
@@ -238,7 +294,7 @@ function findSkillMd(dir: string): string | null {
 /**
  * Parse YAML frontmatter from markdown content.
  */
-function parseFrontmatter(content: string): {
+export function parseFrontmatter(content: string): {
 	frontmatter: Record<string, unknown>;
 	body: string;
 } {
@@ -254,82 +310,11 @@ function parseFrontmatter(content: string): {
 	}
 
 	const [, yamlContent, body] = match;
-
-	// Simple YAML parser for common patterns
-	const frontmatter: Record<string, unknown> = {};
-	const lines = yamlContent!.split("\n");
-	let currentKey: string | null = null;
-	let currentArray: string[] | null = null;
-	let inMetadata = false;
-	let metadataObj: Record<string, string> = {};
-
-	for (const line of lines) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-
-		// Check for array item
-		if (trimmed.startsWith("- ") && currentKey && currentArray) {
-			currentArray.push(trimmed.slice(2).trim());
-			continue;
-		}
-
-		// Check for metadata nested key
-		if (inMetadata && line.startsWith("  ") && !trimmed.startsWith("-")) {
-			const colonIndex = trimmed.indexOf(":");
-			if (colonIndex > 0) {
-				const key = trimmed.slice(0, colonIndex).trim();
-				const value = trimmed
-					.slice(colonIndex + 1)
-					.trim()
-					.replace(/^["']|["']$/g, "");
-				metadataObj[key] = value;
-				continue;
-			}
-		}
-
-		// Save previous array if exists
-		if (currentKey && currentArray) {
-			frontmatter[currentKey] = currentArray;
-			currentArray = null;
-		}
-
-		// End metadata block
-		if (inMetadata && !line.startsWith("  ")) {
-			frontmatter.metadata = metadataObj;
-			inMetadata = false;
-			metadataObj = {};
-		}
-
-		// Parse key: value
-		const colonIndex = trimmed.indexOf(":");
-		if (colonIndex > 0) {
-			const key = trimmed.slice(0, colonIndex).trim();
-			const value = trimmed.slice(colonIndex + 1).trim();
-
-			if (key === "metadata" && value === "") {
-				inMetadata = true;
-				currentKey = null;
-			} else if (value === "") {
-				// Start of array
-				currentKey = key;
-				currentArray = [];
-			} else {
-				// Simple value - remove quotes if present
-				frontmatter[key] = value.replace(/^["']|["']$/g, "");
-				currentKey = null;
-			}
-		}
+	const parsed = loadYaml(yamlContent ?? "") ?? {};
+	if (typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("Frontmatter must be a YAML object");
 	}
-
-	// Save final array if exists
-	if (currentKey && currentArray) {
-		frontmatter[currentKey] = currentArray;
-	}
-
-	// Save metadata if still in block
-	if (inMetadata && Object.keys(metadataObj).length > 0) {
-		frontmatter.metadata = metadataObj;
-	}
+	const frontmatter = parsed as Record<string, unknown>;
 
 	return { frontmatter, body: body! };
 }
@@ -426,17 +411,29 @@ function loadSkillFromDirectory(
 		// Discover resource directories
 		const resourceDirs: SkillResourceDirs = {};
 		const scriptsDir = join(skillDir, "scripts");
+		const referenceDir = join(skillDir, "reference");
 		const referencesDir = join(skillDir, "references");
 		const assetsDir = join(skillDir, "assets");
+		const toolboxDir = join(skillDir, "toolbox");
+		const mcpJsonPath = join(skillDir, "mcp.json");
 
 		if (existsSync(scriptsDir) && statSync(scriptsDir).isDirectory()) {
 			resourceDirs.scriptsDir = scriptsDir;
+		}
+		if (existsSync(referenceDir) && statSync(referenceDir).isDirectory()) {
+			resourceDirs.referenceDir = referenceDir;
 		}
 		if (existsSync(referencesDir) && statSync(referencesDir).isDirectory()) {
 			resourceDirs.referencesDir = referencesDir;
 		}
 		if (existsSync(assetsDir) && statSync(assetsDir).isDirectory()) {
 			resourceDirs.assetsDir = assetsDir;
+		}
+		if (existsSync(toolboxDir) && statSync(toolboxDir).isDirectory()) {
+			resourceDirs.toolboxDir = toolboxDir;
+		}
+		if (existsSync(mcpJsonPath) && statSync(mcpJsonPath).isFile()) {
+			resourceDirs.mcpJsonPath = mcpJsonPath;
 		}
 
 		// Discover bundled resources (legacy flat structure)
@@ -445,7 +442,13 @@ function loadSkillFromDirectory(
 			const files = readdirSync(skillDir);
 			for (const file of files) {
 				if (file.toLowerCase() === "skill.md") continue;
-				if (["scripts", "references", "assets"].includes(file)) continue;
+				if (
+					["scripts", "reference", "references", "assets", "toolbox"].includes(
+						file,
+					)
+				) {
+					continue;
+				}
 				const filePath = join(skillDir, file);
 				const stat = statSync(filePath);
 				if (stat.isFile()) {
@@ -468,7 +471,12 @@ function loadSkillFromDirectory(
 			description,
 			license: frontmatter.license as string | undefined,
 			compatibility: frontmatter.compatibility as string | undefined,
-			allowedTools: frontmatter["allowed-tools"] as string | undefined,
+			allowedTools: stringArrayValue(frontmatter["allowed-tools"]),
+			builtinTools: stringArrayValue(frontmatter["builtin-tools"]),
+			argumentHint: stringValue(frontmatter["argument-hint"]),
+			model: stringValue(frontmatter.model),
+			mode: stringValue(frontmatter.mode),
+			isolatedContext: booleanValue(frontmatter.isolatedContext),
 			metadata: frontmatter.metadata as Record<string, string> | undefined,
 			// Legacy fields for backwards compatibility
 			tags: Array.isArray(frontmatter.tags)
@@ -740,8 +748,11 @@ export function searchSkills(
  */
 export function skillToDict(
 	skill: LoadedSkill,
-): Record<string, string | Record<string, string>> {
-	const result: Record<string, string | Record<string, string>> = {
+): Record<string, string | string[] | boolean | Record<string, string>> {
+	const result: Record<
+		string,
+		string | string[] | boolean | Record<string, string>
+	> = {
 		name: skill.name,
 		description: skill.description,
 	};
@@ -756,6 +767,21 @@ export function skillToDict(
 
 	if (skill.allowedTools) {
 		result["allowed-tools"] = skill.allowedTools;
+	}
+	if (skill.builtinTools) {
+		result["builtin-tools"] = skill.builtinTools;
+	}
+	if (skill.argumentHint) {
+		result["argument-hint"] = skill.argumentHint;
+	}
+	if (skill.model) {
+		result.model = skill.model;
+	}
+	if (skill.mode) {
+		result.mode = skill.mode;
+	}
+	if (skill.isolatedContext !== undefined) {
+		result.isolatedContext = skill.isolatedContext;
 	}
 
 	if (skill.metadata && Object.keys(skill.metadata).length > 0) {
@@ -854,6 +880,33 @@ export function formatSkillForInjection(skill: LoadedSkill): string {
 		lines.push("");
 		for (const resource of skill.resources) {
 			lines.push(`- \`${resource.path}\` (${resource.type})`);
+		}
+		lines.push("");
+	}
+	if (skill.resourceDirs.referenceDir || skill.resourceDirs.referencesDir) {
+		lines.push("## Reference Resources");
+		lines.push("");
+		lines.push("Load detailed references only when needed:");
+		if (skill.resourceDirs.referenceDir) {
+			lines.push(`- \`${skill.resourceDirs.referenceDir}\``);
+		}
+		if (skill.resourceDirs.referencesDir) {
+			lines.push(`- \`${skill.resourceDirs.referencesDir}\``);
+		}
+		lines.push("");
+	}
+	if (skill.resourceDirs.toolboxDir || skill.resourceDirs.mcpJsonPath) {
+		lines.push("## Tool Package");
+		lines.push("");
+		if (skill.resourceDirs.toolboxDir) {
+			lines.push(
+				`- Toolbox executables are bundled under \`${skill.resourceDirs.toolboxDir}\`.`,
+			);
+		}
+		if (skill.resourceDirs.mcpJsonPath) {
+			lines.push(
+				`- Bundled MCP config: \`${skill.resourceDirs.mcpJsonPath}\`.`,
+			);
 		}
 		lines.push("");
 	}

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -151,6 +151,7 @@ export class SkillLoadError extends Error {
 			| "INVALID_NAME"
 			| "INVALID_DESCRIPTION"
 			| "INVALID_COMPATIBILITY"
+			| "INVALID_TOOL_LIST"
 			| "UNEXPECTED_FIELDS"
 			| "NAME_MISMATCH"
 			| "READ_ERROR",
@@ -166,8 +167,14 @@ function stringValue(value: unknown): string | undefined {
 
 export function stringArrayValue(value: unknown): string[] | undefined {
 	if (Array.isArray(value)) {
+		if (
+			value.length === 0 ||
+			value.some((entry) => typeof entry !== "string" || entry.trim() === "")
+		) {
+			return undefined;
+		}
 		const values = value
-			.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+			.map((entry) => entry.trim())
 			.filter((entry) => entry.length > 0);
 		return values.length > 0 ? values : undefined;
 	}
@@ -179,6 +186,26 @@ export function stringArrayValue(value: unknown): string[] | undefined {
 		return values.length > 0 ? values : undefined;
 	}
 	return undefined;
+}
+
+function validateStringArrayField(
+	value: unknown,
+	field: string,
+): string | null {
+	if (value === undefined) {
+		return null;
+	}
+	if (typeof value === "string") {
+		return stringArrayValue(value)
+			? null
+			: `${field} must be a non-empty string or list of non-empty strings`;
+	}
+	if (Array.isArray(value)) {
+		return stringArrayValue(value)
+			? null
+			: `${field} entries must all be non-empty strings`;
+	}
+	return `${field} must be a non-empty string or list of non-empty strings`;
 }
 
 function booleanValue(value: unknown): boolean | undefined {
@@ -428,6 +455,17 @@ function loadSkillFromDirectory(
 					compatError,
 					skillFile,
 					"INVALID_COMPATIBILITY",
+				);
+			}
+		}
+
+		for (const field of ["allowed-tools", "builtin-tools"]) {
+			const toolListError = validateStringArrayField(frontmatter[field], field);
+			if (toolListError) {
+				return new SkillLoadError(
+					toolListError,
+					skillFile,
+					"INVALID_TOOL_LIST",
 				);
 			}
 		}

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -23,6 +23,14 @@ export interface Skill {
 	tags?: string[];
 	/** Required tools for this skill */
 	requiredTools?: string[];
+	/** Built-in Maestro tools this skill expects to use */
+	builtinTools?: string[];
+	/** Preferred model while this skill is active */
+	model?: string;
+	/** Preferred agent mode while this skill is active */
+	mode?: string;
+	/** Whether the skill should run in isolated context when supported */
+	isolatedContext?: boolean;
 	/** Whether this skill is currently active in the session */
 	active?: boolean;
 }
@@ -39,6 +47,12 @@ export interface SkillMetadata {
 	tags?: string[];
 	/** Required tools */
 	tools?: string[];
+	/** Built-in Maestro tools */
+	builtinTools?: string[];
+	/** Preferred model */
+	model?: string;
+	/** Preferred mode */
+	mode?: string;
 	/** Trigger patterns (when to auto-activate) */
 	triggers?: string[];
 }

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -9,6 +9,7 @@ import {
 	hasSkillLintErrors,
 	lintSkillDirectory,
 	loadSkills,
+	parseFrontmatter,
 	scaffoldSkill,
 } from "../src/skills/index.js";
 
@@ -116,6 +117,22 @@ describe("skill package format", () => {
 			]),
 		);
 		expect(hasSkillLintErrors([result])).toBe(false);
+	});
+
+	it("preserves backslashes in scaffolded descriptions", () => {
+		const root = tempRoot();
+		const description = "Handle C:\\new folder\\templates literally.";
+		const scaffold = scaffoldSkill(root, "handling-windows-paths", {
+			description,
+		});
+
+		const rawSkill = readFileSync(
+			join(scaffold.directory, "SKILL.md"),
+			"utf-8",
+		);
+		const { frontmatter } = parseFrontmatter(rawSkill);
+
+		expect(frontmatter.description).toBe(description);
 	});
 
 	it("routes maestro skill as a command with raw command args", () => {

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -118,6 +118,31 @@ describe("skill package format", () => {
 		);
 	});
 
+	it("rejects mixed-type tool permission lists", async () => {
+		const workspace = tempRoot();
+		const skillDir = join(workspace, ".maestro", "skills", "reviewing-prs");
+		await mkdir(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: reviewing-prs\ndescription: "Review pull requests. Use when the user asks for PR review."\nallowed-tools:\n  - read\n  - 123\nbuiltin-tools:\n  - read\n---\n\n# Reviewing PRs\n`,
+		);
+
+		const lintResult = await lintSkillDirectory(skillDir);
+		const loaded = loadSkills(workspace, { includeSystem: false });
+
+		expect(hasSkillLintErrors([lintResult])).toBe(true);
+		expect(lintResult.issues).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "invalid_string_list",
+					severity: "error",
+				}),
+			]),
+		);
+		expect(loaded.skills).toEqual([]);
+		expect(loaded.errors[0]?.code).toBe("INVALID_TOOL_LIST");
+	});
+
 	it("scaffolds a package that passes lint", async () => {
 		const root = tempRoot();
 		const scaffold = scaffoldSkill(root, "processing-incidents", {

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseArgs } from "../src/cli/args.js";
+import { handleSkillCommand } from "../src/cli/commands/skill.js";
+import {
+	hasSkillLintErrors,
+	lintSkillDirectory,
+	loadSkills,
+	scaffoldSkill,
+} from "../src/skills/index.js";
+
+const tempDirs: string[] = [];
+
+function tempRoot(): string {
+	const dir = mkdtempSync(join(tmpdir(), "maestro-skill-package-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+	process.exitCode = undefined;
+});
+
+describe("skill package format", () => {
+	it("loads Agent Core package metadata without loading reference content", async () => {
+		const workspace = tempRoot();
+		const skillDir = join(workspace, ".maestro", "skills", "reviewing-prs");
+		await mkdir(join(skillDir, "reference"), { recursive: true });
+		await mkdir(join(skillDir, "toolbox"), { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: reviewing-prs\ndescription: "Review pull requests. Use when the user asks for PR review."\nallowed-tools:\n  - read\n  - search\nbuiltin-tools:\n  - read\nmodel: gpt-5.5\nmode: review\nisolatedContext: true\n---\n\n# Reviewing PRs\n\nKeep findings first.\n`,
+		);
+		writeFileSync(
+			join(skillDir, "mcp.json"),
+			JSON.stringify(
+				{
+					github: {
+						command: "npx",
+						args: ["-y", "@modelcontextprotocol/server-github"],
+						includeTools: ["get_pull_request", "list_pull_request_files"],
+					},
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(
+			join(skillDir, "reference", "rubric.md"),
+			"# Rubric\n\nFind bugs before style notes.\n",
+		);
+
+		const { skills, errors } = loadSkills(workspace, { includeSystem: false });
+
+		expect(errors).toEqual([]);
+		expect(skills).toHaveLength(1);
+		expect(skills[0]?.name).toBe("reviewing-prs");
+		expect(skills[0]?.allowedTools).toEqual(["read", "search"]);
+		expect(skills[0]?.builtinTools).toEqual(["read"]);
+		expect(skills[0]?.model).toBe("gpt-5.5");
+		expect(skills[0]?.mode).toBe("review");
+		expect(skills[0]?.isolatedContext).toBe(true);
+		expect(skills[0]?.resourceDirs.referenceDir).toBe(
+			join(skillDir, "reference"),
+		);
+		expect(skills[0]?.resourceDirs.toolboxDir).toBe(join(skillDir, "toolbox"));
+		expect(skills[0]?.resourceDirs.mcpJsonPath).toBe(
+			join(skillDir, "mcp.json"),
+		);
+	});
+
+	it("fails lint when bundled MCP tools are unfiltered", async () => {
+		const skillDir = join(tempRoot(), "researching-code");
+		await mkdir(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: researching-code\ndescription: "Research code paths. Use when the user asks for codebase investigation."\n---\n\n# Researching Code\n`,
+		);
+		writeFileSync(
+			join(skillDir, "mcp.json"),
+			JSON.stringify({ github: { command: "npx", args: ["-y", "server"] } }),
+		);
+
+		const result = await lintSkillDirectory(skillDir);
+
+		expect(hasSkillLintErrors([result])).toBe(true);
+		expect(result.issues.map((issue) => issue.code)).toContain(
+			"mcp_tools_unfiltered",
+		);
+	});
+
+	it("scaffolds a package that passes lint", async () => {
+		const root = tempRoot();
+		const scaffold = scaffoldSkill(root, "processing-incidents", {
+			description:
+				"Process incident reports. Use when the user asks for incident triage.",
+		});
+
+		const result = await lintSkillDirectory(scaffold.directory);
+
+		expect(
+			scaffold.files.map((file) => file.replace(scaffold.directory, "")),
+		).toEqual(
+			expect.arrayContaining([
+				"/SKILL.md",
+				"/reference/overview.md",
+				"/scripts/README.md",
+				"/toolbox/README.md",
+				"/mcp.json.example",
+			]),
+		);
+		expect(hasSkillLintErrors([result])).toBe(false);
+	});
+
+	it("routes maestro skill as a command with raw command args", () => {
+		const parsed = parseArgs(["skill", "lint", "--json", ".maestro/skills"]);
+
+		expect(parsed.command).toBe("skill");
+		expect(parsed.subcommand).toBe("lint");
+		expect(parsed.commandArgs).toEqual(["--json", ".maestro/skills"]);
+	});
+
+	it("supports the skill CLI scaffold command", async () => {
+		const workspace = tempRoot();
+
+		await handleSkillCommand(
+			"new",
+			[
+				"testing-ui",
+				"--description",
+				"Test UI flows. Use when a user asks for browser UI verification.",
+				"--json",
+			],
+			{ workspaceDir: workspace },
+		);
+
+		const result = await lintSkillDirectory(
+			join(workspace, ".maestro", "skills", "testing-ui"),
+		);
+		expect(hasSkillLintErrors([result])).toBe(false);
+	});
+});

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -118,6 +118,37 @@ describe("skill package format", () => {
 		);
 	});
 
+	it("fails lint when mcp includeTools contains invalid entries", async () => {
+		const skillDir = join(tempRoot(), "researching-code");
+		await mkdir(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: researching-code\ndescription: "Research code paths. Use when the user asks for codebase investigation."\n---\n\n# Researching Code\n`,
+		);
+		writeFileSync(
+			join(skillDir, "mcp.json"),
+			JSON.stringify({
+				github: {
+					command: "npx",
+					args: ["-y", "server"],
+					includeTools: ["search", ""],
+				},
+			}),
+		);
+
+		const result = await lintSkillDirectory(skillDir);
+
+		expect(hasSkillLintErrors([result])).toBe(true);
+		expect(result.issues).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "invalid_mcp_include_tools",
+					severity: "error",
+				}),
+			]),
+		);
+	});
+
 	it("rejects mixed-type tool permission lists", async () => {
 		const workspace = tempRoot();
 		const skillDir = join(workspace, ".maestro", "skills", "reviewing-prs");
@@ -141,6 +172,54 @@ describe("skill package format", () => {
 		);
 		expect(loaded.skills).toEqual([]);
 		expect(loaded.errors[0]?.code).toBe("INVALID_TOOL_LIST");
+	});
+
+	it("reports load warnings when list finds no valid skills", async () => {
+		const workspace = tempRoot();
+		const systemSkillsDir = join(workspace, "empty-system-skills");
+		const maestroHome = join(workspace, "maestro-home");
+		const skillDir = join(workspace, ".maestro", "skills", "broken-skill");
+		await mkdir(systemSkillsDir, { recursive: true });
+		await mkdir(maestroHome, { recursive: true });
+		await mkdir(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\ndescription: "Broken skill. Use when the user asks for load warnings."\n---\n\n# Broken Skill\n`,
+		);
+		const previousSystemSkillsDir = process.env.MAESTRO_SYSTEM_SKILLS_DIR;
+		const previousMaestroHome = process.env.MAESTRO_HOME;
+		const originalLog = console.log;
+		const originalError = console.error;
+		const logs: string[] = [];
+		const errors: string[] = [];
+		process.env.MAESTRO_SYSTEM_SKILLS_DIR = systemSkillsDir;
+		process.env.MAESTRO_HOME = maestroHome;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.map((arg) => String(arg)).join(" "));
+		};
+		console.error = (...args: unknown[]) => {
+			errors.push(args.map((arg) => String(arg)).join(" "));
+		};
+
+		try {
+			await handleSkillCommand("list", [], { workspaceDir: workspace });
+		} finally {
+			if (previousSystemSkillsDir === undefined) {
+				delete process.env.MAESTRO_SYSTEM_SKILLS_DIR;
+			} else {
+				process.env.MAESTRO_SYSTEM_SKILLS_DIR = previousSystemSkillsDir;
+			}
+			if (previousMaestroHome === undefined) {
+				delete process.env.MAESTRO_HOME;
+			} else {
+				process.env.MAESTRO_HOME = previousMaestroHome;
+			}
+			console.log = originalLog;
+			console.error = originalError;
+		}
+
+		expect(logs.join("\n")).toContain("No skills found.");
+		expect(errors.join("\n")).toContain("1 skill load warning(s).");
 	});
 
 	it("scaffolds a package that passes lint", async () => {

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parseArgs } from "../src/cli/args.js";
 import { handleSkillCommand } from "../src/cli/commands/skill.js";
+import { buildSkillArtifactMetadata } from "../src/skills/artifact-metadata.js";
 import {
 	hasSkillLintErrors,
 	lintSkillDirectory,
@@ -74,6 +75,27 @@ describe("skill package format", () => {
 		expect(skills[0]?.resourceDirs.mcpJsonPath).toBe(
 			join(skillDir, "mcp.json"),
 		);
+	});
+
+	it("coerces scalar metadata frontmatter values to strings", async () => {
+		const workspace = tempRoot();
+		const skillDir = join(workspace, ".maestro", "skills", "shipping-releases");
+		await mkdir(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: shipping-releases\ndescription: "Ship releases. Use when the user asks for release validation."\nmetadata:\n  currentVersion: 1.2\n  workspaceId: 42\n  dryRun: true\n  nested:\n    ignored: true\n---\n\n# Shipping Releases\n`,
+		);
+
+		const { skills, errors } = loadSkills(workspace, { includeSystem: false });
+
+		expect(errors).toEqual([]);
+		expect(skills[0]?.metadata).toEqual({
+			currentVersion: "1.2",
+			workspaceId: "42",
+			dryRun: "true",
+		});
+		expect(buildSkillArtifactMetadata(skills[0]!).version).toBe("1.2");
+		expect(buildSkillArtifactMetadata(skills[0]!).workspaceId).toBe("42");
 	});
 
 	it("fails lint when bundled MCP tools are unfiltered", async () => {


### PR DESCRIPTION
## Summary

- adds the EvalOps Agent Core parity spec and skill cookbook as the first Hermes-class OSS distribution slice
- extends Maestro skills with package metadata for `reference/`, `toolbox/`, `mcp.json`, model/mode hints, `builtin-tools`, and `isolatedContext`
- adds `maestro skill list|inspect|lint|new` for authoring, validating, and inspecting progressive skill packages
- enforces filtered bundled MCP servers by failing lint when `includeTools` is omitted

## Source-of-truth provenance

- evalops/maestro-internal#1951

## Staged rollout

Did this need staged rollout? Direct exposure is safe because `maestro skill` is an additive authoring and validation surface for local skill packages: it does not change default agent execution, provider routing, session replay, or hosted runtime behavior. The risky runtime pieces remain enabling primitives only: bundled MCP lifecycle and toolbox registration are documented as next slices, while this PR only validates package shape and scaffolds files.

## Validation

- `node ./scripts/run-vitest.js --run test/progressive-skill-disclosure.test.ts test/skill-package-format.test.ts`
- `bunx tsc -p tsconfig.build.json --noEmit`
- `bun run bun:lint`
- `bun run build`
- `node dist/cli.js skill lint skills --json`
- `node dist/cli.js skill --help`
- `npx nx run maestro:test --skip-nx-cache` (7661 passed, 43 skipped)

## Notes

No new repo was needed for this slice. The Agent Core surface belongs in the public Maestro package; Platform and Ensemble remain the attach/control-plane and channel layers called out in the spec.
