### PR TITLE
Add A2A peer task cancellation

### DIFF
--- a/docs/protocols/codex-a2a-peer-relay.md
+++ b/docs/protocols/codex-a2a-peer-relay.md
@@ -33,10 +33,11 @@ python3 scripts/codex-a2a-peer.py card mac-mini
 python3 scripts/codex-a2a-peer.py send --from dev-desktop mac-mini "Validate the desktop sign-in flow on macOS"
 python3 scripts/codex-a2a-peer.py relay dev-desktop --stdin < handoff.md
 python3 scripts/codex-a2a-peer.py task mac-mini codex-a2a-task-123
+python3 scripts/codex-a2a-peer.py cancel mac-mini codex-a2a-task-123
 ```
 
 For async work, pass `--async`; the command prints the task id and current state,
-which can be polled later with `task`.
+which can be polled later with `task` or stopped with `cancel`.
 
 When the bridge receives relay metadata, it prepends a small prompt envelope so
 the receiving Codex turn can see routing/correlation context without the caller

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -327,19 +327,12 @@ def cmd_task(registry: dict[str, Any], args: argparse.Namespace) -> None:
 
 
 def cmd_cancel(registry: dict[str, Any], args: argparse.Namespace) -> None:
-    peer_arg = args.peer
-    task_id = args.task_id
-    if not task_id:
-        if not peer_arg:
-            raise PeerError("task id is required")
-        task_id = peer_arg
-        peer_arg = None
-    _, peer = resolve_peer(registry, peer_arg)
+    _, peer = resolve_peer(registry, args.peer)
     payload = request_json(
         registry,
         peer,
         "POST",
-        f"/tasks/{quote(task_id, safe='')}:cancel",
+        f"/tasks/{quote(args.task_id, safe='')}:cancel",
         timeout_seconds=args.timeout,
     )
     print_task(payload, args.json)
@@ -397,7 +390,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     cancel_parser = subcommands.add_parser("cancel", help="cancel a task on a peer")
     cancel_parser.add_argument("peer", nargs="?", help="peer name")
-    cancel_parser.add_argument("task_id", nargs="?", help="task id")
+    cancel_parser.add_argument("task_id", help="task id")
     cancel_parser.add_argument("--json", action="store_true", help="print JSON")
     cancel_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
     cancel_parser.set_defaults(handler=cmd_cancel)

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -327,6 +327,8 @@ def cmd_task(registry: dict[str, Any], args: argparse.Namespace) -> None:
 
 
 def cmd_cancel(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    if args.peer is None and args.task_id in registry_peers(registry):
+        raise PeerError(f"task id is required for peer {args.task_id!r}")
     _, peer = resolve_peer(registry, args.peer)
     payload = request_json(
         registry,

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -326,6 +326,25 @@ def cmd_task(registry: dict[str, Any], args: argparse.Namespace) -> None:
     print_task(payload, args.json)
 
 
+def cmd_cancel(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    peer_arg = args.peer
+    task_id = args.task_id
+    if not task_id:
+        if not peer_arg:
+            raise PeerError("task id is required")
+        task_id = peer_arg
+        peer_arg = None
+    _, peer = resolve_peer(registry, peer_arg)
+    payload = request_json(
+        registry,
+        peer,
+        "POST",
+        f"/tasks/{quote(task_id, safe='')}:cancel",
+        timeout_seconds=args.timeout,
+    )
+    print_task(payload, args.json)
+
+
 def cmd_tasks(registry: dict[str, Any], args: argparse.Namespace) -> None:
     _, peer = resolve_peer(registry, args.peer)
     payload = request_json(registry, peer, "GET", "/tasks", timeout_seconds=args.timeout)
@@ -375,6 +394,13 @@ def build_parser() -> argparse.ArgumentParser:
     task_parser.add_argument("--json", action="store_true", help="print JSON")
     task_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
     task_parser.set_defaults(handler=cmd_task)
+
+    cancel_parser = subcommands.add_parser("cancel", help="cancel a task on a peer")
+    cancel_parser.add_argument("peer", nargs="?", help="peer name")
+    cancel_parser.add_argument("task_id", nargs="?", help="task id")
+    cancel_parser.add_argument("--json", action="store_true", help="print JSON")
+    cancel_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
+    cancel_parser.set_defaults(handler=cmd_cancel)
 
     tasks_parser = subcommands.add_parser("tasks", help="list retained tasks from a peer")
     tasks_parser.add_argument("peer", nargs="?", help="peer name")

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -123,6 +123,24 @@ describe("codex-a2a-peer", () => {
 				);
 				return;
 			}
+			if (request.url === "/tasks/task-1:cancel") {
+				response.end(
+					JSON.stringify({
+						task: {
+							id: "task-1",
+							contextId: "ctx-1",
+							status: {
+								state: "TASK_STATE_CANCELED",
+								message: {
+									role: "ROLE_AGENT",
+									parts: [{ text: "task canceled", mediaType: "text/plain" }],
+								},
+							},
+						},
+					}),
+				);
+				return;
+			}
 			response.statusCode = 404;
 			response.end(JSON.stringify({ error: { code: "NOT_FOUND" } }));
 		});
@@ -310,6 +328,36 @@ describe("codex-a2a-peer", () => {
 				metadata: { relayPeer: "mock" },
 			},
 		});
+	});
+
+	it("cancels a peer task with A2A headers", async () => {
+		const output = await runPeer(configPath, ["cancel", "mock", "task-1"], {
+			TEST_A2A_PEER_TOKEN: "super-secret-token",
+		});
+
+		expect(output).toContain("task: task-1");
+		expect(output).toContain("state: TASK_STATE_CANCELED");
+		expect(output).toContain("task canceled");
+		const request = requests.find(
+			(item) => item.url === "/tasks/task-1:cancel",
+		);
+		expect(request).toMatchObject({
+			body: "",
+			method: "POST",
+			url: "/tasks/task-1:cancel",
+		});
+		expect(request?.headers.authorization).toBe("Bearer super-secret-token");
+		expect(request?.headers["a2a-version"]).toBe("1.0");
+	});
+
+	it("uses defaultPeer when cancel is called with only a task id", async () => {
+		await runPeer(configPath, ["cancel", "task-1"], {
+			TEST_A2A_PEER_TOKEN: "super-secret-token",
+		});
+
+		expect(requests.some((item) => item.url === "/tasks/task-1:cancel")).toBe(
+			true,
+		);
 	});
 
 	it("fails unknown explicit peers before sending", async () => {

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -360,6 +360,17 @@ describe("codex-a2a-peer", () => {
 		);
 	});
 
+	it("rejects ambiguous one-argument cancel calls that match a peer", async () => {
+		await expect(
+			runPeer(configPath, ["cancel", "mock"], {
+				TEST_A2A_PEER_TOKEN: "super-secret-token",
+			}),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("task id is required for peer 'mock'"),
+		});
+		expect(requests).toHaveLength(0);
+	});
+
 	it("fails unknown explicit peers before sending", async () => {
 		await expect(
 			runPeer(configPath, ["send", "--peer", "mok", "hello"], {


### PR DESCRIPTION
## Summary
- Add a `cancel` subcommand to the Codex A2A peer CLI.
- Call the existing bridge `POST /tasks/{id}:cancel` endpoint and reuse task output rendering.
- Document async task cancellation and cover explicit/default peer cancellation in the peer CLI tests.

## Test plan
- python3 -m py_compile scripts/codex-a2a-peer.py
- node ./scripts/run-vitest.js --run test/scripts/codex-a2a-peer.test.ts
- bunx biome check scripts/codex-a2a-peer.py test/scripts/codex-a2a-peer.test.ts docs/protocols/codex-a2a-peer-relay.md
- bash scripts/guardian.sh --trigger pre-commit

Internal mirror: evalops/maestro-internal#1955

Co-authored-by: dev-desktop A2A peer <dev-desktop@evalops.local>
Co-authored-by: mac-mini A2A peer <mac-mini@evalops.local>