### PR TITLE
Require explicit peer for A2A cancel

### DIFF
--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -327,8 +327,6 @@ def cmd_task(registry: dict[str, Any], args: argparse.Namespace) -> None:
 
 
 def cmd_cancel(registry: dict[str, Any], args: argparse.Namespace) -> None:
-    if args.peer is None and args.task_id in registry_peers(registry):
-        raise PeerError(f"task id is required for peer {args.task_id!r}")
     _, peer = resolve_peer(registry, args.peer)
     payload = request_json(
         registry,
@@ -391,7 +389,7 @@ def build_parser() -> argparse.ArgumentParser:
     task_parser.set_defaults(handler=cmd_task)
 
     cancel_parser = subcommands.add_parser("cancel", help="cancel a task on a peer")
-    cancel_parser.add_argument("peer", nargs="?", help="peer name")
+    cancel_parser.add_argument("peer", help="peer name")
     cancel_parser.add_argument("task_id", help="task id")
     cancel_parser.add_argument("--json", action="store_true", help="print JSON")
     cancel_parser.add_argument("--timeout", type=float, help="request timeout in seconds")

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -350,23 +350,24 @@ describe("codex-a2a-peer", () => {
 		expect(request?.headers["a2a-version"]).toBe("1.0");
 	});
 
-	it("uses defaultPeer when cancel is called with only a task id", async () => {
-		await runPeer(configPath, ["cancel", "task-1"], {
-			TEST_A2A_PEER_TOKEN: "super-secret-token",
-		});
-
-		expect(requests.some((item) => item.url === "/tasks/task-1:cancel")).toBe(
-			true,
-		);
-	});
-
-	it("rejects ambiguous one-argument cancel calls that match a peer", async () => {
+	it("requires an explicit peer and task id for cancel", async () => {
 		await expect(
 			runPeer(configPath, ["cancel", "mock"], {
 				TEST_A2A_PEER_TOKEN: "super-secret-token",
 			}),
 		).rejects.toMatchObject({
-			stderr: expect.stringContaining("task id is required for peer 'mock'"),
+			stderr: expect.stringContaining("the following arguments are required"),
+		});
+		expect(requests).toHaveLength(0);
+	});
+
+	it("fails unknown explicit cancel peers before sending", async () => {
+		await expect(
+			runPeer(configPath, ["cancel", "mok", "task-1"], {
+				TEST_A2A_PEER_TOKEN: "super-secret-token",
+			}),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("unknown peer 'mok'"),
 		});
 		expect(requests).toHaveLength(0);
 	});


### PR DESCRIPTION
## Summary
- Require `codex-a2a-peer.py cancel` to receive both `peer` and `task_id` explicitly.
- Remove the one-argument defaultPeer fallback that could treat a typo as a task id.
- Add regression coverage that argparse stops before any A2A request is sent.

Follow-up to evalops/maestro#407. Internal counterpart: evalops/maestro-internal#1956.

## Test plan
- `python3 -m py_compile scripts/codex-a2a-peer.py`
- `node ./scripts/run-vitest.js --run test/scripts/codex-a2a-peer.test.ts`
- `bunx biome check scripts/codex-a2a-peer.py test/scripts/codex-a2a-peer.test.ts docs/protocols/codex-a2a-peer-relay.md`
- `bash scripts/guardian.sh --trigger pre-commit`
- Commit hook full build/codegen checks