### PR TITLE
Add bounded wait for A2A peer tasks

### DIFF
--- a/docs/protocols/codex-a2a-peer-relay.md
+++ b/docs/protocols/codex-a2a-peer-relay.md
@@ -31,13 +31,22 @@ Common commands:
 python3 scripts/codex-a2a-peer.py list
 python3 scripts/codex-a2a-peer.py card mac-mini
 python3 scripts/codex-a2a-peer.py send --from dev-desktop mac-mini "Validate the desktop sign-in flow on macOS"
+python3 scripts/codex-a2a-peer.py send --wait --from dev-desktop mac-mini "Validate the desktop sign-in flow on macOS"
 python3 scripts/codex-a2a-peer.py relay dev-desktop --stdin < handoff.md
 python3 scripts/codex-a2a-peer.py task mac-mini codex-a2a-task-123
+python3 scripts/codex-a2a-peer.py wait mac-mini codex-a2a-task-123 --max-wait 300
 python3 scripts/codex-a2a-peer.py cancel mac-mini codex-a2a-task-123
 ```
 
 For async work, pass `--async`; the command prints the task id and current state,
-which can be polled later with `task` or stopped with `cancel`.
+which can be polled later with `task`, waited on with `wait`, or stopped with
+`cancel`. For one-shot handoffs where the caller wants the final answer but
+still needs bounded polling, pass `send --wait`; it requests an async task and
+then polls `GET /tasks/{id}` until the task leaves `TASK_STATE_SUBMITTED` or
+`TASK_STATE_WORKING`. `wait` and `send --wait` are bounded by `--max-wait`
+(default: 300 seconds) and sleep between polls with `--interval` or
+`--wait-interval` (default: 5 seconds), so they are safe for fleet scripts that
+must not run unbounded watchers.
 
 When the bridge receives relay metadata, it prepends a small prompt envelope so
 the receiving Codex turn can see routing/correlation context without the caller

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -165,17 +165,6 @@ def peer_headers(registry: dict[str, Any], peer: dict[str, Any]) -> tuple[dict[s
     return headers, token_source
 
 
-def resolve_timeout_seconds(registry: dict[str, Any], peer: dict[str, Any]) -> float:
-    timeout_ms = peer.get("timeoutMs", registry.get("timeoutMs", 600_000))
-    try:
-        timeout = float(timeout_ms) / 1000.0
-    except (TypeError, ValueError) as error:
-        raise PeerError("timeoutMs must be numeric") from error
-    if timeout <= 0:
-        raise PeerError("timeoutMs must be positive")
-    return timeout
-
-
 def request_json(
     registry: dict[str, Any],
     peer: dict[str, Any],
@@ -189,11 +178,7 @@ def request_json(
     if body is not None:
         data = json.dumps(body, separators=(",", ":")).encode("utf-8")
         headers["Content-Type"] = "application/json"
-    timeout = timeout_seconds
-    if timeout is None:
-        timeout = resolve_timeout_seconds(registry, peer)
-    if timeout <= 0:
-        raise PeerError("timeoutMs must be positive")
+    timeout = resolve_request_timeout(registry, peer, timeout_seconds)
     request = Request(
         f"{peer['url']}{path}",
         data=data,
@@ -219,6 +204,34 @@ def request_json(
     if not isinstance(value, dict):
         raise PeerError(f"{method} {path} returned non-object JSON")
     return value
+
+
+def resolve_request_timeout(
+    registry: dict[str, Any],
+    peer: dict[str, Any],
+    timeout_seconds: float | None,
+) -> float:
+    timeout = timeout_seconds
+    if timeout is None:
+        timeout_ms = peer.get("timeoutMs", registry.get("timeoutMs", 600_000))
+        try:
+            timeout = float(timeout_ms) / 1000.0
+        except (TypeError, ValueError) as error:
+            raise PeerError("timeoutMs must be numeric") from error
+    if not math.isfinite(timeout):
+        raise PeerError("timeoutMs must be finite")
+    if timeout <= 0:
+        raise PeerError("timeoutMs must be positive")
+    return timeout
+
+
+def request_timeout_for_remaining_budget(
+    registry: dict[str, Any],
+    peer: dict[str, Any],
+    timeout_seconds: float | None,
+    remaining_seconds: float,
+) -> float:
+    return min(resolve_request_timeout(registry, peer, timeout_seconds), remaining_seconds)
 
 
 def positive_seconds(value: str) -> float:
@@ -315,19 +328,25 @@ def wait_for_task(
     interval_seconds: float,
     max_wait_seconds: float,
     timeout_seconds: float | None,
+    started_at: float | None = None,
 ) -> dict[str, Any]:
-    deadline = time.monotonic() + max_wait_seconds
+    if started_at is None:
+        started_at = time.monotonic()
+    deadline = started_at + max_wait_seconds
     latest_payload: dict[str, Any] = {}
     latest_state = "unknown"
-    default_timeout_seconds = None if timeout_seconds is not None else resolve_timeout_seconds(registry, peer)
-    poll_timeout_seconds = timeout_seconds if timeout_seconds is not None else default_timeout_seconds
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise PeerError(
                 f"task {task_id!r} did not finish within {max_wait_seconds:g}s; latest state: {latest_state}"
             )
-        request_timeout = min(poll_timeout_seconds, remaining)
+        request_timeout = request_timeout_for_remaining_budget(
+            registry,
+            peer,
+            timeout_seconds,
+            remaining,
+        )
         try:
             latest_payload = request_json(
                 registry,
@@ -430,7 +449,24 @@ def cmd_send(registry: dict[str, Any], args: argparse.Namespace) -> None:
         body["message"]["contextId"] = args.context_id
     if args.task_id:
         body["message"]["taskId"] = args.task_id
-    payload = request_json(registry, peer, "POST", "/message:send", body, timeout_seconds=args.timeout)
+    wait_started_at = time.monotonic() if args.wait else None
+    send_timeout = args.timeout
+    if wait_started_at is not None:
+        send_remaining = wait_started_at + args.max_wait - time.monotonic()
+        if send_remaining <= 0:
+            raise PeerError(f"message:send did not finish within {args.max_wait:g}s")
+        send_timeout = request_timeout_for_remaining_budget(
+            registry,
+            peer,
+            args.timeout,
+            send_remaining,
+        )
+    try:
+        payload = request_json(registry, peer, "POST", "/message:send", body, timeout_seconds=send_timeout)
+    except PeerError as error:
+        if wait_started_at is not None and time.monotonic() >= wait_started_at + args.max_wait:
+            raise PeerError(f"message:send did not finish within {args.max_wait:g}s") from error
+        raise
     if args.wait:
         if task_is_active(payload):
             task_id = task_id_from_payload(payload)
@@ -443,6 +479,7 @@ def cmd_send(registry: dict[str, Any], args: argparse.Namespace) -> None:
                 args.wait_interval,
                 args.max_wait,
                 args.timeout,
+                started_at=wait_started_at,
             )
     print_task(payload, args.json)
 

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
+import socket
 import sys
 import time
 import uuid
@@ -23,6 +25,14 @@ from urllib.request import Request, urlopen
 
 DEFAULT_CONFIG_PATH = "~/.codex/fleet/peers.json"
 A2A_VERSION = "1.0"
+ACTIVE_TASK_STATES = {
+    "submitted",
+    "task_state_submitted",
+    "task_state_working",
+    "working",
+}
+DEFAULT_WAIT_INTERVAL_SECONDS = 5.0
+DEFAULT_WAIT_MAX_SECONDS = 300.0
 
 
 class PeerError(Exception):
@@ -189,6 +199,8 @@ def request_json(
     except HTTPError as error:
         detail = error.read().decode("utf-8", errors="replace").strip()
         raise PeerError(f"{method} {path} failed with HTTP {error.code}: {detail}") from error
+    except (TimeoutError, socket.timeout) as error:
+        raise PeerError(f"{method} {path} timed out") from error
     except URLError as error:
         raise PeerError(f"{method} {path} failed: {error}") from error
     if not payload:
@@ -202,17 +214,66 @@ def request_json(
     return value
 
 
-def task_text(task: dict[str, Any]) -> str:
+def positive_seconds(value: str) -> float:
+    try:
+        seconds = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be numeric") from error
+    if not math.isfinite(seconds):
+        raise argparse.ArgumentTypeError("must be finite")
+    if seconds <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return seconds
+
+
+def task_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    task = payload.get("task")
+    if isinstance(task, dict):
+        return task
+    return payload
+
+
+def task_state(payload: dict[str, Any]) -> str:
+    task = task_from_payload(payload)
     status = task.get("status") if isinstance(task.get("status"), dict) else {}
-    message = status.get("message") if isinstance(status.get("message"), dict) else {}
-    parts = message.get("parts") if isinstance(message.get("parts"), list) else []
+    state = status.get("state")
+    return state if isinstance(state, str) else ""
+
+
+def task_is_active(payload: dict[str, Any]) -> bool:
+    return task_state(payload).strip().lower() in ACTIVE_TASK_STATES
+
+
+def task_id_from_payload(payload: dict[str, Any]) -> str:
+    task = task_from_payload(payload)
+    task_id = task.get("id")
+    return task_id if isinstance(task_id, str) else ""
+
+
+def text_from_parts(parts: Any) -> str:
+    if not isinstance(parts, list):
+        return ""
     texts = [
         str(part.get("text"))
         for part in parts
         if isinstance(part, dict) and isinstance(part.get("text"), str)
     ]
-    if texts:
-        return "\n".join(texts).strip()
+    return "\n".join(texts).strip()
+
+
+def task_text(task: dict[str, Any]) -> str:
+    status = task.get("status") if isinstance(task.get("status"), dict) else {}
+    message = status.get("message") if isinstance(status.get("message"), dict) else {}
+    text = text_from_parts(message.get("parts"))
+    if text:
+        return text
+    direct_message = task.get("message") if isinstance(task.get("message"), dict) else {}
+    text = text_from_parts(direct_message.get("parts"))
+    if text:
+        return text
+    text = text_from_parts(task.get("parts"))
+    if text:
+        return text
     artifacts = task.get("artifacts") if isinstance(task.get("artifacts"), list) else []
     for artifact in artifacts:
         if not isinstance(artifact, dict):
@@ -227,7 +288,7 @@ def print_task(payload: dict[str, Any], as_json: bool) -> None:
     if as_json:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return
-    task = payload.get("task") if isinstance(payload.get("task"), dict) else payload
+    task = task_from_payload(payload)
     status = task.get("status") if isinstance(task.get("status"), dict) else {}
     print(f"task: {task.get('id', '')}")
     print(f"state: {status.get('state', '')}")
@@ -238,6 +299,49 @@ def print_task(payload: dict[str, Any], as_json: bool) -> None:
     if text:
         print()
         print(text)
+
+
+def wait_for_task(
+    registry: dict[str, Any],
+    peer: dict[str, Any],
+    task_id: str,
+    interval_seconds: float,
+    max_wait_seconds: float,
+    timeout_seconds: float | None,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + max_wait_seconds
+    latest_payload: dict[str, Any] = {}
+    latest_state = "unknown"
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise PeerError(
+                f"task {task_id!r} did not finish within {max_wait_seconds:g}s; latest state: {latest_state}"
+            )
+        request_timeout = remaining if timeout_seconds is None else min(timeout_seconds, remaining)
+        try:
+            latest_payload = request_json(
+                registry,
+                peer,
+                "GET",
+                f"/tasks/{quote(task_id, safe='')}",
+                timeout_seconds=request_timeout,
+            )
+        except PeerError as error:
+            if time.monotonic() >= deadline:
+                raise PeerError(
+                    f"task {task_id!r} did not finish within {max_wait_seconds:g}s; latest state: {latest_state}"
+                ) from error
+            raise
+        latest_state = task_state(latest_payload) or "unknown"
+        if not task_is_active(latest_payload):
+            return latest_payload
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise PeerError(
+                f"task {task_id!r} did not finish within {max_wait_seconds:g}s; latest state: {latest_state}"
+            )
+        time.sleep(min(interval_seconds, remaining))
 
 
 def prompt_from_args(args: argparse.Namespace) -> str:
@@ -303,6 +407,7 @@ def cmd_send(registry: dict[str, Any], args: argparse.Namespace) -> None:
     }
     if args.from_agent:
         metadata["handoffFrom"] = args.from_agent
+    return_immediately = bool(args.return_immediately or args.wait)
     body = {
         "message": {
             "messageId": args.message_id or f"codex-a2a-peer-{uuid.uuid4().hex}",
@@ -310,19 +415,45 @@ def cmd_send(registry: dict[str, Any], args: argparse.Namespace) -> None:
             "parts": [{"text": text, "mediaType": "text/plain"}],
             "metadata": metadata,
         },
-        "configuration": {"returnImmediately": bool(args.return_immediately)},
+        "configuration": {"returnImmediately": return_immediately},
     }
     if args.context_id:
         body["message"]["contextId"] = args.context_id
     if args.task_id:
         body["message"]["taskId"] = args.task_id
     payload = request_json(registry, peer, "POST", "/message:send", body, timeout_seconds=args.timeout)
+    if args.wait:
+        if task_is_active(payload):
+            task_id = task_id_from_payload(payload)
+            if not task_id:
+                raise PeerError("message:send response did not include a task id to wait on")
+            payload = wait_for_task(
+                registry,
+                peer,
+                task_id,
+                args.wait_interval,
+                args.max_wait,
+                args.timeout,
+            )
     print_task(payload, args.json)
 
 
 def cmd_task(registry: dict[str, Any], args: argparse.Namespace) -> None:
     _, peer = resolve_peer(registry, args.peer)
     payload = request_json(registry, peer, "GET", f"/tasks/{quote(args.task_id, safe='')}", timeout_seconds=args.timeout)
+    print_task(payload, args.json)
+
+
+def cmd_wait(registry: dict[str, Any], args: argparse.Namespace) -> None:
+    _, peer = resolve_peer(registry, args.peer)
+    payload = wait_for_task(
+        registry,
+        peer,
+        args.task_id,
+        args.interval,
+        args.max_wait,
+        args.timeout,
+    )
     print_task(payload, args.json)
 
 
@@ -364,7 +495,7 @@ def build_parser() -> argparse.ArgumentParser:
     card_parser = subcommands.add_parser("card", help="fetch a peer Agent Card")
     card_parser.add_argument("peer", nargs="?", help="peer name")
     card_parser.add_argument("--json", action="store_true", help="print JSON")
-    card_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
+    card_parser.add_argument("--timeout", type=positive_seconds, help="request timeout in seconds")
     card_parser.set_defaults(handler=cmd_card)
 
     for name in ("send", "relay"):
@@ -372,33 +503,65 @@ def build_parser() -> argparse.ArgumentParser:
         send_parser.add_argument("--peer", help="peer name")
         send_parser.add_argument("message", nargs="*", help="message text, or '-' for stdin")
         send_parser.add_argument("--async", dest="return_immediately", action="store_true", help="return immediately with a working task")
+        send_parser.add_argument("--wait", action="store_true", help="poll the returned task until it settles")
+        send_parser.add_argument(
+            "--wait-interval",
+            type=positive_seconds,
+            default=DEFAULT_WAIT_INTERVAL_SECONDS,
+            help=f"seconds between --wait polls (default: {DEFAULT_WAIT_INTERVAL_SECONDS:g})",
+        )
+        send_parser.add_argument(
+            "--max-wait",
+            type=positive_seconds,
+            default=DEFAULT_WAIT_MAX_SECONDS,
+            help=f"maximum seconds to wait before failing (default: {DEFAULT_WAIT_MAX_SECONDS:g})",
+        )
         send_parser.add_argument("--context-id", help="A2A context id")
         send_parser.add_argument("--task-id", help="A2A task id for follow-up messages")
         send_parser.add_argument("--message-id", help="A2A message id")
         send_parser.add_argument("--from", dest="from_agent", help="originating agent name for handoff metadata")
         send_parser.add_argument("--stdin", action="store_true", help="read message text from stdin")
         send_parser.add_argument("--json", action="store_true", help="print JSON")
-        send_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
+        send_parser.add_argument("--timeout", type=positive_seconds, help="request timeout in seconds")
         send_parser.set_defaults(handler=cmd_send)
 
     task_parser = subcommands.add_parser("task", help="fetch a task from a peer")
     task_parser.add_argument("peer", nargs="?", help="peer name")
     task_parser.add_argument("task_id", help="task id")
     task_parser.add_argument("--json", action="store_true", help="print JSON")
-    task_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
+    task_parser.add_argument("--timeout", type=positive_seconds, help="request timeout in seconds")
     task_parser.set_defaults(handler=cmd_task)
+
+    wait_parser = subcommands.add_parser("wait", help="poll a peer task until it settles")
+    wait_parser.add_argument("peer", nargs="?", help="peer name")
+    wait_parser.add_argument("task_id", help="task id")
+    wait_parser.add_argument("--json", action="store_true", help="print JSON")
+    wait_parser.add_argument(
+        "--interval",
+        type=positive_seconds,
+        default=DEFAULT_WAIT_INTERVAL_SECONDS,
+        help=f"seconds between polls (default: {DEFAULT_WAIT_INTERVAL_SECONDS:g})",
+    )
+    wait_parser.add_argument(
+        "--max-wait",
+        type=positive_seconds,
+        default=DEFAULT_WAIT_MAX_SECONDS,
+        help=f"maximum seconds to wait before failing (default: {DEFAULT_WAIT_MAX_SECONDS:g})",
+    )
+    wait_parser.add_argument("--timeout", type=positive_seconds, help="request timeout in seconds")
+    wait_parser.set_defaults(handler=cmd_wait)
 
     cancel_parser = subcommands.add_parser("cancel", help="cancel a task on a peer")
     cancel_parser.add_argument("peer", help="peer name")
     cancel_parser.add_argument("task_id", help="task id")
     cancel_parser.add_argument("--json", action="store_true", help="print JSON")
-    cancel_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
+    cancel_parser.add_argument("--timeout", type=positive_seconds, help="request timeout in seconds")
     cancel_parser.set_defaults(handler=cmd_cancel)
 
     tasks_parser = subcommands.add_parser("tasks", help="list retained tasks from a peer")
     tasks_parser.add_argument("peer", nargs="?", help="peer name")
     tasks_parser.add_argument("--json", action="store_true", help="print JSON")
-    tasks_parser.add_argument("--timeout", type=float, help="request timeout in seconds")
+    tasks_parser.add_argument("--timeout", type=positive_seconds, help="request timeout in seconds")
     tasks_parser.set_defaults(handler=cmd_tasks)
     return parser
 

--- a/scripts/codex-a2a-peer.py
+++ b/scripts/codex-a2a-peer.py
@@ -165,6 +165,17 @@ def peer_headers(registry: dict[str, Any], peer: dict[str, Any]) -> tuple[dict[s
     return headers, token_source
 
 
+def resolve_timeout_seconds(registry: dict[str, Any], peer: dict[str, Any]) -> float:
+    timeout_ms = peer.get("timeoutMs", registry.get("timeoutMs", 600_000))
+    try:
+        timeout = float(timeout_ms) / 1000.0
+    except (TypeError, ValueError) as error:
+        raise PeerError("timeoutMs must be numeric") from error
+    if timeout <= 0:
+        raise PeerError("timeoutMs must be positive")
+    return timeout
+
+
 def request_json(
     registry: dict[str, Any],
     peer: dict[str, Any],
@@ -180,11 +191,7 @@ def request_json(
         headers["Content-Type"] = "application/json"
     timeout = timeout_seconds
     if timeout is None:
-        timeout_ms = peer.get("timeoutMs", registry.get("timeoutMs", 600_000))
-        try:
-            timeout = float(timeout_ms) / 1000.0
-        except (TypeError, ValueError) as error:
-            raise PeerError("timeoutMs must be numeric") from error
+        timeout = resolve_timeout_seconds(registry, peer)
     if timeout <= 0:
         raise PeerError("timeoutMs must be positive")
     request = Request(
@@ -312,13 +319,15 @@ def wait_for_task(
     deadline = time.monotonic() + max_wait_seconds
     latest_payload: dict[str, Any] = {}
     latest_state = "unknown"
+    default_timeout_seconds = None if timeout_seconds is not None else resolve_timeout_seconds(registry, peer)
+    poll_timeout_seconds = timeout_seconds if timeout_seconds is not None else default_timeout_seconds
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise PeerError(
                 f"task {task_id!r} did not finish within {max_wait_seconds:g}s; latest state: {latest_state}"
             )
-        request_timeout = remaining if timeout_seconds is None else min(timeout_seconds, remaining)
+        request_timeout = min(poll_timeout_seconds, remaining)
         try:
             latest_payload = request_json(
                 registry,

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -108,6 +108,28 @@ describe("codex-a2a-peer", () => {
 					);
 					return;
 				}
+				if (messageText === "slow ack") {
+					await new Promise((resolveSlow) => setTimeout(resolveSlow, 100));
+					response.end(
+						JSON.stringify({
+							task: {
+								id: "task-wait",
+								contextId: "ctx-1",
+								status: {
+									state: "TASK_STATE_WORKING",
+									message: {
+										role: "ROLE_AGENT",
+										parts: [{ text: "slow ack", mediaType: "text/plain" }],
+									},
+								},
+								artifacts: [],
+								history: [],
+								metadata: {},
+							},
+						}),
+					);
+					return;
+				}
 				const isAsyncWaitTask =
 					messageText === "slow work" &&
 					parsedBody?.configuration?.returnImmediately === true;
@@ -574,16 +596,16 @@ describe("codex-a2a-peer", () => {
 		expect(requests.some((item) => item.url === "/tasks/task-slow")).toBe(true);
 	});
 
-	it("caps default wait poll timeouts to the configured peer timeout", async () => {
+	it("preserves configured timeoutMs while capping wait poll deadlines", async () => {
 		writeFileSync(
 			configPath,
 			JSON.stringify({
 				defaultPeer: "mock",
-				tokenEnv: "TEST_A2A_PEER_TOKEN",
 				timeoutMs: 20,
 				peers: {
 					mock: {
-						url: `${baseUrl}/message:send`,
+						url: baseUrl,
+						tokenEnv: "TEST_A2A_PEER_TOKEN",
 					},
 				},
 			}),
@@ -592,23 +614,80 @@ describe("codex-a2a-peer", () => {
 		await expect(
 			runPeer(
 				configPath,
-				[
-					"wait",
-					"mock",
-					"task-slow",
-					"--interval",
-					"0.01",
-					"--max-wait",
-					"0.35",
-				],
+				["wait", "mock", "task-slow", "--interval", "0.01", "--max-wait", "1"],
 				{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
 			),
 		).rejects.toMatchObject({
 			stderr: expect.stringContaining("GET /tasks/task-slow timed out"),
 		});
-		expect(
-			requests.filter((item) => item.url === "/tasks/task-slow"),
-		).toHaveLength(1);
+		await expect(
+			runPeer(
+				configPath,
+				["wait", "mock", "task-slow", "--interval", "0.01", "--max-wait", "1"],
+				{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+			),
+		).rejects.not.toMatchObject({
+			stderr: expect.stringContaining("Traceback"),
+		});
+		expect(requests.some((item) => item.url === "/tasks/task-slow")).toBe(true);
+	});
+
+	it("caps the initial send --wait request to the max-wait deadline", async () => {
+		await expect(
+			runPeer(
+				configPath,
+				[
+					"send",
+					"--wait",
+					"--max-wait",
+					"0.05",
+					"--timeout",
+					"10",
+					"mock",
+					"slow",
+					"ack",
+				],
+				{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+			),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining(
+				"message:send did not finish within 0.05s",
+			),
+		});
+		expect(requests.some((item) => item.url === "/message:send")).toBe(true);
+		expect(requests.some((item) => item.url?.startsWith("/tasks/"))).toBe(
+			false,
+		);
+	});
+
+	it("preserves configured timeoutMs for the initial send --wait request", async () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				defaultPeer: "mock",
+				timeoutMs: 20,
+				peers: {
+					mock: {
+						url: baseUrl,
+						tokenEnv: "TEST_A2A_PEER_TOKEN",
+					},
+				},
+			}),
+		);
+
+		await expect(
+			runPeer(
+				configPath,
+				["send", "--wait", "--max-wait", "1", "mock", "slow", "ack"],
+				{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+			),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("POST /message:send timed out"),
+		});
+		expect(requests.some((item) => item.url === "/message:send")).toBe(true);
+		expect(requests.some((item) => item.url?.startsWith("/tasks/"))).toBe(
+			false,
+		);
 	});
 
 	it("rejects non-finite wait arguments before sending", async () => {

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -574,6 +574,43 @@ describe("codex-a2a-peer", () => {
 		expect(requests.some((item) => item.url === "/tasks/task-slow")).toBe(true);
 	});
 
+	it("caps default wait poll timeouts to the configured peer timeout", async () => {
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				defaultPeer: "mock",
+				tokenEnv: "TEST_A2A_PEER_TOKEN",
+				timeoutMs: 20,
+				peers: {
+					mock: {
+						url: `${baseUrl}/message:send`,
+					},
+				},
+			}),
+		);
+
+		await expect(
+			runPeer(
+				configPath,
+				[
+					"wait",
+					"mock",
+					"task-slow",
+					"--interval",
+					"0.01",
+					"--max-wait",
+					"0.35",
+				],
+				{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+			),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("GET /tasks/task-slow timed out"),
+		});
+		expect(
+			requests.filter((item) => item.url === "/tasks/task-slow"),
+		).toHaveLength(1);
+	});
+
 	it("rejects non-finite wait arguments before sending", async () => {
 		await expect(
 			runPeer(configPath, ["wait", "mock", "task-1", "--max-wait", "inf"], {

--- a/test/scripts/codex-a2a-peer.test.ts
+++ b/test/scripts/codex-a2a-peer.test.ts
@@ -49,9 +49,11 @@ describe("codex-a2a-peer", () => {
 	let baseUrl: string;
 	let configPath: string;
 	let requests: CapturedRequest[];
+	let waitTaskPolls: number;
 
 	beforeEach(async () => {
 		requests = [];
+		waitTaskPolls = 0;
 		server = createServer(async (request, response) => {
 			const body = await readBody(request);
 			requests.push({
@@ -93,13 +95,33 @@ describe("codex-a2a-peer", () => {
 				return;
 			}
 			if (request.url === "/message:send") {
+				const parsedBody = JSON.parse(body || "{}");
+				const messageText = parsedBody?.message?.parts?.[0]?.text ?? "";
+				if (messageText === "direct message") {
+					response.end(
+						JSON.stringify({
+							message: {
+								role: "ROLE_AGENT",
+								parts: [{ text: "direct response", mediaType: "text/plain" }],
+							},
+						}),
+					);
+					return;
+				}
+				const isAsyncWaitTask =
+					messageText === "slow work" &&
+					parsedBody?.configuration?.returnImmediately === true;
+				const taskId = isAsyncWaitTask ? "task-wait" : "task-1";
+				const state = isAsyncWaitTask
+					? "TASK_STATE_WORKING"
+					: "TASK_STATE_COMPLETED";
 				response.end(
 					JSON.stringify({
 						task: {
-							id: "task-1",
+							id: taskId,
 							contextId: "ctx-1",
 							status: {
-								state: "TASK_STATE_COMPLETED",
+								state,
 								message: {
 									role: "ROLE_AGENT",
 									parts: [{ text: "hello from peer", mediaType: "text/plain" }],
@@ -108,6 +130,85 @@ describe("codex-a2a-peer", () => {
 							artifacts: [],
 							history: [],
 							metadata: {},
+						},
+					}),
+				);
+				return;
+			}
+			if (request.url === "/tasks/task-wait") {
+				waitTaskPolls += 1;
+				const completed = waitTaskPolls >= 2;
+				response.end(
+					JSON.stringify({
+						id: "task-wait",
+						contextId: "ctx-1",
+						status: {
+							state: completed ? "TASK_STATE_COMPLETED" : "TASK_STATE_WORKING",
+							message: {
+								role: "ROLE_AGENT",
+								parts: [
+									{
+										text: completed ? "done after wait" : "still working",
+										mediaType: "text/plain",
+									},
+								],
+							},
+						},
+					}),
+				);
+				return;
+			}
+			if (request.url === "/tasks/task-lowercase") {
+				waitTaskPolls += 1;
+				const completed = waitTaskPolls >= 2;
+				response.end(
+					JSON.stringify({
+						id: "task-lowercase",
+						contextId: "ctx-1",
+						status: {
+							state: completed ? "completed" : "working",
+							message: {
+								role: "ROLE_AGENT",
+								parts: [
+									{
+										text: completed ? "lowercase done" : "lowercase active",
+										mediaType: "text/plain",
+									},
+								],
+							},
+						},
+					}),
+				);
+				return;
+			}
+			if (request.url === "/tasks/task-slow") {
+				await new Promise((resolveSlow) => setTimeout(resolveSlow, 100));
+				response.end(
+					JSON.stringify({
+						id: "task-slow",
+						contextId: "ctx-1",
+						status: {
+							state: "TASK_STATE_WORKING",
+							message: {
+								role: "ROLE_AGENT",
+								parts: [{ text: "slow poll", mediaType: "text/plain" }],
+							},
+						},
+					}),
+				);
+				return;
+			}
+			if (request.url === "/tasks/task-never") {
+				response.end(
+					JSON.stringify({
+						id: "task-never",
+						contextId: "ctx-1",
+						status: {
+							state: "TASK_STATE_WORKING",
+							message: {
+								role: "ROLE_AGENT",
+								parts: [{ text: "still working", mediaType: "text/plain" }],
+							},
 						},
 					}),
 				);
@@ -328,6 +429,185 @@ describe("codex-a2a-peer", () => {
 				metadata: { relayPeer: "mock" },
 			},
 		});
+	});
+
+	it("sends async work and waits for the returned task to settle", async () => {
+		const output = await runPeer(
+			configPath,
+			[
+				"send",
+				"--wait",
+				"--wait-interval",
+				"0.01",
+				"--max-wait",
+				"1",
+				"mock",
+				"slow",
+				"work",
+			],
+			{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+		);
+
+		expect(output).toContain("task: task-wait");
+		expect(output).toContain("state: TASK_STATE_COMPLETED");
+		expect(output).toContain("done after wait");
+		const sendRequest = requests.find((item) => item.url === "/message:send");
+		expect(JSON.parse(sendRequest?.body ?? "{}")).toMatchObject({
+			configuration: { returnImmediately: true },
+		});
+		expect(
+			requests.filter((item) => item.url === "/tasks/task-wait"),
+		).toHaveLength(2);
+	});
+
+	it("prints direct message responses for send --wait without requiring a task id", async () => {
+		const output = await runPeer(
+			configPath,
+			["send", "--wait", "mock", "direct", "message"],
+			{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+		);
+
+		expect(output).toContain("direct response");
+		expect(
+			requests.filter((item) => item.url?.startsWith("/tasks/")),
+		).toHaveLength(0);
+	});
+
+	it("waits for an existing peer task to settle", async () => {
+		const output = await runPeer(
+			configPath,
+			["wait", "mock", "task-wait", "--interval", "0.01", "--max-wait", "1"],
+			{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+		);
+
+		expect(output).toContain("task: task-wait");
+		expect(output).toContain("state: TASK_STATE_COMPLETED");
+		expect(output).toContain("done after wait");
+		expect(
+			requests.filter((item) => item.url === "/tasks/task-wait"),
+		).toHaveLength(2);
+	});
+
+	it("treats lowercase A2A active states as still waiting", async () => {
+		const output = await runPeer(
+			configPath,
+			[
+				"wait",
+				"mock",
+				"task-lowercase",
+				"--interval",
+				"0.01",
+				"--max-wait",
+				"1",
+			],
+			{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+		);
+
+		expect(output).toContain("task: task-lowercase");
+		expect(output).toContain("state: completed");
+		expect(output).toContain("lowercase done");
+		expect(
+			requests.filter((item) => item.url === "/tasks/task-lowercase"),
+		).toHaveLength(2);
+	});
+
+	it("fails bounded waits without a traceback when a task keeps working", async () => {
+		await expect(
+			runPeer(
+				configPath,
+				[
+					"wait",
+					"mock",
+					"task-never",
+					"--interval",
+					"0.01",
+					"--max-wait",
+					"0.02",
+				],
+				{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+			),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("did not finish within 0.02s"),
+		});
+		await expect(
+			runPeer(
+				configPath,
+				[
+					"wait",
+					"mock",
+					"task-never",
+					"--interval",
+					"0.01",
+					"--max-wait",
+					"0.02",
+				],
+				{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+			),
+		).rejects.not.toMatchObject({
+			stderr: expect.stringContaining("Traceback"),
+		});
+		expect(requests.some((item) => item.url === "/tasks/task-never")).toBe(
+			true,
+		);
+	});
+
+	it("caps each wait poll to the remaining max-wait deadline", async () => {
+		await expect(
+			runPeer(
+				configPath,
+				[
+					"wait",
+					"mock",
+					"task-slow",
+					"--interval",
+					"0.01",
+					"--max-wait",
+					"0.05",
+					"--timeout",
+					"10",
+				],
+				{ TEST_A2A_PEER_TOKEN: "super-secret-token" },
+			),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("did not finish within 0.05s"),
+		});
+		expect(requests.some((item) => item.url === "/tasks/task-slow")).toBe(true);
+	});
+
+	it("rejects non-finite wait arguments before sending", async () => {
+		await expect(
+			runPeer(configPath, ["wait", "mock", "task-1", "--max-wait", "inf"], {
+				TEST_A2A_PEER_TOKEN: "super-secret-token",
+			}),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("must be finite"),
+		});
+		await expect(
+			runPeer(configPath, ["wait", "mock", "task-1", "--interval", "nan"], {
+				TEST_A2A_PEER_TOKEN: "super-secret-token",
+			}),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("must be finite"),
+		});
+		await expect(
+			runPeer(configPath, ["wait", "mock", "task-1", "--timeout", "nan"], {
+				TEST_A2A_PEER_TOKEN: "super-secret-token",
+			}),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("must be finite"),
+		});
+		await expect(
+			runPeer(
+				configPath,
+				["send", "--peer", "mock", "--wait", "--timeout", "inf", "hello"],
+				{
+					TEST_A2A_PEER_TOKEN: "super-secret-token",
+				},
+			),
+		).rejects.toMatchObject({
+			stderr: expect.stringContaining("must be finite"),
+		});
+		expect(requests).toHaveLength(0);
 	});
 
 	it("cancels a peer task with A2A headers", async () => {


### PR DESCRIPTION
## Summary
- Add a bounded `wait` command for polling A2A peer tasks until they settle.
- Add `send --wait` / `relay --wait` so callers can request async execution and collect the final task result without manual polling.
- Document bounded wait behavior and cover completion/timeout paths in the peer CLI tests.

Internal counterparts: evalops/maestro-internal#1957, evalops/maestro-internal#1959, and evalops/maestro-internal#1961.

## Test plan
- `python3 -m py_compile scripts/codex-a2a-peer.py`
- `node ./scripts/run-vitest.js --run test/scripts/codex-a2a-peer.test.ts`
- `bunx biome check scripts/codex-a2a-peer.py test/scripts/codex-a2a-peer.test.ts docs/protocols/codex-a2a-peer-relay.md`
- `bash scripts/guardian.sh --trigger pre-commit`
- Commit hook full build/codegen checks