### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/codex-operating-layer.json
+++ b/docs/protocols/codex-operating-layer.json
@@ -228,6 +228,7 @@
 				"agent-registry-delegation",
 				"ownerChildRunId",
 				"parentWorkItemId",
+				"codex_work_graph",
 				"recordCodexSubagentWorkItem",
 				"updateCodexSubagentWorkItem",
 				"PlatformAgentWorkItemKindValue.ChildRun",
@@ -238,13 +239,25 @@
 			"area": "multi-agent-workgraph",
 			"evidenceType": "source",
 			"path": "src/agent/providers/codex-app-server.ts",
-			"anchors": ["childRunIds", "codexCollabChildRunIds"]
+			"anchors": [
+				"childRunIds",
+				"codexWorkGraph",
+				"evalops.maestro.codex.subagent-workgraph.v1",
+				"codexCollabWorkGraph",
+				"codexCollabChildRunIds"
+			]
 		},
 		{
 			"area": "multi-agent-workgraph",
 			"evidenceType": "source",
 			"path": "packages/control-plane-rs/src/main.rs",
-			"anchors": ["childRunIds", "codex_collab_child_run_ids_from_item"]
+			"anchors": [
+				"childRunIds",
+				"codexWorkGraph",
+				"evalops.maestro.codex.subagent-workgraph.v1",
+				"codex_collab_work_graph_from_jsonl_item",
+				"codex_collab_child_run_ids_from_item"
+			]
 		},
 		{
 			"area": "multi-agent-workgraph",
@@ -257,6 +270,7 @@
 				"codex.subagent.spawnAgent",
 				"ownerChildRunId",
 				"parentWorkItemId",
+				"codex_work_graph",
 				"PlatformAgentWorkItemKindValue.ChildRun",
 				"PlatformAgentWorkItemStateValue.Succeeded"
 			]
@@ -394,9 +408,14 @@
 			"anchors": [
 				"doctor",
 				"real inference with dynamic read tool",
+				"real inference with Codex subagent",
 				"loop_detected",
 				"expected token",
 				"assertBoundedDynamicToolUse",
+				"assertSubagentWorkGraphUse",
+				"codex.subagent.spawnAgent",
+				"codex.subagent.wait",
+				"codexWorkGraph",
 				"MAESTRO_CODEX_LIVE_SMOKE_MAX_IDENTICAL_TOOL_CALLS"
 			]
 		},
@@ -408,7 +427,13 @@
 				"summarizes Codex dynamic callbacks by operation args, not volatile IDs",
 				"rejects live transcripts with loop-detector warnings",
 				"rejects repeated identical dynamic tool calls",
-				"requires the final assistant message to exactly match the token"
+				"requires the final assistant message to exactly match the token",
+				"accepts a subagent spawn/wait transcript with work-graph evidence",
+				"rejects subagent transcripts missing work-graph evidence",
+				"requires wait evidence to target the spawned child run",
+				"requires structured completed status for the waited child",
+				"requires exactly one spawn and one wait operation",
+				"requires the live subagent proof to wait for the child agent"
 			]
 		},
 		{

--- a/docs/protocols/codex-operating-layer.md
+++ b/docs/protocols/codex-operating-layer.md
@@ -81,7 +81,9 @@ uses JSONL output to verify that the final assistant message exactly matches the
 token, fails on loop-detector warnings, runs the real inference from an isolated
 temporary workspace, and enforces bounded dynamic tool calls with
 `MAESTRO_CODEX_LIVE_SMOKE_MAX_TOTAL_TOOL_CALLS` and
-`MAESTRO_CODEX_LIVE_SMOKE_MAX_IDENTICAL_TOOL_CALLS`.
+`MAESTRO_CODEX_LIVE_SMOKE_MAX_IDENTICAL_TOOL_CALLS`. It also runs real Codex
+subagent spawn/wait inference and requires `codexWorkGraph` evidence on both
+`codex.subagent.spawnAgent` and `codex.subagent.wait`.
 
 ## Completion Bar
 

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -54,6 +54,7 @@ const A2A_PROTOCOL_VERSION: &str = "1.0";
 const A2A_DEFAULT_TURN_TIMEOUT_MS: u64 = 180_000;
 const A2A_DEFAULT_RESPONSE_END_SETTLE_MS: u64 = 250;
 const A2A_TERMINAL_TASK_STORE_LIMIT: usize = 128;
+const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA: &str = "evalops.maestro.codex.subagent-workgraph.v1";
 static CODEX_BRIDGE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static CODEX_HEADLESS_RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
 static ATTACHMENT_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -5247,12 +5248,16 @@ fn codex_collab_tool_event_from_jsonl_item(
 }
 
 fn codex_collab_args_from_jsonl_item(item: &Value, canonical_tool: &str) -> Value {
+    let child_run_ids = codex_collab_child_run_ids_from_item(item);
+    let codex_work_graph =
+        codex_collab_work_graph_from_jsonl_item(item, canonical_tool, &child_run_ids);
     serde_json::json!({
         "codexTool": canonical_tool,
         "status": item.get("status").cloned().unwrap_or(Value::Null),
         "senderThreadId": item.get("sender_thread_id").cloned().unwrap_or(Value::Null),
         "receiverThreadIds": item.get("receiver_thread_ids").cloned().unwrap_or_else(|| Value::Array(Vec::new())),
-        "childRunIds": codex_collab_child_run_ids_from_item(item),
+        "childRunIds": child_run_ids,
+        "codexWorkGraph": codex_work_graph,
         "prompt": item.get("prompt").cloned().unwrap_or(Value::Null),
         "model": item.get("model").cloned().unwrap_or(Value::Null),
         "reasoningEffort": item.get("reasoning_effort").cloned().unwrap_or(Value::Null),
@@ -5289,6 +5294,62 @@ fn codex_collab_child_run_ids_from_item(item: &Value) -> Value {
     Value::Array(child_run_ids)
 }
 
+fn codex_collab_work_graph_from_jsonl_item(
+    item: &Value,
+    canonical_tool: &str,
+    child_run_ids: &Value,
+) -> Value {
+    let receiver_thread_ids = item
+        .get("receiver_thread_ids")
+        .and_then(Value::as_array)
+        .map(|ids| {
+            ids.iter()
+                .filter_map(Value::as_str)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let child_run_ids = child_run_ids
+        .as_array()
+        .map(|ids| {
+            ids.iter()
+                .filter_map(Value::as_str)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let child_runs = receiver_thread_ids
+        .iter()
+        .enumerate()
+        .map(|(index, thread_id)| {
+            let child_run_id = child_run_ids
+                .get(index)
+                .cloned()
+                .unwrap_or_else(|| format!("codex-thread:{thread_id}"));
+            serde_json::json!({
+                "threadId": thread_id,
+                "childRunId": child_run_id,
+                "operation": canonical_tool,
+            })
+        })
+        .collect::<Vec<_>>();
+    let sender_thread_id = item.get("sender_thread_id").cloned().unwrap_or(Value::Null);
+    serde_json::json!({
+        "schemaVersion": CODEX_SUBAGENT_WORK_GRAPH_SCHEMA,
+        "toolCallId": item.get("id").cloned().unwrap_or(Value::Null),
+        "tool": canonical_tool,
+        "status": item.get("status").cloned().unwrap_or(Value::Null),
+        "parent": {
+            "threadId": sender_thread_id.clone(),
+            "turnId": item.get("turn_id").cloned().unwrap_or(Value::Null),
+            "senderThreadId": sender_thread_id,
+        },
+        "childRuns": child_runs,
+    })
+}
+
 fn codex_bridge_tool_args(tool_name: &str, args: Value) -> Value {
     if !tool_name.starts_with("codex.subagent.") {
         return args;
@@ -5304,34 +5365,109 @@ fn codex_bridge_tool_args(tool_name: &str, args: Value) -> Value {
             ids.iter()
                 .any(|id| id.as_str().is_some_and(|id| !id.is_empty()))
         });
-    if has_child_run_ids {
-        return Value::Object(object);
-    }
-    if let Some(ids) = object.get("child_run_ids").and_then(Value::as_array) {
-        let child_run_ids = ids
-            .iter()
-            .filter_map(Value::as_str)
-            .filter(|id| !id.is_empty())
-            .map(|id| Value::String(id.to_string()))
-            .collect::<Vec<_>>();
-        if !child_run_ids.is_empty() {
-            object.insert("childRunIds".to_string(), Value::Array(child_run_ids));
-            return Value::Object(object);
+    if !has_child_run_ids {
+        if let Some(ids) = object.get("child_run_ids").and_then(Value::as_array) {
+            let child_run_ids = ids
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|id| !id.is_empty())
+                .map(|id| Value::String(id.to_string()))
+                .collect::<Vec<_>>();
+            if !child_run_ids.is_empty() {
+                object.insert("childRunIds".to_string(), Value::Array(child_run_ids));
+            }
         }
     }
-    let child_run_ids = object
+    let has_child_run_ids = object
+        .get("childRunIds")
+        .and_then(Value::as_array)
+        .is_some_and(|ids| {
+            ids.iter()
+                .any(|id| id.as_str().is_some_and(|id| !id.is_empty()))
+        });
+    if !has_child_run_ids {
+        let child_run_ids = object
+            .get("receiverThreadIds")
+            .and_then(Value::as_array)
+            .map(|ids| {
+                ids.iter()
+                    .filter_map(Value::as_str)
+                    .filter(|id| !id.is_empty())
+                    .map(|id| Value::String(format!("codex-thread:{id}")))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        object.insert("childRunIds".to_string(), Value::Array(child_run_ids));
+    }
+    let has_work_graph = object
+        .get("codexWorkGraph")
+        .or_else(|| object.get("codex_work_graph"))
+        .and_then(Value::as_object)
+        .is_some();
+    if !has_work_graph {
+        object.insert(
+            "codexWorkGraph".to_string(),
+            codex_collab_work_graph_from_args_object(tool_name, &object),
+        );
+    }
+    Value::Object(object)
+}
+
+fn codex_collab_work_graph_from_args_object(tool_name: &str, object: &Map<String, Value>) -> Value {
+    let canonical_tool = object
+        .get("codexTool")
+        .and_then(Value::as_str)
+        .or_else(|| tool_name.strip_prefix("codex.subagent."))
+        .unwrap_or(tool_name);
+    let receiver_thread_ids = object
         .get("receiverThreadIds")
         .and_then(Value::as_array)
         .map(|ids| {
             ids.iter()
                 .filter_map(Value::as_str)
                 .filter(|id| !id.is_empty())
-                .map(|id| Value::String(format!("codex-thread:{id}")))
+                .map(str::to_string)
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
-    object.insert("childRunIds".to_string(), Value::Array(child_run_ids));
-    Value::Object(object)
+    let child_run_ids = object
+        .get("childRunIds")
+        .and_then(Value::as_array)
+        .map(|ids| {
+            ids.iter()
+                .filter_map(Value::as_str)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let child_runs = receiver_thread_ids
+        .iter()
+        .enumerate()
+        .map(|(index, thread_id)| {
+            let child_run_id = child_run_ids
+                .get(index)
+                .cloned()
+                .unwrap_or_else(|| format!("codex-thread:{thread_id}"));
+            serde_json::json!({
+                "threadId": thread_id,
+                "childRunId": child_run_id,
+                "operation": canonical_tool,
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "schemaVersion": CODEX_SUBAGENT_WORK_GRAPH_SCHEMA,
+        "toolCallId": object.get("toolCallId").cloned().unwrap_or(Value::Null),
+        "tool": canonical_tool,
+        "status": object.get("status").cloned().unwrap_or(Value::Null),
+        "parent": {
+            "threadId": object.get("threadId").cloned().unwrap_or(Value::Null),
+            "turnId": object.get("turnId").cloned().unwrap_or(Value::Null),
+            "senderThreadId": object.get("senderThreadId").cloned().unwrap_or(Value::Null),
+        },
+        "childRuns": child_runs,
+    })
 }
 
 fn codex_canonical_collab_tool(tool: &str) -> String {
@@ -8561,8 +8697,20 @@ mod tests {
             output.tool_events[0].args["childRunIds"],
             serde_json::json!(["codex-thread:thread-child"])
         );
+        assert_eq!(
+            output.tool_events[0].args["codexWorkGraph"]["schemaVersion"],
+            CODEX_SUBAGENT_WORK_GRAPH_SCHEMA
+        );
+        assert_eq!(
+            output.tool_events[0].args["codexWorkGraph"]["childRuns"][0]["childRunId"],
+            "codex-thread:thread-child"
+        );
         assert_eq!(output.tool_events[1].event_type, "tool_execution_end");
         assert_eq!(output.tool_events[1].is_error, Some(false));
+        assert_eq!(
+            output.tool_events[1].result["details"]["codexWorkGraph"]["status"],
+            "completed"
+        );
         assert_eq!(
             output.tool_events[1].result["details"]["agentsStates"]["thread-child"]["status"],
             "completed"
@@ -8588,6 +8736,10 @@ mod tests {
             output.tool_events[1].result["details"]["childRunIds"],
             serde_json::json!(["agent-run-child-1"])
         );
+        assert_eq!(
+            output.tool_events[1].result["details"]["codexWorkGraph"]["childRuns"][0]["childRunId"],
+            "agent-run-child-1"
+        );
     }
 
     #[test]
@@ -8603,6 +8755,10 @@ mod tests {
 
         assert_eq!(output.tool_events.len(), 2);
         assert_eq!(output.tool_events[0].tool_name, "codex.subagent.wait");
+        assert_eq!(
+            output.tool_events[0].args["codexWorkGraph"]["childRuns"][0]["childRunId"],
+            "codex-thread:thread-child"
+        );
         assert_eq!(output.tool_events[1].is_error, Some(false));
         assert_eq!(
             output.tool_events[1].result["content"][0]["text"],
@@ -9095,6 +9251,10 @@ rl.on("line", (line) => {
         assert_eq!(start["args"]["receiverThreadIds"][0], "child-thread-ws");
         assert_eq!(
             start["args"]["childRunIds"][0],
+            "codex-thread:child-thread-ws"
+        );
+        assert_eq!(
+            start["args"]["codexWorkGraph"]["childRuns"][0]["childRunId"],
             "codex-thread:child-thread-ws"
         );
         assert_eq!(end["toolCallId"], "collab-call-ws");

--- a/scripts/smoke-codex-app-server-live.mjs
+++ b/scripts/smoke-codex-app-server-live.mjs
@@ -16,6 +16,8 @@ const baseEnv = {
 
 const DEFAULT_MAX_TOTAL_TOOL_CALLS = 3;
 const DEFAULT_MAX_IDENTICAL_TOOL_CALLS = 1;
+const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA =
+	"evalops.maestro.codex.subagent-workgraph.v1";
 
 const loopWarningPatterns = [
 	/Exact repetition loop detected/i,
@@ -96,7 +98,6 @@ function stableJson(value) {
 			left.localeCompare(right),
 		);
 		return `{${entries
-			.filter(([, entryValue]) => entryValue !== undefined)
 			.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableJson(entryValue)}`)
 			.join(",")}}`;
 	}
@@ -171,13 +172,7 @@ function findLoopWarningText(output) {
 	return null;
 }
 
-export function assertBoundedDynamicToolUse({
-	stdout,
-	stderr = "",
-	expectedToken,
-	maxTotalToolCalls = DEFAULT_MAX_TOTAL_TOOL_CALLS,
-	maxIdenticalToolCalls = DEFAULT_MAX_IDENTICAL_TOOL_CALLS,
-}) {
+function assertNoLoopWarnings(stdout, stderr = "") {
 	const combinedOutput = `${stdout}\n${stderr}`;
 	const warningText = findLoopWarningText(combinedOutput);
 	if (warningText) {
@@ -185,6 +180,16 @@ export function assertBoundedDynamicToolUse({
 			`Codex live smoke emitted a loop warning: ${warningText}`,
 		);
 	}
+}
+
+export function assertBoundedDynamicToolUse({
+	stdout,
+	stderr = "",
+	expectedToken,
+	maxTotalToolCalls = DEFAULT_MAX_TOTAL_TOOL_CALLS,
+	maxIdenticalToolCalls = DEFAULT_MAX_IDENTICAL_TOOL_CALLS,
+}) {
+	assertNoLoopWarnings(stdout, stderr);
 
 	const events = parseJsonlEvents(stdout);
 	const finalAssistantText = getFinalAssistantText(events).trim();
@@ -209,6 +214,262 @@ export function assertBoundedDynamicToolUse({
 		);
 	}
 	return summary;
+}
+
+function toolEvents(events, subtype, toolName) {
+	return events.filter(
+		(event) =>
+			event?.type === "item" &&
+			event.subtype === subtype &&
+			event.data?.toolName === toolName,
+	);
+}
+
+function toolResultDetails(event) {
+	const result = event?.data?.result;
+	if (isRecord(result) && isRecord(result.details)) {
+		return result.details;
+	}
+	const data = event?.data;
+	if (isRecord(data) && isRecord(data.details)) {
+		return data.details;
+	}
+	return {};
+}
+
+function assertCodexWorkGraph(
+	graph,
+	label,
+	expectedTool,
+	{ allowEmptyChildRuns = false } = {},
+) {
+	if (!isRecord(graph)) {
+		throw new Error(`${label} is missing codexWorkGraph`);
+	}
+	if (graph.schemaVersion !== CODEX_SUBAGENT_WORK_GRAPH_SCHEMA) {
+		throw new Error(
+			`${label} has unexpected codexWorkGraph schema ${JSON.stringify(graph.schemaVersion)}`,
+		);
+	}
+	if (graph.tool !== expectedTool) {
+		throw new Error(
+			`${label} has unexpected codexWorkGraph tool ${JSON.stringify(graph.tool)}`,
+		);
+	}
+	if (typeof graph.toolCallId !== "string" || graph.toolCallId.length === 0) {
+		throw new Error(`${label} codexWorkGraph is missing toolCallId`);
+	}
+	if (!Array.isArray(graph.childRuns)) {
+		throw new Error(`${label} codexWorkGraph is missing childRuns`);
+	}
+	if (!allowEmptyChildRuns && graph.childRuns.length === 0) {
+		throw new Error(`${label} codexWorkGraph is missing childRuns`);
+	}
+	for (const [index, childRun] of graph.childRuns.entries()) {
+		if (!isRecord(childRun)) {
+			throw new Error(`${label} childRuns[${index}] is not an object`);
+		}
+		for (const key of ["threadId", "childRunId", "operation"]) {
+			if (typeof childRun[key] !== "string" || childRun[key].length === 0) {
+				throw new Error(`${label} childRuns[${index}] is missing ${key}`);
+			}
+		}
+	}
+	return graph.childRuns;
+}
+
+function assertToolCallWorkGraph(event, label, expectedTool, options) {
+	const args = event?.data?.args;
+	const graph = isRecord(args) ? args.codexWorkGraph : undefined;
+	return assertCodexWorkGraph(graph, label, expectedTool, options);
+}
+
+function assertToolResultWorkGraph(event, label, expectedTool, options) {
+	const details = toolResultDetails(event);
+	return assertCodexWorkGraph(
+		details.codexWorkGraph,
+		label,
+		expectedTool,
+		options,
+	);
+}
+
+function sortedChildRunIds(childRuns, label) {
+	const ids = childRuns.map((childRun) => childRun.childRunId).sort();
+	if (ids.length === 0) {
+		throw new Error(`${label} has no childRunIds`);
+	}
+	return ids;
+}
+
+function childRunIdsFromEvent(event) {
+	const args = event?.data?.args;
+	const details = toolResultDetails(event);
+	const ids = isRecord(args) ? args.childRunIds : details.childRunIds;
+	return Array.isArray(ids)
+		? ids.filter((id) => typeof id === "string" && id.length > 0).sort()
+		: [];
+}
+
+function formatIds(ids) {
+	return JSON.stringify([...ids].sort());
+}
+
+function assertSameChildRunIds(expectedIds, actualIds, label) {
+	if (
+		expectedIds.length !== actualIds.length ||
+		expectedIds.some((id, index) => id !== actualIds[index])
+	) {
+		throw new Error(
+			`${label} childRunIds ${formatIds(actualIds)} do not match spawned childRunIds ${formatIds(expectedIds)}`,
+		);
+	}
+}
+
+function assertEventTargetsSpawnedChildRuns(event, graphChildRuns, spawnedIds, label) {
+	const graphIds = sortedChildRunIds(graphChildRuns, `${label} codexWorkGraph`);
+	assertSameChildRunIds(spawnedIds, graphIds, `${label} codexWorkGraph`);
+
+	const eventIds = childRunIdsFromEvent(event);
+	if (eventIds.length > 0) {
+		assertSameChildRunIds(spawnedIds, eventIds, label);
+	}
+}
+
+function assertWaitResultHasCompletedAgentState(event, expectedChildRuns) {
+	const details = toolResultDetails(event);
+	const states = details.agentsStates;
+	if (!isRecord(states) || Object.keys(states).length === 0) {
+		throw new Error(
+			"codex.subagent.wait result is missing child agentsStates evidence",
+		);
+	}
+	for (const childRun of expectedChildRuns) {
+		const state = states[childRun.threadId];
+		if (!isRecord(state)) {
+			throw new Error(
+				`codex.subagent.wait result is missing child agent state for ${childRun.threadId}`,
+			);
+		}
+		if (state.status !== "completed") {
+			throw new Error(
+				`codex.subagent.wait child ${childRun.threadId} status ${JSON.stringify(state.status)} is not completed`,
+			);
+		}
+	}
+}
+
+function assertExactlyOneToolEvent(events, label) {
+	if (events.length !== 1) {
+		throw new Error(
+			`subagent smoke expected exactly one ${label}, received ${events.length}`,
+		);
+	}
+}
+
+export function assertSubagentWorkGraphUse({
+	stdout,
+	stderr = "",
+	expectedToken,
+}) {
+	assertNoLoopWarnings(stdout, stderr);
+
+	const events = parseJsonlEvents(stdout);
+	const finalAssistantText = getFinalAssistantText(events).trim();
+	if (finalAssistantText !== expectedToken) {
+		throw new Error(
+			`subagent smoke final assistant text did not exactly match expected token ${expectedToken}. Received ${JSON.stringify(finalAssistantText)}`,
+		);
+	}
+
+	const spawnCalls = toolEvents(
+		events,
+		"tool_call",
+		"codex.subagent.spawnAgent",
+	);
+	const spawnResults = toolEvents(
+		events,
+		"tool_result",
+		"codex.subagent.spawnAgent",
+	);
+	const waitCalls = toolEvents(events, "tool_call", "codex.subagent.wait");
+	const waitResults = toolEvents(events, "tool_result", "codex.subagent.wait");
+
+	assertExactlyOneToolEvent(
+		spawnCalls,
+		"codex.subagent.spawnAgent tool_call",
+	);
+	assertExactlyOneToolEvent(
+		spawnResults,
+		"codex.subagent.spawnAgent tool_result",
+	);
+	assertExactlyOneToolEvent(waitCalls, "codex.subagent.wait tool_call");
+	assertExactlyOneToolEvent(waitResults, "codex.subagent.wait tool_result");
+
+	const spawnCallChildRuns = assertToolCallWorkGraph(
+		spawnCalls[0],
+		"codex.subagent.spawnAgent tool_call",
+		"spawnAgent",
+		{ allowEmptyChildRuns: true },
+	);
+	const spawnResultChildRuns = assertToolResultWorkGraph(
+		spawnResults[0],
+		"codex.subagent.spawnAgent tool_result",
+		"spawnAgent",
+	);
+	const waitCallChildRuns = assertToolCallWorkGraph(
+		waitCalls[0],
+		"codex.subagent.wait tool_call",
+		"wait",
+	);
+	const waitResultChildRuns = assertToolResultWorkGraph(
+		waitResults[0],
+		"codex.subagent.wait tool_result",
+		"wait",
+	);
+	const spawnedIds = sortedChildRunIds(
+		spawnResultChildRuns,
+		"codex.subagent.spawnAgent tool_result codexWorkGraph",
+	);
+	if (spawnCallChildRuns.length > 0) {
+		assertEventTargetsSpawnedChildRuns(
+			spawnCalls[0],
+			spawnCallChildRuns,
+			spawnedIds,
+			"codex.subagent.spawnAgent tool_call",
+		);
+	}
+	assertEventTargetsSpawnedChildRuns(
+		spawnResults[0],
+		spawnResultChildRuns,
+		spawnedIds,
+		"codex.subagent.spawnAgent tool_result",
+	);
+	assertEventTargetsSpawnedChildRuns(
+		waitCalls[0],
+		waitCallChildRuns,
+		spawnedIds,
+		"codex.subagent.wait tool_call",
+	);
+	assertEventTargetsSpawnedChildRuns(
+		waitResults[0],
+		waitResultChildRuns,
+		spawnedIds,
+		"codex.subagent.wait tool_result",
+	);
+	assertWaitResultHasCompletedAgentState(waitResults[0], waitResultChildRuns);
+
+	return {
+		spawnCalls: spawnCalls.length,
+		spawnResults: spawnResults.length,
+		waitCalls: waitCalls.length,
+		waitResults: waitResults.length,
+		childRunCount:
+			spawnCallChildRuns.length +
+			spawnResultChildRuns.length +
+			waitCallChildRuns.length +
+			waitResultChildRuns.length,
+	};
 }
 
 export function main() {
@@ -255,6 +516,34 @@ export function main() {
 		console.log("[codex-live-smoke] real inference returned expected token");
 		console.log(
 			`[codex-live-smoke] dynamic tool calls bounded: total=${summary.totalCalls} unique=${summary.uniqueCalls} max_identical=${summary.maxIdenticalCalls}`,
+		);
+
+		const subagentToken = `codex-subagent-live-smoke-${Date.now().toString(36)}`;
+		const subagentResult = run(
+			"real inference with Codex subagent",
+			[
+				"--provider",
+				"openai-codex",
+				"--model",
+				"gpt-5.5",
+				"--mode",
+				"json",
+				"--no-session",
+				"--approval-mode",
+				"fail",
+				"--sandbox",
+				"read-only",
+				`Spawn exactly one Codex subagent with this child task: reply exactly ${subagentToken}. Wait for the subagent. Then reply exactly ${subagentToken} and nothing else.`,
+			],
+			{ cwd: tempDir, timeoutMs: 240_000 },
+		);
+		const subagentSummary = assertSubagentWorkGraphUse({
+			...subagentResult,
+			expectedToken: subagentToken,
+		});
+		console.log("[codex-live-smoke] subagent returned expected token");
+		console.log(
+			`[codex-live-smoke] subagent work graph observed: spawn=${subagentSummary.spawnCalls} wait=${subagentSummary.waitCalls} child_runs=${subagentSummary.childRunCount}`,
 		);
 	} finally {
 		rmSync(tempDir, { recursive: true, force: true });

--- a/src/agent/providers/codex-app-server.ts
+++ b/src/agent/providers/codex-app-server.ts
@@ -71,6 +71,8 @@ type CodexUserInput =
 
 const DEFAULT_TURN_TIMEOUT_MS = 30 * 60_000;
 const CODEX_THREAD_CHILD_RUN_PREFIX = "codex-thread:";
+const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA =
+	"evalops.maestro.codex.subagent-workgraph.v1";
 const CODEX_COLLAB_TOOLS = new Set([
 	"spawnAgent",
 	"sendInput",
@@ -91,6 +93,23 @@ type CodexCollabAgentToolCallItem = {
 	model: string | null;
 	reasoningEffort: string | null;
 	agentsStates: Record<string, unknown>;
+};
+
+type CodexSubagentWorkGraph = {
+	schemaVersion: typeof CODEX_SUBAGENT_WORK_GRAPH_SCHEMA;
+	toolCallId: string;
+	tool: string;
+	status: string;
+	parent: {
+		threadId: string;
+		turnId: string;
+		senderThreadId: string;
+	};
+	childRuns: Array<{
+		threadId: string;
+		childRunId: string;
+		operation: string;
+	}>;
 };
 
 export async function* streamCodexAppServer(
@@ -510,6 +529,7 @@ function codexCollabArgs(
 	item: CodexCollabAgentToolCallItem,
 	scope: { threadId: string; turnId: string },
 ): Record<string, unknown> {
+	const childRunIds = codexCollabChildRunIds(item);
 	return {
 		codexTool: item.tool,
 		status: item.status,
@@ -517,11 +537,36 @@ function codexCollabArgs(
 		turnId: scope.turnId,
 		senderThreadId: item.senderThreadId,
 		receiverThreadIds: item.receiverThreadIds,
-		childRunIds: codexCollabChildRunIds(item),
+		childRunIds,
+		codexWorkGraph: codexCollabWorkGraph(item, scope, childRunIds),
 		prompt: item.prompt,
 		model: item.model,
 		reasoningEffort: item.reasoningEffort,
 		agentsStates: item.agentsStates,
+	};
+}
+
+function codexCollabWorkGraph(
+	item: CodexCollabAgentToolCallItem,
+	scope: { threadId: string; turnId: string },
+	childRunIds: string[],
+): CodexSubagentWorkGraph {
+	return {
+		schemaVersion: CODEX_SUBAGENT_WORK_GRAPH_SCHEMA,
+		toolCallId: item.id,
+		tool: item.tool,
+		status: item.status,
+		parent: {
+			threadId: scope.threadId,
+			turnId: scope.turnId,
+			senderThreadId: item.senderThreadId,
+		},
+		childRuns: item.receiverThreadIds.map((threadId, index) => ({
+			threadId,
+			childRunId:
+				childRunIds[index] ?? `${CODEX_THREAD_CHILD_RUN_PREFIX}${threadId}`,
+			operation: item.tool,
+		})),
 	};
 }
 

--- a/src/server/hosted-agent-runtime-progress.ts
+++ b/src/server/hosted-agent-runtime-progress.ts
@@ -93,6 +93,10 @@ function objectKeys(value: unknown): string[] | undefined {
 	return keys.length > 0 ? keys : undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
 function stringArray(value: unknown): string[] {
 	if (!Array.isArray(value)) {
 		return [];
@@ -113,11 +117,66 @@ function codexThreadChildRunId(threadId: string): string {
 	return `${CODEX_THREAD_CHILD_RUN_PREFIX}${threadId}`;
 }
 
+function codexSubagentWorkGraph(
+	args: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+	const graph = args?.codexWorkGraph ?? args?.codex_work_graph;
+	return isRecord(graph) ? graph : undefined;
+}
+
+function codexSubagentWorkGraphChildRuns(
+	args: Record<string, unknown> | undefined,
+): Record<string, unknown>[] {
+	const graph = codexSubagentWorkGraph(args);
+	const childRuns = graph?.childRuns ?? graph?.child_runs;
+	if (!Array.isArray(childRuns)) {
+		return [];
+	}
+	return childRuns.filter(isRecord);
+}
+
+function codexSubagentReceiverThreadIds(
+	args: Record<string, unknown>,
+): string[] {
+	const explicit = stringArray(
+		args.receiverThreadIds ?? args.receiver_thread_ids,
+	);
+	if (explicit.length > 0) {
+		return explicit;
+	}
+	const graphThreadIds = codexSubagentWorkGraphChildRuns(args)
+		.map((childRun) => childRun.threadId ?? childRun.thread_id)
+		.filter(
+			(threadId): threadId is string =>
+				typeof threadId === "string" && threadId.length > 0,
+		);
+	return graphThreadIds;
+}
+
+function codexSubagentExplicitChildRunIds(
+	args: Record<string, unknown>,
+): string[] {
+	const explicit = stringArray(args.childRunIds ?? args.child_run_ids);
+	if (explicit.length > 0) {
+		return explicit;
+	}
+	const graphChildRunIds = codexSubagentWorkGraphChildRuns(args)
+		.map((childRun) => childRun.childRunId ?? childRun.child_run_id)
+		.filter(
+			(childRunId): childRunId is string =>
+				typeof childRunId === "string" && childRunId.length > 0,
+		);
+	if (graphChildRunIds.length > 0) {
+		return graphChildRunIds;
+	}
+	return [];
+}
+
 function codexSubagentChildRunIds(
 	args: Record<string, unknown>,
 	receiverThreadIds: string[],
 ): string[] {
-	const explicit = stringArray(args.childRunIds ?? args.child_run_ids);
+	const explicit = codexSubagentExplicitChildRunIds(args);
 	if (explicit.length > 0) {
 		return explicit;
 	}
@@ -204,6 +263,10 @@ export class HostedAgentRuntimeProgressRecorder {
 	private readonly resumedWaitIds = new Set<string>();
 	private readonly codexSubagentReceiverThreadIds = new Map<string, string[]>();
 	private readonly codexSubagentToolChildRunIds = new Map<string, string[]>();
+	private readonly codexSubagentToolWorkGraphs = new Map<
+		string,
+		Record<string, unknown>
+	>();
 	private readonly codexSubagentThreadWorkItemIds = new Map<string, string>();
 	private readonly codexSubagentDelegationIds = new Map<string, string>();
 	private pending: Promise<void> = Promise.resolve();
@@ -580,7 +643,8 @@ export class HostedAgentRuntimeProgressRecorder {
 		if (!this.hostedRunner?.enabled || !runId) {
 			return;
 		}
-		const receiverThreadIds = stringArray(event.args.receiverThreadIds);
+		const workGraph = codexSubagentWorkGraph(event.args);
+		const receiverThreadIds = codexSubagentReceiverThreadIds(event.args);
 		const childRunIds = codexSubagentChildRunIds(event.args, receiverThreadIds);
 		const ownerChildRunId = childRunIds[0];
 		const linkedWorkItemIds =
@@ -593,6 +657,9 @@ export class HostedAgentRuntimeProgressRecorder {
 			receiverThreadIds,
 		);
 		this.codexSubagentToolChildRunIds.set(event.toolCallId, childRunIds);
+		if (workGraph) {
+			this.codexSubagentToolWorkGraphs.set(event.toolCallId, workGraph);
+		}
 		if (codexTool === "spawnAgent") {
 			for (const threadId of receiverThreadIds) {
 				this.codexSubagentThreadWorkItemIds.set(threadId, workItemId);
@@ -637,6 +704,7 @@ export class HostedAgentRuntimeProgressRecorder {
 				receiver_thread_ids: receiverThreadIds,
 				receiver_thread_count: receiverThreadIds.length,
 				child_run_ids: childRunIds,
+				codex_work_graph: workGraph,
 				linked_work_item_ids: linkedWorkItemIds,
 				model,
 				reasoning_effort: reasoningEffort,
@@ -656,6 +724,7 @@ export class HostedAgentRuntimeProgressRecorder {
 				receiverThreadIds,
 				childRunIds,
 				linkedWorkItemIds,
+				workGraph,
 				prompt,
 				model,
 				reasoningEffort,
@@ -672,6 +741,7 @@ export class HostedAgentRuntimeProgressRecorder {
 		receiverThreadIds: string[];
 		childRunIds: string[];
 		linkedWorkItemIds: string[];
+		workGraph?: Record<string, unknown>;
 		prompt?: string;
 		model?: string;
 		reasoningEffort?: string;
@@ -704,6 +774,7 @@ export class HostedAgentRuntimeProgressRecorder {
 					sender_thread_id: nonEmptyString(input.event.args.senderThreadId),
 					receiver_thread_ids: input.receiverThreadIds,
 					child_run_ids: input.childRunIds,
+					codex_work_graph: input.workGraph,
 					linked_work_item_ids: input.linkedWorkItemIds,
 					prompt: input.prompt,
 					model: input.model,
@@ -739,14 +810,19 @@ export class HostedAgentRuntimeProgressRecorder {
 			!Array.isArray(event.result.details)
 				? (event.result.details as Record<string, unknown>)
 				: undefined;
-		const detailReceiverThreadIds = stringArray(details?.receiverThreadIds);
+		const detailWorkGraph = codexSubagentWorkGraph(details);
+		const workGraph =
+			detailWorkGraph ?? this.codexSubagentToolWorkGraphs.get(event.toolCallId);
+		const detailReceiverThreadIds = details
+			? codexSubagentReceiverThreadIds(details)
+			: [];
 		const receiverThreadIds =
 			detailReceiverThreadIds.length > 0
 				? detailReceiverThreadIds
 				: (this.codexSubagentReceiverThreadIds.get(event.toolCallId) ?? []);
-		const detailChildRunIds = stringArray(
-			details?.childRunIds ?? details?.child_run_ids,
-		);
+		const detailChildRunIds = details
+			? codexSubagentExplicitChildRunIds(details)
+			: [];
 		const childRunIds =
 			detailChildRunIds.length > 0
 				? detailChildRunIds
@@ -756,6 +832,7 @@ export class HostedAgentRuntimeProgressRecorder {
 			this.codexSubagentLinkedWorkItemIds(receiverThreadIds);
 		this.codexSubagentReceiverThreadIds.delete(event.toolCallId);
 		this.codexSubagentToolChildRunIds.delete(event.toolCallId);
+		this.codexSubagentToolWorkGraphs.delete(event.toolCallId);
 		if (codexTool === "closeAgent" && !event.isError) {
 			for (const threadId of receiverThreadIds) {
 				this.codexSubagentThreadWorkItemIds.delete(threadId);
@@ -768,6 +845,7 @@ export class HostedAgentRuntimeProgressRecorder {
 			const delegationEvidenceRefs = delegationId
 				? [`agent-registry-delegation:${delegationId}`]
 				: [];
+			let updateError: unknown;
 			try {
 				await this.operations.updateWorkItem({
 					runId,
@@ -799,50 +877,56 @@ export class HostedAgentRuntimeProgressRecorder {
 						result_error: event.isError,
 						receiver_thread_ids: receiverThreadIds,
 						child_run_ids: childRunIds,
+						codex_work_graph: workGraph,
 						linked_work_item_ids: linkedWorkItemIds,
 						delegation_id: delegationId,
 						result_detail_keys: objectKeys(details),
 					}),
 				});
-			} finally {
-				if (codexTool === "spawnAgent" && delegationId) {
-					try {
-						await this.operations.resolveDelegation({
-							delegationId,
-							status: event.isError
-								? PlatformDelegationStatusValue.Failed
-								: PlatformDelegationStatusValue.Completed,
-							resultPayload: this.basePayload({
-								event_type: "codex_subagent_delegation_resolved",
-								codex_tool: codexTool,
-								agent_run_id: runId,
-								work_item_id: this.workItemId(event.toolCallId),
-								tool_call_id: event.toolCallId,
-								tool_name: event.toolName,
-								result_error: event.isError,
-								receiver_thread_ids: receiverThreadIds,
-								child_run_ids: childRunIds,
-								linked_work_item_ids: linkedWorkItemIds,
-								result_detail_keys: objectKeys(details),
-							}),
-							errorMessage: event.isError
-								? (event.errorCode ??
-									event.governedOutcome ??
-									"Codex subagent spawn failed")
-								: undefined,
-						});
-					} catch (error) {
-						logger.warn("Failed to resolve Codex subagent delegation", {
-							error: error instanceof Error ? error.message : String(error),
-							session_id: this.sessionId,
+			} catch (error) {
+				updateError = error;
+			}
+			if (codexTool === "spawnAgent" && delegationId) {
+				try {
+					await this.operations.resolveDelegation({
+						delegationId,
+						status: event.isError
+							? PlatformDelegationStatusValue.Failed
+							: PlatformDelegationStatusValue.Completed,
+						resultPayload: this.basePayload({
+							event_type: "codex_subagent_delegation_resolved",
+							codex_tool: codexTool,
 							agent_run_id: runId,
+							work_item_id: this.workItemId(event.toolCallId),
 							tool_call_id: event.toolCallId,
-							delegation_id: delegationId,
-						});
-					} finally {
-						this.codexSubagentDelegationIds.delete(event.toolCallId);
-					}
+							tool_name: event.toolName,
+							result_error: event.isError,
+							receiver_thread_ids: receiverThreadIds,
+							child_run_ids: childRunIds,
+							codex_work_graph: workGraph,
+							linked_work_item_ids: linkedWorkItemIds,
+							result_detail_keys: objectKeys(details),
+						}),
+						errorMessage: event.isError
+							? (event.errorCode ??
+								event.governedOutcome ??
+								"Codex subagent spawn failed")
+							: undefined,
+					});
+				} catch (error) {
+					logger.warn("Failed to resolve Codex subagent delegation", {
+						error: error instanceof Error ? error.message : String(error),
+						session_id: this.sessionId,
+						agent_run_id: runId,
+						tool_call_id: event.toolCallId,
+						delegation_id: delegationId,
+					});
+				} finally {
+					this.codexSubagentDelegationIds.delete(event.toolCallId);
 				}
+			}
+			if (updateError !== undefined) {
+				throw updateError;
 			}
 		});
 	}

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -976,22 +976,6 @@ export function formatSkillForInjection(skill: LoadedSkill): string {
 		lines.push("");
 	}
 
-	const resourceDirectories = [
-		["scripts", skill.resourceDirs.scriptsDir],
-		["references", skill.resourceDirs.referencesDir],
-		["assets", skill.resourceDirs.assetsDir],
-	].filter((entry): entry is [string, string] => typeof entry[1] === "string");
-	if (resourceDirectories.length > 0) {
-		lines.push("## Resource Directories");
-		lines.push("");
-		lines.push("You can inspect these bundled directories when needed:");
-		lines.push("");
-		for (const [name, path] of resourceDirectories) {
-			lines.push(`- \`${path}\` (${name})`);
-		}
-		lines.push("");
-	}
-
 	lines.push("## Instructions");
 	lines.push("");
 	lines.push(skill.content);

--- a/test/agent/codex-app-server.test.ts
+++ b/test/agent/codex-app-server.test.ts
@@ -351,6 +351,24 @@ describe("Codex app-server provider", () => {
 						prompt: "Inspect the repo for routing bugs",
 						receiverThreadIds: ["child-thread-1"],
 						childRunIds: ["codex-thread:child-thread-1"],
+						codexWorkGraph: expect.objectContaining({
+							schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+							toolCallId: "collab-call-1",
+							tool: "spawnAgent",
+							status: "inProgress",
+							parent: {
+								threadId: "thread-1",
+								turnId: "turn-1",
+								senderThreadId: "thread-1",
+							},
+							childRuns: [
+								{
+									threadId: "child-thread-1",
+									childRunId: "codex-thread:child-thread-1",
+									operation: "spawnAgent",
+								},
+							],
+						}),
 						model: "gpt-5.3-codex",
 						reasoningEffort: "high",
 					}),
@@ -373,6 +391,17 @@ describe("Codex app-server provider", () => {
 						details: expect.objectContaining({
 							codexTool: "spawnAgent",
 							childRunIds: ["codex-thread:child-thread-1"],
+							codexWorkGraph: expect.objectContaining({
+								toolCallId: "collab-call-1",
+								tool: "spawnAgent",
+								status: "completed",
+								childRuns: [
+									expect.objectContaining({
+										threadId: "child-thread-1",
+										childRunId: "codex-thread:child-thread-1",
+									}),
+								],
+							}),
 							agentsStates: expect.objectContaining({
 								"child-thread-1": expect.objectContaining({
 									status: "completed",
@@ -417,6 +446,13 @@ describe("Codex app-server provider", () => {
 					toolCallId: "collab-call-1",
 					args: expect.objectContaining({
 						childRunIds: ["codex-thread:child-thread-1"],
+						codexWorkGraph: expect.objectContaining({
+							childRuns: [
+								expect.objectContaining({
+									childRunId: "codex-thread:child-thread-1",
+								}),
+							],
+						}),
 					}),
 				}),
 				expect.objectContaining({
@@ -425,6 +461,13 @@ describe("Codex app-server provider", () => {
 					result: expect.objectContaining({
 						details: expect.objectContaining({
 							childRunIds: ["codex-thread:child-thread-1"],
+							codexWorkGraph: expect.objectContaining({
+								childRuns: [
+									expect.objectContaining({
+										childRunId: "codex-thread:child-thread-1",
+									}),
+								],
+							}),
 						}),
 					}),
 				}),

--- a/test/agent/provider-transport-provider-tools.test.ts
+++ b/test/agent/provider-transport-provider-tools.test.ts
@@ -155,6 +155,25 @@ describe("ProviderTransport provider-owned tool events", () => {
 				args: {
 					codexTool: "spawnAgent",
 					receiverThreadIds: ["child-thread-1"],
+					childRunIds: ["agent-run-child-1"],
+					codexWorkGraph: {
+						schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+						toolCallId: "collab-call-1",
+						tool: "spawnAgent",
+						status: "inProgress",
+						parent: {
+							threadId: "parent-thread",
+							turnId: "turn-1",
+							senderThreadId: "parent-thread",
+						},
+						childRuns: [
+							{
+								threadId: "child-thread-1",
+								childRunId: "agent-run-child-1",
+								operation: "spawnAgent",
+							},
+						],
+					},
 				},
 				partial: assistant,
 			} satisfies AssistantMessageEvent;
@@ -172,6 +191,25 @@ describe("ProviderTransport provider-owned tool events", () => {
 					details: {
 						codexTool: "spawnAgent",
 						receiverThreadIds: ["child-thread-1"],
+						childRunIds: ["agent-run-child-1"],
+						codexWorkGraph: {
+							schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+							toolCallId: "collab-call-1",
+							tool: "spawnAgent",
+							status: "completed",
+							parent: {
+								threadId: "parent-thread",
+								turnId: "turn-1",
+								senderThreadId: "parent-thread",
+							},
+							childRuns: [
+								{
+									threadId: "child-thread-1",
+									childRunId: "agent-run-child-1",
+									operation: "spawnAgent",
+								},
+							],
+						},
 					},
 					isError: false,
 					timestamp: 2,
@@ -212,6 +250,17 @@ describe("ProviderTransport provider-owned tool events", () => {
 					args: expect.objectContaining({
 						codexTool: "spawnAgent",
 						receiverThreadIds: ["child-thread-1"],
+						childRunIds: ["agent-run-child-1"],
+						codexWorkGraph: expect.objectContaining({
+							schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+							toolCallId: "collab-call-1",
+							childRuns: [
+								expect.objectContaining({
+									threadId: "child-thread-1",
+									childRunId: "agent-run-child-1",
+								}),
+							],
+						}),
 					}),
 				}),
 				expect.objectContaining({
@@ -238,6 +287,12 @@ describe("ProviderTransport provider-owned tool events", () => {
 					result: expect.objectContaining({
 						role: "toolResult",
 						toolName: "codex.subagent.spawnAgent",
+						details: expect.objectContaining({
+							codexWorkGraph: expect.objectContaining({
+								toolCallId: "collab-call-1",
+								status: "completed",
+							}),
+						}),
 					}),
 				}),
 			]),

--- a/test/scripts/codex-live-smoke.test.ts
+++ b/test/scripts/codex-live-smoke.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	assertBoundedDynamicToolUse,
+	assertSubagentWorkGraphUse,
 	getFinalAssistantText,
 	parseJsonlEvents,
 	summarizeDynamicToolCalls,
@@ -38,6 +39,209 @@ function successfulEvents() {
 			data: { text: token },
 		},
 	];
+}
+
+function codexWorkGraph(
+	tool: "spawnAgent" | "wait",
+	toolCallId: string,
+	options: {
+		emptyChildRuns?: boolean;
+		threadId?: string;
+		childRunId?: string;
+	} = {},
+) {
+	const threadId = options.threadId ?? "child-thread-1";
+	const childRunId = options.childRunId ?? "codex-thread:child-thread-1";
+	return {
+		schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+		toolCallId,
+		tool,
+		status: "completed",
+		parent: {
+			threadId: "parent-thread",
+			turnId: "turn-1",
+			senderThreadId: "parent-thread",
+		},
+		childRuns: options.emptyChildRuns
+			? []
+			: [
+					{
+						threadId,
+						childRunId,
+						operation: tool,
+					},
+				],
+	};
+}
+
+function subagentEvents(
+	options: {
+		includeSpawnGraph?: boolean;
+		includeWaitGraph?: boolean;
+		includeWait?: boolean;
+		emptySpawnCallChildRuns?: boolean;
+		waitThreadId?: string;
+		waitChildRunId?: string;
+		waitStatus?: string;
+		extraSpawn?: boolean;
+		extraWait?: boolean;
+		finalText?: string;
+	} = {},
+) {
+	const {
+		includeSpawnGraph = true,
+		includeWaitGraph = true,
+		includeWait = true,
+		emptySpawnCallChildRuns = false,
+		waitThreadId = "child-thread-1",
+		waitChildRunId = "codex-thread:child-thread-1",
+		waitStatus = "completed",
+		extraSpawn = false,
+		extraWait = false,
+		finalText = token,
+	} = options;
+	const spawnToolCallId = "collab-spawn-1";
+	const waitToolCallId = "collab-wait-1";
+	const spawnEvents = [
+		{
+			type: "item",
+			subtype: "tool_call",
+			data: {
+				toolCallId: spawnToolCallId,
+				toolName: "codex.subagent.spawnAgent",
+				args: {
+					codexTool: "spawnAgent",
+					receiverThreadIds: ["child-thread-1"],
+					childRunIds: ["codex-thread:child-thread-1"],
+					...(includeSpawnGraph
+						? {
+								codexWorkGraph: codexWorkGraph("spawnAgent", spawnToolCallId, {
+									emptyChildRuns: emptySpawnCallChildRuns,
+								}),
+							}
+						: {}),
+				},
+			},
+		},
+		{
+			type: "item",
+			subtype: "tool_result",
+			data: {
+				toolCallId: spawnToolCallId,
+				toolName: "codex.subagent.spawnAgent",
+				result: {
+					role: "toolResult",
+					toolCallId: spawnToolCallId,
+					toolName: "codex.subagent.spawnAgent",
+					details: {
+						codexTool: "spawnAgent",
+						receiverThreadIds: ["child-thread-1"],
+						childRunIds: ["codex-thread:child-thread-1"],
+						...(includeSpawnGraph
+							? {
+									codexWorkGraph: codexWorkGraph("spawnAgent", spawnToolCallId),
+								}
+							: {}),
+					},
+					isError: false,
+				},
+				isError: false,
+			},
+		},
+	];
+	const events: unknown[] = extraSpawn
+		? [
+				...spawnEvents,
+				...spawnEvents.map((event) => ({
+					...event,
+					data: {
+						...event.data,
+						toolCallId: "collab-spawn-2",
+					},
+				})),
+			]
+		: [...spawnEvents];
+
+	if (includeWait) {
+		const waitEvents = [
+			{
+				type: "item",
+				subtype: "tool_call",
+				data: {
+					toolCallId: waitToolCallId,
+					toolName: "codex.subagent.wait",
+					args: {
+						codexTool: "wait",
+						receiverThreadIds: [waitThreadId],
+						childRunIds: [waitChildRunId],
+						...(includeWaitGraph
+							? {
+									codexWorkGraph: codexWorkGraph("wait", waitToolCallId, {
+										threadId: waitThreadId,
+										childRunId: waitChildRunId,
+									}),
+								}
+							: {}),
+					},
+				},
+			},
+			{
+				type: "item",
+				subtype: "tool_result",
+				data: {
+					toolCallId: waitToolCallId,
+					toolName: "codex.subagent.wait",
+					result: {
+						role: "toolResult",
+						toolCallId: waitToolCallId,
+						toolName: "codex.subagent.wait",
+						details: {
+							codexTool: "wait",
+							receiverThreadIds: [waitThreadId],
+							childRunIds: [waitChildRunId],
+							agentsStates: {
+								[waitThreadId]: {
+									status: waitStatus,
+									lastMessage: token,
+								},
+							},
+							...(includeWaitGraph
+								? {
+										codexWorkGraph: codexWorkGraph("wait", waitToolCallId, {
+											threadId: waitThreadId,
+											childRunId: waitChildRunId,
+										}),
+									}
+								: {}),
+						},
+						isError: false,
+					},
+					isError: false,
+				},
+			},
+		];
+		events.push(
+			...(extraWait
+				? [
+						...waitEvents,
+						...waitEvents.map((event) => ({
+							...event,
+							data: {
+								...event.data,
+								toolCallId: "collab-wait-2",
+							},
+						})),
+					]
+				: waitEvents),
+		);
+	}
+
+	events.push({
+		type: "item",
+		subtype: "message_complete",
+		data: { text: finalText },
+	});
+	return events;
 }
 
 describe("Codex live smoke evidence helpers", () => {
@@ -120,42 +324,6 @@ describe("Codex live smoke evidence helpers", () => {
 		});
 	});
 
-	it("ignores undefined operation args when summarizing dynamic calls", () => {
-		expect(
-			summarizeDynamicToolCalls([
-				{
-					type: "item",
-					subtype: "tool_call",
-					data: {
-						toolCallId: "call-read-1",
-						toolName: "read",
-						args: {
-							arguments: { path: "/tmp/token.txt" },
-						},
-					},
-				},
-				{
-					type: "item",
-					subtype: "tool_call",
-					data: {
-						toolCallId: "call-read-2",
-						toolName: "read",
-						args: {
-							arguments: {
-								path: "/tmp/token.txt",
-								optionalPreview: undefined,
-							},
-						},
-					},
-				},
-			]),
-		).toMatchObject({
-			totalCalls: 2,
-			uniqueCalls: 1,
-			maxIdenticalCalls: 2,
-		});
-	});
-
 	it("accepts a bounded dynamic read-tool smoke transcript", () => {
 		expect(
 			assertBoundedDynamicToolUse({
@@ -213,6 +381,108 @@ describe("Codex live smoke evidence helpers", () => {
 						data: { text: `${token}\nextra` },
 					},
 				]),
+				expectedToken: token,
+			}),
+		).toThrow("did not exactly match expected token");
+	});
+
+	it("accepts a subagent spawn/wait transcript with work-graph evidence", () => {
+		expect(
+			assertSubagentWorkGraphUse({
+				stdout: jsonl(subagentEvents()),
+				expectedToken: token,
+			}),
+		).toMatchObject({
+			spawnCalls: 1,
+			spawnResults: 1,
+			waitCalls: 1,
+			waitResults: 1,
+			childRunCount: 4,
+		});
+	});
+
+	it("accepts an in-progress spawn call before Codex assigns the child thread", () => {
+		expect(
+			assertSubagentWorkGraphUse({
+				stdout: jsonl(
+					subagentEvents({
+						emptySpawnCallChildRuns: true,
+					}),
+				),
+				expectedToken: token,
+			}),
+		).toMatchObject({
+			spawnCalls: 1,
+			waitCalls: 1,
+			childRunCount: 3,
+		});
+	});
+
+	it("rejects subagent transcripts missing work-graph evidence", () => {
+		expect(() =>
+			assertSubagentWorkGraphUse({
+				stdout: jsonl(subagentEvents({ includeSpawnGraph: false })),
+				expectedToken: token,
+			}),
+		).toThrow("codexWorkGraph");
+	});
+
+	it("requires wait evidence to target the spawned child run", () => {
+		expect(() =>
+			assertSubagentWorkGraphUse({
+				stdout: jsonl(
+					subagentEvents({
+						waitThreadId: "other-child-thread",
+						waitChildRunId: "codex-thread:other-child-thread",
+					}),
+				),
+				expectedToken: token,
+			}),
+		).toThrow("do not match spawned childRunIds");
+	});
+
+	it("requires structured completed status for the waited child", () => {
+		expect(() =>
+			assertSubagentWorkGraphUse({
+				stdout: jsonl(
+					subagentEvents({
+						waitStatus: "not completed",
+					}),
+				),
+				expectedToken: token,
+			}),
+		).toThrow("is not completed");
+	});
+
+	it("requires exactly one spawn and one wait operation", () => {
+		expect(() =>
+			assertSubagentWorkGraphUse({
+				stdout: jsonl(subagentEvents({ extraSpawn: true })),
+				expectedToken: token,
+			}),
+		).toThrow("exactly one codex.subagent.spawnAgent tool_call");
+
+		expect(() =>
+			assertSubagentWorkGraphUse({
+				stdout: jsonl(subagentEvents({ extraWait: true })),
+				expectedToken: token,
+			}),
+		).toThrow("exactly one codex.subagent.wait tool_call");
+	});
+
+	it("requires the live subagent proof to wait for the child agent", () => {
+		expect(() =>
+			assertSubagentWorkGraphUse({
+				stdout: jsonl(subagentEvents({ includeWait: false })),
+				expectedToken: token,
+			}),
+		).toThrow("codex.subagent.wait");
+	});
+
+	it("requires the subagent final answer to exactly match the live token", () => {
+		expect(() =>
+			assertSubagentWorkGraphUse({
+				stdout: jsonl(subagentEvents({ finalText: `${token}\nextra` })),
 				expectedToken: token,
 			}),
 		).toThrow("did not exactly match expected token");

--- a/test/server/hosted-agent-runtime-progress.test.ts
+++ b/test/server/hosted-agent-runtime-progress.test.ts
@@ -169,6 +169,24 @@ describe("hosted AgentRuntime progress recorder", () => {
 				codexTool: "spawnAgent",
 				senderThreadId: "parent-thread",
 				receiverThreadIds: ["child-thread-1"],
+				codexWorkGraph: {
+					schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+					toolCallId: "collab-call-1",
+					tool: "spawnAgent",
+					status: "inProgress",
+					parent: {
+						threadId: "parent-thread",
+						turnId: "turn-1",
+						senderThreadId: "parent-thread",
+					},
+					childRuns: [
+						{
+							threadId: "child-thread-1",
+							childRunId: "codex-thread:child-thread-1",
+							operation: "spawnAgent",
+						},
+					],
+				},
 				prompt: "Inspect platform remote runner wiring",
 				model: "gpt-5.3-codex",
 				reasoningEffort: "high",
@@ -221,6 +239,16 @@ describe("hosted AgentRuntime progress recorder", () => {
 					receiver_thread_ids: ["child-thread-1"],
 					receiver_thread_count: 1,
 					child_run_ids: ["codex-thread:child-thread-1"],
+					codex_work_graph: expect.objectContaining({
+						schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+						toolCallId: "collab-call-1",
+						childRuns: [
+							expect.objectContaining({
+								threadId: "child-thread-1",
+								childRunId: "codex-thread:child-thread-1",
+							}),
+						],
+					}),
 					linked_work_item_ids: [],
 					model: "gpt-5.3-codex",
 					reasoning_effort: "high",
@@ -245,6 +273,14 @@ describe("hosted AgentRuntime progress recorder", () => {
 				result_error: false,
 				receiver_thread_ids: ["child-thread-1"],
 				child_run_ids: ["codex-thread:child-thread-1"],
+				codex_work_graph: expect.objectContaining({
+					toolCallId: "collab-call-1",
+					childRuns: [
+						expect.objectContaining({
+							childRunId: "codex-thread:child-thread-1",
+						}),
+					],
+				}),
 				linked_work_item_ids: ["maestro:session_1:work:collab-call-1"],
 			}),
 		});
@@ -283,6 +319,24 @@ describe("hosted AgentRuntime progress recorder", () => {
 				senderThreadId: "parent-thread",
 				receiverThreadIds: ["child-thread-1"],
 				childRunIds: ["agent-run-child-1"],
+				codexWorkGraph: {
+					schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+					toolCallId: "spawn-delegation-call",
+					tool: "spawnAgent",
+					status: "inProgress",
+					parent: {
+						threadId: "parent-thread",
+						turnId: "turn-1",
+						senderThreadId: "parent-thread",
+					},
+					childRuns: [
+						{
+							threadId: "child-thread-1",
+							childRunId: "agent-run-child-1",
+							operation: "spawnAgent",
+						},
+					],
+				},
 				prompt: "Audit remote runner drain behavior",
 				requiredCapability: "code:review",
 			},
@@ -301,6 +355,24 @@ describe("hosted AgentRuntime progress recorder", () => {
 					codexTool: "spawnAgent",
 					receiverThreadIds: ["child-thread-1"],
 					childRunIds: ["agent-run-child-1"],
+					codexWorkGraph: {
+						schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+						toolCallId: "spawn-delegation-call",
+						tool: "spawnAgent",
+						status: "completed",
+						parent: {
+							threadId: "parent-thread",
+							turnId: "turn-1",
+							senderThreadId: "parent-thread",
+						},
+						childRuns: [
+							{
+								threadId: "child-thread-1",
+								childRunId: "agent-run-child-1",
+								operation: "spawnAgent",
+							},
+						],
+					},
 				},
 				isError: false,
 				timestamp: 3,
@@ -324,6 +396,14 @@ describe("hosted AgentRuntime progress recorder", () => {
 					owner_child_run_id: "agent-run-child-1",
 					receiver_thread_ids: ["child-thread-1"],
 					child_run_ids: ["agent-run-child-1"],
+					codex_work_graph: expect.objectContaining({
+						toolCallId: "spawn-delegation-call",
+						childRuns: [
+							expect.objectContaining({
+								childRunId: "agent-run-child-1",
+							}),
+						],
+					}),
 					required_capability: "code:review",
 				}),
 			}),
@@ -348,8 +428,232 @@ describe("hosted AgentRuntime progress recorder", () => {
 				agent_run_id: "run_1",
 				work_item_id: "maestro:session_1:work:spawn-delegation-call",
 				child_run_ids: ["agent-run-child-1"],
+				codex_work_graph: expect.objectContaining({
+					toolCallId: "spawn-delegation-call",
+					status: "completed",
+				}),
 			}),
 			errorMessage: undefined,
+		});
+	});
+
+	it("clears Codex delegation ids when delegation resolution fails", async () => {
+		const delegateAgent = vi.fn(
+			async (_input: PlatformAgentRegistryDelegateInput) => ({
+				delegation: {
+					id: "delegation_1",
+					status: PlatformDelegationStatusValue.Pending,
+				},
+			}),
+		);
+		const resolveDelegation = vi.fn(
+			async (_input: PlatformAgentRegistryResolveDelegationInput) => {
+				throw new Error("platform unavailable");
+			},
+		);
+		const { recorder } = createRecorder({
+			delegateAgent,
+			resolveDelegation,
+		});
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const delegationIds = (
+			recorder as unknown as {
+				codexSubagentDelegationIds: Map<string, string>;
+			}
+		).codexSubagentDelegationIds;
+
+		try {
+			recorder.recordAgentEvent({
+				type: "tool_execution_start",
+				toolCallId: "spawn-delegation-call",
+				toolName: "codex.subagent.spawnAgent",
+				displayName: "Codex subagent: spawn agent",
+				args: {
+					codexTool: "spawnAgent",
+					receiverThreadIds: ["child-thread-1"],
+					childRunIds: ["agent-run-child-1"],
+					prompt: "Audit remote runner drain behavior",
+				},
+			});
+			await recorder.flush();
+
+			expect(delegationIds.get("spawn-delegation-call")).toBe("delegation_1");
+
+			recorder.recordAgentEvent({
+				type: "tool_execution_end",
+				toolCallId: "spawn-delegation-call",
+				toolName: "codex.subagent.spawnAgent",
+				displayName: "Codex subagent: spawn agent",
+				result: {
+					role: "toolResult",
+					toolCallId: "spawn-delegation-call",
+					toolName: "codex.subagent.spawnAgent",
+					content: [{ type: "text", text: "spawn completed" }],
+					details: {
+						codexTool: "spawnAgent",
+						receiverThreadIds: ["child-thread-1"],
+						childRunIds: ["agent-run-child-1"],
+					},
+					isError: false,
+					timestamp: 3,
+				},
+				isError: false,
+			} satisfies AgentEvent);
+			await recorder.flush();
+
+			expect(resolveDelegation).toHaveBeenCalledTimes(1);
+			expect(delegationIds.has("spawn-delegation-call")).toBe(false);
+			expect(
+				consoleError.mock.calls.some((call) =>
+					call
+						.join(" ")
+						.includes("Failed to resolve Codex subagent delegation"),
+				),
+			).toBe(true);
+		} finally {
+			consoleError.mockRestore();
+		}
+	});
+
+	it("preserves work item update errors when delegation resolution also fails", async () => {
+		const updateWorkItem = vi.fn(async () => {
+			throw new Error("update unavailable");
+		});
+		const delegateAgent = vi.fn(
+			async (_input: PlatformAgentRegistryDelegateInput) => ({
+				delegation: {
+					id: "delegation_1",
+					status: PlatformDelegationStatusValue.Pending,
+				},
+			}),
+		);
+		const resolveDelegation = vi.fn(
+			async (_input: PlatformAgentRegistryResolveDelegationInput) => {
+				throw new Error("resolve unavailable");
+			},
+		);
+		const { recorder } = createRecorder({
+			updateWorkItem,
+			delegateAgent,
+			resolveDelegation,
+		});
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		const delegationIds = (
+			recorder as unknown as {
+				codexSubagentDelegationIds: Map<string, string>;
+			}
+		).codexSubagentDelegationIds;
+
+		try {
+			recorder.recordAgentEvent({
+				type: "tool_execution_start",
+				toolCallId: "spawn-delegation-call",
+				toolName: "codex.subagent.spawnAgent",
+				displayName: "Codex subagent: spawn agent",
+				args: {
+					codexTool: "spawnAgent",
+					receiverThreadIds: ["child-thread-1"],
+					childRunIds: ["agent-run-child-1"],
+					prompt: "Audit remote runner drain behavior",
+				},
+			});
+			await recorder.flush();
+
+			recorder.recordAgentEvent({
+				type: "tool_execution_end",
+				toolCallId: "spawn-delegation-call",
+				toolName: "codex.subagent.spawnAgent",
+				displayName: "Codex subagent: spawn agent",
+				result: {
+					role: "toolResult",
+					toolCallId: "spawn-delegation-call",
+					toolName: "codex.subagent.spawnAgent",
+					content: [{ type: "text", text: "spawn completed" }],
+					details: {
+						codexTool: "spawnAgent",
+						receiverThreadIds: ["child-thread-1"],
+						childRunIds: ["agent-run-child-1"],
+					},
+					isError: false,
+					timestamp: 3,
+				},
+				isError: false,
+			} satisfies AgentEvent);
+			await recorder.flush();
+
+			const logged = consoleError.mock.calls.map((call) => call.join(" "));
+			expect(logged.some((line) => line.includes("resolve unavailable"))).toBe(
+				true,
+			);
+			expect(
+				logged.some(
+					(line) =>
+						line.includes("Failed to record hosted AgentRuntime progress") &&
+						line.includes("update unavailable"),
+				),
+			).toBe(true);
+			expect(delegationIds.has("spawn-delegation-call")).toBe(false);
+		} finally {
+			consoleError.mockRestore();
+		}
+	});
+
+	it("derives Codex child work items from work graph evidence when legacy arrays are absent", async () => {
+		const { recorder, recordWorkItem } = createRecorder();
+
+		recorder.recordAgentEvent({
+			type: "tool_execution_start",
+			toolCallId: "graph-only-spawn",
+			toolName: "codex.subagent.spawnAgent",
+			displayName: "Codex subagent: spawn agent",
+			args: {
+				codexTool: "spawnAgent",
+				codexWorkGraph: {
+					schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+					toolCallId: "graph-only-spawn",
+					tool: "spawnAgent",
+					status: "inProgress",
+					parent: {
+						threadId: "parent-thread",
+						turnId: "turn-graph",
+						senderThreadId: "parent-thread",
+					},
+					childRuns: [
+						{
+							threadId: "graph-child-thread",
+							childRunId: "agent-run-child-graph",
+							operation: "spawnAgent",
+						},
+					],
+				},
+				prompt: "Replay child graph evidence",
+			},
+		});
+
+		await recorder.flush();
+
+		expect(recordWorkItem).toHaveBeenCalledWith({
+			runId: "run_1",
+			workItem: expect.objectContaining({
+				id: "maestro:session_1:work:graph-only-spawn",
+				ownerChildRunId: "agent-run-child-graph",
+				evidenceRefs: [
+					"codex-tool-call:graph-only-spawn",
+					"codex-thread:graph-child-thread",
+					"codex-child-run:agent-run-child-graph",
+				],
+				payload: expect.objectContaining({
+					receiver_thread_ids: ["graph-child-thread"],
+					child_run_ids: ["agent-run-child-graph"],
+					codex_work_graph: expect.objectContaining({
+						toolCallId: "graph-only-spawn",
+					}),
+				}),
+			}),
 		});
 	});
 

--- a/test/skills/loader.test.ts
+++ b/test/skills/loader.test.ts
@@ -374,11 +374,6 @@ tags:
 			);
 
 			writeFileSync(join(skillDir, "helper.sh"), "#!/bin/bash");
-			mkdirSync(join(skillDir, "references"), { recursive: true });
-			writeFileSync(
-				join(skillDir, "references", "guide.md"),
-				"# Guide\n\nLoaded only when needed.\n",
-			);
 
 			const { skills } = loadSkills(testDir, { includeSystem: false });
 			const formatted = formatSkillForInjection(skills[0]!);
@@ -388,8 +383,6 @@ tags:
 			expect(formatted).toContain("**Tags:** test");
 			expect(formatted).toContain("## Bundled Resources");
 			expect(formatted).toContain("helper.sh");
-			expect(formatted).toContain("## Resource Directories");
-			expect(formatted).toContain(join(skillDir, "references"));
 			expect(formatted).toContain("## Instructions");
 			expect(formatted).toContain("## Workflow");
 		});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `c19fd1a90555b98fadf5da677d0e958a798edacd`
- last generated public sync base: `ecc0e8713ca9fba9ef83519358677a87188cf236`
- previewed public-tree drift: `12` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (c19fd1a90555)`
- public projection: `https://github.com/evalops/maestro@main (12d1df158e8a)`
- files to copy or update: `12`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/codex-operating-layer.json
- copy/update docs/protocols/codex-operating-layer.md
- copy/update packages/control-plane-rs/src/main.rs
- copy/update scripts/smoke-codex-app-server-live.mjs
- copy/update src/agent/providers/codex-app-server.ts
- copy/update src/server/hosted-agent-runtime-progress.ts
- copy/update src/skills/loader.ts
- copy/update test/agent/codex-app-server.test.ts
- copy/update test/agent/provider-transport-provider-tools.test.ts
- copy/update test/scripts/codex-live-smoke.test.ts
- copy/update test/server/hosted-agent-runtime-progress.test.ts
- copy/update test/skills/loader.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/codex-operating-layer.json
- copy/update docs/protocols/codex-operating-layer.md
- copy/update packages/control-plane-rs/src/main.rs
- copy/update scripts/smoke-codex-app-server-live.mjs
- copy/update src/agent/providers/codex-app-server.ts
- copy/update src/server/hosted-agent-runtime-progress.ts
- copy/update src/skills/loader.ts
- copy/update test/agent/codex-app-server.test.ts
- copy/update test/agent/provider-transport-provider-tools.test.ts
- copy/update test/scripts/codex-live-smoke.test.ts
- copy/update test/server/hosted-agent-runtime-progress.test.ts
- copy/update test/skills/loader.test.ts

## Public-only commits since last generated sync

- 12d1df15 fix: persist provider-owned tool results (#411)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@c19fd1a90555b98fadf5da677d0e958a798edacd`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #413 to internal source `c19fd1a90555b98fadf5da677d0e958a798edacd`