### PR TITLE
Expose skill runtime activation manifests

### DIFF
--- a/docs/cookbook/skills/README.md
+++ b/docs/cookbook/skills/README.md
@@ -55,6 +55,21 @@ Run strict validation with:
 maestro skill lint .maestro/skills/reviewing-prs --describe-toolbox
 ```
 
+## Runtime Activation
+
+Loading a skill through the `Skill` tool returns a `skillRuntimeActivation`
+object in the tool result details. The same shape is available locally:
+
+```bash
+maestro skill inspect reviewing-prs --json
+```
+
+Use this manifest in harnesses and adapters when you need to see which
+references, toolbox executables, MCP servers, and tool bounds become active. MCP
+environment values remain in `mcp.json`; they are not copied into the activation
+manifest. Servers with missing or malformed `includeTools` are reported as
+warnings and omitted from the activatable server list.
+
 ## Eval Harness
 
 Use `maestro skill eval` when a package needs pass/fail evidence rather than

--- a/docs/design/EVALOPS_AGENT_CORE_PARITY.md
+++ b/docs/design/EVALOPS_AGENT_CORE_PARITY.md
@@ -88,6 +88,52 @@ Unfiltered MCP servers are rejected because they inflate prompt/tool surface and
 
 `toolbox/` is optional. Executables in that directory are expected to support `MAESTRO_TOOLBOX_ACTION=describe` so Maestro can register them as typed tools when the skill is active.
 
+When the `Skill` tool loads a package, it returns a `skillRuntimeActivation`
+manifest alongside artifact metadata. `maestro skill inspect <name> --json`
+emits the same contract for local harnesses:
+
+```json
+{
+  "runtimeActivation": {
+    "name": "reviewing-prs",
+    "source": "project",
+    "profile": {
+      "model": "gpt-5.5",
+      "mode": "review",
+      "isolatedContext": true
+    },
+    "tools": {
+      "allowed": ["github.get_pull_request"],
+      "builtin": ["read", "search"]
+    },
+    "resources": {
+      "directories": {
+        "reference": ".maestro/skills/reviewing-prs/reference",
+        "toolbox": ".maestro/skills/reviewing-prs/toolbox"
+      }
+    },
+    "toolPackage": {
+      "mcp": {
+        "configPath": ".maestro/skills/reviewing-prs/mcp.json",
+        "servers": [
+          {
+            "name": "github",
+            "command": "npx",
+            "includeTools": ["get_pull_request", "list_pull_request_files"]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+The activation manifest exposes scoped paths, toolbox entries, MCP server names,
+and `includeTools` bounds. It does not copy MCP environment values into
+agent-visible details or telemetry. MCP servers with missing or malformed
+`includeTools` are omitted from the activatable server list and reported through
+manifest warnings.
+
 ## CLI Contract
 
 `maestro skill` is the public authoring surface:
@@ -117,6 +163,6 @@ Lint rules:
 1. Local AgentRuntime ledger: one SQLite store for runs, tool calls, waits, summaries, checkpoints, and session search.
 2. `maestro goal`: persistent objective loop backed by the local ledger, promotable to Platform Objectives.
 3. `maestro workboard`: local multi-agent board mapped to Platform AgentRuns when attached.
-4. Skill-bundled MCP lifecycle: start servers only when the skill triggers, stop them on cooldown/session end.
-5. Skill-bundled toolbox registration: expose described toolbox commands as governed tools while the skill is active.
+4. Skill-bundled MCP lifecycle: activate servers from `skillRuntimeActivation` only when the skill triggers, stop them on cooldown/session end.
+5. Skill-bundled toolbox registration: expose described toolbox commands from `skillRuntimeActivation` as governed tools while the skill is active.
 6. Public cookbook and conformance fixtures for third-party skill authors.

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -4,6 +4,7 @@ import { inspect } from "node:util";
 import chalk from "chalk";
 import { PATHS } from "../../config/constants.js";
 import {
+	buildSkillRuntimeActivation,
 	evaluateSkillPackages,
 	findSkill,
 	formatSkillEvalText,
@@ -172,6 +173,7 @@ async function handleInspect(
 		sourcePath: skill.sourcePath,
 		resources: skill.resources,
 		resourceDirs: skill.resourceDirs,
+		runtimeActivation: buildSkillRuntimeActivation(skill),
 	};
 	if (options.json) {
 		console.log(JSON.stringify(payload, null, 2));

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -52,6 +52,16 @@ export {
 
 export { createSkillTool, invalidateSkillCache } from "./tool.js";
 export {
+	type SkillRuntimeActivation,
+	type SkillRuntimeMcpActivation,
+	type SkillRuntimeMcpServer,
+	type SkillRuntimeResource,
+	type SkillRuntimeResourceDirectories,
+	type SkillRuntimeToolboxActivation,
+	type SkillRuntimeToolboxEntry,
+	buildSkillRuntimeActivation,
+} from "./runtime-activation.js";
+export {
 	type SkillLintIssue,
 	type SkillLintResult,
 	type SkillScaffoldOptions,

--- a/src/skills/runtime-activation.ts
+++ b/src/skills/runtime-activation.ts
@@ -70,7 +70,7 @@ export interface SkillRuntimeMcpActivation {
 
 export interface SkillRuntimeMcpServer {
 	name: string;
-	command?: string;
+	command: string;
 	includeTools: string[];
 }
 

--- a/src/skills/runtime-activation.ts
+++ b/src/skills/runtime-activation.ts
@@ -10,6 +10,8 @@ import { join } from "node:path";
 import { isWindowsRunnableToolboxEntry } from "./linter.js";
 import type { LoadedSkill, SkillResource } from "./loader.js";
 
+const MAX_MCP_JSON_BYTES = 1024 * 1024;
+
 export interface SkillRuntimeActivation {
 	name: string;
 	source: LoadedSkill["sourceType"];
@@ -203,6 +205,13 @@ function buildMcpActivation(
 	}
 
 	const warnings: string[] = [];
+	const stats = statSync(mcpJsonPath);
+	if (stats.size > MAX_MCP_JSON_BYTES) {
+		warnings.push(
+			`mcp.json is too large to load: ${stats.size} bytes exceeds ${MAX_MCP_JSON_BYTES} byte limit.`,
+		);
+		return { configPath: mcpJsonPath, servers: [], warnings };
+	}
 	let parsed: unknown;
 	try {
 		parsed = JSON.parse(readFileSync(mcpJsonPath, "utf8"));

--- a/src/skills/runtime-activation.ts
+++ b/src/skills/runtime-activation.ts
@@ -254,6 +254,22 @@ function buildMcpActivation(
 			);
 			continue;
 		}
+		if (
+			server.args !== undefined &&
+			(!Array.isArray(server.args) ||
+				server.args.some((arg) => typeof arg !== "string"))
+		) {
+			warnings.push(`MCP server '${name}' args entries must be strings.`);
+			continue;
+		}
+		if (
+			server.env !== undefined &&
+			(!isRecord(server.env) ||
+				Object.values(server.env).some((value) => typeof value !== "string"))
+		) {
+			warnings.push(`MCP server '${name}' env values must be strings.`);
+			continue;
+		}
 		servers.push({
 			name,
 			command,

--- a/src/skills/runtime-activation.ts
+++ b/src/skills/runtime-activation.ts
@@ -1,0 +1,305 @@
+import {
+	constants,
+	accessSync,
+	existsSync,
+	readFileSync,
+	readdirSync,
+	statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { isWindowsRunnableToolboxEntry } from "./linter.js";
+import type { LoadedSkill, SkillResource } from "./loader.js";
+
+export interface SkillRuntimeActivation {
+	name: string;
+	source: LoadedSkill["sourceType"];
+	sourcePath?: string;
+	profile: {
+		argumentHint?: string;
+		compatibility?: string;
+		isolatedContext?: boolean;
+		mode?: string;
+		model?: string;
+	};
+	tools: {
+		allowed: string[];
+		builtin: string[];
+	};
+	resources: {
+		files: SkillRuntimeResource[];
+		directories: SkillRuntimeResourceDirectories;
+	};
+	toolPackage: {
+		toolbox?: SkillRuntimeToolboxActivation;
+		mcp?: SkillRuntimeMcpActivation;
+	};
+}
+
+export interface SkillRuntimeResource {
+	name: string;
+	path: string;
+	type: SkillResource["type"];
+}
+
+export interface SkillRuntimeResourceDirectories {
+	scripts?: string;
+	reference?: string;
+	references?: string;
+	assets?: string;
+	toolbox?: string;
+}
+
+export interface SkillRuntimeToolboxActivation {
+	directory: string;
+	entries: SkillRuntimeToolboxEntry[];
+	warnings?: string[];
+}
+
+export interface SkillRuntimeToolboxEntry {
+	name: string;
+	path: string;
+}
+
+export interface SkillRuntimeMcpActivation {
+	configPath: string;
+	servers: SkillRuntimeMcpServer[];
+	warnings?: string[];
+}
+
+export interface SkillRuntimeMcpServer {
+	name: string;
+	command?: string;
+	includeTools: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isDirectory(path: string | undefined): path is string {
+	if (!path || !existsSync(path)) {
+		return false;
+	}
+	try {
+		return statSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function isFile(path: string | undefined): path is string {
+	if (!path || !existsSync(path)) {
+		return false;
+	}
+	try {
+		return statSync(path).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+type StringListParseResult =
+	| { status: "valid"; values: string[] }
+	| { status: "missing"; values: [] }
+	| { status: "invalid"; values: [] };
+
+function nonEmptyStringList(value: unknown): StringListParseResult {
+	if (!Array.isArray(value)) {
+		return { status: "missing", values: [] };
+	}
+	const values: string[] = [];
+	for (const entry of value) {
+		const normalized = nonEmptyString(entry);
+		if (!normalized) {
+			return { status: "invalid", values: [] };
+		}
+		values.push(normalized);
+	}
+	return { status: "valid", values };
+}
+
+function isRunnableFile(path: string | undefined): path is string {
+	if (!isFile(path)) {
+		return false;
+	}
+	if (process.platform === "win32") {
+		return isWindowsRunnableToolboxEntry(path);
+	}
+	try {
+		accessSync(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function buildResourceDirectories(
+	skill: LoadedSkill,
+): SkillRuntimeResourceDirectories {
+	return {
+		...(skill.resourceDirs.scriptsDir
+			? { scripts: skill.resourceDirs.scriptsDir }
+			: {}),
+		...(skill.resourceDirs.referenceDir
+			? { reference: skill.resourceDirs.referenceDir }
+			: {}),
+		...(skill.resourceDirs.referencesDir
+			? { references: skill.resourceDirs.referencesDir }
+			: {}),
+		...(skill.resourceDirs.assetsDir
+			? { assets: skill.resourceDirs.assetsDir }
+			: {}),
+		...(skill.resourceDirs.toolboxDir
+			? { toolbox: skill.resourceDirs.toolboxDir }
+			: {}),
+	};
+}
+
+function buildToolboxActivation(
+	toolboxDir: string | undefined,
+): SkillRuntimeToolboxActivation | undefined {
+	if (!isDirectory(toolboxDir)) {
+		return undefined;
+	}
+	let directoryEntries: string[];
+	try {
+		directoryEntries = readdirSync(toolboxDir);
+	} catch (error) {
+		return {
+			directory: toolboxDir,
+			entries: [],
+			warnings: [`toolbox directory could not be read: ${errorMessage(error)}`],
+		};
+	}
+	const entries = directoryEntries
+		.filter(
+			(entry) => !entry.startsWith(".") && entry.toLowerCase() !== "readme.md",
+		)
+		.map((entry) => ({ name: entry, path: join(toolboxDir, entry) }))
+		.filter((entry) => isRunnableFile(entry.path))
+		.sort((left, right) => left.name.localeCompare(right.name));
+
+	return {
+		directory: toolboxDir,
+		entries,
+	};
+}
+
+function buildMcpActivation(
+	mcpJsonPath: string | undefined,
+): SkillRuntimeMcpActivation | undefined {
+	if (!isFile(mcpJsonPath)) {
+		return undefined;
+	}
+
+	const warnings: string[] = [];
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(readFileSync(mcpJsonPath, "utf8"));
+	} catch (error) {
+		warnings.push(`mcp.json could not be parsed: ${errorMessage(error)}`);
+		return { configPath: mcpJsonPath, servers: [], warnings };
+	}
+
+	if (!isRecord(parsed)) {
+		return {
+			configPath: mcpJsonPath,
+			servers: [],
+			warnings: ["mcp.json must be an object keyed by server name."],
+		};
+	}
+
+	const servers: SkillRuntimeMcpServer[] = [];
+	for (const [name, server] of Object.entries(parsed).sort(([left], [right]) =>
+		left.localeCompare(right),
+	)) {
+		if (!isRecord(server)) {
+			warnings.push(`MCP server '${name}' must be an object.`);
+			continue;
+		}
+		const command = nonEmptyString(server.command);
+		if (!command) {
+			warnings.push(`MCP server '${name}' requires a non-empty command.`);
+			continue;
+		}
+		const includeTools = nonEmptyStringList(server.includeTools);
+		if (includeTools.status === "invalid") {
+			warnings.push(
+				`MCP server '${name}' includeTools entries must be non-empty strings.`,
+			);
+			continue;
+		}
+		if (includeTools.status === "missing" || includeTools.values.length === 0) {
+			warnings.push(
+				`MCP server '${name}' does not declare bounded includeTools.`,
+			);
+			continue;
+		}
+		servers.push({
+			name,
+			command,
+			includeTools: includeTools.values,
+		});
+	}
+
+	return {
+		configPath: mcpJsonPath,
+		servers,
+		...(warnings.length > 0 ? { warnings } : {}),
+	};
+}
+
+/**
+ * Build the runtime-facing activation contract for a loaded skill.
+ *
+ * This intentionally exposes only scoped resource paths and MCP tool bounds. The
+ * raw MCP config remains on disk so runtimes can activate it without copying env
+ * values or credentials into agent-visible telemetry.
+ */
+export function buildSkillRuntimeActivation(
+	skill: LoadedSkill,
+): SkillRuntimeActivation {
+	const toolbox = buildToolboxActivation(skill.resourceDirs.toolboxDir);
+	const mcp = buildMcpActivation(skill.resourceDirs.mcpJsonPath);
+
+	return {
+		name: skill.name,
+		source: skill.sourceType,
+		...(skill.sourcePath ? { sourcePath: skill.sourcePath } : {}),
+		profile: {
+			...(skill.argumentHint ? { argumentHint: skill.argumentHint } : {}),
+			...(skill.compatibility ? { compatibility: skill.compatibility } : {}),
+			...(skill.isolatedContext !== undefined
+				? { isolatedContext: skill.isolatedContext }
+				: {}),
+			...(skill.mode ? { mode: skill.mode } : {}),
+			...(skill.model ? { model: skill.model } : {}),
+		},
+		tools: {
+			allowed: [...(skill.allowedTools ?? [])],
+			builtin: [...(skill.builtinTools ?? [])],
+		},
+		resources: {
+			files: skill.resources.map((resource) => ({
+				name: resource.name,
+				path: resource.path,
+				type: resource.type,
+			})),
+			directories: buildResourceDirectories(skill),
+		},
+		toolPackage: {
+			...(toolbox ? { toolbox } : {}),
+			...(mcp ? { mcp } : {}),
+		},
+	};
+}

--- a/src/skills/runtime-activation.ts
+++ b/src/skills/runtime-activation.ts
@@ -205,7 +205,13 @@ function buildMcpActivation(
 	}
 
 	const warnings: string[] = [];
-	const stats = statSync(mcpJsonPath);
+	let stats: ReturnType<typeof statSync>;
+	try {
+		stats = statSync(mcpJsonPath);
+	} catch (error) {
+		warnings.push(`mcp.json could not be inspected: ${errorMessage(error)}`);
+		return { configPath: mcpJsonPath, servers: [], warnings };
+	}
 	if (stats.size > MAX_MCP_JSON_BYTES) {
 		warnings.push(
 			`mcp.json is too large to load: ${stats.size} bytes exceeds ${MAX_MCP_JSON_BYTES} byte limit.`,

--- a/src/skills/tool.ts
+++ b/src/skills/tool.ts
@@ -17,6 +17,7 @@ import {
 	loadSkills,
 	searchSkills,
 } from "./loader.js";
+import { buildSkillRuntimeActivation } from "./runtime-activation.js";
 import {
 	type SkillsServiceConfig,
 	loadSkillsFromService,
@@ -195,6 +196,7 @@ Available skills can be listed by calling this tool with skill="list".`,
 				content: [{ type: "text", text }],
 				details: {
 					skillMetadata: buildSkillArtifactMetadata(skill),
+					skillRuntimeActivation: buildSkillRuntimeActivation(skill),
 				},
 			};
 		},

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -355,6 +355,27 @@ describe("skill package format", () => {
 		});
 	});
 
+	it("degrades oversized MCP configs to bounded activation warnings", async () => {
+		const workspace = tempRoot();
+		const skillDir = join(workspace, ".maestro", "skills", "oversized-mcp");
+		await mkdir(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			"---\nname: oversized-mcp\ndescription: Test oversized MCP activation surfaces.\n---\n\n# Oversized MCP\n",
+		);
+		writeFileSync(join(skillDir, "mcp.json"), " ".repeat(1024 * 1024 + 1));
+
+		const { skills, errors } = loadSkills(workspace, { includeSystem: false });
+
+		expect(errors).toEqual([]);
+		expect(
+			buildSkillRuntimeActivation(skills[0]!).toolPackage.mcp,
+		).toMatchObject({
+			servers: [],
+			warnings: [expect.stringContaining("mcp.json is too large to load")],
+		});
+	});
+
 	it("degrades unreadable toolbox directories to an empty activation", async () => {
 		if (process.platform === "win32" || process.getuid?.() === 0) {
 			return;

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +13,7 @@ import { parseArgs } from "../src/cli/args.js";
 import { handleSkillCommand } from "../src/cli/commands/skill.js";
 import { buildSkillArtifactMetadata } from "../src/skills/artifact-metadata.js";
 import {
+	buildSkillRuntimeActivation,
 	hasSkillLintErrors,
 	isWindowsRunnableToolboxEntry,
 	lintSkillDirectory,
@@ -91,6 +98,68 @@ describe("skill package format", () => {
 		expect(skills[0]?.resources.map((resource) => resource.name)).not.toContain(
 			"mcp.json.example",
 		);
+	});
+
+	it("emits the runtime activation contract from skill inspect json", async () => {
+		const workspace = tempRoot();
+		const skillDir = join(workspace, ".maestro", "skills", "reviewing-prs");
+		await mkdir(join(skillDir, "reference"), { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: reviewing-prs\ndescription: "Review pull requests. Use when the user asks for PR review."\nallowed-tools:\n  - read\nbuiltin-tools:\n  - read\nisolatedContext: true\n---\n\n# Reviewing PRs\n`,
+		);
+		writeFileSync(
+			join(skillDir, "mcp.json"),
+			JSON.stringify({
+				github: {
+					command: "npx",
+					includeTools: ["get_pull_request"],
+					env: { GITHUB_TOKEN: "${GITHUB_TOKEN}" },
+				},
+			}),
+		);
+
+		const originalLog = console.log;
+		const logs: string[] = [];
+		console.log = (...args: unknown[]) => {
+			logs.push(args.map((arg) => String(arg)).join(" "));
+		};
+		try {
+			await handleSkillCommand("inspect", ["reviewing-prs", "--json"], {
+				workspaceDir: workspace,
+			});
+		} finally {
+			console.log = originalLog;
+		}
+
+		const payload = JSON.parse(logs.join("\n")) as {
+			runtimeActivation?: {
+				name: string;
+				tools: { allowed: string[]; builtin: string[] };
+				resources: { directories: { reference?: string } };
+				toolPackage: {
+					mcp?: {
+						configPath: string;
+						servers: Array<{ name: string; includeTools: string[] }>;
+					};
+				};
+			};
+		};
+
+		expect(payload.runtimeActivation).toMatchObject({
+			name: "reviewing-prs",
+			tools: { allowed: ["read"], builtin: ["read"] },
+			resources: { directories: { reference: join(skillDir, "reference") } },
+			toolPackage: {
+				mcp: {
+					configPath: join(skillDir, "mcp.json"),
+					servers: [{ name: "github", includeTools: ["get_pull_request"] }],
+				},
+			},
+		});
+		expect(
+			payload.runtimeActivation?.toolPackage.mcp?.servers[0],
+		).not.toHaveProperty("env");
 	});
 
 	it("accepts quoted isolatedContext consistently across load and lint", async () => {
@@ -215,6 +284,108 @@ describe("skill package format", () => {
 		expect(result.issues.map((issue) => issue.code)).toContain(
 			"mcp_tools_unfiltered",
 		);
+	});
+
+	it("omits mixed-type bundled MCP includeTools from runtime activation", async () => {
+		const workspace = tempRoot();
+		const skillDir = join(workspace, ".maestro", "skills", "reviewing-prs");
+		await mkdir(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: reviewing-prs\ndescription: "Review pull requests. Use when the user asks for PR review."\nallowed-tools:\n  - read\nbuiltin-tools:\n  - read\n---\n\n# Reviewing PRs\n`,
+		);
+		writeFileSync(
+			join(skillDir, "mcp.json"),
+			JSON.stringify({
+				github: {
+					command: "npx",
+					includeTools: ["get_pull_request", 42, "list_pull_request_files"],
+				},
+			}),
+		);
+
+		const { skills, errors } = loadSkills(workspace, { includeSystem: false });
+
+		expect(errors).toEqual([]);
+		expect(
+			buildSkillRuntimeActivation(skills[0]!).toolPackage.mcp,
+		).toMatchObject({
+			servers: [],
+			warnings: [
+				"MCP server 'github' includeTools entries must be non-empty strings.",
+			],
+		});
+	});
+
+	it("omits unbounded bundled MCP servers from runtime activation", async () => {
+		const workspace = tempRoot();
+		const skillDir = join(workspace, ".maestro", "skills", "reviewing-prs");
+		await mkdir(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: reviewing-prs\ndescription: "Review pull requests. Use when the user asks for PR review."\n---\n\n# Reviewing PRs\n`,
+		);
+		writeFileSync(
+			join(skillDir, "mcp.json"),
+			JSON.stringify({
+				github: {
+					command: "npx",
+				},
+				unsafe: {
+					includeTools: ["unsafe_tool"],
+				},
+				linear: {
+					command: "npx",
+					includeTools: ["get_issue"],
+				},
+			}),
+		);
+
+		const { skills, errors } = loadSkills(workspace, { includeSystem: false });
+
+		expect(errors).toEqual([]);
+		expect(
+			buildSkillRuntimeActivation(skills[0]!).toolPackage.mcp,
+		).toMatchObject({
+			servers: [{ name: "linear", includeTools: ["get_issue"] }],
+			warnings: [
+				"MCP server 'github' does not declare bounded includeTools.",
+				"MCP server 'unsafe' requires a non-empty command.",
+			],
+		});
+	});
+
+	it("degrades unreadable toolbox directories to an empty activation", async () => {
+		if (process.platform === "win32" || process.getuid?.() === 0) {
+			return;
+		}
+
+		const workspace = tempRoot();
+		const skillDir = join(workspace, ".maestro", "skills", "reviewing-prs");
+		const toolboxDir = join(skillDir, "toolbox");
+		await mkdir(toolboxDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: reviewing-prs\ndescription: "Review pull requests. Use when the user asks for PR review."\n---\n\n# Reviewing PRs\n`,
+		);
+		writeFileSync(join(toolboxDir, "run"), "echo ok\n", { mode: 0o755 });
+		const { skills, errors } = loadSkills(workspace, { includeSystem: false });
+		chmodSync(toolboxDir, 0o000);
+
+		try {
+			expect(errors).toEqual([]);
+			expect(
+				buildSkillRuntimeActivation(skills[0]!).toolPackage.toolbox,
+			).toMatchObject({
+				directory: toolboxDir,
+				entries: [],
+				warnings: [
+					expect.stringContaining("toolbox directory could not be read"),
+				],
+			});
+		} finally {
+			chmodSync(toolboxDir, 0o700);
+		}
 	});
 
 	it("classifies Windows toolbox entries by executable extension", () => {
@@ -403,6 +574,7 @@ describe("skill package format", () => {
 				sourcePath: skill.sourcePath,
 				resources: skill.resources,
 				resourceDirs: skill.resourceDirs,
+				runtimeActivation: buildSkillRuntimeActivation(skill),
 			},
 			null,
 			2,

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -355,6 +355,50 @@ describe("skill package format", () => {
 		});
 	});
 
+	it("omits MCP servers with invalid launch metadata from runtime activation", async () => {
+		const workspace = tempRoot();
+		const skillDir = join(workspace, ".maestro", "skills", "bad-launch-mcp");
+		await mkdir(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			"---\nname: bad-launch-mcp\ndescription: Test invalid MCP launch metadata.\n---\n\n# Bad Launch MCP\n",
+		);
+		writeFileSync(
+			join(skillDir, "mcp.json"),
+			JSON.stringify({
+				badArgs: {
+					command: "npx",
+					args: ["-y", 42],
+					includeTools: ["bad_args"],
+				},
+				badEnv: {
+					command: "npx",
+					env: { TOKEN: 42 },
+					includeTools: ["bad_env"],
+				},
+				good: {
+					command: "npx",
+					args: ["-y", "server"],
+					env: { TOKEN: "${TOKEN}" },
+					includeTools: ["good_tool"],
+				},
+			}),
+		);
+
+		const { skills, errors } = loadSkills(workspace, { includeSystem: false });
+
+		expect(errors).toEqual([]);
+		expect(
+			buildSkillRuntimeActivation(skills[0]!).toolPackage.mcp,
+		).toMatchObject({
+			servers: [{ name: "good", includeTools: ["good_tool"] }],
+			warnings: [
+				"MCP server 'badArgs' args entries must be strings.",
+				"MCP server 'badEnv' env values must be strings.",
+			],
+		});
+	});
+
 	it("degrades oversized MCP configs to bounded activation warnings", async () => {
 		const workspace = tempRoot();
 		const skillDir = join(workspace, ".maestro", "skills", "oversized-mcp");

--- a/test/skills/tool.test.ts
+++ b/test/skills/tool.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -177,6 +183,243 @@ ${content}
 				source: "project",
 			});
 			expect(skillMetadata?.hash).toMatch(/^[a-f0-9]{64}$/u);
+		});
+
+		it("returns a runtime activation manifest for scoped skill surfaces", async () => {
+			if (process.platform === "win32") {
+				return;
+			}
+
+			const dir = join(skillsDir, "reviewing-prs");
+			mkdirSync(join(dir, "reference"), { recursive: true });
+			mkdirSync(join(dir, "toolbox"), { recursive: true });
+			writeFileSync(
+				join(dir, "SKILL.md"),
+				`---
+name: reviewing-prs
+description: Review pull requests with scoped runtime resources.
+allowed-tools:
+  - read
+  - search
+builtin-tools:
+  - read
+model: gpt-5.5
+mode: review
+isolatedContext: true
+---
+
+Review the pull request and keep findings first.
+`,
+			);
+			writeFileSync(
+				join(dir, "reference", "rubric.md"),
+				"# Rubric\n\nFind correctness issues before style comments.\n",
+			);
+			const toolboxEntry = join(dir, "toolbox", "summarize-pr");
+			writeFileSync(toolboxEntry, "#!/usr/bin/env bash\necho summary\n");
+			chmodSync(toolboxEntry, 0o755);
+			const toolboxNote = join(dir, "toolbox", "notes.txt");
+			writeFileSync(toolboxNote, "not a runnable command\n");
+			writeFileSync(
+				join(dir, "mcp.json"),
+				JSON.stringify(
+					{
+						github: {
+							command: "npx",
+							args: ["-y", "@modelcontextprotocol/server-github"],
+							env: { GITHUB_TOKEN: "${GITHUB_TOKEN}" },
+							includeTools: ["get_pull_request", "list_pull_request_files"],
+						},
+					},
+					null,
+					2,
+				),
+			);
+
+			const tool = createSkillTool(testDir, { includeSystem: false });
+			const result = await tool.execute("test-runtime-activation", {
+				skill: "reviewing-prs",
+			});
+			const activation = (
+				result.details as
+					| {
+							skillRuntimeActivation?: {
+								name: string;
+								source: string;
+								profile: {
+									model?: string;
+									mode?: string;
+									isolatedContext?: boolean;
+								};
+								tools: { allowed: string[]; builtin: string[] };
+								resources: {
+									directories: {
+										reference?: string;
+										toolbox?: string;
+									};
+								};
+								toolPackage: {
+									toolbox?: {
+										directory: string;
+										entries: Array<{ name: string; path: string }>;
+									};
+									mcp?: {
+										configPath: string;
+										servers: Array<{
+											name: string;
+											command?: string;
+											includeTools: string[];
+										}>;
+									};
+								};
+							};
+					  }
+					| undefined
+			)?.skillRuntimeActivation;
+
+			expect(activation).toMatchObject({
+				name: "reviewing-prs",
+				source: "project",
+				profile: {
+					model: "gpt-5.5",
+					mode: "review",
+					isolatedContext: true,
+				},
+				tools: {
+					allowed: ["read", "search"],
+					builtin: ["read"],
+				},
+				resources: {
+					directories: {
+						reference: join(dir, "reference"),
+						toolbox: join(dir, "toolbox"),
+					},
+				},
+				toolPackage: {
+					toolbox: {
+						directory: join(dir, "toolbox"),
+						entries: [{ name: "summarize-pr", path: toolboxEntry }],
+					},
+					mcp: {
+						configPath: join(dir, "mcp.json"),
+						servers: [
+							{
+								name: "github",
+								command: "npx",
+								includeTools: ["get_pull_request", "list_pull_request_files"],
+							},
+						],
+					},
+				},
+			});
+			expect(activation?.toolPackage.toolbox?.entries).not.toContainEqual({
+				name: "notes.txt",
+				path: toolboxNote,
+			});
+			expect(activation?.toolPackage.mcp?.servers[0]).not.toHaveProperty("env");
+		});
+
+		it("marks malformed MCP includeTools as unbounded instead of silently filtering them", async () => {
+			const dir = join(skillsDir, "bad-mcp");
+			mkdirSync(dir, { recursive: true });
+			writeFileSync(
+				join(dir, "SKILL.md"),
+				`---
+name: bad-mcp
+description: Test malformed MCP activation surfaces.
+---
+
+Use the bundled MCP server.
+`,
+			);
+			writeFileSync(
+				join(dir, "mcp.json"),
+				JSON.stringify({
+					github: {
+						command: "npx",
+						includeTools: ["get_pull_request", 42, "list_pull_request_files"],
+					},
+				}),
+			);
+
+			const tool = createSkillTool(testDir, { includeSystem: false });
+			const result = await tool.execute("test-runtime-activation-bad-mcp", {
+				skill: "bad-mcp",
+			});
+			const activation = (
+				result.details as
+					| {
+							skillRuntimeActivation?: {
+								toolPackage: {
+									mcp?: {
+										servers: Array<{ includeTools: string[] }>;
+										warnings?: string[];
+									};
+								};
+							};
+					  }
+					| undefined
+			)?.skillRuntimeActivation;
+
+			expect(activation?.toolPackage.mcp?.servers).toEqual([]);
+			expect(activation?.toolPackage.mcp?.warnings).toContain(
+				"MCP server 'github' includeTools entries must be non-empty strings.",
+			);
+		});
+
+		it("degrades unreadable toolbox directories to warnings", async () => {
+			if (process.platform === "win32" || process.getuid?.() === 0) {
+				return;
+			}
+
+			const dir = join(skillsDir, "locked-toolbox");
+			const toolboxDir = join(dir, "toolbox");
+			mkdirSync(toolboxDir, { recursive: true });
+			writeFileSync(
+				join(dir, "SKILL.md"),
+				`---
+name: locked-toolbox
+description: Test unreadable toolbox activation surfaces.
+---
+
+Use the bundled toolbox.
+`,
+			);
+			chmodSync(toolboxDir, 0o000);
+
+			const tool = createSkillTool(testDir, { includeSystem: false });
+			let result: Awaited<ReturnType<typeof tool.execute>>;
+			try {
+				result = await tool.execute("test-runtime-activation-locked-toolbox", {
+					skill: "locked-toolbox",
+				});
+			} finally {
+				chmodSync(toolboxDir, 0o755);
+			}
+			const activation = (
+				result.details as
+					| {
+							skillRuntimeActivation?: {
+								toolPackage: {
+									toolbox?: {
+										directory: string;
+										entries: Array<{ name: string; path: string }>;
+										warnings?: string[];
+									};
+								};
+							};
+					  }
+					| undefined
+			)?.skillRuntimeActivation;
+
+			expect(result.isError).toBeUndefined();
+			expect(activation?.toolPackage.toolbox).toMatchObject({
+				directory: toolboxDir,
+				entries: [],
+				warnings: [
+					expect.stringContaining("toolbox directory could not be read:"),
+				],
+			});
 		});
 
 		it("loads skill case-insensitively", async () => {


### PR DESCRIPTION
## Summary
- Add a skill runtime activation manifest that captures active profile hints, allowed/builtin tools, resource directories, executable toolbox entries, and bounded MCP server tool surfaces.
- Return the manifest from the Skill tool alongside skill artifact metadata.
- Include the same contract in `maestro skill inspect --json` and document it in the Agent Core parity spec/cookbook.
- Harden activation parsing so malformed MCP launch metadata and mcp.json stat/read failures degrade to warnings instead of leaking or throwing.

## Internal Source PRs
- evalops/maestro-internal#1967
- evalops/maestro-internal#1972

## Staged rollout
This is an enabling primitive and manifest-only contract. Direct exposure is safe because it does not auto-start MCP servers or toolbox executables; it only reports scoped paths and bounded tool names when a skill is already loaded or inspected. Staging is unnecessary until a later PR wires activation into live MCP/toolbox lifecycle.

## Verification
- `node ./scripts/run-vitest.js --run test/skills/tool.test.ts test/skill-package-format.test.ts test/skill-eval-harness.test.ts`
- `bunx tsc -p tsconfig.build.json --noEmit`
- Commit hook: Guardian, `bunx biome check .`, `bun run lint:evals`, build, and compile completed successfully.
- GitHub CI: build-and-publish, pr-checks, coverage, coverage-scope, rust-hosted-conformance, require-internal-pr, Socket, and Cursor Bugbot passed.