### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
 self-hosted-runner:
   labels:
     - blacksmith-*
-    - evalops-maestro-rbe
+    - evalops-maestro-internal-rbe

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 module(
-    name = "evalops_maestro",
+    name = "evalops_maestro_internal",
     version = "0.0.0",
 )
 

--- a/docs/development/bazel.md
+++ b/docs/development/bazel.md
@@ -29,5 +29,5 @@ make bazel-rbe-smoke
 ```
 
 Trusted CI should run on the repo-scoped Buildfarm runner label
-`evalops-maestro-rbe` after Deploy has registered that runner through
+`evalops-maestro-internal-rbe` after Deploy has registered that runner through
 `additional_bazel_buildfarm_runners`.

--- a/docs/protocols/codex-operating-layer.json
+++ b/docs/protocols/codex-operating-layer.json
@@ -276,6 +276,33 @@
 			]
 		},
 		{
+			"area": "remote-runner-continuity",
+			"evidenceType": "source",
+			"path": "src/server/handlers/hosted-runner-drain.ts",
+			"anchors": [
+				"evalops.remote-runner.work-continuity.v1",
+				"collectHostedRunnerWorkContinuity",
+				"codex_subagent_child_run_ids",
+				"codex_subagent_thread_ids"
+			]
+		},
+		{
+			"area": "remote-runner-continuity",
+			"evidenceType": "test",
+			"path": "test/server/hosted-runner-drain.test.ts",
+			"anchors": [
+				"records Codex subagent continuity without copying prompt payloads into manifest metadata",
+				"HOSTED_RUNNER_WORK_CONTINUITY_VERSION",
+				"codex_subagent_child_run_ids"
+			]
+		},
+		{
+			"area": "remote-runner-continuity",
+			"evidenceType": "doc",
+			"path": "docs/protocols/hosted-runner-contract.md",
+			"anchors": ["work_continuity", "Codex subagent child runs"]
+		},
+		{
 			"area": "realtime-streaming",
 			"evidenceType": "source",
 			"path": "src/server/handlers/runtime-app-server-ws.ts",

--- a/docs/protocols/headless.md
+++ b/docs/protocols/headless.md
@@ -124,6 +124,15 @@ snapshot manifest. The manifest directory comes from `--snapshot-root`,
         }
       ]
     },
+    "work_continuity": {
+      "protocol_version": "evalops.remote-runner.work-continuity.v1",
+      "active_tool_count": 0,
+      "tracked_tool_count": 0,
+      "pending_request_count": 0,
+      "codex_subagent_tool_call_ids": [],
+      "codex_subagent_child_run_ids": [],
+      "codex_subagent_thread_ids": []
+    },
     "retention_policy": {
       "policy_version": "evalops.remote-runner.retention.v1",
       "managed_by": "platform",

--- a/docs/protocols/hosted-runner-contract.md
+++ b/docs/protocols/hosted-runner-contract.md
@@ -187,7 +187,8 @@ The manifest protocol is
 `evalops.remote-runner.snapshot-manifest.v1`. Both Rust-hosted and
 TypeScript-hosted drain paths write this same local manifest envelope, including
 the runtime flush status, workspace export contract, headless runtime snapshot,
-and `retention_policy` metadata describing visibility and redaction classes.
+`work_continuity` metadata for active/pending Codex subagent child runs, and
+`retention_policy` metadata describing visibility and redaction classes.
 Maestro does not upload to GCS, S3, Modal storage, Daytona storage, or any
 other provider store. Upload, retention, workspace artifact hydration, and
 choosing which manifest should be restored are Platform responsibilities. See

--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -5,7 +5,7 @@
 //! contract so Platform and conformance tests can target a Rust runtime without
 //! routing through the Node web server.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::ffi::OsString;
 use std::fs;
 use std::io;
@@ -40,12 +40,15 @@ pub const HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION: &str = "evalops.remote-runner.dr
 pub const HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION: &str =
     "evalops.remote-runner.snapshot-manifest.v1";
 pub const HOSTED_RUNNER_RETENTION_POLICY_VERSION: &str = "evalops.remote-runner.retention.v1";
+pub const HOSTED_RUNNER_WORK_CONTINUITY_VERSION: &str = "evalops.remote-runner.work-continuity.v1";
 
 const DEFAULT_LISTEN_HOST: &str = "0.0.0.0";
 const DEFAULT_LISTEN_PORT: u16 = 8080;
 const DEFAULT_HEARTBEAT_INTERVAL_MS: u64 = 15_000;
 const CONNECTION_IDLE_MS: i64 = (DEFAULT_HEARTBEAT_INTERVAL_MS as i64) * 3;
 const MAX_EVENTS: usize = 1024;
+const CODEX_SUBAGENT_TOOL_PREFIX: &str = "codex.subagent.";
+const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA: &str = "evalops.maestro.codex.subagent-workgraph.v1";
 
 #[derive(Debug, Clone)]
 pub struct HostedRunnerConfig {
@@ -575,6 +578,8 @@ struct SnapshotManifest {
     workspace_root: PathBuf,
     runtime: RuntimeFlushManifest,
     workspace_export: WorkspaceExportManifest,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    work_continuity: Option<WorkContinuityManifest>,
     snapshot: RuntimeSnapshot,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     retention_policy: Option<RetentionPolicyManifest>,
@@ -606,6 +611,17 @@ impl SnapshotManifest {
         }
         Ok(())
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WorkContinuityManifest {
+    protocol_version: String,
+    active_tool_count: usize,
+    tracked_tool_count: usize,
+    pending_request_count: usize,
+    codex_subagent_tool_call_ids: Vec<String>,
+    codex_subagent_child_run_ids: Vec<String>,
+    codex_subagent_thread_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -654,6 +670,153 @@ fn default_retention_policy_manifest() -> RetentionPolicyManifest {
             ],
         },
     }
+}
+
+fn default_work_continuity_manifest(snapshot: &RuntimeSnapshot) -> WorkContinuityManifest {
+    let state = &snapshot.state;
+    let mut tool_call_ids = BTreeSet::new();
+    let mut child_run_ids = BTreeSet::new();
+    let mut thread_ids = BTreeSet::new();
+    let pending_request_count = state.pending_approvals.len()
+        + state.pending_client_tools.len()
+        + state.pending_mcp_elicitations.len()
+        + state.pending_user_inputs.len()
+        + state.pending_tool_retries.len();
+    for source in state
+        .tracked_tools
+        .iter()
+        .chain(state.pending_approvals.iter())
+        .chain(state.pending_client_tools.iter())
+        .chain(state.pending_mcp_elicitations.iter())
+        .chain(state.pending_user_inputs.iter())
+        .chain(state.pending_tool_retries.iter())
+    {
+        let tool = json_string_field(source, &["tool"]).unwrap_or_default();
+        let is_codex_subagent_tool = tool.starts_with(CODEX_SUBAGENT_TOOL_PREFIX);
+        let has_codex_work_args = collect_codex_work_args(
+            source.get("args"),
+            &mut child_run_ids,
+            &mut thread_ids,
+            is_codex_subagent_tool,
+        );
+        if is_codex_subagent_tool || has_codex_work_args {
+            if let Some(call_id) =
+                json_string_field(source, &["call_id", "callId", "tool_call_id", "toolCallId"])
+            {
+                tool_call_ids.insert(call_id);
+            }
+        }
+    }
+    for active_tool in &state.active_tools {
+        let tool = json_string_field(active_tool, &["tool"]).unwrap_or_default();
+        if tool.starts_with(CODEX_SUBAGENT_TOOL_PREFIX) {
+            if let Some(call_id) = json_string_field(
+                active_tool,
+                &["call_id", "callId", "tool_call_id", "toolCallId"],
+            ) {
+                tool_call_ids.insert(call_id);
+            }
+        }
+    }
+    WorkContinuityManifest {
+        protocol_version: HOSTED_RUNNER_WORK_CONTINUITY_VERSION.to_string(),
+        active_tool_count: state.active_tools.len(),
+        tracked_tool_count: state.tracked_tools.len(),
+        pending_request_count,
+        codex_subagent_tool_call_ids: tool_call_ids.into_iter().collect(),
+        codex_subagent_child_run_ids: child_run_ids.into_iter().collect(),
+        codex_subagent_thread_ids: thread_ids.into_iter().collect(),
+    }
+}
+
+fn collect_codex_work_args(
+    args: Option<&serde_json::Value>,
+    child_run_ids: &mut BTreeSet<String>,
+    thread_ids: &mut BTreeSet<String>,
+    include_loose_args: bool,
+) -> bool {
+    let Some(args) = args.and_then(serde_json::Value::as_object) else {
+        return false;
+    };
+    let graph = args
+        .get("codexWorkGraph")
+        .or_else(|| args.get("codex_work_graph"));
+    let has_codex_graph = graph
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|graph| {
+            json_string_field_from_object(graph, &["schemaVersion", "schema_version"]).as_deref()
+                == Some(CODEX_SUBAGENT_WORK_GRAPH_SCHEMA)
+        });
+    if !include_loose_args && !has_codex_graph {
+        return false;
+    }
+    collect_json_string_array_from_object(args, &["childRunIds", "child_run_ids"], child_run_ids);
+    collect_json_string_array_from_object(
+        args,
+        &["receiverThreadIds", "receiver_thread_ids"],
+        thread_ids,
+    );
+    if let Some(graph) = graph.and_then(serde_json::Value::as_object) {
+        let child_runs = graph
+            .get("childRuns")
+            .or_else(|| graph.get("child_runs"))
+            .and_then(serde_json::Value::as_array);
+        if let Some(child_runs) = child_runs {
+            for child_run in child_runs {
+                if let Some(child_run) = child_run.as_object() {
+                    if let Some(child_run_id) =
+                        json_string_field_from_object(child_run, &["childRunId", "child_run_id"])
+                    {
+                        child_run_ids.insert(child_run_id);
+                    }
+                    if let Some(thread_id) =
+                        json_string_field_from_object(child_run, &["threadId", "thread_id"])
+                    {
+                        thread_ids.insert(thread_id);
+                    }
+                }
+            }
+        }
+    }
+    include_loose_args || has_codex_graph
+}
+
+fn collect_json_string_array_from_object(
+    object: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+    values: &mut BTreeSet<String>,
+) {
+    for key in keys {
+        let Some(items) = object.get(*key).and_then(serde_json::Value::as_array) else {
+            continue;
+        };
+        for item in items {
+            if let Some(item) = item.as_str().map(str::trim).filter(|item| !item.is_empty()) {
+                values.insert(item.to_string());
+            }
+        }
+        return;
+    }
+}
+
+fn json_string_field(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    value
+        .as_object()
+        .and_then(|object| json_string_field_from_object(object, keys))
+}
+
+fn json_string_field_from_object(
+    object: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Option<String> {
+    keys.iter().find_map(|key| {
+        object
+            .get(*key)
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -2741,6 +2904,7 @@ async fn write_snapshot_manifest(
             mode: "local_path_contract".to_string(),
             paths: workspace_export_paths,
         },
+        work_continuity: Some(default_work_continuity_manifest(&snapshot)),
         snapshot,
         retention_policy: Some(default_retention_policy_manifest()),
     };
@@ -3632,6 +3796,16 @@ mod tests {
             "directory"
         );
         assert_eq!(
+            manifest["work_continuity"]["protocol_version"],
+            HOSTED_RUNNER_WORK_CONTINUITY_VERSION
+        );
+        assert_eq!(manifest["work_continuity"]["active_tool_count"], 0);
+        assert_eq!(manifest["work_continuity"]["tracked_tool_count"], 0);
+        assert_eq!(
+            manifest["work_continuity"]["codex_subagent_tool_call_ids"],
+            json!([])
+        );
+        assert_eq!(
             manifest["retention_policy"]["policy_version"],
             HOSTED_RUNNER_RETENTION_POLICY_VERSION
         );
@@ -3940,6 +4114,15 @@ mod tests {
                     "type": "file"
                 }]
             },
+            "work_continuity": {
+                "protocol_version": HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
+                "active_tool_count": 1,
+                "tracked_tool_count": 1,
+                "pending_request_count": 0,
+                "codex_subagent_tool_call_ids": ["collab-spawn-ts"],
+                "codex_subagent_child_run_ids": ["agent-run-child-ts"],
+                "codex_subagent_thread_ids": ["child-thread-ts"]
+            },
             "retention_policy": {
                 "policy_version": HOSTED_RUNNER_RETENTION_POLICY_VERSION,
                 "managed_by": "platform",
@@ -4009,9 +4192,97 @@ mod tests {
                 .policy_version,
             HOSTED_RUNNER_RETENTION_POLICY_VERSION
         );
+        let work_continuity = parsed.work_continuity.as_ref().expect("work continuity");
+        assert_eq!(
+            work_continuity.protocol_version,
+            HOSTED_RUNNER_WORK_CONTINUITY_VERSION
+        );
+        assert_eq!(
+            work_continuity.codex_subagent_child_run_ids,
+            vec!["agent-run-child-ts".to_string()]
+        );
         assert_eq!(parsed.snapshot.session_id, "session_ts");
         assert_eq!(parsed.snapshot.cursor, 7);
         assert_eq!(parsed.workspace_export.paths[0].relative_path, "README.md");
+    }
+
+    #[test]
+    fn work_continuity_manifest_extracts_codex_subagent_ids() {
+        let snapshot: RuntimeSnapshot = serde_json::from_value(json!({
+            "protocolVersion": HEADLESS_PROTOCOL_VERSION,
+            "session_id": "session_rust",
+            "cursor": 9,
+            "last_init": null,
+            "state": {
+                "protocol_version": HEADLESS_PROTOCOL_VERSION,
+                "connection_count": 0,
+                "subscriber_count": 0,
+                "connections": [],
+                "model": "gpt-5.4",
+                "provider": "rust",
+                "session_id": "session_rust",
+                "pending_approvals": [{
+                    "id": "approval-rust",
+                    "call_id": "approval-call-rust",
+                    "tool": "shell"
+                }],
+                "pending_client_tools": [],
+                "pending_mcp_elicitations": [],
+                "pending_user_inputs": [{
+                    "id": "input-rust",
+                    "prompt": "continue?"
+                }],
+                "pending_tool_retries": [],
+                "tracked_tools": [{
+                    "call_id": "collab-spawn-rust",
+                    "tool": "codex.subagent.spawnAgent",
+                    "args": {
+                        "prompt": "Sensitive Rust subagent prompt",
+                        "codex_work_graph": {
+                            "schema_version": "evalops.maestro.codex.subagent-workgraph.v1",
+                            "child_runs": [{
+                                "thread_id": "child-thread-rust",
+                                "child_run_id": "agent-run-child-rust"
+                            }]
+                        }
+                    }
+                }],
+                "active_tools": [{
+                    "call_id": "collab-spawn-rust",
+                    "tool": "codex.subagent.spawnAgent",
+                    "output": "starting child"
+                }],
+                "active_utility_commands": [],
+                "active_file_watches": [],
+                "is_ready": true,
+                "is_responding": false
+            }
+        }))
+        .expect("runtime snapshot");
+
+        let continuity = default_work_continuity_manifest(&snapshot);
+
+        assert_eq!(
+            continuity.protocol_version,
+            HOSTED_RUNNER_WORK_CONTINUITY_VERSION
+        );
+        assert_eq!(continuity.active_tool_count, 1);
+        assert_eq!(continuity.tracked_tool_count, 1);
+        assert_eq!(continuity.pending_request_count, 2);
+        assert_eq!(
+            continuity.codex_subagent_tool_call_ids,
+            vec!["collab-spawn-rust".to_string()]
+        );
+        assert_eq!(
+            continuity.codex_subagent_child_run_ids,
+            vec!["agent-run-child-rust".to_string()]
+        );
+        assert_eq!(
+            continuity.codex_subagent_thread_ids,
+            vec!["child-thread-rust".to_string()]
+        );
+        let continuity_json = serde_json::to_string(&continuity).expect("continuity json");
+        assert!(!continuity_json.contains("Sensitive Rust subagent prompt"));
     }
 
     #[tokio::test]

--- a/packages/tui-rs/src/ui_state.rs
+++ b/packages/tui-rs/src/ui_state.rs
@@ -89,7 +89,12 @@ pub fn save_queue_modes(steering_mode: QueueMode, follow_up_mode: QueueMode) -> 
 }
 
 fn ui_state_path() -> Option<PathBuf> {
-    if let Ok(path) = env::var("MAESTRO_UI_STATE") {
+    let configured_path = env::var("MAESTRO_UI_STATE").ok();
+    ui_state_path_from_env_value(configured_path.as_deref())
+}
+
+fn ui_state_path_from_env_value(path: Option<&str>) -> Option<PathBuf> {
+    if let Some(path) = path {
         if !path.trim().is_empty() {
             let raw = PathBuf::from(path);
             if let Some(expanded) = expand_tilde(&raw) {
@@ -159,56 +164,33 @@ mod tests {
     // ========================================================================
     // UI State Path Tests
     // ========================================================================
-    // NOTE: These tests modify environment variables which is not thread-safe.
-    // They use unique env var names to avoid race conditions with parallel tests.
 
     #[test]
     fn test_ui_state_path_default() {
-        // Test default behavior by temporarily checking if env var is unset
-        // Note: Due to parallel test execution, we can't reliably clear env vars
-        // Instead, verify the function returns a valid path structure
-        let current_env = std::env::var("MAESTRO_UI_STATE").ok();
-        if current_env.is_none() || current_env.as_ref().is_some_and(|v| v.trim().is_empty()) {
-            let path = ui_state_path();
-            if let Some(p) = path {
-                assert!(
-                    p.ends_with("ui-state.json"),
-                    "Expected path to end with ui-state.json, got: {:?}",
-                    p
-                );
-                assert!(
-                    p.to_string_lossy().contains(".composer"),
-                    "Expected path to contain .composer, got: {:?}",
-                    p
-                );
-            }
+        let path = ui_state_path_from_env_value(None);
+        if let Some(p) = path {
+            assert!(
+                p.ends_with("ui-state.json"),
+                "Expected path to end with ui-state.json, got: {:?}",
+                p
+            );
+            assert!(
+                p.to_string_lossy().contains(".composer"),
+                "Expected path to contain .composer, got: {:?}",
+                p
+            );
         }
-        // If env var is set by another test, skip this test's assertions
     }
 
     #[test]
     fn test_ui_state_path_from_env() {
-        // Save original value
-        let original = std::env::var("MAESTRO_UI_STATE").ok();
-
-        std::env::set_var("MAESTRO_UI_STATE", "/tmp/custom-ui-state.json");
-        let path = ui_state_path();
+        let path = ui_state_path_from_env_value(Some("/tmp/custom-ui-state.json"));
         assert_eq!(path, Some(PathBuf::from("/tmp/custom-ui-state.json")));
-
-        // Restore original value
-        match original {
-            Some(v) => std::env::set_var("MAESTRO_UI_STATE", v),
-            None => std::env::remove_var("MAESTRO_UI_STATE"),
-        }
     }
 
     #[test]
     fn test_ui_state_path_empty_env() {
-        // Save original value
-        let original = std::env::var("MAESTRO_UI_STATE").ok();
-
-        std::env::set_var("MAESTRO_UI_STATE", "   ");
-        let path = ui_state_path();
+        let path = ui_state_path_from_env_value(Some("   "));
         // Should fall back to default when env var is empty/whitespace
         if let Some(p) = path {
             assert!(
@@ -217,31 +199,15 @@ mod tests {
                 p
             );
         }
-
-        // Restore original value
-        match original {
-            Some(v) => std::env::set_var("MAESTRO_UI_STATE", v),
-            None => std::env::remove_var("MAESTRO_UI_STATE"),
-        }
     }
 
     #[test]
     fn test_ui_state_path_tilde_expansion() {
-        // Save original value
-        let original = std::env::var("MAESTRO_UI_STATE").ok();
-
-        std::env::set_var("MAESTRO_UI_STATE", "~/my-ui-state.json");
-        let path = ui_state_path();
+        let path = ui_state_path_from_env_value(Some("~/my-ui-state.json"));
         if let Some(p) = path {
             // Should not start with ~ after expansion
             assert!(!p.to_string_lossy().starts_with('~'));
             assert!(p.to_string_lossy().ends_with("my-ui-state.json"));
-        }
-
-        // Restore original value
-        match original {
-            Some(v) => std::env::set_var("MAESTRO_UI_STATE", v),
-            None => std::env::remove_var("MAESTRO_UI_STATE"),
         }
     }
 }

--- a/src/server/handlers/hosted-runner-drain.ts
+++ b/src/server/handlers/hosted-runner-drain.ts
@@ -25,6 +25,13 @@ export const HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION =
 export const HOSTED_RUNNER_RETENTION_POLICY_VERSION =
 	"evalops.remote-runner.retention.v1";
 
+export const HOSTED_RUNNER_WORK_CONTINUITY_VERSION =
+	"evalops.remote-runner.work-continuity.v1";
+
+const CODEX_SUBAGENT_TOOL_PREFIX = "codex.subagent.";
+const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA =
+	"evalops.maestro.codex.subagent-workgraph.v1";
+
 export enum HostedRunnerDrainStatusValue {
 	Drained = "drained",
 	Interrupted = "interrupted",
@@ -105,6 +112,24 @@ export interface HostedRunnerRuntimeDrainResult {
 	snapshot?: HeadlessRuntimeSnapshot;
 }
 
+class HostedRunnerRuntimeDrainError extends Error {
+	readonly sessionId: string;
+	readonly sessionFile?: string;
+	readonly protocolVersion?: string;
+	readonly cursor?: number;
+	readonly snapshot?: HeadlessRuntimeSnapshot;
+
+	constructor(message: string, runtime: HostedRunnerRuntimeDrainResult) {
+		super(message);
+		this.name = "HostedRunnerRuntimeDrainError";
+		this.sessionId = runtime.sessionId;
+		this.sessionFile = runtime.sessionFile;
+		this.protocolVersion = runtime.protocolVersion;
+		this.cursor = runtime.cursor;
+		this.snapshot = runtime.snapshot;
+	}
+}
+
 export interface HostedRunnerWorkspaceExportPath {
 	input: string;
 	path: string;
@@ -134,6 +159,7 @@ export interface HostedRunnerSnapshotManifest {
 		mode: HostedRunnerWorkspaceExportMode;
 		paths: HostedRunnerWorkspaceExportPath[];
 	};
+	work_continuity: HostedRunnerWorkContinuity;
 	snapshot: HeadlessRuntimeSnapshot;
 	retention_policy: HostedRunnerRetentionPolicy;
 	git?: {
@@ -141,6 +167,16 @@ export interface HostedRunnerSnapshotManifest {
 		branch?: string;
 		dirty?: boolean;
 	};
+}
+
+export interface HostedRunnerWorkContinuity {
+	protocol_version: typeof HOSTED_RUNNER_WORK_CONTINUITY_VERSION;
+	active_tool_count: number;
+	tracked_tool_count: number;
+	pending_request_count: number;
+	codex_subagent_tool_call_ids: string[];
+	codex_subagent_child_run_ids: string[];
+	codex_subagent_thread_ids: string[];
 }
 
 export interface HostedRunnerDrainResult {
@@ -412,6 +448,115 @@ function buildHostedRunnerRetentionPolicy(): HostedRunnerRetentionPolicy {
 	};
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function stringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter(
+				(item): item is string => typeof item === "string" && item.length > 0,
+			)
+		: [];
+}
+
+function collectCodexWorkArgs(
+	args: unknown,
+	childRunIds: Set<string>,
+	threadIds: Set<string>,
+	includeLooseArgs = false,
+): boolean {
+	if (!isRecord(args)) {
+		return false;
+	}
+	const graph = args.codexWorkGraph ?? args.codex_work_graph;
+	const hasCodexGraph =
+		isRecord(graph) &&
+		(graph.schemaVersion === CODEX_SUBAGENT_WORK_GRAPH_SCHEMA ||
+			graph.schema_version === CODEX_SUBAGENT_WORK_GRAPH_SCHEMA);
+	if (!includeLooseArgs && !hasCodexGraph) {
+		return false;
+	}
+	for (const childRunId of stringArray(
+		args.childRunIds ?? args.child_run_ids,
+	)) {
+		childRunIds.add(childRunId);
+	}
+	for (const threadId of stringArray(
+		args.receiverThreadIds ?? args.receiver_thread_ids,
+	)) {
+		threadIds.add(threadId);
+	}
+	if (isRecord(graph)) {
+		const graphChildRuns = graph.childRuns ?? graph.child_runs;
+		for (const childRun of Array.isArray(graphChildRuns)
+			? graphChildRuns
+			: []) {
+			if (!isRecord(childRun)) {
+				continue;
+			}
+			const childRunId = childRun.childRunId ?? childRun.child_run_id;
+			if (typeof childRunId === "string" && childRunId) {
+				childRunIds.add(childRunId);
+			}
+			const threadId = childRun.threadId ?? childRun.thread_id;
+			if (typeof threadId === "string" && threadId) {
+				threadIds.add(threadId);
+			}
+		}
+	}
+	return includeLooseArgs || hasCodexGraph;
+}
+
+function collectHostedRunnerWorkContinuity(
+	snapshot: HeadlessRuntimeSnapshot,
+): HostedRunnerWorkContinuity {
+	const state = snapshot.state;
+	const codexToolCallIds = new Set<string>();
+	const childRunIds = new Set<string>();
+	const threadIds = new Set<string>();
+	const trackedSources = [
+		...state.tracked_tools,
+		...state.pending_approvals,
+		...state.pending_client_tools,
+		...state.pending_mcp_elicitations,
+		...state.pending_user_inputs,
+		...state.pending_tool_retries,
+	];
+	for (const source of trackedSources) {
+		const tool = source.tool;
+		const isCodexSubagentTool = tool.startsWith(CODEX_SUBAGENT_TOOL_PREFIX);
+		const hasCodexWorkArgs = collectCodexWorkArgs(
+			source.args,
+			childRunIds,
+			threadIds,
+			isCodexSubagentTool,
+		);
+		if (isCodexSubagentTool || hasCodexWorkArgs) {
+			codexToolCallIds.add(source.call_id);
+		}
+	}
+	for (const activeTool of state.active_tools) {
+		if (activeTool.tool.startsWith(CODEX_SUBAGENT_TOOL_PREFIX)) {
+			codexToolCallIds.add(activeTool.call_id);
+		}
+	}
+	return {
+		protocol_version: HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
+		active_tool_count: state.active_tools.length,
+		tracked_tool_count: state.tracked_tools.length,
+		pending_request_count:
+			state.pending_approvals.length +
+			state.pending_client_tools.length +
+			state.pending_mcp_elicitations.length +
+			state.pending_user_inputs.length +
+			state.pending_tool_retries.length,
+		codex_subagent_tool_call_ids: [...codexToolCallIds].sort(),
+		codex_subagent_child_run_ids: [...childRunIds].sort(),
+		codex_subagent_thread_ids: [...threadIds].sort(),
+	};
+}
+
 export async function drainHostedRunner(
 	input: HostedRunnerDrainInput,
 	options: DrainHostedRunnerOptions,
@@ -474,9 +619,21 @@ export async function drainHostedRunner(
 			runtimeSnapshot = runtimeResult?.snapshot;
 		} catch (error) {
 			status = HostedRunnerDrainStatusValue.Interrupted;
+			const interruptedRuntime =
+				error instanceof HostedRunnerRuntimeDrainError ? error : undefined;
+			runtimeSnapshot = interruptedRuntime?.snapshot;
 			runtime = {
 				flush_status: HostedRunnerRuntimeFlushStatusValue.Failed,
-				session_id: activeSessionId,
+				session_id: interruptedRuntime?.sessionId ?? activeSessionId,
+				...(interruptedRuntime?.sessionFile
+					? { session_file: interruptedRuntime.sessionFile }
+					: {}),
+				...(interruptedRuntime?.protocolVersion
+					? { protocol_version: interruptedRuntime.protocolVersion }
+					: {}),
+				...(interruptedRuntime?.cursor !== undefined
+					? { cursor: interruptedRuntime.cursor }
+					: {}),
 				error: error instanceof Error ? error.message : String(error),
 			};
 		}
@@ -510,6 +667,7 @@ export async function drainHostedRunner(
 			mode: HostedRunnerWorkspaceExportModeValue.LocalPathContract,
 			paths: exportPaths,
 		},
+		work_continuity: collectHostedRunnerWorkContinuity(snapshot),
 		snapshot,
 		retention_policy: buildHostedRunnerRetentionPolicy(),
 		...(git ? { git } : {}),
@@ -566,7 +724,16 @@ async function drainActiveRuntime(
 			requestedBy: terminal.requestedBy,
 			retryable: false,
 		});
-		throw error;
+		throw new HostedRunnerRuntimeDrainError(
+			error instanceof Error ? error.message : String(error),
+			{
+				sessionId: snapshot.session_id,
+				sessionFile,
+				protocolVersion: snapshot.protocolVersion,
+				cursor: snapshot.cursor,
+				snapshot,
+			},
+		);
 	}
 	return {
 		sessionId: snapshot.session_id,

--- a/test/server/hosted-runner-drain.test.ts
+++ b/test/server/hosted-runner-drain.test.ts
@@ -17,6 +17,7 @@ import type { HostedRunnerContext } from "../../src/server/app-context.js";
 import {
 	HOSTED_RUNNER_RETENTION_POLICY_VERSION,
 	HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
+	HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
 	HostedRunnerDrainReasonValue,
 	HostedRunnerDrainRequestedByValue,
 	HostedRunnerDrainStatusValue,
@@ -139,6 +140,15 @@ describe("hosted runner drain", () => {
 				protocol_version: HEADLESS_PROTOCOL_VERSION,
 				cursor: 7,
 			},
+			work_continuity: {
+				protocol_version: HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
+				active_tool_count: 0,
+				tracked_tool_count: 0,
+				pending_request_count: 0,
+				codex_subagent_tool_call_ids: [],
+				codex_subagent_child_run_ids: [],
+				codex_subagent_thread_ids: [],
+			},
 			retention_policy: {
 				policy_version: HOSTED_RUNNER_RETENTION_POLICY_VERSION,
 				managed_by: "platform",
@@ -190,6 +200,38 @@ describe("hosted runner drain", () => {
 		expect(persisted).toEqual(result?.manifest);
 	});
 
+	it("counts pending requests from source arrays when the derived list is stale", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const context = hostedRunnerContext(workspaceRoot);
+		const snapshot = runtimeSnapshot(workspaceRoot);
+		snapshot.state.pending_approvals = [
+			{
+				call_id: "call_pending",
+				tool: "bash",
+				args: { command: "ls" },
+			},
+		];
+		snapshot.state.pending_requests = [];
+		const drainRuntime = vi.fn().mockResolvedValue({
+			sessionId: "session_123",
+			sessionFile: join(workspaceRoot, ".maestro", "sessions", "session.jsonl"),
+			protocolVersion: HEADLESS_PROTOCOL_VERSION,
+			cursor: 7,
+			snapshot,
+		});
+
+		const result = await drainHostedRunner(
+			{ reason: "ttl_expired" },
+			{
+				hostedRunner: context,
+				drainRuntime,
+				now: () => new Date("2026-04-23T00:00:30.000Z"),
+			},
+		);
+
+		expect(result?.manifest.work_continuity.pending_request_count).toBe(1);
+	});
+
 	it("records an interrupted manifest when runtime drain fails", async () => {
 		const workspaceRoot = await createTempWorkspace();
 		const context = hostedRunnerContext(workspaceRoot);
@@ -233,6 +275,127 @@ describe("hosted runner drain", () => {
 		) as Record<string, unknown>;
 		expect(persisted).not.toHaveProperty("status");
 		expect(persisted).toEqual(result?.manifest);
+	});
+
+	it("records Codex subagent continuity without copying prompt payloads into manifest metadata", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const context = hostedRunnerContext(workspaceRoot);
+		const snapshot = runtimeSnapshot(workspaceRoot);
+		snapshot.state.active_tools = [
+			{
+				call_id: "collab-spawn-1",
+				tool: "codex.subagent.spawnAgent",
+				output: "starting child",
+			},
+		];
+		snapshot.state.tracked_tools = [
+			{
+				call_id: "collab-spawn-1",
+				tool: "codex.subagent.spawnAgent",
+				args: {
+					prompt: "Sensitive child task prompt must stay in snapshot only",
+					codex_work_graph: {
+						schema_version: "evalops.maestro.codex.subagent-workgraph.v1",
+						tool_call_id: "collab-spawn-1",
+						tool: "spawnAgent",
+						status: "inProgress",
+						child_runs: [
+							{
+								thread_id: "child-thread-1",
+								child_run_id: "agent-run-child-1",
+								operation: "spawnAgent",
+							},
+						],
+					},
+				},
+			},
+		];
+
+		const result = await drainHostedRunner(
+			{ reason: "ttl_expired" },
+			{
+				hostedRunner: context,
+				drainRuntime: vi.fn().mockResolvedValue({
+					sessionId: "session_123",
+					snapshot,
+				}),
+				now: () => new Date("2026-04-23T00:03:00.000Z"),
+			},
+		);
+
+		expect(result?.manifest.work_continuity).toEqual({
+			protocol_version: HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
+			active_tool_count: 1,
+			tracked_tool_count: 1,
+			pending_request_count: 0,
+			codex_subagent_tool_call_ids: ["collab-spawn-1"],
+			codex_subagent_child_run_ids: ["agent-run-child-1"],
+			codex_subagent_thread_ids: ["child-thread-1"],
+		});
+		const manifestWithoutSnapshot = {
+			...result!.manifest,
+			snapshot: undefined,
+		};
+		expect(JSON.stringify(manifestWithoutSnapshot)).not.toContain(
+			"Sensitive child task prompt",
+		);
+	});
+
+	it("records snake_case Codex graph child run continuity fields", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const context = hostedRunnerContext(workspaceRoot);
+		const snapshot = runtimeSnapshot(workspaceRoot);
+		snapshot.state.active_tools = [
+			{
+				call_id: "collab-spawn-2",
+				tool: "codex.subagent.spawnAgent",
+				output: "starting child",
+			},
+		];
+		snapshot.state.tracked_tools = [
+			{
+				call_id: "collab-spawn-2",
+				tool: "codex.subagent.spawnAgent",
+				args: {
+					prompt: "Sensitive child task prompt must stay in snapshot only",
+					codex_work_graph: {
+						schema_version: "evalops.maestro.codex.subagent-workgraph.v1",
+						toolCallId: "collab-spawn-2",
+						tool: "spawnAgent",
+						status: "inProgress",
+						child_runs: [
+							{
+								thread_id: "child-thread-2",
+								child_run_id: "agent-run-child-2",
+								operation: "spawnAgent",
+							},
+						],
+					},
+				},
+			},
+		];
+
+		const result = await drainHostedRunner(
+			{ reason: "ttl_expired" },
+			{
+				hostedRunner: context,
+				drainRuntime: vi.fn().mockResolvedValue({
+					sessionId: "session_123",
+					snapshot,
+				}),
+				now: () => new Date("2026-04-23T00:04:00.000Z"),
+			},
+		);
+
+		expect(result?.manifest.work_continuity).toEqual({
+			protocol_version: HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
+			active_tool_count: 1,
+			tracked_tool_count: 1,
+			pending_request_count: 0,
+			codex_subagent_tool_call_ids: ["collab-spawn-2"],
+			codex_subagent_child_run_ids: ["agent-run-child-2"],
+			codex_subagent_thread_ids: ["child-thread-2"],
+		});
 	});
 
 	it("records a skipped manifest when no runtime state is available", async () => {
@@ -334,6 +497,31 @@ describe("hosted runner drain", () => {
 		const workspaceRoot = await createTempWorkspace();
 		const context = hostedRunnerContext(workspaceRoot);
 		const snapshot = runtimeSnapshot(workspaceRoot, 12);
+		snapshot.state.active_tools = [
+			{
+				call_id: "collab-spawn-interrupted",
+				tool: "codex.subagent.spawnAgent",
+				output: "still starting child",
+			},
+		];
+		snapshot.state.tracked_tools = [
+			{
+				call_id: "collab-spawn-interrupted",
+				tool: "codex.subagent.spawnAgent",
+				args: {
+					prompt: "Sensitive interrupted child task prompt",
+					codex_work_graph: {
+						schema_version: "evalops.maestro.codex.subagent-workgraph.v1",
+						child_runs: [
+							{
+								thread_id: "child-thread-interrupted",
+								child_run_id: "agent-run-child-interrupted",
+							},
+						],
+					},
+				},
+			},
+		];
 		const runtime = {
 			getSnapshot: vi.fn(() => snapshot),
 			getSessionFile: vi.fn(() =>
@@ -370,6 +558,17 @@ describe("hosted runner drain", () => {
 		expect(result?.manifest.runtime).toMatchObject({
 			flush_status: HostedRunnerRuntimeFlushStatusValue.Failed,
 			error: "flush timed out",
+			cursor: 12,
+		});
+		expect(result?.manifest.snapshot).toEqual(snapshot);
+		expect(result?.manifest.work_continuity).toEqual({
+			protocol_version: HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
+			active_tool_count: 1,
+			tracked_tool_count: 1,
+			pending_request_count: 0,
+			codex_subagent_tool_call_ids: ["collab-spawn-interrupted"],
+			codex_subagent_child_run_ids: ["agent-run-child-interrupted"],
+			codex_subagent_thread_ids: ["child-thread-interrupted"],
 		});
 	});
 

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -355,6 +355,27 @@ describe("skill package format", () => {
 		});
 	});
 
+	it("degrades oversized MCP configs to bounded activation warnings", async () => {
+		const workspace = tempRoot();
+		const skillDir = join(workspace, ".maestro", "skills", "oversized-mcp");
+		await mkdir(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			"---\nname: oversized-mcp\ndescription: Test oversized MCP activation surfaces.\n---\n\n# Oversized MCP\n",
+		);
+		writeFileSync(join(skillDir, "mcp.json"), " ".repeat(1024 * 1024 + 1));
+
+		const { skills, errors } = loadSkills(workspace, { includeSystem: false });
+
+		expect(errors).toEqual([]);
+		expect(
+			buildSkillRuntimeActivation(skills[0]!).toolPackage.mcp,
+		).toMatchObject({
+			servers: [],
+			warnings: [expect.stringContaining("mcp.json is too large to load")],
+		});
+	});
+
 	it("omits MCP servers with invalid launch metadata from runtime activation", async () => {
 		const workspace = tempRoot();
 		const skillDir = join(workspace, ".maestro", "skills", "bad-launch-mcp");
@@ -396,27 +417,6 @@ describe("skill package format", () => {
 				"MCP server 'badArgs' args entries must be strings.",
 				"MCP server 'badEnv' env values must be strings.",
 			],
-		});
-	});
-
-	it("degrades oversized MCP configs to bounded activation warnings", async () => {
-		const workspace = tempRoot();
-		const skillDir = join(workspace, ".maestro", "skills", "oversized-mcp");
-		await mkdir(skillDir, { recursive: true });
-		writeFileSync(
-			join(skillDir, "SKILL.md"),
-			"---\nname: oversized-mcp\ndescription: Test oversized MCP activation surfaces.\n---\n\n# Oversized MCP\n",
-		);
-		writeFileSync(join(skillDir, "mcp.json"), " ".repeat(1024 * 1024 + 1));
-
-		const { skills, errors } = loadSkills(workspace, { includeSystem: false });
-
-		expect(errors).toEqual([]);
-		expect(
-			buildSkillRuntimeActivation(skills[0]!).toolPackage.mcp,
-		).toMatchObject({
-			servers: [],
-			warnings: [expect.stringContaining("mcp.json is too large to load")],
 		});
 	});
 


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `103df07bcc7e84e2bc4e01428d1275a119e7dff8`
- last generated public sync base: `1e379abc58b01b695553bfbd0b39c99127af120d`
- previewed public-tree drift: `11` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `3`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (103df07bcc7e)`
- public projection: `https://github.com/evalops/maestro@main (09369c829785)`
- files to copy or update: `11`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update .github/actionlint.yaml
- copy/update MODULE.bazel
- copy/update docs/development/bazel.md
- copy/update docs/protocols/codex-operating-layer.json
- copy/update docs/protocols/headless.md
- copy/update docs/protocols/hosted-runner-contract.md
- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update packages/tui-rs/src/ui_state.rs
- copy/update src/server/handlers/hosted-runner-drain.ts
- copy/update test/server/hosted-runner-drain.test.ts
- copy/update test/skill-package-format.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update .github/actionlint.yaml
- copy/update MODULE.bazel
- copy/update docs/development/bazel.md
- copy/update docs/protocols/codex-operating-layer.json
- copy/update docs/protocols/headless.md
- copy/update docs/protocols/hosted-runner-contract.md
- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update packages/tui-rs/src/ui_state.rs
- copy/update src/server/handlers/hosted-runner-drain.ts
- copy/update test/server/hosted-runner-drain.test.ts
- copy/update test/skill-package-format.test.ts

## Public-only commits since last generated sync

- 09369c82 fix: harden Bazel RBE follow-up (#418)
- 661ef730 Expose skill runtime activation manifests (#414)
- 185f1ea1 Add Bazel RBE lane (#416)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@103df07bcc7e84e2bc4e01428d1275a119e7dff8`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #417 to internal source `103df07bcc7e84e2bc4e01428d1275a119e7dff8`