### PR TITLE
fix: harden Bazel RBE follow-up

### DIFF
--- a/.github/workflows/bazel-rbe.yml
+++ b/.github/workflows/bazel-rbe.yml
@@ -14,6 +14,7 @@ on:
       - .node-version
       - BUILD.bazel
       - MODULE.bazel
+      - MODULE.bazel.lock
       - Makefile
       - bun.lockb
       - docs/development/bazel.md

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,21 @@ export ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY \
        MAESTRO_EVALOPS_MEMORY_MODE EVALOPS_MEMORY_MODE
 
 LOCAL_CEREBRO_REPO ?= ../cerebro
-BAZEL ?= $(shell if command -v bazelisk >/dev/null 2>&1; then command -v bazelisk; elif command -v go >/dev/null 2>&1 && test -x "$$(go env GOPATH)/bin/bazelisk"; then printf '%s/bin/bazelisk' "$$(go env GOPATH)"; elif command -v bazel >/dev/null 2>&1; then command -v bazel; else printf bazelisk; fi)
+BAZEL ?= $(shell \
+	if command -v bazelisk >/dev/null 2>&1; then \
+		command -v bazelisk; \
+	elif command -v go >/dev/null 2>&1; then \
+		OLD_IFS="$$IFS"; IFS=":"; \
+		for dir in $$(go env GOPATH); do \
+			if test -x "$$dir/bin/bazelisk"; then printf '%s/bin/bazelisk' "$$dir"; exit 0; fi; \
+		done; \
+		IFS="$$OLD_IFS"; \
+		if command -v bazel >/dev/null 2>&1; then command -v bazel; else printf bazelisk; fi; \
+	elif command -v bazel >/dev/null 2>&1; then \
+		command -v bazel; \
+	else \
+		printf bazelisk; \
+	fi)
 BUILDIFIER ?= $(shell if command -v buildifier >/dev/null 2>&1; then command -v buildifier; elif command -v go >/dev/null 2>&1; then printf '%s/bin/buildifier' "$$(go env GOPATH)"; else printf buildifier; fi)
 BAZEL_TARGETS ?= //...
 BAZEL_REMOTE_CONFIG ?= remote-gcp-dev

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ export ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY GROQ_API_KEY \
        MAESTRO_EVALOPS_MEMORY_MODE EVALOPS_MEMORY_MODE
 
 LOCAL_CEREBRO_REPO ?= ../cerebro
-BAZEL ?= $(shell if command -v bazelisk >/dev/null 2>&1; then command -v bazelisk; elif command -v go >/dev/null 2>&1; then printf '%s/bin/bazelisk' "$$(go env GOPATH)"; else printf bazelisk; fi)
+BAZEL ?= $(shell if command -v bazelisk >/dev/null 2>&1; then command -v bazelisk; elif command -v go >/dev/null 2>&1 && test -x "$$(go env GOPATH)/bin/bazelisk"; then printf '%s/bin/bazelisk' "$$(go env GOPATH)"; elif command -v bazel >/dev/null 2>&1; then command -v bazel; else printf bazelisk; fi)
 BUILDIFIER ?= $(shell if command -v buildifier >/dev/null 2>&1; then command -v buildifier; elif command -v go >/dev/null 2>&1; then printf '%s/bin/buildifier' "$$(go env GOPATH)"; else printf buildifier; fi)
 BAZEL_TARGETS ?= //...
 BAZEL_REMOTE_CONFIG ?= remote-gcp-dev


### PR DESCRIPTION
## Summary
- include MODULE.bazel.lock in the Bazel RBE push path filter
- fall back to a usable bazel binary when Go is present but GOPATH/bin/bazelisk is absent
- resolve bazelisk from every GOPATH entry before falling back

Internal source PR: evalops/maestro-internal#1973

## Verification
- git diff --check
- ruby YAML.load_file(.github/workflows/bazel-rbe.yml)
- make -n bazel-test BAZEL=/bin/echo
- fake multi-GOPATH smoke resolving bazelisk from the second GOPATH entry