### PR TITLE
feat: add local AgentRuntime ledger projection

### DIFF
--- a/docs/design/AGENT_RUNTIME_TASK_MAPPING.md
+++ b/docs/design/AGENT_RUNTIME_TASK_MAPPING.md
@@ -113,6 +113,9 @@ plan for existing local todo stores.
 
 ## Minimal Maestro Work For The Next Phase
 
+0. Expose saved sessions as a local AgentRuntime ledger through
+   `maestro run ledger|replay|promote`, giving harnesses an inspectable dry-run
+   promotion contract before live Platform write-through is enabled.
 1. Add a small `HostedAgentRuntimeTaskProgressRecorder` adapter beside the
    existing hosted progress recorder, or extend the existing recorder with
    methods that accept normalized task events.

--- a/docs/design/EVALOPS_AGENT_CORE_PARITY.md
+++ b/docs/design/EVALOPS_AGENT_CORE_PARITY.md
@@ -170,9 +170,11 @@ maestro run promote <session-id>
 
 `maestro run ledger` emits `evalops.maestro.agent-runtime-ledger.v1`: run
 metadata, ordered ledger entries, replay determinism, and a dry-run promotion
-plan. `maestro run replay` emits the replay summary, while `maestro run promote`
-emits `evalops.maestro.agent-runtime-promotion-plan.v1` operations shaped like
-Platform AgentRuntime trigger, step, work-item, wait, and terminal writes.
+plan. `maestro run replay` emits
+`evalops.maestro.agent-runtime-replay-summary.v1`, while
+`maestro run promote` emits `evalops.maestro.agent-runtime-promotion-plan.v1`
+operations shaped like Platform AgentRuntime trigger, step, work-item, wait,
+and terminal writes.
 
 This is the local parity layer before live promotion: it gives harnesses and
 operators a stable inspect/replay/promote contract without introducing a second

--- a/docs/design/EVALOPS_AGENT_CORE_PARITY.md
+++ b/docs/design/EVALOPS_AGENT_CORE_PARITY.md
@@ -153,6 +153,30 @@ Lint rules:
 - `description` exists, is <= 1024 chars, and says when to use the skill.
 - The body stays under 500 lines and about 5k tokens.
 - `allowed-tools` and `builtin-tools` are strings or lists of strings.
+
+## Local AgentRuntime Ledger
+
+Saved sessions now have a local AgentRuntime projection layered on top of the
+existing run reconstruction command. The ledger is deterministic and dry-run
+only: it does not require Platform credentials, does not write remote
+AgentRuntime state, and does not copy raw tool outputs into promotion payloads.
+
+```bash
+maestro run inspect <session-id> --json
+maestro run ledger <session-id>
+maestro run replay <session-id>
+maestro run promote <session-id>
+```
+
+`maestro run ledger` emits `evalops.maestro.agent-runtime-ledger.v1`: run
+metadata, ordered ledger entries, replay determinism, and a dry-run promotion
+plan. `maestro run replay` emits the replay summary, while `maestro run promote`
+emits `evalops.maestro.agent-runtime-promotion-plan.v1` operations shaped like
+Platform AgentRuntime trigger, step, work-item, wait, and terminal writes.
+
+This is the local parity layer before live promotion: it gives harnesses and
+operators a stable inspect/replay/promote contract without introducing a second
+runtime source of truth or a new local database dependency.
 - `isolatedContext` is boolean when present.
 - `mcp.json` is valid JSON.
 - Every MCP server has `command` and non-empty `includeTools`.

--- a/src/cli-tui/commands/command-catalog.ts
+++ b/src/cli-tui/commands/command-catalog.ts
@@ -179,11 +179,14 @@ export const PRIMARY_COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
 		tags: ["session", "automation"],
 	}),
 	withArgs("a2a", "a2a", {
-		description: "Pair and inspect A2A peer agents",
-		usage: "/a2a [accept <code>|peers|send <peer> <text>]",
+		description: "Pair, inspect, and delegate to A2A peer agents",
+		usage: "/a2a [accept <code>|fleet|peers|tasks|delegate <peer> <text>]",
 		tags: ["tools", "agents"],
 		examples: [
+			"/a2a fleet",
 			"/a2a peers",
+			"/a2a tasks",
+			"/a2a delegate mac-mini run workspace smoke",
 			"/a2a accept maestro-pair-v1.payload.checksum --name mac-mini",
 		],
 	}),

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -104,6 +104,7 @@ const SUBCOMMAND_COMMANDS = new Set([
 	"remote",
 	"scenario",
 ]);
+const RUN_SUBCOMMANDS = new Set(["inspect", "ledger", "replay", "promote"]);
 
 const FLAGS_WITH_VALUES = new Set([
 	"--mode",
@@ -363,7 +364,7 @@ export function parseArgs(args: string[]): Args {
 				COMMANDS.has(arg) &&
 				(arg !== "run" ||
 					(result.messages.length === 0 &&
-						nextNonFlagToken(args, i + 1) === "inspect"));
+						RUN_SUBCOMMANDS.has(nextNonFlagToken(args, i + 1) ?? "")));
 			if (!result.command && isCommandToken) {
 				result.command = arg;
 				const shouldConsumeSubcommand =
@@ -398,9 +399,10 @@ export function parseArgs(args: string[]): Args {
 	if (
 		result.command === "run" &&
 		!result.subcommand &&
-		result.messages[0] === "inspect"
+		result.messages[0] &&
+		RUN_SUBCOMMANDS.has(result.messages[0])
 	) {
-		result.subcommand = "inspect";
+		result.subcommand = result.messages[0];
 		result.messages = result.messages.slice(1);
 	}
 

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -1,6 +1,10 @@
 import chalk from "chalk";
 import { parseMcpToolName } from "../../mcp/names.js";
 import {
+	type AgentRuntimeLedgerReport,
+	buildAgentRuntimeLedgerReport,
+} from "../../server/agent-runtime-ledger.js";
+import {
 	type AgentTrajectoryInspectionReport,
 	buildAgentTrajectoryInspectionReport,
 } from "../../server/agent-trajectory-inspection.js";
@@ -109,10 +113,11 @@ interface RunReconstructionReport {
 	trajectoryReplay: AgentTrajectoryReplayReport;
 	trajectoryScore: AgentTrajectoryScoreReport;
 	trajectoryInspection: AgentTrajectoryInspectionReport;
+	agentRuntimeLedger: AgentRuntimeLedgerReport;
 }
 
 function usage(): string {
-	return "Usage: maestro run inspect <session-id> [--json]";
+	return "Usage: maestro run inspect|ledger|replay|promote <session-id> [--json]";
 }
 
 function exitWithUsage(message: string): never {
@@ -341,6 +346,17 @@ async function buildRunReconstructionReport(
 		replay: trajectoryReplay,
 		score: trajectoryScore,
 	});
+	const agentRuntimeLedger = buildAgentRuntimeLedgerReport({
+		session: {
+			id: session.id,
+			sessionFile,
+			...(header?.cwd ? { cwd: header.cwd } : {}),
+			...(header?.model ? { model: header.model } : {}),
+		},
+		timeline,
+		trajectory,
+		replay: trajectoryReplay,
+	});
 	const counts = countTimeline(timeline);
 	const context = promptContextSummary(header, timeline);
 	const contextManifest = contextManifestSummary(header, timeline, context);
@@ -377,6 +393,7 @@ async function buildRunReconstructionReport(
 		trajectoryReplay,
 		trajectoryScore,
 		trajectoryInspection,
+		agentRuntimeLedger,
 	};
 }
 
@@ -424,6 +441,7 @@ function renderRunReconstruction(report: RunReconstructionReport): string {
 		`Replay deltas: ${report.trajectoryReplay.counts.deltas} (${report.trajectoryReplay.counts.errors} errors, ${report.trajectoryReplay.counts.warnings} warnings)`,
 		`Trajectory score: ${report.trajectoryScore.counts.failed} failed, ${report.trajectoryScore.counts.warnings} warnings across ${report.trajectoryScore.counts.rules} rule(s)`,
 		`Replay lab: ${report.trajectoryInspection.counts.jumpTargets} event/source jump target(s), redaction=${report.trajectoryInspection.redaction.default}`,
+		`AgentRuntime ledger: ${report.agentRuntimeLedger.counts.entries} entries, ${report.agentRuntimeLedger.counts.promotionOperations} dry-run promotion op(s), replay deterministic=${report.agentRuntimeLedger.replay.deterministic ? "yes" : "no"}`,
 		`Coverage: ${renderCoverage(report.coverage)}`,
 		`Prompt context: ${report.promptContext.entries} entries (${report.promptContext.projectDocs} docs, ${report.promptContext.mcpServers} MCP servers)`,
 		`Context manifest: ${report.contextManifest.entries} entries (${report.contextManifest.projectDocs} docs, ${report.contextManifest.mcpServers} MCP servers, ${report.contextManifest.mcpResources} resources, ${report.contextManifest.mcpPrompts} prompts, ${report.contextManifest.diagnostics} diagnostics)`,
@@ -442,7 +460,12 @@ export async function handleRunCommand(
 	args: string[] = [],
 	options: RunInspectOptions = {},
 ): Promise<void> {
-	if (subcommand !== "inspect") {
+	if (
+		subcommand !== "inspect" &&
+		subcommand !== "ledger" &&
+		subcommand !== "replay" &&
+		subcommand !== "promote"
+	) {
 		exitWithUsage("Run subcommand required.");
 	}
 	const sessionId = args.find((arg) => !arg.startsWith("-"));
@@ -453,6 +476,19 @@ export async function handleRunCommand(
 	const report = await buildRunReconstructionReport(sessionId, options);
 	if (!report) {
 		exitWithUsage(`Session not found: ${sessionId}`);
+	}
+
+	if (subcommand === "ledger") {
+		console.log(JSON.stringify(report.agentRuntimeLedger, null, 2));
+		return;
+	}
+	if (subcommand === "replay") {
+		console.log(JSON.stringify(report.agentRuntimeLedger.replay, null, 2));
+		return;
+	}
+	if (subcommand === "promote") {
+		console.log(JSON.stringify(report.agentRuntimeLedger.promotion, null, 2));
+		return;
 	}
 
 	if (options.json || args.includes("--json")) {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -192,6 +192,7 @@ export function printHelp(
 
   # Reconstruct the timeline, trajectory, and evidence coverage for a saved run
   maestro run inspect <session-id> --json
+  maestro run promote <session-id>
 
   # Validate and run a deterministic scenario fixture
   maestro scenario validate ./test/fixtures/agent-trajectory-scenarios/local-diagnostic-success.json
@@ -280,10 +281,14 @@ export function printHelp(
 	)}`;
 	const runSection = `${sectionHeading("maestro run")}${muted(
 		`  maestro run inspect <session-id> [--json]
+  maestro run ledger <session-id>
+  maestro run replay <session-id>
+  maestro run promote <session-id>
 
   Reconstructs a saved session into a timeline plus canonical agent trajectory
   with prompt, tool, file-change, artifact, policy, diagnostic, compaction,
-  pending-wait, and MCP-context coverage.`,
+  pending-wait, and MCP-context coverage. The ledger/replay/promote commands
+  expose the local AgentRuntime projection and dry-run Platform promotion plan.`,
 	)}`;
 	const initSection = `${sectionHeading("maestro init")}${muted(
 		`  maestro init                         Login, create or reuse an API key, and register this agent

--- a/src/server/agent-runtime-ledger.ts
+++ b/src/server/agent-runtime-ledger.ts
@@ -1,0 +1,483 @@
+import type {
+	ComposerRunTimelineItem,
+	ComposerRunTimelineResponse,
+	ComposerRunTimelineStatus,
+	ComposerRunTimelineVisibility,
+} from "@evalops/contracts";
+import type { AgentTrajectoryReplayReport } from "./agent-trajectory-replay.js";
+import type {
+	AgentTrajectoryEvent,
+	AgentTrajectoryReport,
+} from "./agent-trajectory.js";
+
+export const AGENT_RUNTIME_LEDGER_SCHEMA =
+	"evalops.maestro.agent-runtime-ledger.v1";
+export const AGENT_RUNTIME_PROMOTION_PLAN_SCHEMA =
+	"evalops.maestro.agent-runtime-promotion-plan.v1";
+
+export type AgentRuntimeLedgerEntryKind =
+	| "run"
+	| "message"
+	| "model_call"
+	| "tool_call"
+	| "tool_result"
+	| "wait"
+	| "checkpoint"
+	| "artifact"
+	| "evidence"
+	| "governance"
+	| "context"
+	| "child_run"
+	| "runtime";
+
+export type AgentRuntimeLedgerState =
+	| "pending"
+	| "running"
+	| "waiting"
+	| "blocked"
+	| "succeeded"
+	| "failed"
+	| "cancelled"
+	| "skipped";
+
+export interface AgentRuntimeLedgerEntry {
+	id: string;
+	sequence: number;
+	timestamp: string;
+	kind: AgentRuntimeLedgerEntryKind;
+	phase: AgentTrajectoryEvent["phase"];
+	actor: AgentTrajectoryEvent["actor"];
+	type: string;
+	state: AgentRuntimeLedgerState;
+	title: string;
+	visibility: ComposerRunTimelineVisibility;
+	source: ComposerRunTimelineItem["source"];
+	timelineItemId?: string;
+	trajectoryEventId: string;
+	toolName?: string;
+	summary?: string;
+	relatedIds: string[];
+	evidence: AgentTrajectoryEvent["evidence"];
+	platformShape: {
+		stepKind: string;
+		workItemKind: string;
+		waitType?: string;
+	};
+}
+
+export interface AgentRuntimeLedgerReport {
+	schemaVersion: typeof AGENT_RUNTIME_LEDGER_SCHEMA;
+	run: {
+		id: string;
+		sessionId: string;
+		source: ComposerRunTimelineResponse["source"];
+		generatedAt: string;
+		platformBacked: boolean;
+		sessionFile?: string;
+		cwd?: string;
+		model?: string;
+	};
+	counts: {
+		entries: number;
+		promotionOperations: number;
+		byKind: Record<string, number>;
+		byState: Record<string, number>;
+	};
+	entries: AgentRuntimeLedgerEntry[];
+	replay: AgentRuntimeLedgerReplaySummary;
+	promotion: AgentRuntimePromotionPlan;
+}
+
+export interface AgentRuntimeLedgerReplaySummary {
+	schemaVersion: AgentTrajectoryReplayReport["schemaVersion"];
+	deterministic: boolean;
+	events: number;
+	deltas: number;
+	errors: number;
+	warnings: number;
+	cursor: {
+		startSequence?: number;
+		endSequence?: number;
+	};
+}
+
+export interface AgentRuntimePromotionPlan {
+	schemaVersion: typeof AGENT_RUNTIME_PROMOTION_PLAN_SCHEMA;
+	runId: string;
+	sessionId: string;
+	idempotencyKey: string;
+	operations: AgentRuntimePromotionOperation[];
+	warnings: string[];
+}
+
+export type AgentRuntimePromotionOperation =
+	| {
+			operation: "handle_trigger";
+			id: string;
+			payload: {
+				sourceEventType: "maestro.local_ledger_promote";
+				sourceEventId: string;
+				idempotencyKey: string;
+				sessionId: string;
+				generatedAt: string;
+			};
+	  }
+	| {
+			operation: "record_run_step";
+			id: string;
+			ledgerEntryId: string;
+			payload: {
+				stepId: string;
+				kind: string;
+				state: AgentRuntimeLedgerState;
+				title: string;
+				timestamp: string;
+				toolName?: string;
+			};
+	  }
+	| {
+			operation: "record_run_work_item";
+			id: string;
+			ledgerEntryId: string;
+			payload: {
+				workItemId: string;
+				kind: string;
+				state: AgentRuntimeLedgerState;
+				title: string;
+				timestamp: string;
+			};
+	  }
+	| {
+			operation: "wait_run";
+			id: string;
+			ledgerEntryId: string;
+			payload: {
+				waitId: string;
+				waitType: string;
+				title: string;
+				timestamp: string;
+			};
+	  }
+	| {
+			operation: "complete_run" | "fail_run";
+			id: string;
+			payload: {
+				state: "succeeded" | "failed";
+				timestamp: string;
+				reason?: string;
+			};
+	  };
+
+export interface BuildAgentRuntimeLedgerOptions {
+	session: {
+		id: string;
+		sessionFile?: string;
+		cwd?: string;
+		model?: string;
+	};
+	timeline: ComposerRunTimelineResponse;
+	trajectory: AgentTrajectoryReport;
+	replay: AgentTrajectoryReplayReport;
+}
+
+function increment(map: Record<string, number>, key: string): void {
+	map[key] = (map[key] ?? 0) + 1;
+}
+
+function timelineIdForEvent(event: AgentTrajectoryEvent): string | undefined {
+	return event.evidence.find((anchor) => anchor.kind === "timeline_item")?.id;
+}
+
+function stateForStatus(
+	status: ComposerRunTimelineStatus,
+): AgentRuntimeLedgerState {
+	switch (status) {
+		case "completed":
+		case "info":
+		case "approved":
+			return "succeeded";
+		case "running":
+			return "running";
+		case "pending":
+			return "waiting";
+		case "denied":
+			return "blocked";
+		case "failed":
+			return "failed";
+		default:
+			return "pending";
+	}
+}
+
+function kindForEvent(
+	event: AgentTrajectoryEvent,
+): AgentRuntimeLedgerEntryKind {
+	switch (event.kind) {
+		case "session":
+			return "run";
+		case "message":
+			return event.actor === "assistant" ? "model_call" : "message";
+		case "tool":
+			return event.type === "tool.completed" || event.type === "tool.failed"
+				? "tool_result"
+				: "tool_call";
+		case "wait":
+			return "wait";
+		case "artifact":
+			return "artifact";
+		case "evidence":
+			return "evidence";
+		case "governance":
+			return "governance";
+		case "context":
+			return event.type.startsWith("compaction.") ? "checkpoint" : "context";
+		case "agent":
+			return "child_run";
+		case "runtime":
+			return "runtime";
+		default:
+			return "runtime";
+	}
+}
+
+function stepKindForEntry(
+	entryKind: AgentRuntimeLedgerEntryKind,
+	event: AgentTrajectoryEvent,
+): string {
+	if (entryKind === "model_call") return "AGENT_RUN_STEP_KIND_MODEL_CALL";
+	if (entryKind === "tool_call") return "AGENT_RUN_STEP_KIND_TOOL_CALL_INTENT";
+	if (entryKind === "tool_result") return "AGENT_RUN_STEP_KIND_TOOL_RESULT";
+	if (entryKind === "wait" || entryKind === "governance") {
+		return "AGENT_RUN_STEP_KIND_APPROVAL_WAIT";
+	}
+	if (event.status === "failed") return "AGENT_RUN_STEP_KIND_ERROR";
+	return "AGENT_RUN_STEP_KIND_SYSTEM";
+}
+
+function workItemKindForEntry(kind: AgentRuntimeLedgerEntryKind): string {
+	switch (kind) {
+		case "message":
+			return "AGENT_WORK_ITEM_KIND_USER_INPUT";
+		case "model_call":
+			return "AGENT_WORK_ITEM_KIND_MODEL_CALL";
+		case "tool_call":
+		case "tool_result":
+			return "AGENT_WORK_ITEM_KIND_TOOL_CALL";
+		case "child_run":
+			return "AGENT_WORK_ITEM_KIND_CHILD_RUN";
+		case "wait":
+		case "governance":
+			return "AGENT_WORK_ITEM_KIND_WAIT";
+		case "checkpoint":
+			return "AGENT_WORK_ITEM_KIND_RECOVERY";
+		case "artifact":
+		case "evidence":
+			return "AGENT_WORK_ITEM_KIND_MEMORY";
+		default:
+			return "AGENT_WORK_ITEM_KIND_ROOT";
+	}
+}
+
+function waitTypeForEntry(
+	kind: AgentRuntimeLedgerEntryKind,
+): string | undefined {
+	if (kind === "wait" || kind === "governance") {
+		return "AGENT_RUN_WAIT_TYPE_APPROVAL";
+	}
+	return undefined;
+}
+
+function buildLedgerEntries(
+	trajectory: AgentTrajectoryReport,
+): AgentRuntimeLedgerEntry[] {
+	return trajectory.events.map((event) => {
+		const kind = kindForEvent(event);
+		const state = stateForStatus(event.status);
+		return {
+			id: `ledger:${event.id}`,
+			sequence: event.sequence,
+			timestamp: event.timestamp,
+			kind,
+			phase: event.phase,
+			actor: event.actor,
+			type: event.type,
+			state,
+			title: event.title,
+			visibility: event.visibility,
+			source: event.source,
+			trajectoryEventId: event.id,
+			...(timelineIdForEvent(event)
+				? { timelineItemId: timelineIdForEvent(event) }
+				: {}),
+			...(event.toolName ? { toolName: event.toolName } : {}),
+			...(event.summary ? { summary: event.summary } : {}),
+			relatedIds: event.relatedIds ?? [],
+			evidence: event.evidence,
+			platformShape: {
+				stepKind: stepKindForEntry(kind, event),
+				workItemKind: workItemKindForEntry(kind),
+				...(waitTypeForEntry(kind) ? { waitType: waitTypeForEntry(kind) } : {}),
+			},
+		};
+	});
+}
+
+function replaySummary(
+	replay: AgentTrajectoryReplayReport,
+	entries: AgentRuntimeLedgerEntry[],
+): AgentRuntimeLedgerReplaySummary {
+	return {
+		schemaVersion: replay.schemaVersion,
+		deterministic: replay.counts.deltas === 0 && replay.counts.errors === 0,
+		events: replay.counts.events,
+		deltas: replay.counts.deltas,
+		errors: replay.counts.errors,
+		warnings: replay.counts.warnings,
+		cursor: {
+			...(entries[0] ? { startSequence: entries[0].sequence } : {}),
+			...(entries.at(-1) ? { endSequence: entries.at(-1)?.sequence } : {}),
+		},
+	};
+}
+
+function terminalOperation(
+	runId: string,
+	entries: AgentRuntimeLedgerEntry[],
+): AgentRuntimePromotionOperation {
+	const last = entries.at(-1);
+	const succeeded = last?.state === "succeeded" || last?.state === "skipped";
+	return {
+		operation: succeeded ? "complete_run" : "fail_run",
+		id: `promote:${runId}:terminal`,
+		payload: {
+			state: succeeded ? "succeeded" : "failed",
+			timestamp: last?.timestamp ?? new Date(0).toISOString(),
+			...(succeeded
+				? {}
+				: {
+						reason: `Final ledger entry ended in ${last?.state ?? "unknown"} state.`,
+					}),
+		},
+	};
+}
+
+function buildPromotionPlan(
+	runId: string,
+	sessionId: string,
+	generatedAt: string,
+	entries: AgentRuntimeLedgerEntry[],
+): AgentRuntimePromotionPlan {
+	const idempotencyKey = `maestro-local-ledger:${sessionId}:${runId}`;
+	const operations: AgentRuntimePromotionOperation[] = [
+		{
+			operation: "handle_trigger",
+			id: `promote:${runId}:trigger`,
+			payload: {
+				sourceEventType: "maestro.local_ledger_promote",
+				sourceEventId: sessionId,
+				idempotencyKey,
+				sessionId,
+				generatedAt,
+			},
+		},
+	];
+
+	for (const entry of entries) {
+		operations.push({
+			operation: "record_run_step",
+			id: `promote:${entry.id}:step`,
+			ledgerEntryId: entry.id,
+			payload: {
+				stepId: entry.id,
+				kind: entry.platformShape.stepKind,
+				state: entry.state,
+				title: entry.title,
+				timestamp: entry.timestamp,
+				...(entry.toolName ? { toolName: entry.toolName } : {}),
+			},
+		});
+		operations.push({
+			operation: "record_run_work_item",
+			id: `promote:${entry.id}:work-item`,
+			ledgerEntryId: entry.id,
+			payload: {
+				workItemId: entry.id,
+				kind: entry.platformShape.workItemKind,
+				state: entry.state,
+				title: entry.title,
+				timestamp: entry.timestamp,
+			},
+		});
+		if (entry.platformShape.waitType) {
+			operations.push({
+				operation: "wait_run",
+				id: `promote:${entry.id}:wait`,
+				ledgerEntryId: entry.id,
+				payload: {
+					waitId: entry.id,
+					waitType: entry.platformShape.waitType,
+					title: entry.title,
+					timestamp: entry.timestamp,
+				},
+			});
+		}
+	}
+
+	operations.push(terminalOperation(runId, entries));
+
+	return {
+		schemaVersion: AGENT_RUNTIME_PROMOTION_PLAN_SCHEMA,
+		runId,
+		sessionId,
+		idempotencyKey,
+		operations,
+		warnings: [
+			"Promotion plan is dry-run only; no Platform AgentRuntime writes were performed.",
+		],
+	};
+}
+
+export function buildAgentRuntimeLedgerReport(
+	options: BuildAgentRuntimeLedgerOptions,
+): AgentRuntimeLedgerReport {
+	const entries = buildLedgerEntries(options.trajectory);
+	const byKind: Record<string, number> = {};
+	const byState: Record<string, number> = {};
+	for (const entry of entries) {
+		increment(byKind, entry.kind);
+		increment(byState, entry.state);
+	}
+	const runId = options.trajectory.run.id;
+	const sessionId = options.trajectory.run.sessionId;
+	const promotion = buildPromotionPlan(
+		runId,
+		sessionId,
+		options.trajectory.run.generatedAt,
+		entries,
+	);
+
+	return {
+		schemaVersion: AGENT_RUNTIME_LEDGER_SCHEMA,
+		run: {
+			id: runId,
+			sessionId,
+			source: options.timeline.source,
+			generatedAt: options.trajectory.run.generatedAt,
+			platformBacked: options.trajectory.run.platformBacked,
+			...(options.session.sessionFile
+				? { sessionFile: options.session.sessionFile }
+				: {}),
+			...(options.session.cwd ? { cwd: options.session.cwd } : {}),
+			...(options.session.model ? { model: options.session.model } : {}),
+		},
+		counts: {
+			entries: entries.length,
+			promotionOperations: promotion.operations.length,
+			byKind,
+			byState,
+		},
+		entries,
+		replay: replaySummary(options.replay, entries),
+		promotion,
+	};
+}

--- a/src/server/agent-runtime-ledger.ts
+++ b/src/server/agent-runtime-ledger.ts
@@ -12,6 +12,8 @@ import type {
 
 export const AGENT_RUNTIME_LEDGER_SCHEMA =
 	"evalops.maestro.agent-runtime-ledger.v1";
+export const AGENT_RUNTIME_REPLAY_SUMMARY_SCHEMA =
+	"evalops.maestro.agent-runtime-replay-summary.v1";
 export const AGENT_RUNTIME_PROMOTION_PLAN_SCHEMA =
 	"evalops.maestro.agent-runtime-promotion-plan.v1";
 
@@ -89,7 +91,7 @@ export interface AgentRuntimeLedgerReport {
 }
 
 export interface AgentRuntimeLedgerReplaySummary {
-	schemaVersion: AgentTrajectoryReplayReport["schemaVersion"];
+	schemaVersion: typeof AGENT_RUNTIME_REPLAY_SUMMARY_SCHEMA;
 	deterministic: boolean;
 	events: number;
 	deltas: number;
@@ -327,7 +329,7 @@ function replaySummary(
 	entries: AgentRuntimeLedgerEntry[],
 ): AgentRuntimeLedgerReplaySummary {
 	return {
-		schemaVersion: replay.schemaVersion,
+		schemaVersion: AGENT_RUNTIME_REPLAY_SUMMARY_SCHEMA,
 		deterministic: replay.counts.deltas === 0 && replay.counts.errors === 0,
 		events: replay.counts.events,
 		deltas: replay.counts.deltas,

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -248,7 +248,7 @@ describe("parseArgs", () => {
 		});
 	});
 
-	it("only treats run as a command for the inspect subcommand", () => {
+	it("only treats run as a command for known run subcommands", () => {
 		expect(
 			parseArgs(["run", "inspect", "session-123", "--json"]),
 		).toMatchObject({
@@ -281,6 +281,16 @@ describe("parseArgs", () => {
 			messages: ["session-123"],
 			execJson: true,
 		});
+		for (const subcommand of ["ledger", "replay", "promote"] as const) {
+			expect(
+				parseArgs(["run", "--json", subcommand, "session-123"]),
+			).toMatchObject({
+				command: "run",
+				subcommand,
+				messages: ["session-123"],
+				execJson: true,
+			});
+		}
 		expect(
 			parseArgs([
 				"run",

--- a/test/cli/run-command.test.ts
+++ b/test/cli/run-command.test.ts
@@ -418,6 +418,7 @@ describe("run command", () => {
 				model: "openai/gpt-5.5",
 			},
 			replay: {
+				schemaVersion: "evalops.maestro.agent-runtime-replay-summary.v1",
 				deterministic: true,
 				deltas: 0,
 				errors: 0,
@@ -559,6 +560,9 @@ describe("run command", () => {
 		expect(payload.agentRuntimeLedger.schemaVersion).toBe(
 			"evalops.maestro.agent-runtime-ledger.v1",
 		);
+		expect(payload.agentRuntimeLedger.replay.schemaVersion).toBe(
+			"evalops.maestro.agent-runtime-replay-summary.v1",
+		);
 		expect(payload.agentRuntimeLedger.promotion.operations[0]).toMatchObject({
 			operation: "handle_trigger",
 			payload: {
@@ -607,7 +611,7 @@ describe("run command", () => {
 			ledger.counts.entries,
 		);
 		expect(replay).toMatchObject({
-			schemaVersion: "evalops.maestro.agent-trajectory-replay.v1",
+			schemaVersion: "evalops.maestro.agent-runtime-replay-summary.v1",
 			deterministic: true,
 			deltas: 0,
 		});

--- a/test/cli/run-command.test.ts
+++ b/test/cli/run-command.test.ts
@@ -189,8 +189,8 @@ describe("run command", () => {
 					role: "toolResult",
 					toolCallId: "call-mcp-search",
 					toolName: "mcp__platform__search",
-					content: [{ type: "text", text: "no results" }],
-					isError: false,
+					content: [{ type: "text", text: "search failed" }],
+					isError: true,
 					timestamp: 1778320803500,
 				},
 			},
@@ -340,7 +340,8 @@ describe("run command", () => {
 			"message.user": 1,
 			"message.assistant": 1,
 			"tool.requested": 2,
-			"tool.completed": 2,
+			"tool.completed": 1,
+			"tool.failed": 1,
 			"file.changed": 1,
 			"compaction.created": 1,
 		});
@@ -368,12 +369,12 @@ describe("run command", () => {
 				},
 			},
 		});
-		const toolCompleted = report?.trajectory.events.find(
+		const failedToolResult = report?.trajectory.events.find(
 			(event) =>
-				event.type === "tool.completed" &&
+				event.type === "tool.failed" &&
 				event.toolName === "mcp__platform__search",
 		);
-		expect(toolCompleted).toMatchObject({
+		expect(failedToolResult).toMatchObject({
 			actor: "tool",
 			phase: "verify",
 			relatedIds: ["call-mcp-search"],
@@ -436,6 +437,10 @@ describe("run command", () => {
 			evidence: 1,
 			checkpoint: 1,
 		});
+		expect(report?.agentRuntimeLedger.counts.byState).toMatchObject({
+			running: 2,
+			failed: 1,
+		});
 		expect(
 			report?.agentRuntimeLedger.entries.find(
 				(entry) => entry.type === "tool.completed",
@@ -450,11 +455,29 @@ describe("run command", () => {
 		});
 		expect(
 			report?.agentRuntimeLedger.entries.find(
-				(entry) => entry.type === "tool.requested",
+				(entry) =>
+					entry.type === "tool.requested" &&
+					entry.toolName === "mcp__platform__search",
 			),
 		).toMatchObject({
 			kind: "tool_call",
 			state: "running",
+			platformShape: {
+				stepKind: "AGENT_RUN_STEP_KIND_TOOL_CALL_INTENT",
+				workItemKind: "AGENT_WORK_ITEM_KIND_TOOL_CALL",
+			},
+		});
+		expect(
+			report?.agentRuntimeLedger.entries.find(
+				(entry) => entry.type === "tool.failed",
+			),
+		).toMatchObject({
+			kind: "tool_result",
+			state: "failed",
+			platformShape: {
+				stepKind: "AGENT_RUN_STEP_KIND_TOOL_RESULT",
+				workItemKind: "AGENT_WORK_ITEM_KIND_TOOL_CALL",
+			},
 		});
 		expect(
 			report?.agentRuntimeLedger.promotion.operations.at(-1),

--- a/test/cli/run-command.test.ts
+++ b/test/cli/run-command.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseArgs } from "../../src/cli/args.js";
 import { handleRunCommand, testing } from "../../src/cli/commands/run.js";
+import { buildAgentRuntimeLedgerReport } from "../../src/server/agent-runtime-ledger.js";
 import { SessionManager } from "../../src/session/manager.js";
 
 describe("run command", () => {
@@ -271,6 +272,23 @@ describe("run command", () => {
 		expect(parsed.execJson).toBe(true);
 	});
 
+	it("parses run ledger as a subcommand", () => {
+		const parsed = parseArgs(["run", "ledger", "session-1"]);
+
+		expect(parsed.command).toBe("run");
+		expect(parsed.subcommand).toBe("ledger");
+		expect(parsed.messages).toEqual(["session-1"]);
+	});
+
+	it("parses run subcommands when flags appear before the subcommand", () => {
+		const parsed = parseArgs(["run", "--json", "ledger", "session-1"]);
+
+		expect(parsed.command).toBe("run");
+		expect(parsed.subcommand).toBe("ledger");
+		expect(parsed.messages).toEqual(["session-1"]);
+		expect(parsed.execJson).toBe(true);
+	});
+
 	it("builds a JSON reconstruction report from a saved session", async () => {
 		const { sessionDir, sessionId } = makeSessionDir();
 
@@ -388,6 +406,62 @@ describe("run command", () => {
 				events: report?.trajectory.counts.events,
 			},
 		});
+		expect(report?.agentRuntimeLedger).toMatchObject({
+			schemaVersion: "evalops.maestro.agent-runtime-ledger.v1",
+			run: {
+				id: sessionId,
+				sessionId,
+				source: "local",
+				platformBacked: false,
+				cwd: "/workspace/app",
+				model: "openai/gpt-5.5",
+			},
+			replay: {
+				deterministic: true,
+				deltas: 0,
+				errors: 0,
+			},
+			promotion: {
+				schemaVersion: "evalops.maestro.agent-runtime-promotion-plan.v1",
+				sessionId,
+				warnings: [
+					"Promotion plan is dry-run only; no Platform AgentRuntime writes were performed.",
+				],
+			},
+		});
+		expect(report?.agentRuntimeLedger.counts.byKind).toMatchObject({
+			model_call: 1,
+			tool_call: 2,
+			tool_result: 2,
+			evidence: 1,
+			checkpoint: 1,
+		});
+		expect(
+			report?.agentRuntimeLedger.entries.find(
+				(entry) => entry.type === "tool.completed",
+			),
+		).toMatchObject({
+			kind: "tool_result",
+			state: "succeeded",
+			platformShape: {
+				stepKind: "AGENT_RUN_STEP_KIND_TOOL_RESULT",
+				workItemKind: "AGENT_WORK_ITEM_KIND_TOOL_CALL",
+			},
+		});
+		expect(
+			report?.agentRuntimeLedger.entries.find(
+				(entry) => entry.type === "tool.requested",
+			),
+		).toMatchObject({
+			kind: "tool_call",
+			state: "running",
+		});
+		expect(
+			report?.agentRuntimeLedger.promotion.operations.at(-1),
+		).toMatchObject({
+			operation: "complete_run",
+			payload: { state: "succeeded" },
+		});
 		expect(
 			report?.trajectoryInspection.scoreFindings[0]?.timelineItemIds,
 		).toEqual(["compaction:compact-1"]);
@@ -459,6 +533,16 @@ describe("run command", () => {
 		expect(payload.trajectoryInspection.redaction.omitted).toContain(
 			"raw tool outputs",
 		);
+		expect(payload.agentRuntimeLedger.schemaVersion).toBe(
+			"evalops.maestro.agent-runtime-ledger.v1",
+		);
+		expect(payload.agentRuntimeLedger.promotion.operations[0]).toMatchObject({
+			operation: "handle_trigger",
+			payload: {
+				sourceEventType: "maestro.local_ledger_promote",
+				sessionId,
+			},
+		});
 		expect(payload.trajectoryInspection.events[0]).toMatchObject({
 			timelineItemIds: ["session-started:session-reconstruct-1"],
 			evidence: [
@@ -479,5 +563,114 @@ describe("run command", () => {
 				(item: { type: string }) => item.type === "tool.completed",
 			),
 		).toBe(true);
+	});
+
+	it("prints JSON AgentRuntime ledger, replay, and promotion projections", async () => {
+		const { sessionDir, sessionId } = makeSessionDir();
+		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+		await handleRunCommand("ledger", [sessionId], { sessionDir });
+		await handleRunCommand("replay", [sessionId], { sessionDir });
+		await handleRunCommand("promote", [sessionId], { sessionDir });
+
+		const ledger = JSON.parse(String(log.mock.calls[0]?.[0]));
+		const replay = JSON.parse(String(log.mock.calls[1]?.[0]));
+		const promote = JSON.parse(String(log.mock.calls[2]?.[0]));
+
+		expect(ledger.schemaVersion).toBe(
+			"evalops.maestro.agent-runtime-ledger.v1",
+		);
+		expect(ledger.counts.promotionOperations).toBeGreaterThan(
+			ledger.counts.entries,
+		);
+		expect(replay).toMatchObject({
+			schemaVersion: "evalops.maestro.agent-trajectory-replay.v1",
+			deterministic: true,
+			deltas: 0,
+		});
+		expect(promote).toMatchObject({
+			schemaVersion: "evalops.maestro.agent-runtime-promotion-plan.v1",
+			runId: sessionId,
+			sessionId,
+		});
+		expect(
+			promote.operations.some(
+				(operation: { operation: string }) =>
+					operation.operation === "record_run_step",
+			),
+		).toBe(true);
+	});
+
+	it("uses the final ledger entry for dry-run terminal promotion state", () => {
+		const ledger = buildAgentRuntimeLedgerReport({
+			session: { id: "session-recovered" },
+			timeline: {
+				source: "local",
+				generatedAt: "2026-05-09T10:00:03.000Z",
+				items: [],
+			},
+			trajectory: {
+				schemaVersion: "evalops.maestro.agent-trajectory.v1",
+				run: {
+					id: "session-recovered",
+					sessionId: "session-recovered",
+					source: "local",
+					generatedAt: "2026-05-09T10:00:03.000Z",
+					platformBacked: false,
+				},
+				counts: {
+					events: 2,
+					evidenceAnchors: 0,
+					byKind: {},
+					byPhase: {},
+					byStatus: {},
+				},
+				events: [
+					{
+						id: "event-failed-tool",
+						sequence: 1,
+						timestamp: "2026-05-09T10:00:01.000Z",
+						kind: "tool",
+						phase: "verify",
+						actor: "tool",
+						type: "tool.completed",
+						status: "failed",
+						visibility: "user",
+						source: "local",
+						title: "Tool failed",
+						evidence: [],
+					},
+					{
+						id: "event-final-message",
+						sequence: 2,
+						timestamp: "2026-05-09T10:00:02.000Z",
+						kind: "message",
+						phase: "think",
+						actor: "assistant",
+						type: "message.assistant",
+						status: "completed",
+						visibility: "user",
+						source: "local",
+						title: "Assistant response",
+						evidence: [],
+					},
+				],
+			},
+			replay: {
+				schemaVersion: "evalops.maestro.agent-trajectory-replay.v1",
+				trajectorySchemaVersion: "evalops.maestro.agent-trajectory.v1",
+				counts: { events: 2, deltas: 0, errors: 0, warnings: 0 },
+				deltas: [],
+			},
+		});
+
+		expect(ledger.counts.byState).toMatchObject({
+			failed: 1,
+			succeeded: 1,
+		});
+		expect(ledger.promotion.operations.at(-1)).toMatchObject({
+			operation: "complete_run",
+			payload: { state: "succeeded" },
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Add a deterministic local AgentRuntime ledger projection for saved Maestro sessions.
- Wire `maestro run ledger`, `maestro run replay`, and `maestro run promote` to emit the ledger, replay summary, and dry-run Platform promotion plan.
- Include the ledger in `maestro run inspect --json` and document the inspect/replay/promote contract.

## Internal Source PR
- evalops/maestro-internal#1974

## Verification
- `node ./scripts/run-vitest.js --run test/cli/run-command.test.ts test/server/agent-trajectory-replay.test.ts test/server/agent-trajectory-validation.test.ts`
- `bunx tsc -p tsconfig.build.json --noEmit`
- Commit hook: Guardian, Biome, eval/fixture checks, generated contract sync, drift/staged rollout/parity checks, full build, Bun compile