### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/a2a-fleet-delegation.md
+++ b/docs/protocols/a2a-fleet-delegation.md
@@ -1,0 +1,66 @@
+# A2A Fleet And Delegation
+
+Native A2A pairing makes peers discoverable. The fleet layer turns those peers
+into a small, durable operator network: inspect who is available, delegate work,
+poll task state, and keep a local transcript of what was asked and what came
+back.
+
+## Commands
+
+```sh
+maestro a2a fleet [--json] [--registry <path>] [--tasks <path>]
+maestro a2a delegate <peer> <text> [--role <role>] [--cwd <path>] [--wait]
+maestro a2a tasks [peer] [--json] [--refresh]
+maestro a2a wait <peer> <task-id>
+```
+
+`fleet` reads the native peer registry, fetches each peer Agent Card when
+reachable, and joins the result with the local task ledger. It never prints
+bearer token values. Peers that cannot be reached are still shown with their
+registry URL and a bounded error.
+
+`delegate` sends a normal A2A `message:send` request with Maestro delegation
+metadata: origin, peer name, role, and working directory. The resulting task is
+recorded in the local ledger before optional waiting begins.
+
+`tasks` reads the durable ledger and can refresh known task IDs from their
+registered peers. This gives the operator a single place to see outstanding work
+across the Mac mini, dev desktop, and local Maestro instances.
+
+## Files
+
+The peer registry remains:
+
+```text
+~/.maestro/a2a/peers.json
+```
+
+The task ledger defaults to:
+
+```text
+~/.maestro/a2a/tasks.json
+```
+
+`MAESTRO_A2A_TASKS_FILE` overrides the ledger path. `CODEX_A2A_TASKS_FILE` is
+accepted as a migration alias.
+
+## Acceptance Tests
+
+Before this feature, the following tests fail:
+
+```sh
+npm run test:fast -- test/cli/commands/a2a-fleet-delegation.test.ts test/cli-tui/commands/a2a-handlers.test.ts
+cargo test -p maestro-tui commands::registry::tests::a2a_command_parses_peer_actions
+```
+
+After implementation, they must pass and prove:
+
+- `maestro a2a delegate <peer> <text> --wait` sends real HTTP+JSON A2A traffic,
+  records the task, updates the final state, and stores a transcript.
+- `maestro a2a fleet --json` shows peer health, Agent Card capabilities, and the
+  peer's most recent ledger task without leaking token values.
+- `maestro a2a tasks --json` reads the ledger and can be used as a fleet task
+  view.
+- TypeScript and Rust TUIs both recognize `/a2a fleet`, `/a2a tasks`, and
+  `/a2a delegate`.
+

--- a/docs/protocols/a2a-peer-pairing.md
+++ b/docs/protocols/a2a-peer-pairing.md
@@ -41,9 +41,10 @@ bash scripts/smoke-maestro-a2a-tmux.sh
 ```
 
 The smoke launches two local Maestro peers in tmux, exchanges native pairing
-codes, accepts each peer into isolated registries, then verifies `send --wait`
-and explicit `wait`. See [A2A tmux smoke](./a2a-tmux-smoke.md) for the harness
-contract and troubleshooting knobs.
+codes, accepts each peer into isolated registries, delegates work into a durable
+task ledger, then verifies `fleet`, `tasks`, `send`, and explicit `wait`. See
+[A2A tmux smoke](./a2a-tmux-smoke.md) for the harness contract and
+troubleshooting knobs.
 
 ## TUI Surface
 

--- a/docs/protocols/a2a-tmux-smoke.md
+++ b/docs/protocols/a2a-tmux-smoke.md
@@ -1,10 +1,10 @@
 # A2A tmux smoke
 
 `scripts/smoke-maestro-a2a-tmux.sh` is the local end-to-end smoke for native
-Maestro A2A pairing. It launches two local Maestro control-plane peers in tmux,
-uses the TypeScript `maestro a2a` CLI to exchange pairing codes, stores each
-peer in an isolated registry, then verifies both `send --wait` and explicit
-`wait`.
+Maestro A2A pairing and delegation. It launches two local Maestro control-plane
+peers in tmux, uses the TypeScript `maestro a2a` CLI to exchange pairing codes,
+stores each peer in an isolated registry, delegates work into a durable task
+ledger, then verifies fleet health, task listing, `send`, and explicit `wait`.
 
 Run it from the repo root:
 
@@ -19,6 +19,9 @@ entrypoint it drives is:
 bun run a2a -- offer ...
 bun run a2a -- accept ...
 bun run a2a -- peers
+bun run a2a -- delegate ...
+bun run a2a -- fleet ...
+bun run a2a -- tasks ...
 bun run a2a -- send ...
 bun run a2a -- wait ...
 ```
@@ -29,7 +32,10 @@ bun run a2a -- wait ...
 - Pairing codes are generated from each peer's Agent Card.
 - Each side accepts the other side into an isolated
   `MAESTRO_A2A_PEERS_FILE` registry.
-- Peer A can send to peer B and block with bounded `send --wait`.
+- Peer A can delegate work to peer B and block with bounded `delegate --wait`.
+- Fleet output joins live Agent Card health with the durable local task ledger.
+- Task output reads the recorded delegated task without resolving or printing
+  bearer token values.
 - Peer B can send to peer A, parse the returned task id, and complete a bounded
   explicit `wait`.
 
@@ -47,7 +53,8 @@ MAESTRO_A2A_TMUX_READY_TIMEOUT_SECONDS=180 bash scripts/smoke-maestro-a2a-tmux.s
 
 By default the script kills the tmux session on exit. Set
 `MAESTRO_A2A_TMUX_KEEP_SESSION=1` to inspect the peer panes after a failure.
-Logs and temporary peer registries are written under `tmp/a2a-tmux-smoke/`.
+Logs, temporary peer registries, and task ledgers are written under
+`tmp/a2a-tmux-smoke/`.
 
 ## Expected output
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "smoke:codex-app-server-live": "node scripts/smoke-codex-app-server-live.mjs",
     "smoke:event-bus": "tsx scripts/smoke-maestro-event-bus.ts",
     "smoke:a2a-local": "tsx scripts/smoke-maestro-a2a-local.ts",
+    "smoke:a2a-tmux": "bash scripts/smoke-maestro-a2a-tmux.sh",
     "a2a": "tsx src/cli.ts a2a",
     "a2a:codex-bridge": "python3 scripts/codex-a2a-bridge.py",
     "a2a:peer": "tsx src/cli.ts a2a",

--- a/packages/tui-rs/src/app.rs
+++ b/packages/tui-rs/src/app.rs
@@ -3371,13 +3371,22 @@ Add the required fields and retry.",
                     [
                         "## A2A peer pairing",
                         "",
+                        "/a2a fleet",
                         "/a2a peers",
+                        "/a2a tasks [peer]",
                         "/a2a accept <pairing-code>",
+                        "/a2a delegate <peer> <text>",
                         "/a2a send <peer> <text>",
                         "",
-                        "Native pairing codes are shared with the TypeScript CLI/TUI. Use `maestro a2a offer` to create a code from a running peer.",
+                        "Native pairing codes, fleet views, and delegation ledgers are shared with the TypeScript CLI/TUI.",
                     ]
                     .join("\n"),
+                );
+            }
+            A2aAction::Fleet => {
+                self.state.add_system_message(
+                    "A2A fleet inspection uses the shared Maestro peer registry. Run `maestro a2a fleet` for live health and task summaries until the Rust fleet reader is wired into this view."
+                        .to_string(),
                 );
             }
             A2aAction::Peers => {
@@ -3386,10 +3395,22 @@ Add the required fields and retry.",
                         .to_string(),
                 );
             }
+            A2aAction::Tasks { peer } => {
+                let scope = peer.as_deref().unwrap_or("all peers");
+                self.state.add_system_message(format!(
+                    "A2A task ledger requested for {scope}. Run `maestro a2a tasks` for the current durable ledger until the Rust task reader is wired into this view."
+                ));
+            }
             A2aAction::Accept { code } => {
                 self.state.add_system_message(format!(
                     "A2A pairing code captured ({} chars). Run `maestro a2a accept <code>` or use the TypeScript TUI `/a2a accept <code>` to persist it in the shared registry.",
                     code.len()
+                ));
+            }
+            A2aAction::Delegate { peer, text } => {
+                self.state.add_system_message(format!(
+                    "A2A delegation prepared for `{peer}` ({} chars). Run `maestro a2a delegate {peer} <text> --wait` while the Rust delegation controller is connected to the shared A2A client.",
+                    text.len()
                 ));
             }
             A2aAction::Send { peer, text } => {

--- a/packages/tui-rs/src/commands/registry.rs
+++ b/packages/tui-rs/src/commands/registry.rs
@@ -511,12 +511,29 @@ fn parse_a2a_action(raw: &str) -> Result<A2aAction, CommandError> {
         .unwrap_or_default();
     match subcommand.as_str() {
         "" | "help" => Ok(A2aAction::Help),
+        "fleet" => Ok(A2aAction::Fleet),
         "peers" | "list" => Ok(A2aAction::Peers),
+        "tasks" => Ok(A2aAction::Tasks {
+            peer: tokens.get(1).cloned(),
+        }),
         "accept" => {
             let code = tokens
                 .get(1)
                 .ok_or_else(|| CommandError::new("Usage: /a2a accept <pairing-code>"))?;
             Ok(A2aAction::Accept { code: code.clone() })
+        }
+        "delegate" => {
+            let peer = tokens
+                .get(1)
+                .ok_or_else(|| CommandError::new("Usage: /a2a delegate <peer> <text>"))?;
+            let text = tokens.get(2..).unwrap_or(&[]).join(" ");
+            if text.trim().is_empty() {
+                return Err(CommandError::new("Usage: /a2a delegate <peer> <text>"));
+            }
+            Ok(A2aAction::Delegate {
+                peer: peer.clone(),
+                text,
+            })
         }
         "send" => {
             let peer = tokens
@@ -533,7 +550,7 @@ fn parse_a2a_action(raw: &str) -> Result<A2aAction, CommandError> {
         }
         _ => Err(
             CommandError::new(format!("Unknown A2A subcommand: {subcommand}"))
-                .with_hint("Usage: /a2a [peers|accept <code>|send <peer> <text>]"),
+                .with_hint("Usage: /a2a [fleet|peers|tasks|accept <code>|delegate <peer> <text>|send <peer> <text>]"),
         ),
     }
 }
@@ -754,7 +771,7 @@ pub fn build_command_registry() -> CommandRegistry {
     registry.register(
         Command::new(
             "a2a",
-            "Pair and inspect A2A peer agents",
+            "Pair, inspect, and delegate to A2A peer agents",
             CommandCategory::Tools,
             Box::new(|ctx| {
                 Ok(CommandOutput::Action(CommandAction::A2a(parse_a2a_action(
@@ -762,7 +779,7 @@ pub fn build_command_registry() -> CommandRegistry {
                 )?)))
             }),
         )
-        .usage("/a2a [peers|accept <code>|send <peer> <text>]"),
+        .usage("/a2a [fleet|peers|tasks|accept <code>|delegate <peer> <text>|send <peer> <text>]"),
     );
 
     // Queue command
@@ -1958,6 +1975,17 @@ mod tests {
     #[test]
     fn a2a_command_parses_peer_actions() {
         let registry = build_command_registry();
+
+        assert!(registry.execute("/a2a fleet", "/tmp", None, None).is_ok());
+        assert!(registry.execute("/a2a tasks", "/tmp", None, None).is_ok());
+        assert!(registry
+            .execute(
+                "/a2a delegate mac-mini run workspace smoke",
+                "/tmp",
+                None,
+                None,
+            )
+            .is_ok());
 
         match registry
             .execute("/a2a peers", "/tmp", None, None)

--- a/packages/tui-rs/src/commands/types.rs
+++ b/packages/tui-rs/src/commands/types.rs
@@ -357,10 +357,16 @@ pub enum McpAction {
 pub enum A2aAction {
     /// Show native A2A pairing help.
     Help,
+    /// Show A2A fleet health.
+    Fleet,
     /// List paired peers.
     Peers,
+    /// List delegated A2A tasks.
+    Tasks { peer: Option<String> },
     /// Accept a pairing code.
     Accept { code: String },
+    /// Delegate work to a peer.
+    Delegate { peer: String, text: String },
     /// Send a message to a peer.
     Send { peer: String, text: String },
 }

--- a/scripts/smoke-maestro-a2a-tmux.sh
+++ b/scripts/smoke-maestro-a2a-tmux.sh
@@ -7,6 +7,8 @@ WORK_DIR="${MAESTRO_A2A_TMUX_WORK_DIR:-"$ROOT_DIR/tmp/a2a-tmux-smoke"}"
 LOG_DIR="$WORK_DIR/logs"
 REGISTRY_A="$WORK_DIR/peer-a-registry.json"
 REGISTRY_B="$WORK_DIR/peer-b-registry.json"
+TASKS_A="$WORK_DIR/peer-a-tasks.json"
+TASKS_B="$WORK_DIR/peer-b-tasks.json"
 READY_TIMEOUT_SECONDS="${MAESTRO_A2A_TMUX_READY_TIMEOUT_SECONDS:-120}"
 KEEP_SESSION="${MAESTRO_A2A_TMUX_KEEP_SESSION:-0}"
 
@@ -74,7 +76,7 @@ require_cmd curl
 
 cd "$ROOT_DIR"
 mkdir -p "$LOG_DIR"
-rm -f "$REGISTRY_A" "$REGISTRY_B"
+rm -f "$REGISTRY_A" "$REGISTRY_B" "$TASKS_A" "$TASKS_B"
 
 if tmux has-session -t "$SESSION_NAME" >/dev/null 2>&1; then
 	echo "tmux session already exists: $SESSION_NAME" >&2
@@ -108,11 +110,29 @@ a2a_cli "$REGISTRY_B" accept "$CODE_A" --name peer-a --default
 a2a_cli "$REGISTRY_A" peers
 a2a_cli "$REGISTRY_B" peers
 
-echo "sending peer-a -> peer-b with bounded wait"
-SEND_A_TO_B="$(a2a_cli "$REGISTRY_A" send peer-b "hello from tmux peer A" --wait --max-wait-ms 30000 --interval-ms 250 --timeout-ms 3000)"
-echo "$SEND_A_TO_B"
-if ! grep -q "tmux peer B received the A2A message" <<<"$SEND_A_TO_B"; then
-	echo "peer-a -> peer-b response did not include expected peer B text" >&2
+echo "delegating peer-a -> peer-b with bounded wait and durable ledger"
+DELEGATE_A_TO_B="$(a2a_cli "$REGISTRY_A" delegate peer-b "run the tmux A2A smoke from peer A" --role background-worker --cwd "$ROOT_DIR" --wait --tasks "$TASKS_A" --max-wait-ms 30000 --interval-ms 250 --timeout-ms 3000)"
+echo "$DELEGATE_A_TO_B"
+if ! grep -q "tmux peer B received the A2A message" <<<"$DELEGATE_A_TO_B"; then
+	echo "peer-a -> peer-b delegation response did not include expected peer B text" >&2
+	exit 1
+fi
+
+echo "checking fleet and delegated task views"
+FLEET_A="$(a2a_cli "$REGISTRY_A" fleet --json --tasks "$TASKS_A" --timeout-ms 3000)"
+echo "$FLEET_A"
+if ! grep -q '"status": "online"' <<<"$FLEET_A"; then
+	echo "fleet output did not show peer-b online" >&2
+	exit 1
+fi
+if ! grep -q '"lastTask"' <<<"$FLEET_A"; then
+	echo "fleet output did not include the delegated task summary" >&2
+	exit 1
+fi
+TASKS_A_OUT="$(a2a_cli "$REGISTRY_A" tasks --json --tasks "$TASKS_A")"
+echo "$TASKS_A_OUT"
+if ! grep -q '"state": "TASK_STATE_COMPLETED"' <<<"$TASKS_A_OUT"; then
+	echo "task ledger did not record completed delegation" >&2
 	exit 1
 fi
 

--- a/src/cli-tui/commands/a2a-handlers.ts
+++ b/src/cli-tui/commands/a2a-handlers.ts
@@ -1,9 +1,15 @@
 import { parseA2AArgs } from "../../cli/commands/a2a.js";
+import { inspectA2AFleet } from "../../platform/a2a-fleet.js";
 import { decodeA2APeerPairingCode } from "../../platform/a2a-peer-pairing.js";
 import {
 	listA2APeers,
 	upsertA2APeerFromPairingPayload,
 } from "../../platform/a2a-peer-registry.js";
+import {
+	getA2ATaskLedgerPath,
+	listA2ATaskEntries,
+	loadA2ATaskLedger,
+} from "../../platform/a2a-task-ledger.js";
 import type { CommandExecutionContext } from "./types.js";
 
 export interface A2ACommandHandlerDeps {
@@ -18,7 +24,9 @@ export async function handleA2ATuiCommand(
 	const parsed = parseA2AArgs(splitCommandArgs(context.argumentText));
 	const subcommand = parsed.positionals.shift()?.toLowerCase() ?? "help";
 	if (subcommand === "peers" || subcommand === "list") {
-		const { path, registry } = await listA2APeers();
+		const { path, registry } = await listA2APeers({
+			path: stringFlag(parsed.flags, "--registry"),
+		});
 		const entries = Object.entries(registry.peers).sort(([left], [right]) =>
 			left.localeCompare(right),
 		);
@@ -43,6 +51,50 @@ export async function handleA2ATuiCommand(
 		deps.requestRender();
 		return;
 	}
+	if (subcommand === "fleet") {
+		const fleet = await inspectA2AFleet({
+			registryPath: stringFlag(parsed.flags, "--registry"),
+			tasksPath: stringFlag(parsed.flags, "--tasks"),
+		});
+		deps.addContent(
+			[
+				`A2A fleet (${fleet.registryPath})`,
+				fleet.peers.length === 0
+					? "No peers registered. Use /a2a accept <pairing-code>."
+					: fleet.peers
+							.map((peer) => {
+								const last = peer.lastTask
+									? ` last=${peer.lastTask.id} ${peer.lastTask.state}`
+									: "";
+								return `${peer.status} ${peer.name} ${peer.url}${last}`;
+							})
+							.join("\n"),
+			].join("\n"),
+		);
+		deps.requestRender();
+		return;
+	}
+	if (subcommand === "tasks") {
+		const peer = parsed.positionals.shift();
+		const tasksPath = stringFlag(parsed.flags, "--tasks");
+		const ledger = await loadA2ATaskLedger({ path: tasksPath });
+		const entries = listA2ATaskEntries(ledger, { peer });
+		deps.addContent(
+			[
+				`A2A tasks (${getA2ATaskLedgerPath(tasksPath)})`,
+				entries.length === 0
+					? "No delegated tasks recorded yet."
+					: entries
+							.map(
+								(entry) =>
+									`${entry.peer} ${entry.taskId} ${entry.state} ${entry.text}`,
+							)
+							.join("\n"),
+			].join("\n"),
+		);
+		deps.requestRender();
+		return;
+	}
 	if (subcommand === "accept") {
 		const code = parsed.positionals.shift();
 		if (!code) {
@@ -55,6 +107,7 @@ export async function handleA2ATuiCommand(
 			makeDefault: parsed.flags.get("--default") === true,
 			tokenEnv: stringFlag(parsed.flags, "--token-env"),
 			tokenFile: stringFlag(parsed.flags, "--token-file"),
+			path: stringFlag(parsed.flags, "--registry"),
 		});
 		context.showInfo(`Registered A2A peer ${result.name}.`);
 		deps.addContent(
@@ -76,10 +129,19 @@ export async function handleA2ATuiCommand(
 		);
 		return;
 	}
+	if (subcommand === "delegate") {
+		context.showInfo(
+			"Use `maestro a2a delegate <peer> <text> --wait` for native A2A delegation while the TUI task panel is being wired.",
+		);
+		return;
+	}
 	deps.addContent(
 		[
 			"/a2a accept <pairing-code> [--name <peer>] [--default] [--token-env ENV]",
+			"/a2a fleet",
 			"/a2a peers",
+			"/a2a delegate <peer> <text>",
+			"/a2a tasks [peer]",
 			"/a2a send <peer> <text>",
 		].join("\n"),
 	);

--- a/src/cli/commands/a2a.ts
+++ b/src/cli/commands/a2a.ts
@@ -9,6 +9,7 @@ import {
 	getA2ATask,
 	sendA2AMessage,
 } from "../../platform/a2a-client.js";
+import { inspectA2AFleet } from "../../platform/a2a-fleet.js";
 import {
 	createA2APeerPairingPayload,
 	createA2APeerPairingPayloadFromAgentCard,
@@ -21,27 +22,71 @@ import {
 	resolveA2APeer,
 	upsertA2APeerFromPairingPayload,
 } from "../../platform/a2a-peer-registry.js";
+import {
+	extractA2ATaskText,
+	getA2ATaskLedgerPath,
+	isTerminalA2AState,
+	listA2ATaskEntries,
+	loadA2ATaskLedger,
+	recordA2ATaskStart,
+	updateA2ATaskInLedger,
+} from "../../platform/a2a-task-ledger.js";
 import { getEnvValue } from "../../platform/client.js";
 
 const DEFAULT_WAIT_MS = 300_000;
 const DEFAULT_WAIT_INTERVAL_MS = 5_000;
-const A2A_VALUE_FLAGS = new Set([
-	"--agent-card-url",
-	"--base-url",
-	"--interval-ms",
-	"--max-wait-ms",
-	"--name",
-	"--organization-id",
-	"--peer-id",
-	"--registry",
-	"--timeout-ms",
-	"--token-env",
-	"--token-file",
-	"--ttl-minutes",
-	"--url",
-	"--workspace-id",
-]);
-const A2A_BOOLEAN_FLAGS = new Set(["--default", "--wait"]);
+const A2A_VALUE_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> = {
+	accept: [
+		"--name",
+		"--organization-id",
+		"--registry",
+		"--token-env",
+		"--token-file",
+		"--workspace-id",
+	],
+	card: ["--registry", "--timeout-ms"],
+	delegate: [
+		"--cwd",
+		"--interval-ms",
+		"--max-wait-ms",
+		"--registry",
+		"--role",
+		"--tasks",
+		"--timeout-ms",
+	],
+	fleet: ["--registry", "--tasks", "--timeout-ms"],
+	offer: [
+		"--agent-card-url",
+		"--base-url",
+		"--name",
+		"--peer-id",
+		"--ttl-minutes",
+		"--url",
+	],
+	peers: ["--registry"],
+	send: ["--interval-ms", "--max-wait-ms", "--registry", "--timeout-ms"],
+	tasks: ["--registry", "--tasks", "--timeout-ms"],
+	wait: [
+		"--interval-ms",
+		"--max-wait-ms",
+		"--registry",
+		"--tasks",
+		"--timeout-ms",
+	],
+};
+const A2A_BOOLEAN_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> = {
+	accept: ["--default"],
+	delegate: ["--wait"],
+	fleet: ["--json"],
+	send: ["--wait"],
+	tasks: ["--json", "--refresh"],
+};
+const A2A_LEADING_VALUE_FLAGS = new Set(
+	Object.values(A2A_VALUE_FLAGS_BY_SUBCOMMAND).flat(),
+);
+const A2A_LEADING_BOOLEAN_FLAGS = new Set(
+	Object.values(A2A_BOOLEAN_FLAGS_BY_SUBCOMMAND).flat(),
+);
 
 export interface ParsedA2AArgs {
 	positionals: string[];
@@ -64,11 +109,21 @@ export async function handleA2ACommand(args: string[]): Promise<void> {
 		case "list":
 			await handleA2APeers(parsed);
 			return;
+		case "fleet":
+			await handleA2AFleet(parsed);
+			return;
 		case "card":
 			await handleA2ACard(parsed);
 			return;
 		case "send":
 			await handleA2ASend(parsed);
+			return;
+		case "delegate":
+		case "delegation":
+			await handleA2ADelegate(parsed);
+			return;
+		case "tasks":
+			await handleA2ATasks(parsed);
 			return;
 		case "wait":
 			await handleA2AWait(parsed);
@@ -81,6 +136,15 @@ export async function handleA2ACommand(args: string[]): Promise<void> {
 export function parseA2AArgs(args: string[]): ParsedA2AArgs {
 	const flags = new Map<string, string | boolean>();
 	const positionals: string[] = [];
+	const subcommandIndex = findA2ASubcommandIndex(args);
+	const subcommand =
+		subcommandIndex >= 0
+			? canonicalA2ASubcommand(args[subcommandIndex])
+			: "help";
+	const valueFlags = new Set(A2A_VALUE_FLAGS_BY_SUBCOMMAND[subcommand] ?? []);
+	const booleanFlags = new Set(
+		A2A_BOOLEAN_FLAGS_BY_SUBCOMMAND[subcommand] ?? [],
+	);
 	for (let index = 0; index < args.length; index++) {
 		const arg = args[index];
 		if (!arg) continue;
@@ -93,7 +157,19 @@ export function parseA2AArgs(args: string[]): ParsedA2AArgs {
 			if (!flag) {
 				continue;
 			}
-			if (!A2A_VALUE_FLAGS.has(flag) && !A2A_BOOLEAN_FLAGS.has(flag)) {
+			if (
+				index < subcommandIndex &&
+				!valueFlags.has(flag) &&
+				!booleanFlags.has(flag) &&
+				(A2A_LEADING_VALUE_FLAGS.has(flag) ||
+					A2A_LEADING_BOOLEAN_FLAGS.has(flag))
+			) {
+				if (A2A_LEADING_VALUE_FLAGS.has(flag) && inlineValue === undefined) {
+					index++;
+				}
+				continue;
+			}
+			if (!valueFlags.has(flag) && !booleanFlags.has(flag)) {
 				positionals.push(arg);
 				continue;
 			}
@@ -101,7 +177,7 @@ export function parseA2AArgs(args: string[]): ParsedA2AArgs {
 				flags.set(flag, inlineValue);
 				continue;
 			}
-			if (A2A_BOOLEAN_FLAGS.has(flag)) {
+			if (booleanFlags.has(flag)) {
 				flags.set(flag, true);
 				continue;
 			}
@@ -117,6 +193,45 @@ export function parseA2AArgs(args: string[]): ParsedA2AArgs {
 		positionals.push(arg);
 	}
 	return { flags, positionals };
+}
+
+function findA2ASubcommandIndex(args: readonly string[]): number {
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
+		if (!arg || arg === "--") {
+			break;
+		}
+		if (!arg.startsWith("--")) {
+			return index;
+		}
+		const [flag = "", inlineValue] = arg.split("=", 2);
+		if (A2A_LEADING_VALUE_FLAGS.has(flag) && inlineValue === undefined) {
+			index++;
+			continue;
+		}
+		if (
+			A2A_LEADING_VALUE_FLAGS.has(flag) ||
+			A2A_LEADING_BOOLEAN_FLAGS.has(flag)
+		) {
+			continue;
+		}
+		break;
+	}
+	return -1;
+}
+
+function canonicalA2ASubcommand(input: string | undefined): string {
+	switch (input?.toLowerCase()) {
+		case "pair":
+		case "create":
+			return "offer";
+		case "list":
+			return "peers";
+		case "delegation":
+			return "delegate";
+		default:
+			return input?.toLowerCase() ?? "help";
+	}
 }
 
 async function handleA2AOffer(parsed: ParsedA2AArgs): Promise<void> {
@@ -239,6 +354,56 @@ async function handleA2ACard(parsed: ParsedA2AArgs): Promise<void> {
 	console.log(JSON.stringify(card, null, 2));
 }
 
+async function handleA2AFleet(parsed: ParsedA2AArgs): Promise<void> {
+	const fleet = await inspectA2AFleet({
+		registryPath: stringFlag(parsed, "--registry"),
+		tasksPath: stringFlag(parsed, "--tasks"),
+		timeoutMs: numberFlag(parsed, "--timeout-ms"),
+	});
+	if (booleanFlag(parsed, "--json")) {
+		console.log(JSON.stringify(fleet, null, 2));
+		return;
+	}
+	console.log(`A2A fleet (${fleet.registryPath})`);
+	if (fleet.peers.length === 0) {
+		console.log(
+			chalk.dim("  No peers registered. Run maestro a2a accept <code>."),
+		);
+		return;
+	}
+	for (const peer of fleet.peers) {
+		const status =
+			peer.status === "online" ? chalk.green("online") : chalk.yellow("down");
+		const label = peer.displayName
+			? `${peer.name} (${peer.displayName})`
+			: peer.name;
+		console.log(`${status} ${chalk.bold(label)} ${chalk.dim(peer.url)}`);
+		if (peer.model || peer.cwd || peer.auth) {
+			console.log(
+				chalk.dim(
+					`  ${[
+						peer.model ? `model=${peer.model}` : undefined,
+						peer.cwd ? `cwd=${peer.cwd}` : undefined,
+						peer.auth ? `auth=${peer.auth}` : undefined,
+					]
+						.filter(Boolean)
+						.join(" ")}`,
+				),
+			);
+		}
+		if (peer.lastTask) {
+			console.log(
+				chalk.dim(
+					`  last=${peer.lastTask.id} ${peer.lastTask.state} ${peer.lastTask.text}`,
+				),
+			);
+		}
+		if (peer.error) {
+			console.log(chalk.dim(`  error=${peer.error}`));
+		}
+	}
+}
+
 async function handleA2ASend(parsed: ParsedA2AArgs): Promise<void> {
 	const peerName =
 		parsed.positionals.shift() ?? fail("Usage: maestro a2a send <peer> <text>");
@@ -269,6 +434,122 @@ async function handleA2ASend(parsed: ParsedA2AArgs): Promise<void> {
 	printTask(task);
 }
 
+async function handleA2ADelegate(parsed: ParsedA2AArgs): Promise<void> {
+	const peerName =
+		parsed.positionals.shift() ??
+		fail("Usage: maestro a2a delegate <peer> <text>");
+	const text = parsed.positionals.join(" ").trim();
+	if (!text) {
+		fail("Usage: maestro a2a delegate <peer> <text>");
+	}
+	const peer = await resolveA2APeer(peerName, {
+		path: stringFlag(parsed, "--registry"),
+		timeoutMs: numberFlag(parsed, "--timeout-ms"),
+	});
+	const wait = booleanFlag(parsed, "--wait");
+	const role = stringFlag(parsed, "--role");
+	const cwd = stringFlag(parsed, "--cwd") ?? process.cwd();
+	const messageId = `maestro-a2a-message-${randomUUID()}`;
+	const contextId = `maestro-a2a-context-${randomUUID()}`;
+	const sent = await sendA2AMessage(peer.config, {
+		message: buildA2AUserMessage({
+			messageId,
+			contextId,
+			text,
+			metadata: {
+				requestKind: "maestro-peer-delegation",
+				relayPeer: peer.name,
+				...(role ? { delegationRole: role } : {}),
+				...(cwd ? { delegationCwd: cwd } : {}),
+			},
+		}),
+		configuration: { returnImmediately: true },
+	});
+	console.log(`Delegated to ${chalk.bold(peer.name)} as task ${sent.task.id}`);
+	await persistA2ALedgerBestEffort("record delegated task locally", () =>
+		recordA2ATaskStart({
+			path: stringFlag(parsed, "--tasks"),
+			peer: peer.name,
+			peerDisplayName: peer.entry.displayName,
+			task: sent.task,
+			text,
+			messageId,
+			contextId,
+			kind: "delegation",
+			role,
+			cwd,
+			metadata: {
+				requestKind: "maestro-peer-delegation",
+				relayPeer: peer.name,
+				delegationRole: role,
+				delegationCwd: cwd,
+			},
+		}),
+	);
+	const task = wait
+		? await waitForA2ATask(peer.config, sent.task.id, parsed)
+		: sent.task;
+	if (wait) {
+		await persistA2ALedgerBestEffort("sync delegated task result locally", () =>
+			updateA2ATaskInLedger({
+				path: stringFlag(parsed, "--tasks"),
+				peer: peer.name,
+				task,
+			}),
+		);
+	}
+	printTask(task);
+}
+
+async function handleA2ATasks(parsed: ParsedA2AArgs): Promise<void> {
+	const peerName = parsed.positionals.shift();
+	if (booleanFlag(parsed, "--refresh")) {
+		await refreshA2ATaskLedger(parsed, peerName);
+	}
+	const ledger = await loadA2ATaskLedger({
+		path: stringFlag(parsed, "--tasks"),
+	});
+	const tasks = listA2ATaskEntries(ledger, { peer: peerName });
+	if (booleanFlag(parsed, "--json")) {
+		console.log(
+			JSON.stringify(
+				{
+					path: getA2ATaskLedgerPath(stringFlag(parsed, "--tasks")),
+					tasks: tasks.map((entry) => ({
+						id: entry.id,
+						kind: entry.kind,
+						peer: entry.peer,
+						taskId: entry.taskId,
+						state: entry.state,
+						text: entry.text,
+						responseText: entry.responseText,
+						updatedAt: entry.updatedAt,
+					})),
+				},
+				null,
+				2,
+			),
+		);
+		return;
+	}
+	console.log(
+		`A2A tasks (${getA2ATaskLedgerPath(stringFlag(parsed, "--tasks"))})`,
+	);
+	if (tasks.length === 0) {
+		console.log(chalk.dim("  No delegated tasks recorded yet."));
+		return;
+	}
+	for (const task of tasks) {
+		console.log(
+			`${task.peer} ${chalk.bold(task.taskId)} ${task.state} ${chalk.dim(task.updatedAt)}`,
+		);
+		console.log(chalk.dim(`  ${task.text}`));
+		if (task.responseText) {
+			console.log(`  ${task.responseText}`);
+		}
+	}
+}
+
 async function handleA2AWait(parsed: ParsedA2AArgs): Promise<void> {
 	const peerName =
 		parsed.positionals.shift() ??
@@ -280,7 +561,39 @@ async function handleA2AWait(parsed: ParsedA2AArgs): Promise<void> {
 		path: stringFlag(parsed, "--registry"),
 		timeoutMs: numberFlag(parsed, "--timeout-ms"),
 	});
-	printTask(await waitForA2ATask(peer.config, taskId, parsed));
+	const task = await waitForA2ATask(peer.config, taskId, parsed);
+	await persistA2ALedgerBestEffort("sync task result locally", () =>
+		updateA2ATaskInLedger({
+			path: stringFlag(parsed, "--tasks"),
+			peer: peer.name,
+			task,
+		}),
+	);
+	printTask(task);
+}
+
+async function refreshA2ATaskLedger(
+	parsed: ParsedA2AArgs,
+	peerFilter: string | undefined,
+): Promise<void> {
+	const ledger = await loadA2ATaskLedger({
+		path: stringFlag(parsed, "--tasks"),
+	});
+	for (const entry of listA2ATaskEntries(ledger, { peer: peerFilter })) {
+		if (isTerminalA2AState(entry.state)) {
+			continue;
+		}
+		const peer = await resolveA2APeer(entry.peer, {
+			path: stringFlag(parsed, "--registry"),
+			timeoutMs: numberFlag(parsed, "--timeout-ms"),
+		});
+		const task = await getA2ATask(peer.config, entry.taskId);
+		await updateA2ATaskInLedger({
+			path: stringFlag(parsed, "--tasks"),
+			peer: entry.peer,
+			task,
+		});
+	}
 }
 
 async function waitForA2ATask(
@@ -293,14 +606,11 @@ async function waitForA2ATask(
 		numberFlag(parsed, "--interval-ms") ?? DEFAULT_WAIT_INTERVAL_MS;
 	const deadline = Date.now() + maxWaitMs;
 	let lastTask = await getA2ATask(config, taskId);
-	while (
-		!isA2AWaitCompletionState(lastTask.status.state) &&
-		Date.now() < deadline
-	) {
+	while (!isTerminalA2AState(lastTask.status.state) && Date.now() < deadline) {
 		await sleep(intervalMs);
 		lastTask = await getA2ATask(config, taskId);
 	}
-	if (!isA2AWaitCompletionState(lastTask.status.state)) {
+	if (!isTerminalA2AState(lastTask.status.state)) {
 		throw new Error(
 			`Timed out waiting for A2A task ${taskId}; last state ${lastTask.status.state}`,
 		);
@@ -317,36 +627,10 @@ function printTask(task: A2ATask): void {
 }
 
 function a2aTaskText(task: A2ATask): string | undefined {
-	const statusText = task.status.message?.parts
-		.map((part) => part.text)
-		.find(
-			(text): text is string =>
-				typeof text === "string" && text.trim().length > 0,
-		);
-	if (statusText) {
-		return statusText;
-	}
-	return task.artifacts
-		?.flatMap((artifact) => artifact.parts)
-		.map((part) => part.text)
-		.find(
-			(text): text is string =>
-				typeof text === "string" && text.trim().length > 0,
-		);
+	return extractA2ATaskText(task);
 }
 
-export function isA2AWaitCompletionState(state: string): boolean {
-	const normalized = state.toUpperCase().replace(/[\s-]+/gu, "_");
-	return (
-		normalized.includes("COMPLETED") ||
-		normalized.includes("FAILED") ||
-		normalized.includes("CANCELED") ||
-		normalized.includes("CANCELLED") ||
-		normalized.includes("REJECTED") ||
-		normalized.includes("INPUT_REQUIRED") ||
-		normalized.includes("AUTH_REQUIRED")
-	);
-}
+export const isA2AWaitCompletionState = isTerminalA2AState;
 
 function baseUrlFromAgentCardUrl(agentCardUrl: string): string {
 	const parsed = new URL(agentCardUrl);
@@ -385,6 +669,21 @@ function booleanFlag(parsed: ParsedA2AArgs, name: string): boolean {
 	return parsed.flags.get(name) === true;
 }
 
+async function persistA2ALedgerBestEffort(
+	description: string,
+	action: () => Promise<unknown>,
+): Promise<void> {
+	try {
+		await action();
+	} catch (error) {
+		console.error(
+			chalk.yellow(
+				`A2A task ledger warning: could not ${description}: ${errorMessage(error)}`,
+			),
+		);
+	}
+}
+
 function fail(message: string): never {
 	throw new Error(message);
 }
@@ -402,8 +701,11 @@ function printA2AHelp(): void {
   maestro a2a offer --url <base-url> [--name <display-name>] [--peer-id <id>]
   maestro a2a accept <pairing-code> [--name <peer>] [--default] [--token-env ENV]
   maestro a2a peers
+  maestro a2a fleet [--json]
   maestro a2a card <peer>
+  maestro a2a delegate <peer> <text> [--role <role>] [--cwd <path>] [--wait]
   maestro a2a send <peer> <text> [--wait]
+  maestro a2a tasks [peer] [--json] [--refresh]
   maestro a2a wait <peer> <task-id>
 
 Pairing codes carry Agent Card and transport coordinates only. Configure auth with

--- a/src/platform/a2a-fleet.ts
+++ b/src/platform/a2a-fleet.ts
@@ -1,0 +1,164 @@
+import { type A2AAgentCard, discoverA2AAgentCard } from "./a2a-client.js";
+import {
+	type A2APeerRegistryEntry,
+	listA2APeers,
+	resolveA2APeer,
+} from "./a2a-peer-registry.js";
+import {
+	type A2ATaskLedgerEntry,
+	getA2ATaskLedgerPath,
+	latestA2ATaskForPeer,
+	loadA2ATaskLedger,
+} from "./a2a-task-ledger.js";
+
+export interface A2AFleetOptions {
+	registryPath?: string;
+	tasksPath?: string;
+	timeoutMs?: number;
+}
+
+export interface A2AFleetSummary {
+	generatedAt: string;
+	registryPath: string;
+	tasksPath: string;
+	peers: A2AFleetPeerSummary[];
+}
+
+export interface A2AFleetPeerSummary {
+	name: string;
+	displayName?: string;
+	url: string;
+	agentCardUrl?: string;
+	status: "online" | "unreachable";
+	error?: string;
+	auth?: string;
+	protocolBinding?: string;
+	protocolVersion?: string;
+	provider?: A2AAgentCard["provider"];
+	capabilities?: A2AAgentCard["capabilities"];
+	skills?: A2AAgentCard["skills"];
+	model?: string;
+	cwd?: string;
+	lastTask?: A2AFleetTaskSummary;
+}
+
+export interface A2AFleetTaskSummary {
+	id: string;
+	ledgerId: string;
+	state: string;
+	text: string;
+	responseText?: string;
+	updatedAt: string;
+}
+
+export async function inspectA2AFleet(
+	options: A2AFleetOptions = {},
+): Promise<A2AFleetSummary> {
+	const [{ path: registryPath, registry }, ledger] = await Promise.all([
+		listA2APeers({ path: options.registryPath }),
+		loadA2ATaskLedger({ path: options.tasksPath }),
+	]);
+	const peers = await Promise.all(
+		Object.entries(registry.peers)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(async ([name, entry]) =>
+				inspectPeer(name, entry, latestA2ATaskForPeer(ledger, name), options),
+			),
+	);
+	return {
+		generatedAt: new Date().toISOString(),
+		registryPath,
+		tasksPath: getA2ATaskLedgerPath(options.tasksPath),
+		peers,
+	};
+}
+
+function fleetTaskSummary(
+	entry: A2ATaskLedgerEntry | undefined,
+): A2AFleetTaskSummary | undefined {
+	if (!entry) {
+		return undefined;
+	}
+	return {
+		id: entry.taskId,
+		ledgerId: entry.id,
+		state: entry.state,
+		text: entry.text,
+		...(entry.responseText ? { responseText: entry.responseText } : {}),
+		updatedAt: entry.updatedAt,
+	};
+}
+
+async function inspectPeer(
+	name: string,
+	entry: A2APeerRegistryEntry,
+	lastTask: A2ATaskLedgerEntry | undefined,
+	options: A2AFleetOptions,
+): Promise<A2AFleetPeerSummary> {
+	const base = basePeerSummary(name, entry, lastTask);
+	try {
+		const peer = await resolveA2APeer(name, {
+			path: options.registryPath,
+			timeoutMs: options.timeoutMs,
+		});
+		const card = await discoverA2AAgentCard(peer.config);
+		return {
+			...base,
+			status: "online",
+			displayName: card.name || base.displayName,
+			provider: card.provider,
+			capabilities: card.capabilities,
+			skills: card.skills,
+			protocolBinding:
+				card.supportedInterfaces[0]?.protocolBinding ?? base.protocolBinding,
+			protocolVersion:
+				card.supportedInterfaces[0]?.protocolVersion ?? base.protocolVersion,
+		};
+	} catch (error) {
+		return {
+			...base,
+			status: "unreachable",
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+function basePeerSummary(
+	name: string,
+	entry: A2APeerRegistryEntry,
+	lastTask: A2ATaskLedgerEntry | undefined,
+): A2AFleetPeerSummary {
+	return {
+		name,
+		...(entry.displayName ? { displayName: entry.displayName } : {}),
+		url: entry.url,
+		...(entry.agentCardUrl ? { agentCardUrl: entry.agentCardUrl } : {}),
+		status: "unreachable",
+		...(entry.tokenEnv
+			? { auth: `env:${entry.tokenEnv}` }
+			: entry.tokenFile
+				? { auth: "file" }
+				: {}),
+		...(entry.protocolBinding
+			? { protocolBinding: entry.protocolBinding }
+			: {}),
+		...(entry.protocolVersion
+			? { protocolVersion: entry.protocolVersion }
+			: {}),
+		...(stringMetadata(entry, "model")
+			? { model: stringMetadata(entry, "model") }
+			: {}),
+		...(stringMetadata(entry, "cwd")
+			? { cwd: stringMetadata(entry, "cwd") }
+			: {}),
+		...(lastTask ? { lastTask: fleetTaskSummary(lastTask) } : {}),
+	};
+}
+
+function stringMetadata(
+	entry: A2APeerRegistryEntry,
+	key: string,
+): string | undefined {
+	const value = entry.metadata?.[key];
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/src/platform/a2a-task-ledger.ts
+++ b/src/platform/a2a-task-ledger.ts
@@ -1,0 +1,398 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { A2AMessage, A2ATask } from "./a2a-client.js";
+import { getEnvValue, trimString } from "./client.js";
+
+export type A2ATaskKind = "delegation" | "message";
+export type A2ATranscriptRole = "user" | "agent";
+
+export interface A2ATaskTranscriptEntry {
+	at: string;
+	role: A2ATranscriptRole;
+	text: string;
+	state?: string;
+	messageId?: string;
+}
+
+export interface A2ATaskLedgerEntry {
+	id: string;
+	kind: A2ATaskKind;
+	peer: string;
+	peerDisplayName?: string;
+	taskId: string;
+	contextId?: string;
+	messageId?: string;
+	text: string;
+	role?: string;
+	cwd?: string;
+	state: string;
+	responseText?: string;
+	metadata?: Record<string, string | number | boolean>;
+	transcript: A2ATaskTranscriptEntry[];
+	createdAt: string;
+	updatedAt: string;
+	completedAt?: string;
+}
+
+export interface A2ATaskLedgerFile {
+	tasks: A2ATaskLedgerEntry[];
+}
+
+export interface A2ATaskLedgerOptions {
+	path?: string;
+	now?: Date;
+}
+
+export interface RecordA2ATaskStartInput extends A2ATaskLedgerOptions {
+	peer: string;
+	peerDisplayName?: string;
+	task: A2ATask;
+	text: string;
+	messageId?: string;
+	contextId?: string;
+	kind?: A2ATaskKind;
+	role?: string;
+	cwd?: string;
+	metadata?: Record<string, string | number | boolean | undefined>;
+}
+
+export interface UpdateA2ATaskInput extends A2ATaskLedgerOptions {
+	peer: string;
+	task: A2ATask;
+}
+
+const TERMINAL_STATE_PATTERN =
+	/(COMPLETED|FAILED|CANCELED|CANCELLED|REJECTED|INPUT_REQUIRED|AUTH_REQUIRED)/u;
+
+export function getA2ATaskLedgerPath(path?: string): string {
+	const configured =
+		trimString(path) ??
+		getEnvValue(["MAESTRO_A2A_TASKS_FILE", "CODEX_A2A_TASKS_FILE"]);
+	if (configured) {
+		return expandHome(configured);
+	}
+	return join(homedir(), ".maestro", "a2a", "tasks.json");
+}
+
+export async function loadA2ATaskLedger(
+	options: A2ATaskLedgerOptions = {},
+): Promise<A2ATaskLedgerFile> {
+	const path = getA2ATaskLedgerPath(options.path);
+	let raw: string;
+	try {
+		raw = await readFile(path, "utf8");
+	} catch (error) {
+		if (hasNodeCode(error, "ENOENT")) {
+			return { tasks: [] };
+		}
+		throw error;
+	}
+	const parsed = JSON.parse(raw) as unknown;
+	if (!isRecord(parsed)) {
+		throw new Error(`A2A task ledger at ${path} must be a JSON object`);
+	}
+	const tasks = Array.isArray(parsed.tasks) ? parsed.tasks : [];
+	return {
+		tasks: tasks.map((task, index) =>
+			normalizeLedgerEntry(task, `tasks[${index}]`),
+		),
+	};
+}
+
+export async function saveA2ATaskLedger(
+	ledger: A2ATaskLedgerFile,
+	options: A2ATaskLedgerOptions = {},
+): Promise<string> {
+	const path = getA2ATaskLedgerPath(options.path);
+	await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+	await writeFile(`${path}.tmp`, `${JSON.stringify(ledger, null, 2)}\n`, {
+		mode: 0o600,
+	});
+	await rename(`${path}.tmp`, path);
+	return path;
+}
+
+export async function recordA2ATaskStart(
+	input: RecordA2ATaskStartInput,
+): Promise<{ entry: A2ATaskLedgerEntry; path: string }> {
+	const ledger = await loadA2ATaskLedger(input);
+	const now = (input.now ?? new Date()).toISOString();
+	const taskId = trimString(input.task.id) ?? fail("A2A task id is required");
+	const existingIndex = ledger.tasks.findIndex(
+		(entry) => entry.peer === input.peer && entry.taskId === taskId,
+	);
+	const metadata = cleanMetadata(input.metadata);
+	const userText = input.text.trim();
+	const entry: A2ATaskLedgerEntry = {
+		...(existingIndex >= 0 ? ledger.tasks[existingIndex] : {}),
+		id:
+			existingIndex >= 0
+				? ledger.tasks[existingIndex]!.id
+				: `maestro-a2a-task-${randomUUID()}`,
+		kind: input.kind ?? "delegation",
+		peer: input.peer,
+		...(input.peerDisplayName
+			? { peerDisplayName: input.peerDisplayName }
+			: {}),
+		taskId,
+		...(trimString(input.task.contextId ?? input.contextId)
+			? { contextId: trimString(input.task.contextId ?? input.contextId) }
+			: {}),
+		...(trimString(input.messageId)
+			? { messageId: trimString(input.messageId) }
+			: {}),
+		text: userText,
+		...(trimString(input.role) ? { role: trimString(input.role) } : {}),
+		...(trimString(input.cwd) ? { cwd: trimString(input.cwd) } : {}),
+		state: input.task.status.state,
+		...(metadata ? { metadata } : {}),
+		transcript: [
+			{
+				at: now,
+				role: "user",
+				text: userText,
+				...(trimString(input.messageId)
+					? { messageId: trimString(input.messageId) }
+					: {}),
+			},
+		],
+		createdAt:
+			existingIndex >= 0 ? ledger.tasks[existingIndex]!.createdAt : now,
+		updatedAt: now,
+	};
+	const taskText = extractA2ATaskText(input.task);
+	if (taskText) {
+		entry.responseText = taskText;
+		entry.transcript.push({
+			at: now,
+			role: "agent",
+			text: taskText,
+			state: input.task.status.state,
+			messageId: input.task.status.message?.messageId,
+		});
+	}
+	if (isTerminalA2AState(entry.state)) {
+		entry.completedAt = now;
+	}
+	if (existingIndex >= 0) {
+		ledger.tasks[existingIndex] = entry;
+	} else {
+		ledger.tasks.push(entry);
+	}
+	const path = await saveA2ATaskLedger(ledger, input);
+	return { entry, path };
+}
+
+export async function updateA2ATaskInLedger(
+	input: UpdateA2ATaskInput,
+): Promise<{ entry: A2ATaskLedgerEntry | null; path: string }> {
+	const ledger = await loadA2ATaskLedger(input);
+	const taskId = trimString(input.task.id) ?? fail("A2A task id is required");
+	const index = ledger.tasks.findIndex(
+		(entry) => entry.peer === input.peer && entry.taskId === taskId,
+	);
+	const path = getA2ATaskLedgerPath(input.path);
+	if (index < 0) {
+		return { entry: null, path };
+	}
+	const now = (input.now ?? new Date()).toISOString();
+	const previous = ledger.tasks[index]!;
+	const responseText = extractA2ATaskText(input.task) ?? previous.responseText;
+	const entry: A2ATaskLedgerEntry = {
+		...previous,
+		state: input.task.status.state,
+		...(trimString(input.task.contextId)
+			? { contextId: trimString(input.task.contextId) }
+			: {}),
+		...(responseText ? { responseText } : {}),
+		updatedAt: now,
+		...(isTerminalA2AState(input.task.status.state)
+			? { completedAt: previous.completedAt ?? now }
+			: {}),
+	};
+	if (
+		responseText &&
+		!entry.transcript.some(
+			(item) => item.role === "agent" && item.text === responseText,
+		)
+	) {
+		entry.transcript = [
+			...entry.transcript,
+			{
+				at: now,
+				role: "agent",
+				text: responseText,
+				state: input.task.status.state,
+				messageId: input.task.status.message?.messageId,
+			},
+		];
+	}
+	ledger.tasks[index] = entry;
+	await saveA2ATaskLedger(ledger, input);
+	return { entry, path };
+}
+
+export function listA2ATaskEntries(
+	ledger: A2ATaskLedgerFile,
+	options: { peer?: string } = {},
+): A2ATaskLedgerEntry[] {
+	const peer = trimString(options.peer);
+	return ledger.tasks
+		.filter((entry) => !peer || entry.peer === peer)
+		.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+export function latestA2ATaskForPeer(
+	ledger: A2ATaskLedgerFile,
+	peer: string,
+): A2ATaskLedgerEntry | undefined {
+	return listA2ATaskEntries(ledger, { peer })[0];
+}
+
+export function extractA2ATaskText(task: A2ATask): string | undefined {
+	return (
+		firstMessageText(task.status.message) ??
+		task.artifacts
+			?.flatMap((artifact) => artifact.parts)
+			.map((part) => trimString(part.text))
+			.find((text): text is string => Boolean(text)) ??
+		task.history
+			?.filter(isAgentMessage)
+			.map(firstMessageText)
+			.find((text): text is string => Boolean(text))
+	);
+}
+
+export function isTerminalA2AState(state: string): boolean {
+	return TERMINAL_STATE_PATTERN.test(
+		state.toUpperCase().replace(/[\s-]+/gu, "_"),
+	);
+}
+
+function firstMessageText(message: A2AMessage | undefined): string | undefined {
+	return message?.parts.map((part) => trimString(part.text)).find(Boolean);
+}
+
+function isAgentMessage(message: A2AMessage): boolean {
+	const role = message.role.toUpperCase();
+	return role === "ROLE_AGENT" || role === "AGENT";
+}
+
+function normalizeLedgerEntry(
+	input: unknown,
+	path: string,
+): A2ATaskLedgerEntry {
+	if (!isRecord(input)) {
+		throw new Error(`A2A task ledger ${path} must be a JSON object`);
+	}
+	const id = requiredString(input.id, `${path}.id`);
+	const peer = requiredString(input.peer, `${path}.peer`);
+	const taskId = requiredString(input.taskId, `${path}.taskId`);
+	const text = requiredString(input.text, `${path}.text`);
+	const state = requiredString(input.state, `${path}.state`);
+	const createdAt = requiredString(input.createdAt, `${path}.createdAt`);
+	const updatedAt = requiredString(input.updatedAt, `${path}.updatedAt`);
+	const transcript = Array.isArray(input.transcript)
+		? input.transcript.map((item, index) =>
+				normalizeTranscriptEntry(item, `${path}.transcript[${index}]`),
+			)
+		: [];
+	const entry: A2ATaskLedgerEntry = {
+		id,
+		kind: input.kind === "message" ? "message" : "delegation",
+		peer,
+		taskId,
+		text,
+		state,
+		transcript,
+		createdAt,
+		updatedAt,
+	};
+	for (const key of [
+		"peerDisplayName",
+		"contextId",
+		"messageId",
+		"role",
+		"cwd",
+		"responseText",
+		"completedAt",
+	] as const) {
+		const value = stringValue(input[key]);
+		if (value) {
+			entry[key] = value;
+		}
+	}
+	if (isRecord(input.metadata)) {
+		entry.metadata = cleanMetadata(input.metadata);
+	}
+	return entry;
+}
+
+function normalizeTranscriptEntry(
+	input: unknown,
+	path: string,
+): A2ATaskTranscriptEntry {
+	if (!isRecord(input)) {
+		throw new Error(`A2A task ledger ${path} must be a JSON object`);
+	}
+	const role = input.role === "agent" ? "agent" : "user";
+	const entry: A2ATaskTranscriptEntry = {
+		at: requiredString(input.at, `${path}.at`),
+		role,
+		text: requiredString(input.text, `${path}.text`),
+	};
+	for (const key of ["state", "messageId"] as const) {
+		const value = stringValue(input[key]);
+		if (value) {
+			entry[key] = value;
+		}
+	}
+	return entry;
+}
+
+function cleanMetadata(
+	input: Record<string, unknown> | undefined,
+): Record<string, string | number | boolean> | undefined {
+	if (!input) {
+		return undefined;
+	}
+	const entries = Object.entries(input).filter(
+		(entry): entry is [string, string | number | boolean] =>
+			typeof entry[1] === "string" ||
+			typeof entry[1] === "number" ||
+			typeof entry[1] === "boolean",
+	);
+	return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function stringValue(input: unknown): string | undefined {
+	return typeof input === "string" ? trimString(input) : undefined;
+}
+
+function requiredString(input: unknown, path: string): string {
+	const value = stringValue(input);
+	if (!value) {
+		throw new Error(`A2A task ledger ${path} is required`);
+	}
+	return value;
+}
+
+function expandHome(path: string): string {
+	return path === "~" || path.startsWith("~/")
+		? join(homedir(), path.slice(2))
+		: path;
+}
+
+function hasNodeCode(error: unknown, code: string): boolean {
+	return isRecord(error) && error.code === code;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fail(message: string): never {
+	throw new Error(message);
+}

--- a/src/safety/bash-parser.ts
+++ b/src/safety/bash-parser.ts
@@ -53,9 +53,25 @@ const logger = createLogger("safety:bash-parser");
 const isTestEnv =
 	process.env.VITEST === "true" || process.env.NODE_ENV === "test";
 
-// Dynamic import types - tree-sitter is loaded at runtime to handle missing bindings
-type ParserType = InstanceType<typeof import("tree-sitter")>;
-type SyntaxNode = import("tree-sitter").SyntaxNode;
+// Tree-sitter is optional at runtime, so keep its compile-time shape local.
+interface SyntaxNode {
+	type: string;
+	hasError: boolean;
+	children: SyntaxNode[];
+	startIndex: number;
+	endIndex: number;
+	childForFieldName(name: string): SyntaxNode | null;
+}
+
+interface ParserType {
+	parse(input: string): { rootNode: SyntaxNode };
+	setLanguage(language: unknown): void;
+}
+
+type ParserConstructor = new () => ParserType;
+
+const treeSitterModuleName = "tree-sitter";
+const treeSitterBashModuleName = "tree-sitter-bash";
 
 /**
  * Parser State - Lazy initialization with singleton pattern
@@ -101,12 +117,13 @@ async function initParser(): Promise<boolean> {
 	try {
 		// Dynamic imports for native modules - may fail if bindings missing
 		const [Parser, BashLanguage] = await Promise.all([
-			import("tree-sitter").then((m) => m.default),
-			import("tree-sitter-bash").then((m) => m.default),
+			import(treeSitterModuleName).then(
+				(m) => (m.default ?? m) as ParserConstructor,
+			),
+			import(treeSitterBashModuleName).then((m) => m.default ?? m),
 		]);
 		parser = new Parser();
-		// Type cast needed because tree-sitter-bash types don't perfectly align
-		parser.setLanguage(BashLanguage as import("tree-sitter").Language);
+		parser.setLanguage(BashLanguage);
 		parserAvailable = true;
 		logger.debug("Tree-sitter bash parser initialized successfully");
 	} catch (error) {

--- a/test/cli-tui/commands/a2a-handlers.test.ts
+++ b/test/cli-tui/commands/a2a-handlers.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleA2ATuiCommand } from "../../../src/cli-tui/commands/a2a-handlers.js";
+import type { CommandExecutionContext } from "../../../src/cli-tui/commands/types.js";
+
+describe("A2A TUI command handler", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("renders the durable A2A task ledger", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-tui-"));
+		const tasksPath = join(dir, "tasks.json");
+		await writeFile(
+			tasksPath,
+			JSON.stringify({
+				tasks: [
+					{
+						id: "maestro-a2a-local-task-1",
+						peer: "dev-desktop",
+						taskId: "task-dev-1",
+						text: "run full workspace checks",
+						state: "TASK_STATE_WORKING",
+						createdAt: "2026-05-16T00:00:00.000Z",
+						updatedAt: "2026-05-16T00:00:00.000Z",
+					},
+				],
+			}),
+		);
+		vi.stubEnv("MAESTRO_A2A_TASKS_FILE", tasksPath);
+		const content: string[] = [];
+		const context = createContext("tasks");
+
+		await handleA2ATuiCommand(context, {
+			addContent(text) {
+				content.push(text);
+			},
+			requestRender: vi.fn(),
+		});
+
+		expect(content.join("\n")).toContain("A2A tasks");
+		expect(content.join("\n")).toContain("dev-desktop");
+		expect(content.join("\n")).toContain("task-dev-1");
+		expect(content.join("\n")).toContain("TASK_STATE_WORKING");
+		expect(context.showError).not.toHaveBeenCalled();
+	});
+});
+
+function createContext(argumentText: string): CommandExecutionContext {
+	return {
+		command: { name: "a2a", description: "A2A" },
+		rawInput: `/a2a ${argumentText}`,
+		argumentText,
+		showInfo: vi.fn(),
+		showError: vi.fn(),
+		renderHelp: vi.fn(),
+	};
+}

--- a/test/cli/commands/a2a-fleet-delegation.test.ts
+++ b/test/cli/commands/a2a-fleet-delegation.test.ts
@@ -1,0 +1,367 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { type IncomingMessage, type Server, createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleA2ACommand } from "../../../src/cli/commands/a2a.js";
+
+const ANSI_ESCAPE_PATTERN = new RegExp(
+	`${String.fromCharCode(27)}\\[[0-9;]*m`,
+	"gu",
+);
+
+interface RequestRecord {
+	method: string | undefined;
+	url: string | undefined;
+	body: unknown;
+}
+
+describe("A2A fleet delegation CLI", () => {
+	let server: Server;
+	let baseUrl: string;
+	let requests: RequestRecord[];
+	let logs: string[];
+	let errors: string[];
+
+	beforeEach(async () => {
+		requests = [];
+		logs = [];
+		errors = [];
+		vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			logs.push(args.join(" "));
+		});
+		vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+			errors.push(args.join(" "));
+		});
+		server = createServer(async (request, response) => {
+			if (request.method === "GET" && request.url === "/healthz") {
+				response.writeHead(200, { "Content-Type": "application/json" });
+				response.end(JSON.stringify({ ok: true }));
+				return;
+			}
+			if (
+				request.method === "GET" &&
+				request.url === "/.well-known/agent-card.json"
+			) {
+				response.writeHead(200, { "Content-Type": "application/json" });
+				response.end(
+					JSON.stringify({
+						name: "Mac mini Maestro",
+						description: "Always-on local build and smoke peer",
+						version: "0.10.18",
+						provider: {
+							organization: "EvalOps",
+							url: "https://evalops.dev",
+						},
+						capabilities: { streaming: true },
+						defaultInputModes: ["text/plain"],
+						defaultOutputModes: ["text/plain"],
+						supportedInterfaces: [
+							{
+								url: `${baseUrl}/message:send`,
+								protocolBinding: "HTTP+JSON",
+								protocolVersion: "1.0",
+							},
+						],
+						skills: [
+							{
+								id: "repo-smoke",
+								name: "Repo smoke",
+								description: "Run focused repository smoke tests",
+								tags: ["repo", "smoke"],
+							},
+						],
+					}),
+				);
+				return;
+			}
+			if (request.method === "POST" && request.url === "/message:send") {
+				const body = await readJson(request);
+				requests.push({ method: request.method, url: request.url, body });
+				response.writeHead(200, { "Content-Type": "application/json" });
+				response.end(
+					JSON.stringify({
+						task: {
+							id: "task-mac-mini-1",
+							contextId:
+								recordValue(body, "message.contextId") ??
+								"maestro-a2a-context-test",
+							status: {
+								state: "TASK_STATE_SUBMITTED",
+							},
+							history: [recordValue(body, "message")].filter(Boolean),
+							metadata: {
+								worker: "mac-mini",
+							},
+						},
+					}),
+				);
+				return;
+			}
+			if (
+				request.method === "GET" &&
+				request.url === "/tasks/task-mac-mini-1"
+			) {
+				response.writeHead(200, { "Content-Type": "application/json" });
+				response.end(
+					JSON.stringify({
+						id: "task-mac-mini-1",
+						contextId: "maestro-a2a-context-test",
+						status: {
+							state: "TASK_STATE_COMPLETED",
+							message: {
+								messageId: "agent-message-1",
+								role: "ROLE_AGENT",
+								parts: [
+									{
+										text: "mac mini finished the smoke plan",
+										mediaType: "text/plain",
+									},
+								],
+							},
+						},
+						artifacts: [
+							{
+								artifactId: "result",
+								parts: [
+									{
+										text: "mac mini finished the smoke plan",
+										mediaType: "text/plain",
+									},
+								],
+							},
+						],
+					}),
+				);
+				return;
+			}
+			response.writeHead(404, { "Content-Type": "application/json" });
+			response.end(JSON.stringify({ error: "not found" }));
+		});
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", resolve),
+		);
+		const address = server.address() as AddressInfo;
+		baseUrl = `http://127.0.0.1:${address.port}`;
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	});
+
+	it("delegates work, records a transcript, and reports fleet health", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-fleet-"));
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks.json");
+		await writeRegistry(registryPath, baseUrl);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+
+		await handleA2ACommand([
+			"delegate",
+			"mac-mini",
+			"run",
+			"the",
+			"tmux",
+			"smoke",
+			"--role",
+			"background-worker",
+			"--cwd",
+			"/Users/jonathanhaas/Documents/Projects/maestro-internal",
+			"--wait",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--max-wait-ms",
+			"1000",
+			"--interval-ms",
+			"10",
+			"--timeout-ms",
+			"1000",
+		]);
+
+		expect(requests).toHaveLength(1);
+		expect(recordValue(requests[0]!.body, "message.metadata")).toMatchObject({
+			requestKind: "maestro-peer-delegation",
+			delegationRole: "background-worker",
+			delegationCwd: "/Users/jonathanhaas/Documents/Projects/maestro-internal",
+			relayPeer: "mac-mini",
+		});
+		expect(plainLogs(logs)).toContain("Delegated to mac-mini");
+		expect(plainLogs(logs)).toContain("mac mini finished the smoke plan");
+
+		const ledgerRaw = await readFile(tasksPath, "utf8");
+		expect(ledgerRaw).toContain("task-mac-mini-1");
+		expect(ledgerRaw).toContain("run the tmux smoke");
+		expect(ledgerRaw).toContain("mac mini finished the smoke plan");
+		expect(ledgerRaw).not.toContain("super-secret-token");
+
+		logs = [];
+		await handleA2ACommand([
+			"fleet",
+			"--json",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--timeout-ms",
+			"1000",
+		]);
+		const fleet = JSON.parse(logs.join("\n")) as {
+			peers: Array<{
+				name: string;
+				status: string;
+				displayName?: string;
+				capabilities?: { streaming?: boolean };
+				lastTask?: { id: string; state: string };
+			}>;
+		};
+		expect(fleet.peers).toEqual([
+			expect.objectContaining({
+				name: "mac-mini",
+				status: "online",
+				displayName: "Mac mini Maestro",
+				capabilities: expect.objectContaining({ streaming: true }),
+				lastTask: expect.objectContaining({
+					id: "task-mac-mini-1",
+					state: "TASK_STATE_COMPLETED",
+				}),
+			}),
+		]);
+		expect(JSON.stringify(fleet)).not.toContain("super-secret-token");
+
+		logs = [];
+		await handleA2ACommand(["tasks", "--json", "--tasks", tasksPath]);
+		const taskView = JSON.parse(logs.join("\n")) as {
+			tasks: Array<{ peer: string; taskId: string; state: string }>;
+		};
+		expect(taskView.tasks).toEqual([
+			expect.objectContaining({
+				peer: "mac-mini",
+				taskId: "task-mac-mini-1",
+				state: "TASK_STATE_COMPLETED",
+			}),
+		]);
+		expect(errors.join("\n")).toBe("");
+	});
+
+	it("reports delegation success when local ledger persistence fails", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-ledger-fail-"));
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks-as-dir");
+		await writeRegistry(registryPath, baseUrl);
+		await mkdir(tasksPath);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+
+		await expect(
+			handleA2ACommand([
+				"delegate",
+				"mac-mini",
+				"run",
+				"the",
+				"tmux",
+				"smoke",
+				"--wait",
+				"--registry",
+				registryPath,
+				"--tasks",
+				tasksPath,
+				"--max-wait-ms",
+				"1000",
+				"--interval-ms",
+				"10",
+				"--timeout-ms",
+				"1000",
+			]),
+		).resolves.toBeUndefined();
+
+		expect(requests).toHaveLength(1);
+		expect(plainLogs(logs)).toContain("Delegated to mac-mini");
+		expect(plainLogs(logs)).toContain(
+			"Task task-mac-mini-1: TASK_STATE_COMPLETED",
+		);
+		expect(plainLogs(logs)).toContain("mac mini finished the smoke plan");
+		expect(plainLogs(errors)).toContain("A2A task ledger warning");
+		expect(plainLogs(errors)).not.toContain("super-secret-token");
+	});
+
+	it("reports wait completion when local ledger update fails", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-wait-ledger-fail-"));
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks-as-dir");
+		await writeRegistry(registryPath, baseUrl);
+		await mkdir(tasksPath);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+
+		await expect(
+			handleA2ACommand([
+				"wait",
+				"mac-mini",
+				"task-mac-mini-1",
+				"--registry",
+				registryPath,
+				"--tasks",
+				tasksPath,
+				"--max-wait-ms",
+				"1000",
+				"--interval-ms",
+				"10",
+				"--timeout-ms",
+				"1000",
+			]),
+		).resolves.toBeUndefined();
+
+		expect(plainLogs(logs)).toContain(
+			"Task task-mac-mini-1: TASK_STATE_COMPLETED",
+		);
+		expect(plainLogs(logs)).toContain("mac mini finished the smoke plan");
+		expect(plainLogs(errors)).toContain("A2A task ledger warning");
+		expect(plainLogs(errors)).not.toContain("super-secret-token");
+	});
+});
+
+async function readJson(request: IncomingMessage): Promise<unknown> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of request) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function recordValue(input: unknown, path: string): unknown {
+	let current = input;
+	for (const segment of path.split(".")) {
+		if (!current || typeof current !== "object") {
+			return undefined;
+		}
+		current = (current as Record<string, unknown>)[segment];
+	}
+	return current;
+}
+
+function plainLogs(entries: string[]): string {
+	return entries.join("\n").replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+async function writeRegistry(path: string, baseUrl: string): Promise<void> {
+	await writeFile(
+		path,
+		JSON.stringify({
+			defaultPeer: "mac-mini",
+			peers: {
+				"mac-mini": {
+					url: baseUrl,
+					displayName: "Mac mini Maestro",
+					agentCardUrl: `${baseUrl}/.well-known/agent-card.json`,
+					tokenEnv: "MAC_MINI_A2A_TOKEN",
+					metadata: {
+						model: "opus",
+						cwd: "/Users/jonathanhaas/Documents/Projects/maestro-internal",
+					},
+				},
+			},
+		}),
+	);
+}

--- a/test/cli/commands/a2a.test.ts
+++ b/test/cli/commands/a2a.test.ts
@@ -60,6 +60,58 @@ describe("A2A CLI command helpers", () => {
 		expect(parsed.flags.get("--timeout-ms")).toBe("1000");
 	});
 
+	it("scopes json and refresh flags to fleet task views", () => {
+		const delegate = parseA2AArgs([
+			"delegate",
+			"mac-mini",
+			"emit",
+			"--json",
+			"--refresh",
+		]);
+		expect(delegate.positionals).toEqual([
+			"delegate",
+			"mac-mini",
+			"emit",
+			"--json",
+			"--refresh",
+		]);
+		expect(delegate.flags.size).toBe(0);
+
+		const tasks = parseA2AArgs(["tasks", "--json", "--refresh"]);
+		expect(tasks.positionals).toEqual(["tasks"]);
+		expect(tasks.flags.get("--json")).toBe(true);
+		expect(tasks.flags.get("--refresh")).toBe(true);
+	});
+
+	it("parses leading flags after locating the subcommand", () => {
+		const parsed = parseA2AArgs(["--registry", "/tmp/peers.json", "peers"]);
+
+		expect(parsed.positionals).toEqual(["peers"]);
+		expect(parsed.flags.get("--registry")).toBe("/tmp/peers.json");
+	});
+
+	it("ignores leading flags from other subcommands during dispatch", () => {
+		const delegate = parseA2AArgs([
+			"--json",
+			"delegate",
+			"mac-mini",
+			"do",
+			"stuff",
+		]);
+
+		expect(delegate.positionals).toEqual([
+			"delegate",
+			"mac-mini",
+			"do",
+			"stuff",
+		]);
+		expect(delegate.flags.size).toBe(0);
+
+		const peers = parseA2AArgs(["--timeout-ms", "1000", "peers"]);
+		expect(peers.positionals).toEqual(["peers"]);
+		expect(peers.flags.size).toBe(0);
+	});
+
 	it("treats actionable A2A states as wait completion", () => {
 		expect(isA2AWaitCompletionState("completed")).toBe(true);
 		expect(isA2AWaitCompletionState("input-required")).toBe(true);

--- a/test/platform/a2a-task-ledger.test.ts
+++ b/test/platform/a2a-task-ledger.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	getA2ATaskLedgerPath,
+	loadA2ATaskLedger,
+	recordA2ATaskStart,
+	updateA2ATaskInLedger,
+} from "../../src/platform/a2a-task-ledger.js";
+
+const NOW = new Date("2026-05-16T00:00:00.000Z");
+const LATER = new Date("2026-05-16T00:01:00.000Z");
+
+describe("A2A task ledger", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("records delegated task transcripts using the migration env alias", async () => {
+		const path = join(
+			await mkdtemp(join(tmpdir(), "maestro-a2a-ledger-")),
+			"tasks.json",
+		);
+		vi.stubEnv("CODEX_A2A_TASKS_FILE", path);
+
+		await recordA2ATaskStart({
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-1",
+				status: { state: "TASK_STATE_SUBMITTED" },
+			},
+			text: "run the full checks",
+			messageId: "message-1",
+			kind: "delegation",
+			role: "heavy-builder",
+			cwd: "/repo",
+			now: NOW,
+		});
+		await updateA2ATaskInLedger({
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-1",
+				status: {
+					state: "TASK_STATE_COMPLETED",
+					message: {
+						messageId: "agent-message-1",
+						role: "ROLE_AGENT",
+						parts: [{ text: "checks passed", mediaType: "text/plain" }],
+					},
+				},
+			},
+			now: LATER,
+		});
+
+		expect(getA2ATaskLedgerPath()).toBe(path);
+		await expect(loadA2ATaskLedger()).resolves.toMatchObject({
+			tasks: [
+				{
+					peer: "dev-desktop",
+					taskId: "task-dev-1",
+					state: "TASK_STATE_COMPLETED",
+					responseText: "checks passed",
+					transcript: [
+						{ role: "user", text: "run the full checks" },
+						{ role: "agent", text: "checks passed" },
+					],
+				},
+			],
+		});
+		const raw = await readFile(path, "utf8");
+		expect(raw).toContain("heavy-builder");
+		expect(raw).not.toContain("Bearer ");
+	});
+
+	it("does not treat echoed user history as agent response text", async () => {
+		const path = join(
+			await mkdtemp(join(tmpdir(), "maestro-a2a-ledger-history-")),
+			"tasks.json",
+		);
+
+		const result = await recordA2ATaskStart({
+			path,
+			peer: "mac-mini",
+			task: {
+				id: "task-mac-1",
+				status: { state: "TASK_STATE_SUBMITTED" },
+				history: [
+					{
+						messageId: "message-1",
+						role: "ROLE_USER",
+						parts: [{ text: "run --json checks", mediaType: "text/plain" }],
+					},
+				],
+			},
+			text: "run --json checks",
+			now: NOW,
+		});
+
+		expect(result.entry.responseText).toBeUndefined();
+		expect(result.entry.transcript).toEqual([
+			expect.objectContaining({
+				role: "user",
+				text: "run --json checks",
+			}),
+		]);
+	});
+	it("rejects array-shaped ledger files instead of treating them as empty", async () => {
+		const path = join(
+			await mkdtemp(join(tmpdir(), "maestro-a2a-ledger-array-")),
+			"tasks.json",
+		);
+		await writeFile(path, "[]\n", "utf8");
+
+		await expect(loadA2ATaskLedger({ path })).rejects.toThrow(
+			`A2A task ledger at ${path} must be a JSON object`,
+		);
+		await expect(readFile(path, "utf8")).resolves.toBe("[]\n");
+	});
+});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `070671068b00bf119ebcf83bffb8a0149447aa7d`
- last generated public sync base: `b0bc8c532b6e802adb61715775a9e1d27a9a4aca`
- previewed public-tree drift: `17` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `4`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (070671068b00)`
- public projection: `https://github.com/evalops/maestro@main (39c0c810c5a5)`
- files to copy or update: `17`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update docs/protocols/a2a-peer-pairing.md
- copy/update docs/protocols/a2a-tmux-smoke.md
- copy/update package.json
- copy/update packages/tui-rs/src/app.rs
- copy/update packages/tui-rs/src/commands/registry.rs
- copy/update packages/tui-rs/src/commands/types.rs
- copy/update scripts/smoke-maestro-a2a-tmux.sh
- copy/update src/cli-tui/commands/a2a-handlers.ts
- copy/update src/cli/commands/a2a.ts
- copy/update src/platform/a2a-fleet.ts
- copy/update src/platform/a2a-task-ledger.ts
- copy/update src/safety/bash-parser.ts
- copy/update test/cli-tui/commands/a2a-handlers.test.ts
- copy/update test/cli/commands/a2a-fleet-delegation.test.ts
- copy/update test/cli/commands/a2a.test.ts
- copy/update test/platform/a2a-task-ledger.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update docs/protocols/a2a-peer-pairing.md
- copy/update docs/protocols/a2a-tmux-smoke.md
- copy/update package.json
- copy/update packages/tui-rs/src/app.rs
- copy/update packages/tui-rs/src/commands/registry.rs
- copy/update packages/tui-rs/src/commands/types.rs
- copy/update scripts/smoke-maestro-a2a-tmux.sh
- copy/update src/cli-tui/commands/a2a-handlers.ts
- copy/update src/cli/commands/a2a.ts
- copy/update src/platform/a2a-fleet.ts
- copy/update src/platform/a2a-task-ledger.ts
- copy/update src/safety/bash-parser.ts
- copy/update test/cli-tui/commands/a2a-handlers.test.ts
- copy/update test/cli/commands/a2a-fleet-delegation.test.ts
- copy/update test/cli/commands/a2a.test.ts
- copy/update test/platform/a2a-task-ledger.test.ts

## Public-only commits since last generated sync

- 39c0c810 fix: preserve runtime wait semantics (#423)
- 1c350a2f fix: preserve runtime wait semantics (#422)
- 68e00035 fix: omit non-terminal runtime promotion writes (#421)
- 7f648137 feat: add local AgentRuntime ledger projection (#419)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@070671068b00bf119ebcf83bffb8a0149447aa7d`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #420 to internal source `070671068b00bf119ebcf83bffb8a0149447aa7d`