### PR TITLE
fix: harden runtime wait promotion semantics

### DIFF
--- a/src/server/agent-runtime-ledger.ts
+++ b/src/server/agent-runtime-ledger.ts
@@ -251,9 +251,11 @@ function stepKindForEntry(
 	entryKind: AgentRuntimeLedgerEntryKind,
 	event: AgentTrajectoryEvent,
 ): string {
-	if (event.status === "failed") return "AGENT_RUN_STEP_KIND_ERROR";
 	if (entryKind === "model_call") return "AGENT_RUN_STEP_KIND_MODEL_CALL";
 	if (entryKind === "tool_call") return "AGENT_RUN_STEP_KIND_TOOL_CALL_INTENT";
+	if (entryKind === "tool_result" && event.status === "failed") {
+		return "AGENT_RUN_STEP_KIND_ERROR";
+	}
 	if (entryKind === "tool_result") return "AGENT_RUN_STEP_KIND_TOOL_RESULT";
 	if (entryKind === "wait" || entryKind === "governance") {
 		return "AGENT_RUN_STEP_KIND_APPROVAL_WAIT";
@@ -303,7 +305,7 @@ function waitTypeForEntry(
 	}
 	if (timelineItem?.approvalRequestId) return "AGENT_RUN_WAIT_TYPE_APPROVAL";
 	if (timelineItem?.pendingRequestId) return "AGENT_RUN_WAIT_TYPE_INPUT";
-	return undefined;
+	return "AGENT_RUN_WAIT_TYPE_APPROVAL";
 }
 
 function buildLedgerEntries(

--- a/test/cli/run-command.test.ts
+++ b/test/cli/run-command.test.ts
@@ -1014,6 +1014,39 @@ describe("run command", () => {
 		}
 	});
 
+	it("keeps unknown wait entries represented with an approval fallback", () => {
+		const ledger = buildLedgerForEvents("session-unknown-wait", [
+			{
+				id: "event-unknown-wait",
+				sequence: 1,
+				timestamp: "2026-05-09T10:00:01.000Z",
+				kind: "wait",
+				phase: "wait",
+				actor: "platform",
+				type: "wait.pending",
+				status: "pending",
+				visibility: "user",
+				source: "platform",
+				title: "Wait pending",
+				evidence: [{ kind: "timeline_item", id: "platform-wait" }],
+			},
+		]);
+
+		expect(ledger.entries[0]?.platformShape.waitType).toBe(
+			"AGENT_RUN_WAIT_TYPE_APPROVAL",
+		);
+		expect(
+			ledger.promotion.operations.find(
+				(operation) =>
+					operation.operation === "wait_run" &&
+					operation.ledgerEntryId === "ledger:event-unknown-wait",
+			),
+		).toMatchObject({
+			operation: "wait_run",
+			payload: { waitType: "AGENT_RUN_WAIT_TYPE_APPROVAL" },
+		});
+	});
+
 	it("classifies failed tool results as error steps", () => {
 		const ledger = buildLedgerForEvents("session-failed-tool", [
 			{
@@ -1048,6 +1081,44 @@ describe("run command", () => {
 			operation: "record_run_step",
 			payload: {
 				kind: "AGENT_RUN_STEP_KIND_ERROR",
+				state: "failed",
+			},
+		});
+	});
+
+	it("keeps failed model calls classified as model-call steps", () => {
+		const ledger = buildLedgerForEvents("session-failed-model", [
+			{
+				id: "event-model-failed",
+				sequence: 1,
+				timestamp: "2026-05-09T10:00:01.000Z",
+				kind: "message",
+				phase: "think",
+				actor: "assistant",
+				type: "message.assistant",
+				status: "failed",
+				visibility: "user",
+				source: "local",
+				title: "Assistant failed",
+				evidence: [],
+			},
+		]);
+
+		expect(ledger.entries[0]).toMatchObject({
+			kind: "model_call",
+			state: "failed",
+			platformShape: { stepKind: "AGENT_RUN_STEP_KIND_MODEL_CALL" },
+		});
+		expect(
+			ledger.promotion.operations.find(
+				(operation) =>
+					operation.operation === "record_run_step" &&
+					operation.ledgerEntryId === "ledger:event-model-failed",
+			),
+		).toMatchObject({
+			operation: "record_run_step",
+			payload: {
+				kind: "AGENT_RUN_STEP_KIND_MODEL_CALL",
 				state: "failed",
 			},
 		});


### PR DESCRIPTION
Follow-up to #422 for review feedback that landed after the merge.

Changes:
- narrow error-step promotion to failed tool-result entries only
- keep failed model-call entries classified as model-call steps
- preserve input vs approval wait types when pending request metadata exists
- default metadata-poor wait entries to an approval wait so they remain represented in promotion plans
- add focused regression tests for failed model calls and unknown waits

Mirrors evalops/maestro-internal#1974.

Verification:
- bunx biome check --write --unsafe src/server/agent-runtime-ledger.ts test/cli/run-command.test.ts
- node ./scripts/run-vitest.js --run test/cli/run-command.test.ts test/server/agent-trajectory-replay.test.ts test/server/agent-trajectory-validation.test.ts
- bunx tsc -p tsconfig.build.json --noEmit
- commit hook guardian/Biome/generated-contract/build checks