### PR TITLE
feat: add first-party operational skill packages

### DIFF
--- a/docs/cookbook/skills/README.md
+++ b/docs/cookbook/skills/README.md
@@ -18,6 +18,21 @@ reviewing-prs/
   mcp.json.example
 ```
 
+## First-Party Operational Skills
+
+Maestro ships three system skills for common EvalOps operator workflows:
+
+- `pr-review`: reviews pull requests for correctness, regressions, missing tests,
+  and merge readiness.
+- `release-verification`: checks release readiness and post-release health from
+  CI, tags, deploy evidence, rollback notes, and operator artifacts.
+- `incident-triage`: builds an incident timeline, scopes blast radius, identifies
+  mitigation, and preserves evidence.
+
+Each package includes `SKILL.md`, scoped `reference/` guidance, bounded
+`mcp.json`, and an executable `toolbox/` helper. They are scored by
+`npm run evals:skill-package` alongside the synthetic pass/fail corpus.
+
 ## Bundled MCP Server
 
 Copy `mcp.json.example` to `mcp.json` and keep the exposed tools filtered:

--- a/docs/cookbook/skills/README.md
+++ b/docs/cookbook/skills/README.md
@@ -30,8 +30,9 @@ Maestro ships three system skills for common EvalOps operator workflows:
   mitigation, and preserves evidence.
 
 Each package includes `SKILL.md`, scoped `reference/` guidance, bounded
-`mcp.json`, and an executable `toolbox/` helper. They are scored by
-`npm run evals:skill-package` alongside the synthetic pass/fail corpus.
+`mcp.json`, and executable `toolbox/` helpers for Unix and Windows shells. They
+are scored by `npm run evals:skill-package` alongside the synthetic pass/fail
+corpus.
 
 ## Bundled MCP Server
 
@@ -69,6 +70,10 @@ Run strict validation with:
 ```bash
 maestro skill lint .maestro/skills/reviewing-prs --describe-toolbox
 ```
+
+If a toolbox helper is shell-specific, include a same-stem Windows companion such
+as `list-pr-files.cmd` or `list-pr-files.ps1`. The linter validates the runnable
+entry for the target platform and ignores the sibling meant for the other shell.
 
 ## Runtime Activation
 

--- a/scripts/evals/run-skill-package-evals.ts
+++ b/scripts/evals/run-skill-package-evals.ts
@@ -75,9 +75,19 @@ try {
 	const nonExecutableToolbox = await writePackage(root, "non-executable-toolbox", {
 		toolboxMode: "non-executable",
 	});
+	const firstPartySkillPackages = [
+		"pr-review",
+		"release-verification",
+		"incident-triage",
+	].map((name) => ({
+		id: `first-party-${name}`,
+		path: join(process.cwd(), "skills", name),
+		expectedOutcome: "pass" as const,
+	}));
 
 	const report = await evaluateSkillPackages(
 		[
+			...firstPartySkillPackages,
 			{
 				id: "valid-agent-core-package",
 				path: valid,

--- a/skills/incident-triage/SKILL.md
+++ b/skills/incident-triage/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: incident-triage
+description: Triage production incidents by building a timeline, scoping blast radius, identifying mitigations, and preserving evidence. Use when the user asks about an outage, regression, alert, Sentry issue, or incident follow-up.
+license: Complete terms in LICENSE.txt
+compatibility: "Maestro skill packages with bounded GitHub MCP tools and executable toolbox entries."
+allowed-tools:
+  - read
+  - search
+  - bash
+builtin-tools:
+  - read
+  - search
+mode: incident
+isolatedContext: true
+metadata:
+  version: "0.1.0"
+  category: evalops-operations
+  artifactSchema: evalops.maestro.skill.incident_triage.v1
+---
+
+# Incident Triage
+
+Use this skill to turn scattered incident evidence into a concise operator plan.
+
+## Workflow
+
+1. Confirm the symptom, start time, affected surface, and urgency.
+2. Load `reference/triage.md` for the detailed timeline and mitigation checklist.
+3. Gather only scoped evidence from granted tools and local files. Keep customer data and internal handles out of the normal answer.
+4. Build a timeline with known, inferred, and unknown entries separated.
+5. Identify the likely owner, immediate mitigation, verification signal, and follow-up issue.
+6. End with current state, blast radius, next action, and what evidence was withheld or unavailable.
+
+## Toolbox
+
+Run `toolbox/incident-timeline` to emit the required incident report skeleton.
+
+## MCP Scope
+
+The bundled GitHub MCP config exposes issue, code, workflow, and file lookups for incident context. Live observability systems must be granted by the runtime separately.

--- a/skills/incident-triage/mcp.json
+++ b/skills/incident-triage/mcp.json
@@ -1,0 +1,14 @@
+{
+  "github": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github"],
+    "includeTools": [
+      "search_issues",
+      "get_issue",
+      "list_issue_comments",
+      "search_code",
+      "get_file_contents",
+      "list_workflow_runs"
+    ]
+  }
+}

--- a/skills/incident-triage/reference/triage.md
+++ b/skills/incident-triage/reference/triage.md
@@ -1,0 +1,20 @@
+# Incident Triage Reference
+
+## Timeline Discipline
+
+- Known: directly observed logs, alerts, commits, deploys, or operator reports.
+- Inferred: plausible links that need confirmation.
+- Unknown: missing evidence that affects the decision.
+
+## Mitigation Checklist
+
+1. Is the incident still active?
+2. What changed before the first symptom?
+3. Which customers, tenants, or environments are affected?
+4. Is there a reversible mitigation?
+5. What signal proves recovery?
+6. What follow-up issue or post-incident artifact is needed?
+
+## Answer Shape
+
+Use concise sections: current state, blast radius, likely cause, mitigation, verification, next action, withheld or unavailable evidence.

--- a/skills/incident-triage/toolbox/incident-timeline
+++ b/skills/incident-triage/toolbox/incident-timeline
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${MAESTRO_TOOLBOX_ACTION:-}" = "describe" ]; then
+  cat <<'JSON'
+{"name":"incident-timeline","description":"Prints the required incident triage timeline and mitigation sections.","inputs":["incident","start_time","surface"],"outputs":["timeline","blast_radius","mitigation","next_action"]}
+JSON
+  exit 0
+fi
+
+cat <<'TEXT'
+Current state:
+Blast radius:
+Timeline:
+- Known:
+- Inferred:
+- Unknown:
+Mitigation:
+Verification:
+Next action:
+Withheld or unavailable evidence:
+TEXT

--- a/skills/incident-triage/toolbox/incident-timeline.cmd
+++ b/skills/incident-triage/toolbox/incident-timeline.cmd
@@ -1,0 +1,16 @@
+@echo off
+if /I "%MAESTRO_TOOLBOX_ACTION%"=="describe" (
+  echo {"name":"incident-timeline","description":"Prints the required incident triage timeline and mitigation sections.","inputs":["incident","start_time","surface"],"outputs":["timeline","blast_radius","mitigation","next_action"]}
+  exit /b 0
+)
+
+echo Current state:
+echo Blast radius:
+echo Timeline:
+echo - Known:
+echo - Inferred:
+echo - Unknown:
+echo Mitigation:
+echo Verification:
+echo Next action:
+echo Withheld or unavailable evidence:

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: pr-review
+description: Review GitHub pull requests for correctness, regressions, missing tests, and merge readiness. Use when the user asks for PR review, review feedback, or a pre-merge risk pass.
+license: Complete terms in LICENSE.txt
+compatibility: "Maestro skill packages with bounded GitHub MCP tools and executable toolbox entries."
+allowed-tools:
+  - read
+  - search
+  - bash
+builtin-tools:
+  - read
+  - search
+mode: review
+isolatedContext: true
+metadata:
+  version: "0.1.0"
+  category: evalops-operations
+  artifactSchema: evalops.maestro.skill.pr_review.v1
+---
+
+# PR Review
+
+Use this skill to produce a merge-readiness review, not a broad design memo.
+
+## Workflow
+
+1. Identify the PR, base branch, changed files, linked issue, CI status, and review history.
+2. Load `reference/rubric.md` only when you need the detailed severity rubric or checklist.
+3. Inspect the changed code and nearby tests. Prefer local repo reads for code and bounded GitHub MCP calls for PR metadata.
+4. Lead with findings ordered by severity. Include file and line when the issue is in code.
+5. Call out missing tests only when they hide real risk.
+6. If no issues are found, say that clearly and name the remaining residual risk.
+
+## Toolbox
+
+Run `toolbox/review-summary` when you need the expected output sections without loading the reference file.
+
+## MCP Scope
+
+The bundled GitHub MCP config exposes only pull-request, review, file, and check metadata needed for review. Do not ask it for broad organization scans from this skill.

--- a/skills/pr-review/mcp.json
+++ b/skills/pr-review/mcp.json
@@ -1,0 +1,14 @@
+{
+  "github": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github"],
+    "includeTools": [
+      "get_pull_request",
+      "list_pull_request_files",
+      "list_pull_request_reviews",
+      "list_pull_request_comments",
+      "get_file_contents",
+      "list_check_runs"
+    ]
+  }
+}

--- a/skills/pr-review/reference/rubric.md
+++ b/skills/pr-review/reference/rubric.md
@@ -1,0 +1,20 @@
+# PR Review Rubric
+
+## Severity
+
+- Critical: data loss, auth bypass, secret exposure, production outage, or a change that cannot be safely rolled back.
+- High: user-visible regression, broken deploy path, incorrect persisted state, race condition, or unhandled error path.
+- Medium: missing validation, incomplete migration, flaky workflow, or test gap on changed behavior.
+- Low: maintainability issue that is likely to slow future work but does not block merge.
+
+## Review Checklist
+
+1. Confirm the PR changes the behavior it claims to change.
+2. Trace changed inputs through persistence, queues, caches, and external APIs.
+3. Check rollback and partial-failure behavior.
+4. Verify tests exercise the risky branch, not only the happy path.
+5. Check docs or operator runbooks when the change affects release, incident, or customer support behavior.
+
+## Output Contract
+
+Write findings first. Each finding should include impact, evidence, and a concrete fix direction. Keep summaries short and put them after findings.

--- a/skills/pr-review/toolbox/review-summary
+++ b/skills/pr-review/toolbox/review-summary
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${MAESTRO_TOOLBOX_ACTION:-}" = "describe" ]; then
+  cat <<'JSON'
+{"name":"review-summary","description":"Prints the required PR review output sections for Maestro first-party review skills.","inputs":["pr","repo","risk_level"],"outputs":["findings","open_questions","verification"]}
+JSON
+  exit 0
+fi
+
+cat <<'TEXT'
+Findings:
+- [severity] file:line - impact and concrete fix direction
+
+Open questions:
+- None.
+
+Verification:
+- State the exact checks inspected or run.
+TEXT

--- a/skills/pr-review/toolbox/review-summary.cmd
+++ b/skills/pr-review/toolbox/review-summary.cmd
@@ -1,0 +1,14 @@
+@echo off
+if /I "%MAESTRO_TOOLBOX_ACTION%"=="describe" (
+  echo {"name":"review-summary","description":"Prints the required PR review output sections for Maestro first-party review skills.","inputs":["pr","repo","risk_level"],"outputs":["findings","open_questions","verification"]}
+  exit /b 0
+)
+
+echo Findings:
+echo - [severity] file:line - impact and concrete fix direction
+echo.
+echo Open questions:
+echo - None.
+echo.
+echo Verification:
+echo - State the exact checks inspected or run.

--- a/skills/release-verification/SKILL.md
+++ b/skills/release-verification/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: release-verification
+description: Verify release readiness and post-release health from PRs, CI, tags, deploy evidence, rollback notes, and operator artifacts. Use when the user asks whether a release can ship, has shipped, or is safe to promote.
+license: Complete terms in LICENSE.txt
+compatibility: "Maestro skill packages with bounded GitHub MCP tools and executable toolbox entries."
+allowed-tools:
+  - read
+  - search
+  - bash
+builtin-tools:
+  - read
+  - search
+mode: ship
+isolatedContext: true
+metadata:
+  version: "0.1.0"
+  category: evalops-operations
+  artifactSchema: evalops.maestro.skill.release_verification.v1
+---
+
+# Release Verification
+
+Use this skill to prove release state from artifacts, not from branch vibes.
+
+## Workflow
+
+1. Identify the release candidate, target environment, owning repo, and rollback boundary.
+2. Load `reference/checklist.md` when the release has deploy, migration, or customer-visible risk.
+3. Inspect CI, release notes, tags, deployment references, and outstanding blockers.
+4. Separate required evidence from optional confidence checks.
+5. Report allowed evidence links or revisions, unavailable sources, blockers, next action, and what was withheld or out of scope.
+6. Never call a release shipped until the artifact or deployment state supports it.
+
+## Toolbox
+
+Run `toolbox/release-readiness` to emit the required release-verification report skeleton.
+
+## MCP Scope
+
+The bundled GitHub MCP config is limited to release, workflow, pull request, and check metadata. Use platform or deploy-specific tools only when the runtime grants them separately.

--- a/skills/release-verification/mcp.json
+++ b/skills/release-verification/mcp.json
@@ -1,0 +1,15 @@
+{
+  "github": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github"],
+    "includeTools": [
+      "get_pull_request",
+      "list_check_runs",
+      "list_workflow_runs",
+      "get_workflow_run",
+      "list_workflow_jobs",
+      "list_releases",
+      "get_release_by_tag"
+    ]
+  }
+}

--- a/skills/release-verification/reference/checklist.md
+++ b/skills/release-verification/reference/checklist.md
@@ -1,0 +1,21 @@
+# Release Verification Checklist
+
+## Required Evidence
+
+- Candidate revision, tag, or build receipt.
+- Required CI checks and their final states.
+- Deployment target and environment ownership.
+- Migration, feature flag, or config changes.
+- Rollback path and rollback owner.
+- Known customer or operator impact.
+
+## Report Shape
+
+Use this order:
+
+1. Decision: ready, blocked, already promoted, or needs more evidence.
+2. Evidence: links, revisions, check names, and artifact IDs that are safe to cite.
+3. Unavailable sources: what could not be verified and why.
+4. Blockers: only blockers that change the release decision.
+5. Next action: the smallest action that moves the release forward.
+6. Withheld or out of scope: customer data, internal handles, or evidence that should stay in durable runtime state.

--- a/skills/release-verification/toolbox/release-readiness
+++ b/skills/release-verification/toolbox/release-readiness
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${MAESTRO_TOOLBOX_ACTION:-}" = "describe" ]; then
+  cat <<'JSON'
+{"name":"release-readiness","description":"Prints the required release verification report skeleton.","inputs":["repo","revision","environment"],"outputs":["decision","evidence","blockers","next_action"]}
+JSON
+  exit 0
+fi
+
+cat <<'TEXT'
+Decision:
+Evidence:
+Unavailable sources:
+Blockers:
+Next action:
+Withheld or out of scope:
+TEXT

--- a/skills/release-verification/toolbox/release-readiness.cmd
+++ b/skills/release-verification/toolbox/release-readiness.cmd
@@ -1,0 +1,12 @@
+@echo off
+if /I "%MAESTRO_TOOLBOX_ACTION%"=="describe" (
+  echo {"name":"release-readiness","description":"Prints the required release verification report skeleton.","inputs":["repo","revision","environment"],"outputs":["decision","evidence","blockers","next_action"]}
+  exit /b 0
+)
+
+echo Decision:
+echo Evidence:
+echo Unavailable sources:
+echo Blockers:
+echo Next action:
+echo Withheld or out of scope:

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -53,6 +53,7 @@ export {
 export { createSkillTool, invalidateSkillCache } from "./tool.js";
 export {
 	type SkillRuntimeActivation,
+	type SkillRuntimeActivationOptions,
 	type SkillRuntimeMcpActivation,
 	type SkillRuntimeMcpServer,
 	type SkillRuntimeResource,

--- a/src/skills/linter.ts
+++ b/src/skills/linter.ts
@@ -358,6 +358,26 @@ export function isWindowsRunnableToolboxEntry(
 	);
 }
 
+function hasWindowsRunnableToolboxCompanion(
+	entry: string,
+	directoryEntries: string[],
+	pathExt = process.env.PATHEXT,
+): boolean {
+	if (isWindowsRunnableToolboxEntry(entry, pathExt)) {
+		return false;
+	}
+	const entryStem = basename(entry, extname(entry)).toLowerCase();
+	return directoryEntries.some((candidate) => {
+		if (candidate === entry) {
+			return false;
+		}
+		if (!isWindowsRunnableToolboxEntry(candidate, pathExt)) {
+			return false;
+		}
+		return basename(candidate, extname(candidate)).toLowerCase() === entryStem;
+	});
+}
+
 export function shouldUseShellForToolboxDescribe(
 	platform: NodeJS.Platform = process.platform,
 ): boolean {
@@ -394,11 +414,23 @@ async function validateToolbox(
 	if (!existsSync(toolboxDir) || !statSync(toolboxDir).isDirectory()) return [];
 
 	const issues: SkillLintIssue[] = [];
-	for (const entry of readdirSync(toolboxDir)) {
+	const directoryEntries = readdirSync(toolboxDir);
+	const platform = options.platform ?? process.platform;
+	for (const entry of directoryEntries) {
 		if (entry.startsWith(".") || entry.toLowerCase() === "readme.md") continue;
 		const path = join(toolboxDir, entry);
 		if (!statSync(path).isFile()) continue;
-		if (!(await isExecutable(path, options.platform))) {
+		if (platform !== "win32" && isWindowsRunnableToolboxEntry(path)) {
+			continue;
+		}
+		if (
+			platform === "win32" &&
+			!isWindowsRunnableToolboxEntry(path) &&
+			hasWindowsRunnableToolboxCompanion(entry, directoryEntries)
+		) {
+			continue;
+		}
+		if (!(await isExecutable(path, platform))) {
 			issues.push(
 				issue(
 					"toolbox_not_executable",
@@ -410,15 +442,12 @@ async function validateToolbox(
 			continue;
 		}
 		if (options.describeToolbox) {
-			const result = spawnSync(
-				toolboxDescribeSpawnCommand(path, options.platform),
-				{
-					env: { ...process.env, MAESTRO_TOOLBOX_ACTION: "describe" },
-					encoding: "utf8",
-					shell: shouldUseShellForToolboxDescribe(options.platform),
-					timeout: 5000,
-				},
-			);
+			const result = spawnSync(toolboxDescribeSpawnCommand(path, platform), {
+				env: { ...process.env, MAESTRO_TOOLBOX_ACTION: "describe" },
+				encoding: "utf8",
+				shell: shouldUseShellForToolboxDescribe(platform),
+				timeout: 5000,
+			});
 			if (result.status !== 0) {
 				issues.push(
 					issue(

--- a/src/skills/linter.ts
+++ b/src/skills/linter.ts
@@ -416,10 +416,13 @@ async function validateToolbox(
 	const issues: SkillLintIssue[] = [];
 	const directoryEntries = readdirSync(toolboxDir);
 	const platform = options.platform ?? process.platform;
+	let toolboxEntryCount = 0;
+	let runnableEntryCount = 0;
 	for (const entry of directoryEntries) {
 		if (entry.startsWith(".") || entry.toLowerCase() === "readme.md") continue;
 		const path = join(toolboxDir, entry);
 		if (!statSync(path).isFile()) continue;
+		toolboxEntryCount += 1;
 		if (platform !== "win32" && isWindowsRunnableToolboxEntry(path)) {
 			continue;
 		}
@@ -441,6 +444,7 @@ async function validateToolbox(
 			);
 			continue;
 		}
+		runnableEntryCount += 1;
 		if (options.describeToolbox) {
 			const result = spawnSync(toolboxDescribeSpawnCommand(path, platform), {
 				env: { ...process.env, MAESTRO_TOOLBOX_ACTION: "describe" },
@@ -459,6 +463,20 @@ async function validateToolbox(
 				);
 			}
 		}
+	}
+	if (
+		toolboxEntryCount > 0 &&
+		runnableEntryCount === 0 &&
+		issues.length === 0
+	) {
+		issues.push(
+			issue(
+				"toolbox_no_runnable_entries",
+				"error",
+				toolboxDir,
+				"Toolbox must include at least one executable entry runnable on the target platform.",
+			),
+		);
 	}
 	return issues;
 }

--- a/src/skills/runtime-activation.ts
+++ b/src/skills/runtime-activation.ts
@@ -74,6 +74,10 @@ export interface SkillRuntimeMcpServer {
 	includeTools: string[];
 }
 
+export interface SkillRuntimeActivationOptions {
+	platform?: NodeJS.Platform;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
@@ -126,11 +130,14 @@ function nonEmptyStringList(value: unknown): StringListParseResult {
 	return { status: "valid", values };
 }
 
-function isRunnableFile(path: string | undefined): path is string {
+function isRunnableFile(
+	path: string | undefined,
+	platform: NodeJS.Platform = process.platform,
+): path is string {
 	if (!isFile(path)) {
 		return false;
 	}
-	if (process.platform === "win32") {
+	if (platform === "win32") {
 		return isWindowsRunnableToolboxEntry(path);
 	}
 	try {
@@ -169,6 +176,7 @@ function buildResourceDirectories(
 
 function buildToolboxActivation(
 	toolboxDir: string | undefined,
+	options: SkillRuntimeActivationOptions = {},
 ): SkillRuntimeToolboxActivation | undefined {
 	if (!isDirectory(toolboxDir)) {
 		return undefined;
@@ -188,7 +196,9 @@ function buildToolboxActivation(
 			(entry) => !entry.startsWith(".") && entry.toLowerCase() !== "readme.md",
 		)
 		.map((entry) => ({ name: entry, path: join(toolboxDir, entry) }))
-		.filter((entry) => isRunnableFile(entry.path))
+		.filter((entry) =>
+			isRunnableFile(entry.path, options.platform ?? process.platform),
+		)
 		.sort((left, right) => left.name.localeCompare(right.name));
 
 	return {
@@ -299,8 +309,12 @@ function buildMcpActivation(
  */
 export function buildSkillRuntimeActivation(
 	skill: LoadedSkill,
+	options: SkillRuntimeActivationOptions = {},
 ): SkillRuntimeActivation {
-	const toolbox = buildToolboxActivation(skill.resourceDirs.toolboxDir);
+	const toolbox = buildToolboxActivation(
+		skill.resourceDirs.toolboxDir,
+		options,
+	);
 	const mcp = buildMcpActivation(skill.resourceDirs.mcpJsonPath);
 
 	return {

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -219,6 +219,29 @@ describe("skill package format", () => {
 				expect(
 					activation.toolPackage.toolbox?.entries.map((entry) => entry.name),
 				).toContain(toolbox);
+				const windowsActivation = buildSkillRuntimeActivation(skill!, {
+					platform: "win32",
+				});
+				expect(
+					windowsActivation.toolPackage.toolbox?.entries.map(
+						(entry) => entry.name,
+					),
+				).toContain(`${toolbox}.cmd`);
+				expect(
+					windowsActivation.toolPackage.toolbox?.entries.map(
+						(entry) => entry.name,
+					),
+				).not.toContain(toolbox);
+
+				const windowsLint = await lintSkillDirectory(
+					join(systemSkillsDir, name),
+					{ platform: "win32" },
+				);
+				expect(
+					windowsLint.issues.filter((issue) =>
+						issue.code.startsWith("toolbox_"),
+					),
+				).toEqual([]);
 			}
 		} finally {
 			if (originalHome === undefined) {

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -14,6 +14,8 @@ import { handleSkillCommand } from "../src/cli/commands/skill.js";
 import { buildSkillArtifactMetadata } from "../src/skills/artifact-metadata.js";
 import {
 	buildSkillRuntimeActivation,
+	evaluateSkillPackages,
+	hasSkillEvalFailures,
 	hasSkillLintErrors,
 	isWindowsRunnableToolboxEntry,
 	lintSkillDirectory,
@@ -160,6 +162,76 @@ describe("skill package format", () => {
 		expect(
 			payload.runtimeActivation?.toolPackage.mcp?.servers[0],
 		).not.toHaveProperty("env");
+	});
+
+	it("loads first-party operational system skills with scoped runtime surfaces", async () => {
+		const originalHome = process.env.MAESTRO_HOME;
+		const originalSystemSkills = process.env.MAESTRO_SYSTEM_SKILLS_DIR;
+		const isolatedHome = tempRoot();
+		const workspace = tempRoot();
+		const systemSkillsDir = join(process.cwd(), "skills");
+		const expected = [
+			{ name: "pr-review", toolbox: "review-summary" },
+			{ name: "release-verification", toolbox: "release-readiness" },
+			{ name: "incident-triage", toolbox: "incident-timeline" },
+		];
+
+		try {
+			process.env.MAESTRO_HOME = isolatedHome;
+			process.env.MAESTRO_SYSTEM_SKILLS_DIR = systemSkillsDir;
+
+			const { skills, errors } = loadSkills(workspace);
+			const skillsByName = new Map(skills.map((skill) => [skill.name, skill]));
+			const report = await evaluateSkillPackages(
+				expected.map((skill) => ({
+					id: `first-party-${skill.name}`,
+					path: join(systemSkillsDir, skill.name),
+					expectedOutcome: "pass" as const,
+				})),
+				{ describeToolbox: true },
+			);
+
+			expect(errors).toEqual([]);
+			expect(report.summary).toMatchObject({
+				total: 3,
+				passed: 3,
+				failed: 0,
+				score: 1,
+			});
+			expect(hasSkillEvalFailures(report)).toBe(false);
+
+			for (const { name, toolbox } of expected) {
+				const skill = skillsByName.get(name);
+				expect(skill).toBeTruthy();
+				expect(skill?.sourceType).toBe("system");
+				expect(skill?.resourceDirs.referenceDir).toBe(
+					join(systemSkillsDir, name, "reference"),
+				);
+
+				const activation = buildSkillRuntimeActivation(skill!);
+				expect(activation.resources.directories.reference).toBe(
+					join(systemSkillsDir, name, "reference"),
+				);
+				expect(activation.toolPackage.mcp?.servers[0]?.name).toBe("github");
+				expect(
+					activation.toolPackage.mcp?.servers[0]?.includeTools.length,
+				).toBeGreaterThan(0);
+				expect(
+					activation.toolPackage.toolbox?.entries.map((entry) => entry.name),
+				).toContain(toolbox);
+			}
+		} finally {
+			if (originalHome === undefined) {
+				delete process.env.MAESTRO_HOME;
+			} else {
+				process.env.MAESTRO_HOME = originalHome;
+			}
+			if (originalSystemSkills === undefined) {
+				delete process.env.MAESTRO_SYSTEM_SKILLS_DIR;
+			} else {
+				process.env.MAESTRO_SYSTEM_SKILLS_DIR = originalSystemSkills;
+			}
+		}
 	});
 
 	it("accepts quoted isolatedContext consistently across load and lint", async () => {

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -618,6 +618,25 @@ describe("skill package format", () => {
 		expect(hasSkillLintErrors([validResult])).toBe(false);
 	});
 
+	it("requires at least one platform-runnable toolbox entry", async () => {
+		const root = tempRoot();
+		const skillDir = join(root, "windows-only-toolbox");
+		await mkdir(join(skillDir, "toolbox"), { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			`---\nname: windows-only-toolbox\ndescription: "Run toolbox commands. Use when testing platform runnable validation."\n---\n\n# Windows Only Toolbox\n`,
+		);
+		writeFileSync(join(skillDir, "toolbox", "run.cmd"), "@echo off\n");
+
+		const result = await lintSkillDirectory(skillDir, { platform: "linux" });
+
+		expect(result.issues).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ code: "toolbox_no_runnable_entries" }),
+			]),
+		);
+	});
+
 	it("preserves backslashes in scaffolded descriptions", () => {
 		const root = tempRoot();
 		const description = "Handle C:\\new folder\\templates literally.";


### PR DESCRIPTION
## Summary
- add bundled first-party system skills for PR review, release verification, and incident triage
- include scoped SKILL.md, reference files, bounded GitHub MCP configs, and executable toolbox helpers for each package
- extend the skill package eval harness and tests so these real packages are scored for loadability, bounded MCP, toolbox describe, and progressive disclosure

## Verification
- npm run evals:skill-package
- npm run test -- test/skill-package-format.test.ts test/skill-eval-harness.test.ts
- bunx biome check .
- bunx tsc -p tsconfig.build.json --noEmit
- npm run lint:evals
- commit hook: guardian + lint + build + compile

## Source of Truth
- evalops/maestro-internal#1982