### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/platform/a2a-task-ledger.ts
+++ b/src/platform/a2a-task-ledger.ts
@@ -68,7 +68,7 @@ const TERMINAL_STATE_PATTERN =
 const LEDGER_LOCK_RETRY_MS = 25;
 const LEDGER_LOCK_HEARTBEAT_MS = 10_000;
 const LEDGER_LOCK_STALE_MS = 30_000;
-const LEDGER_LOCK_TIMEOUT_MS = 5000;
+const LEDGER_LOCK_TIMEOUT_MS = LEDGER_LOCK_STALE_MS + LEDGER_LOCK_RETRY_MS;
 const LEDGER_LOCK_OWNER_FILE = "owner";
 const LEDGER_LOCK_HEARTBEAT_FILE = "heartbeat";
 
@@ -150,12 +150,15 @@ async function withA2ATaskLedgerLock<T>(
 			await writeLedgerLockMetadata(lockPath, lockToken);
 			break;
 		} catch (error) {
-			if (!hasNodeCode(error, "EEXIST") || Date.now() >= deadline) {
+			if (!hasNodeCode(error, "EEXIST")) {
 				throw error;
 			}
 			if (await isStaleLedgerLock(lockPath)) {
 				await rm(lockPath, { force: true, recursive: true });
 				continue;
+			}
+			if (Date.now() >= deadline) {
+				throw error;
 			}
 			await sleep(LEDGER_LOCK_RETRY_MS);
 		}

--- a/test/platform/a2a-task-ledger.test.ts
+++ b/test/platform/a2a-task-ledger.test.ts
@@ -21,6 +21,7 @@ const LATER = new Date("2026-05-16T00:01:00.000Z");
 
 describe("A2A task ledger", () => {
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.unstubAllEnvs();
 	});
 
@@ -185,6 +186,40 @@ describe("A2A task ledger", () => {
 			"tasks.length",
 			1,
 		);
+		await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("waits through the stale-lock horizon before failing acquisition", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-05-16T00:00:00.000Z"));
+		const path = join(
+			await mkdtemp(join(tmpdir(), "maestro-a2a-ledger-lock-horizon-")),
+			"tasks.json",
+		);
+		const lockPath = `${path}.lock`;
+		await mkdir(lockPath);
+		const freshEnough = new Date(Date.now() - 1000);
+		await utimes(lockPath, freshEnough, freshEnough);
+
+		const write = recordA2ATaskStart({
+			path,
+			peer: "mac-mini",
+			task: {
+				id: "task-mac-1",
+				status: { state: "TASK_STATE_SUBMITTED" },
+			},
+			text: "recover after abandoned lock",
+			now: NOW,
+		});
+		await vi.advanceTimersByTimeAsync(31_000);
+
+		await expect(write).resolves.toMatchObject({
+			entry: {
+				peer: "mac-mini",
+				taskId: "task-mac-1",
+				text: "recover after abandoned lock",
+			},
+		});
 		await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
 	});
 


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `e55105ff43c9f14bf25faff1f7004fe0a0b60062`
- last generated public sync base: `6ff9a35c80592be69777527d734abfd61e36af1c`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (e55105ff43c9)`
- public projection: `https://github.com/evalops/maestro@main (6ff9a35c8059)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/platform/a2a-task-ledger.ts
- copy/update test/platform/a2a-task-ledger.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/platform/a2a-task-ledger.ts
- copy/update test/platform/a2a-task-ledger.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@e55105ff43c9f14bf25faff1f7004fe0a0b60062`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.