### PR TITLE
feat: add OSS skill publish install contract

### DIFF
--- a/docs/cookbook/skills/README.md
+++ b/docs/cookbook/skills/README.md
@@ -108,6 +108,43 @@ the progressive-disclosure budget. The checked-in smoke corpus runs with:
 npm run evals:skill-package
 ```
 
+## OSS Publish And Install
+
+Distribute OSS skill packs as normal npm or git packages with this
+`package.json` shape:
+
+```json
+{
+  "name": "@acme/maestro-review-skills",
+  "version": "1.0.0",
+  "keywords": ["maestro-package", "maestro-skill-package"],
+  "maestro": {
+    "skills": ["./skills"]
+  }
+}
+```
+
+Before publishing, run the contract check from the package root or a consumer
+workspace:
+
+```bash
+maestro skill publish-check ./packages/review-skills --describe-toolbox
+maestro skill publish-check ./packages/review-skills --json
+```
+
+Consumers install through the same package runtime used by the TUI package
+commands:
+
+```bash
+maestro skill install npm:@acme/maestro-review-skills@1.0.0 --scope user
+maestro skill install git:github.com/acme/maestro-review-skills@v1.0.0 --scope project
+maestro skill install ./packages/review-skills --scope local
+```
+
+`maestro skill install` validates the publish contract first, writes the package
+source into the selected config scope, and leaves toolbox execution disabled
+during validation unless `publish-check --describe-toolbox` is used explicitly.
+
 ## Model And Mode Hints
 
 Skills can declare model and mode preferences:

--- a/docs/cookbook/skills/README.md
+++ b/docs/cookbook/skills/README.md
@@ -132,6 +132,10 @@ maestro skill publish-check ./packages/review-skills --describe-toolbox
 maestro skill publish-check ./packages/review-skills --json
 ```
 
+The emitted install hint mirrors the checked source. Local checks print a
+`local:` command, git checks print the stable `git:` spec, and npm checks print
+the npm install spec rather than inferring one from package metadata.
+
 Consumers install through the same package runtime used by the TUI package
 commands:
 

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -4,11 +4,17 @@ import { inspect } from "node:util";
 import chalk from "chalk";
 import { PATHS } from "../../config/constants.js";
 import {
+	type WritablePackageScope,
+	addConfiguredPackageSpecToConfig,
+} from "../../config/index.js";
+import {
+	buildSkillPackagePublishContract,
 	buildSkillRuntimeActivation,
 	evaluateSkillPackages,
 	findSkill,
 	formatSkillEvalText,
 	formatSkillListItem,
+	formatSkillPackagePublishContract,
 	hasSkillEvalFailures,
 	hasSkillLintErrors,
 	lintSkillPaths,
@@ -24,6 +30,7 @@ interface SkillCommandOptions {
 	description?: string;
 	force?: boolean;
 	describeToolbox?: boolean;
+	scope?: WritablePackageScope;
 }
 
 interface SkillCommandContext {
@@ -37,12 +44,15 @@ function formatSkillHelp(): string {
 Commands:
   list                         List available system, user, and project skills
   inspect <name>               Print one skill package manifest
+  install <source>             Validate and install an OSS skill package
+  publish-check <source>       Validate an OSS skill package before publishing
   lint [path...]               Validate skill packages
   eval [path...]               Score skill packages against Agent Core constraints
   new <name>                   Scaffold a skill package
 
 Options:
   --json                       Emit machine-readable JSON
+  --scope <local|project|user> Install scope for 'install' (default: local)
   --dir <path>                 Base directory for 'new' (default: .maestro/skills)
   --description <text>         Description for 'new'
   --force                      Allow 'new' to overwrite an existing directory
@@ -58,6 +68,13 @@ function readValue(args: string[], index: number, flag: string): string {
 	return value;
 }
 
+function parseScope(value: string): WritablePackageScope {
+	if (value === "local" || value === "project" || value === "user") {
+		return value;
+	}
+	throw new Error("--scope must be local, project, or user");
+}
+
 function parseOptions(args: string[]): {
 	options: SkillCommandOptions;
 	positionals: string[];
@@ -69,6 +86,10 @@ function parseOptions(args: string[]): {
 		switch (arg) {
 			case "--json":
 				options.json = true;
+				break;
+			case "--scope":
+				options.scope = parseScope(readValue(args, i, arg));
+				i++;
 				break;
 			case "--dir":
 				options.dir = readValue(args, i, arg);
@@ -105,6 +126,74 @@ function defaultLintPaths(workspaceDir: string): string[] {
 		join(PATHS.MAESTRO_HOME, "skills"),
 	].filter((path) => existsSync(path));
 	return candidates.length > 0 ? candidates : [join(workspaceDir, "skills")];
+}
+
+async function handleInstall(
+	workspaceDir: string,
+	sourceSpec: string | undefined,
+	options: SkillCommandOptions,
+) {
+	if (!sourceSpec) {
+		throw new Error("maestro skill install requires a package source");
+	}
+	const contract = await buildSkillPackagePublishContract(sourceSpec, {
+		cwd: workspaceDir,
+		describeToolbox: false,
+	});
+	if (contract.issues.length > 0) {
+		if (options.json) {
+			console.log(JSON.stringify({ installed: false, contract }, null, 2));
+		} else {
+			console.log(formatSkillPackagePublishContract(contract));
+			console.error(
+				chalk.red("Skill package install blocked by contract issues."),
+			);
+		}
+		process.exitCode = 1;
+		return;
+	}
+
+	const installed = addConfiguredPackageSpecToConfig({
+		workspaceDir,
+		scope: options.scope ?? "local",
+		spec: sourceSpec,
+	});
+	if (options.json) {
+		console.log(
+			JSON.stringify({ installed: true, config: installed, contract }, null, 2),
+		);
+		return;
+	}
+	console.log(
+		chalk.green(
+			`Installed skill package ${contract.package.name ?? sourceSpec}`,
+		),
+	);
+	console.log(chalk.dim(`scope: ${installed.scope}`));
+	console.log(chalk.dim(`config: ${installed.path}`));
+	console.log(chalk.dim("Run `maestro skill list` to see loaded skills."));
+}
+
+async function handlePublishCheck(
+	workspaceDir: string,
+	sourceSpec: string | undefined,
+	options: SkillCommandOptions,
+) {
+	if (!sourceSpec) {
+		throw new Error("maestro skill publish-check requires a package source");
+	}
+	const contract = await buildSkillPackagePublishContract(sourceSpec, {
+		cwd: workspaceDir,
+		describeToolbox: options.describeToolbox,
+	});
+	if (options.json) {
+		console.log(JSON.stringify(contract, null, 2));
+	} else {
+		console.log(formatSkillPackagePublishContract(contract));
+	}
+	if (contract.issues.length > 0) {
+		process.exitCode = 1;
+	}
 }
 
 async function handleList(
@@ -280,6 +369,12 @@ export async function handleSkillCommand(
 			return;
 		case "inspect":
 			await handleInspect(workspaceDir, positionals[0], parsedOptions);
+			return;
+		case "install":
+			await handleInstall(workspaceDir, positionals[0], parsedOptions);
+			return;
+		case "publish-check":
+			await handlePublishCheck(workspaceDir, positionals[0], parsedOptions);
 			return;
 		case "lint":
 			await handleLint(workspaceDir, positionals, parsedOptions);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -269,6 +269,8 @@ export function printHelp(
 	const skillSection = `${sectionHeading("maestro skill")}${muted(
 		`  maestro skill list                 List available progressive skills
   maestro skill inspect <name>       Print one skill package manifest
+  maestro skill install <source>     Validate and install an OSS skill package
+  maestro skill publish-check <src>  Validate an OSS skill package for publishing
   maestro skill new <name>           Scaffold SKILL.md, reference/, scripts/, toolbox/, and mcp.json.example
   maestro skill lint [path...]       Validate frontmatter, budget, mcp.json includeTools, and toolbox shape`,
 	)}`;

--- a/src/packages/constants.ts
+++ b/src/packages/constants.ts
@@ -1,0 +1,2 @@
+export const MAESTRO_PACKAGE_KEYWORD = "maestro-package";
+export const MISSING_MAESTRO_PACKAGE_KEYWORD_MESSAGE = `Missing "${MAESTRO_PACKAGE_KEYWORD}" keyword.`;

--- a/src/packages/inspection.ts
+++ b/src/packages/inspection.ts
@@ -4,6 +4,7 @@ import {
 	type ConfiguredPackageSpec,
 	loadConfiguredPackageSpecs,
 } from "../config/toml-config.js";
+import { MISSING_MAESTRO_PACKAGE_KEYWORD_MESSAGE } from "./constants.js";
 import { discoverPackage } from "./discovery.js";
 import {
 	loadPackage,
@@ -70,7 +71,7 @@ export function collectPackageValidationIssues(
 
 	const issues: string[] = [];
 	if (!inspected.discovered.isMaestroPackage) {
-		issues.push('Missing "maestro-package" keyword.');
+		issues.push(MISSING_MAESTRO_PACKAGE_KEYWORD_MESSAGE);
 	}
 
 	for (const error of inspected.discovered.errors ?? []) {

--- a/src/packages/search.ts
+++ b/src/packages/search.ts
@@ -1,3 +1,5 @@
+import { MAESTRO_PACKAGE_KEYWORD } from "./constants.js";
+
 export interface PackageSearchEntry {
 	name: string;
 	version?: string;
@@ -35,7 +37,6 @@ interface NpmRegistrySearchPayload {
 }
 
 const PACKAGE_DISCOVERY_LIMIT = 8;
-const MAESTRO_PACKAGE_KEYWORD = "maestro-package";
 
 function buildPackageSearchText(query: string): string {
 	const trimmed = query.trim();

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -88,3 +88,14 @@ export {
 	formatSkillEvalText,
 	hasSkillEvalFailures,
 } from "./eval-harness.js";
+export {
+	MAESTRO_PACKAGE_KEYWORD,
+	MAESTRO_SKILL_PACKAGE_KEYWORD,
+	SKILL_PACKAGE_CONTRACT_SCHEMA,
+	type BuildSkillPackagePublishContractOptions,
+	type SkillPackageContractIssue,
+	type SkillPackageInstallCommandSet,
+	type SkillPackagePublishContract,
+	buildSkillPackagePublishContract,
+	formatSkillPackagePublishContract,
+} from "./package-contract.js";

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -97,5 +97,6 @@ export {
 	type SkillPackageInstallCommandSet,
 	type SkillPackagePublishContract,
 	buildSkillPackagePublishContract,
+	formatSkillPackageInstallSource,
 	formatSkillPackagePublishContract,
 } from "./package-contract.js";

--- a/src/skills/package-contract.ts
+++ b/src/skills/package-contract.ts
@@ -54,6 +54,7 @@ export interface SkillPackagePublishContract {
 export interface BuildSkillPackagePublishContractOptions {
 	cwd?: string;
 	describeToolbox?: boolean;
+	platform?: NodeJS.Platform;
 }
 
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
@@ -83,13 +84,14 @@ function mapValidationIssue(message: string): SkillPackageContractIssue {
 
 function buildInstallCommands(input: {
 	cwd: string;
+	platform: NodeJS.Platform;
 	source: PackageSource;
 }): SkillPackageInstallCommandSet {
 	const installSource = formatSkillPackageInstallSource(
 		input.source,
 		input.cwd,
 	);
-	const command = `maestro skill install ${quoteShellArg(installSource)}`;
+	const command = `maestro skill install ${quoteShellArg(installSource, input.platform)}`;
 	switch (input.source.type) {
 		case "local":
 			return { source: command, local: command };
@@ -100,9 +102,12 @@ function buildInstallCommands(input: {
 	}
 }
 
-function quoteShellArg(value: string): string {
+function quoteShellArg(value: string, platform: NodeJS.Platform): string {
 	if (SHELL_SAFE_INSTALL_SOURCE_REGEX.test(value)) {
 		return value;
+	}
+	if (platform === "win32") {
+		return `"${value.replace(/"/g, '\\"')}"`;
 	}
 	return `'${value.replace(/'/g, "'\\''")}'`;
 }
@@ -209,6 +214,7 @@ export async function buildSkillPackagePublishContract(
 		},
 		install: buildInstallCommands({
 			cwd,
+			platform: options.platform ?? process.platform,
 			source: inspected.source,
 		}),
 		evalReport,

--- a/src/skills/package-contract.ts
+++ b/src/skills/package-contract.ts
@@ -63,6 +63,12 @@ function issue(code: string, message: string): SkillPackageContractIssue {
 	return { code, message };
 }
 
+function mapValidationIssue(message: string): SkillPackageContractIssue {
+	return message === `Missing "${MAESTRO_PACKAGE_KEYWORD}" keyword.`
+		? issue("missing_maestro_package_keyword", message)
+		: issue("package_validation", message);
+}
+
 function buildInstallCommands(input: {
 	cwd: string;
 	resolvedPath: string;
@@ -91,18 +97,8 @@ function collectContractIssues(input: {
 	skillCount: number;
 	evalReport: SkillEvalReport | null;
 }): SkillPackageContractIssue[] {
-	const issues = input.validationIssues.map((message) =>
-		issue("package_validation", message),
-	);
+	const issues = input.validationIssues.map(mapValidationIssue);
 	const keywords = packageKeywords(input.discovered);
-	if (!keywords.includes(MAESTRO_PACKAGE_KEYWORD)) {
-		issues.push(
-			issue(
-				"missing_maestro_package_keyword",
-				`package.json keywords must include "${MAESTRO_PACKAGE_KEYWORD}".`,
-			),
-		);
-	}
 	if (!keywords.includes(MAESTRO_SKILL_PACKAGE_KEYWORD)) {
 		issues.push(
 			issue(
@@ -111,7 +107,7 @@ function collectContractIssues(input: {
 			),
 		);
 	}
-	if (input.skillCount === 0) {
+	if (input.validationIssues.length === 0 && input.skillCount === 0) {
 		issues.push(
 			issue(
 				"missing_skill_resources",

--- a/src/skills/package-contract.ts
+++ b/src/skills/package-contract.ts
@@ -130,7 +130,7 @@ function collectContractIssues(input: {
 }): SkillPackageContractIssue[] {
 	const issues = input.validationIssues.map(mapValidationIssue);
 	const keywords = packageKeywords(input.discovered);
-	if (!keywords.includes(MAESTRO_SKILL_PACKAGE_KEYWORD)) {
+	if (input.discovered && !keywords.includes(MAESTRO_SKILL_PACKAGE_KEYWORD)) {
 		issues.push(
 			issue(
 				"missing_maestro_skill_package_keyword",

--- a/src/skills/package-contract.ts
+++ b/src/skills/package-contract.ts
@@ -1,4 +1,4 @@
-import { relative } from "node:path";
+import { isAbsolute, relative } from "node:path";
 import {
 	collectPackageValidationIssues,
 	inspectPackageSource,
@@ -55,6 +55,14 @@ export interface BuildSkillPackagePublishContractOptions {
 	describeToolbox?: boolean;
 }
 
+const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
+
+function windowsDriveLetter(path: string): string | null {
+	return WINDOWS_DRIVE_PATH_REGEX.test(path)
+		? path.slice(0, 1).toLowerCase()
+		: null;
+}
+
 function packageKeywords(discovered: DiscoveredPackage | null): string[] {
 	return Array.isArray(discovered?.packageJson.keywords)
 		? discovered.packageJson.keywords
@@ -75,7 +83,10 @@ function buildInstallCommands(input: {
 	cwd: string;
 	source: PackageSource;
 }): SkillPackageInstallCommandSet {
-	const installSource = formatInstallSource(input.source, input.cwd);
+	const installSource = formatSkillPackageInstallSource(
+		input.source,
+		input.cwd,
+	);
 	const command = `maestro skill install ${installSource}`;
 	switch (input.source.type) {
 		case "local":
@@ -87,11 +98,23 @@ function buildInstallCommands(input: {
 	}
 }
 
-function formatInstallSource(source: PackageSource, cwd: string): string {
+export function formatSkillPackageInstallSource(
+	source: PackageSource,
+	cwd: string,
+): string {
 	if (source.type !== "local") {
 		return formatPackageSource(source);
 	}
+	const sourceDrive = windowsDriveLetter(source.path);
+	const cwdDrive = windowsDriveLetter(cwd);
+	if (sourceDrive && cwdDrive && sourceDrive !== cwdDrive) {
+		return `local:${source.path}`;
+	}
+
 	const relativePath = relative(cwd, source.path) || ".";
+	if (isAbsolute(relativePath) || WINDOWS_DRIVE_PATH_REGEX.test(relativePath)) {
+		return `local:${relativePath}`;
+	}
 	const localPath = relativePath.startsWith(".")
 		? relativePath
 		: `./${relativePath}`;

--- a/src/skills/package-contract.ts
+++ b/src/skills/package-contract.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, relative } from "node:path";
+import { MISSING_MAESTRO_PACKAGE_KEYWORD_MESSAGE } from "../packages/constants.js";
 import {
 	collectPackageValidationIssues,
 	inspectPackageSource,
@@ -14,7 +15,7 @@ import {
 
 export const SKILL_PACKAGE_CONTRACT_SCHEMA =
 	"evalops.maestro.skill-package-publish-contract.v1";
-export const MAESTRO_PACKAGE_KEYWORD = "maestro-package";
+export { MAESTRO_PACKAGE_KEYWORD } from "../packages/constants.js";
 export const MAESTRO_SKILL_PACKAGE_KEYWORD = "maestro-skill-package";
 
 export interface SkillPackageContractIssue {
@@ -74,7 +75,7 @@ function issue(code: string, message: string): SkillPackageContractIssue {
 }
 
 function mapValidationIssue(message: string): SkillPackageContractIssue {
-	return message === `Missing "${MAESTRO_PACKAGE_KEYWORD}" keyword.`
+	return message === MISSING_MAESTRO_PACKAGE_KEYWORD_MESSAGE
 		? issue("missing_maestro_package_keyword", message)
 		: issue("package_validation", message);
 }

--- a/src/skills/package-contract.ts
+++ b/src/skills/package-contract.ts
@@ -4,7 +4,7 @@ import {
 	inspectPackageSource,
 } from "../packages/inspection.js";
 import { formatPackageSource } from "../packages/sources.js";
-import type { DiscoveredPackage } from "../packages/types.js";
+import type { DiscoveredPackage, PackageSource } from "../packages/types.js";
 import {
 	type SkillEvalReport,
 	evaluateSkillPackages,
@@ -23,7 +23,9 @@ export interface SkillPackageContractIssue {
 }
 
 export interface SkillPackageInstallCommandSet {
-	local: string;
+	source: string;
+	local?: string;
+	git?: string;
 	npm?: string;
 }
 
@@ -71,24 +73,29 @@ function mapValidationIssue(message: string): SkillPackageContractIssue {
 
 function buildInstallCommands(input: {
 	cwd: string;
-	resolvedPath: string;
-	discovered: DiscoveredPackage | null;
+	source: PackageSource;
 }): SkillPackageInstallCommandSet {
-	const relativePath = relative(input.cwd, input.resolvedPath) || ".";
+	const installSource = formatInstallSource(input.source, input.cwd);
+	const command = `maestro skill install ${installSource}`;
+	switch (input.source.type) {
+		case "local":
+			return { source: command, local: command };
+		case "git":
+			return { source: command, git: command };
+		case "npm":
+			return { source: command, npm: command };
+	}
+}
+
+function formatInstallSource(source: PackageSource, cwd: string): string {
+	if (source.type !== "local") {
+		return formatPackageSource(source);
+	}
+	const relativePath = relative(cwd, source.path) || ".";
 	const localPath = relativePath.startsWith(".")
 		? relativePath
 		: `./${relativePath}`;
-	const local = `maestro skill install local:${localPath}`;
-	const name = input.discovered?.packageJson.name;
-	const version = input.discovered?.packageJson.version;
-	return {
-		local,
-		...(name
-			? {
-					npm: `maestro skill install npm:${name}${version ? `@${version}` : ""}`,
-				}
-			: {}),
-	};
+	return `local:${localPath}`;
 }
 
 function collectContractIssues(input: {
@@ -170,8 +177,7 @@ export async function buildSkillPackagePublishContract(
 		},
 		install: buildInstallCommands({
 			cwd,
-			resolvedPath: inspected.resolvedPath,
-			discovered: inspected.discovered,
+			source: inspected.source,
 		}),
 		evalReport,
 		issues,
@@ -181,16 +187,22 @@ export async function buildSkillPackagePublishContract(
 export function formatSkillPackagePublishContract(
 	contract: SkillPackagePublishContract,
 ): string {
+	const installCommands = [
+		contract.install.source,
+		contract.install.local,
+		contract.install.git,
+		contract.install.npm,
+	].filter(
+		(command, index, commands): command is string =>
+			typeof command === "string" && commands.indexOf(command) === index,
+	);
 	const lines = [
 		`Skill package: ${contract.package.name ?? "(unknown)"}${contract.package.version ? `@${contract.package.version}` : ""}`,
 		`Source: ${contract.resolvedSource}`,
 		`Skills: ${contract.resources.skills.length}`,
 		"Install:",
-		`  ${contract.install.local}`,
+		...installCommands.map((command) => `  ${command}`),
 	];
-	if (contract.install.npm) {
-		lines.push(`  ${contract.install.npm}`);
-	}
 	if (contract.evalReport) {
 		lines.push("", "Eval:", formatSkillEvalText(contract.evalReport));
 	}

--- a/src/skills/package-contract.ts
+++ b/src/skills/package-contract.ts
@@ -57,6 +57,7 @@ export interface BuildSkillPackagePublishContractOptions {
 }
 
 const WINDOWS_DRIVE_PATH_REGEX = /^[A-Za-z]:[\\/]/;
+const SHELL_SAFE_INSTALL_SOURCE_REGEX = /^[A-Za-z0-9_@%+=:,./\\-]+$/;
 
 function windowsDriveLetter(path: string): string | null {
 	return WINDOWS_DRIVE_PATH_REGEX.test(path)
@@ -88,7 +89,7 @@ function buildInstallCommands(input: {
 		input.source,
 		input.cwd,
 	);
-	const command = `maestro skill install ${installSource}`;
+	const command = `maestro skill install ${quoteShellArg(installSource)}`;
 	switch (input.source.type) {
 		case "local":
 			return { source: command, local: command };
@@ -97,6 +98,13 @@ function buildInstallCommands(input: {
 		case "npm":
 			return { source: command, npm: command };
 	}
+}
+
+function quoteShellArg(value: string): string {
+	if (SHELL_SAFE_INSTALL_SOURCE_REGEX.test(value)) {
+		return value;
+	}
+	return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 export function formatSkillPackageInstallSource(

--- a/src/skills/package-contract.ts
+++ b/src/skills/package-contract.ts
@@ -1,0 +1,210 @@
+import { relative } from "node:path";
+import {
+	collectPackageValidationIssues,
+	inspectPackageSource,
+} from "../packages/inspection.js";
+import { formatPackageSource } from "../packages/sources.js";
+import type { DiscoveredPackage } from "../packages/types.js";
+import {
+	type SkillEvalReport,
+	evaluateSkillPackages,
+	formatSkillEvalText,
+	hasSkillEvalFailures,
+} from "./eval-harness.js";
+
+export const SKILL_PACKAGE_CONTRACT_SCHEMA =
+	"evalops.maestro.skill-package-publish-contract.v1";
+export const MAESTRO_PACKAGE_KEYWORD = "maestro-package";
+export const MAESTRO_SKILL_PACKAGE_KEYWORD = "maestro-skill-package";
+
+export interface SkillPackageContractIssue {
+	code: string;
+	message: string;
+}
+
+export interface SkillPackageInstallCommandSet {
+	local: string;
+	npm?: string;
+}
+
+export interface SkillPackagePublishContract {
+	schemaVersion: typeof SKILL_PACKAGE_CONTRACT_SCHEMA;
+	sourceSpec: string;
+	resolvedSource: string;
+	resolvedPath: string;
+	package: {
+		name: string | null;
+		version: string | null;
+		keywords: string[];
+	};
+	resources: {
+		skills: string[];
+		prompts: string[];
+		extensions: string[];
+		themes: string[];
+	};
+	install: SkillPackageInstallCommandSet;
+	evalReport: SkillEvalReport | null;
+	issues: SkillPackageContractIssue[];
+}
+
+export interface BuildSkillPackagePublishContractOptions {
+	cwd?: string;
+	describeToolbox?: boolean;
+}
+
+function packageKeywords(discovered: DiscoveredPackage | null): string[] {
+	return Array.isArray(discovered?.packageJson.keywords)
+		? discovered.packageJson.keywords
+		: [];
+}
+
+function issue(code: string, message: string): SkillPackageContractIssue {
+	return { code, message };
+}
+
+function buildInstallCommands(input: {
+	cwd: string;
+	resolvedPath: string;
+	discovered: DiscoveredPackage | null;
+}): SkillPackageInstallCommandSet {
+	const relativePath = relative(input.cwd, input.resolvedPath) || ".";
+	const localPath = relativePath.startsWith(".")
+		? relativePath
+		: `./${relativePath}`;
+	const local = `maestro skill install local:${localPath}`;
+	const name = input.discovered?.packageJson.name;
+	const version = input.discovered?.packageJson.version;
+	return {
+		local,
+		...(name
+			? {
+					npm: `maestro skill install npm:${name}${version ? `@${version}` : ""}`,
+				}
+			: {}),
+	};
+}
+
+function collectContractIssues(input: {
+	discovered: DiscoveredPackage | null;
+	validationIssues: string[];
+	skillCount: number;
+	evalReport: SkillEvalReport | null;
+}): SkillPackageContractIssue[] {
+	const issues = input.validationIssues.map((message) =>
+		issue("package_validation", message),
+	);
+	const keywords = packageKeywords(input.discovered);
+	if (!keywords.includes(MAESTRO_PACKAGE_KEYWORD)) {
+		issues.push(
+			issue(
+				"missing_maestro_package_keyword",
+				`package.json keywords must include "${MAESTRO_PACKAGE_KEYWORD}".`,
+			),
+		);
+	}
+	if (!keywords.includes(MAESTRO_SKILL_PACKAGE_KEYWORD)) {
+		issues.push(
+			issue(
+				"missing_maestro_skill_package_keyword",
+				`package.json keywords must include "${MAESTRO_SKILL_PACKAGE_KEYWORD}" for OSS skill registry discovery.`,
+			),
+		);
+	}
+	if (input.skillCount === 0) {
+		issues.push(
+			issue(
+				"missing_skill_resources",
+				"package.json maestro.skills must expose at least one skill directory.",
+			),
+		);
+	}
+	if (input.evalReport && hasSkillEvalFailures(input.evalReport)) {
+		issues.push(
+			issue(
+				"skill_package_eval_failed",
+				"One or more bundled skills failed the Agent Core package eval contract.",
+			),
+		);
+	}
+	return issues;
+}
+
+export async function buildSkillPackagePublishContract(
+	sourceSpec: string,
+	options: BuildSkillPackagePublishContractOptions = {},
+): Promise<SkillPackagePublishContract> {
+	const cwd = options.cwd ?? process.cwd();
+	const inspected = await inspectPackageSource(sourceSpec, cwd);
+	const resources = inspected.resources ?? {
+		extensions: [],
+		skills: [],
+		prompts: [],
+		themes: [],
+	};
+	const evalReport =
+		resources.skills.length > 0
+			? await evaluateSkillPackages(
+					resources.skills.map((path) => ({ path })),
+					{ describeToolbox: options.describeToolbox },
+				)
+			: null;
+	const issues = collectContractIssues({
+		discovered: inspected.discovered,
+		validationIssues: collectPackageValidationIssues(inspected),
+		skillCount: resources.skills.length,
+		evalReport,
+	});
+
+	return {
+		schemaVersion: SKILL_PACKAGE_CONTRACT_SCHEMA,
+		sourceSpec,
+		resolvedSource: formatPackageSource(inspected.source),
+		resolvedPath: inspected.resolvedPath,
+		package: {
+			name: inspected.discovered?.packageJson.name ?? null,
+			version: inspected.discovered?.packageJson.version ?? null,
+			keywords: packageKeywords(inspected.discovered),
+		},
+		resources: {
+			skills: resources.skills,
+			prompts: resources.prompts,
+			extensions: resources.extensions,
+			themes: resources.themes,
+		},
+		install: buildInstallCommands({
+			cwd,
+			resolvedPath: inspected.resolvedPath,
+			discovered: inspected.discovered,
+		}),
+		evalReport,
+		issues,
+	};
+}
+
+export function formatSkillPackagePublishContract(
+	contract: SkillPackagePublishContract,
+): string {
+	const lines = [
+		`Skill package: ${contract.package.name ?? "(unknown)"}${contract.package.version ? `@${contract.package.version}` : ""}`,
+		`Source: ${contract.resolvedSource}`,
+		`Skills: ${contract.resources.skills.length}`,
+		"Install:",
+		`  ${contract.install.local}`,
+	];
+	if (contract.install.npm) {
+		lines.push(`  ${contract.install.npm}`);
+	}
+	if (contract.evalReport) {
+		lines.push("", "Eval:", formatSkillEvalText(contract.evalReport));
+	}
+	if (contract.issues.length > 0) {
+		lines.push("", "Issues:");
+		for (const item of contract.issues) {
+			lines.push(`- ${item.code}: ${item.message}`);
+		}
+	} else {
+		lines.push("", "Result: publish/install contract passed.");
+	}
+	return lines.join("\n");
+}

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -17,6 +17,7 @@ import {
 	buildSkillPackagePublishContract,
 	buildSkillRuntimeActivation,
 	evaluateSkillPackages,
+	formatSkillPackageInstallSource,
 	hasSkillEvalFailures,
 	hasSkillLintErrors,
 	isWindowsRunnableToolboxEntry,
@@ -358,6 +359,15 @@ describe("skill package format", () => {
 		expect(payload.install.local).toBe(payload.install.source);
 		expect(payload.install.npm).toBeUndefined();
 		expect(payload.issues).toEqual([]);
+	});
+
+	it("preserves drive-qualified local install hints across Windows drives", () => {
+		expect(
+			formatSkillPackageInstallSource(
+				{ type: "local", path: "D:\\skills\\review-pack" },
+				"C:\\workspace",
+			),
+		).toBe("local:D:\\skills\\review-pack");
 	});
 
 	it("keeps publish-check install hints tied to the inspected source type", async () => {

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import {
 	chmodSync,
 	mkdtempSync,
@@ -39,6 +40,23 @@ function tempRoot(): string {
 	const dir = mkdtempSync(join(tmpdir(), "maestro-skill-package-"));
 	tempDirs.push(dir);
 	return dir;
+}
+
+function createCommittedGitRepo(dir: string): void {
+	execFileSync("git", ["init", "-q"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.email", "test@example.com"], {
+		cwd: dir,
+		stdio: "ignore",
+	});
+	execFileSync("git", ["config", "user.name", "Test User"], {
+		cwd: dir,
+		stdio: "ignore",
+	});
+	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["commit", "-q", "-m", "initial"], {
+		cwd: dir,
+		stdio: "ignore",
+	});
 }
 
 async function writeOssSkillPackage(workspace: string): Promise<string> {
@@ -323,7 +341,7 @@ describe("skill package format", () => {
 			schemaVersion: string;
 			package: { name: string; version: string };
 			resources: { skills: string[] };
-			install: { npm?: string };
+			install: { source: string; local?: string; npm?: string };
 			issues: unknown[];
 		};
 		expect(payload.schemaVersion).toBe(
@@ -334,10 +352,32 @@ describe("skill package format", () => {
 			version: "1.0.0",
 		});
 		expect(payload.resources.skills).toHaveLength(1);
-		expect(payload.install.npm).toBe(
-			"maestro skill install npm:@test/maestro-review-skills@1.0.0",
+		expect(payload.install.source).toBe(
+			"maestro skill install local:./vendor/review-skills",
 		);
+		expect(payload.install.local).toBe(payload.install.source);
+		expect(payload.install.npm).toBeUndefined();
 		expect(payload.issues).toEqual([]);
+	});
+
+	it("keeps publish-check install hints tied to the inspected source type", async () => {
+		const workspace = tempRoot();
+		const packageDir = await writeOssSkillPackage(workspace);
+		createCommittedGitRepo(packageDir);
+
+		const contract = await buildSkillPackagePublishContract(
+			`git:${packageDir}`,
+			{ cwd: workspace },
+		);
+
+		expect(contract.install.source).toBe(
+			`maestro skill install git:${packageDir}`,
+		);
+		expect(contract.install.git).toBe(contract.install.source);
+		expect(contract.install.local).toBeUndefined();
+		expect(contract.install.npm).toBeUndefined();
+		expect(contract.install.source).not.toContain(".maestro");
+		expect(contract.issues).toEqual([]);
 	});
 
 	it('emits one issue when the "maestro-package" keyword is missing', async () => {
@@ -364,11 +404,7 @@ describe("skill package format", () => {
 			{ cwd: workspace },
 		);
 
-		expect(
-			contract.issues.filter(
-				(item) => item.code === "missing_maestro_package_keyword",
-			),
-		).toEqual([
+		expect(contract.issues).toEqual([
 			{
 				code: "missing_maestro_package_keyword",
 				message: 'Missing "maestro-package" keyword.',

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -390,6 +390,26 @@ describe("skill package format", () => {
 		expect(contract.issues).toEqual([]);
 	});
 
+	it("does not add skill keyword issues when package discovery fails", async () => {
+		const workspace = tempRoot();
+		await mkdir(join(workspace, "vendor", "broken-skills"), {
+			recursive: true,
+		});
+
+		const contract = await buildSkillPackagePublishContract(
+			"./vendor/broken-skills",
+			{ cwd: workspace },
+		);
+
+		expect(contract.issues).toHaveLength(1);
+		expect(contract.issues[0]).toMatchObject({
+			code: "package_validation",
+		});
+		expect(contract.issues[0]?.message).toContain(
+			"No valid package.json found",
+		);
+	});
+
 	it('emits one issue when the "maestro-package" keyword is missing', async () => {
 		const workspace = tempRoot();
 		const packageDir = await writeOssSkillPackage(workspace);

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -13,6 +13,7 @@ import { parseArgs } from "../src/cli/args.js";
 import { handleSkillCommand } from "../src/cli/commands/skill.js";
 import { buildSkillArtifactMetadata } from "../src/skills/artifact-metadata.js";
 import {
+	buildSkillPackagePublishContract,
 	buildSkillRuntimeActivation,
 	evaluateSkillPackages,
 	hasSkillEvalFailures,
@@ -337,6 +338,38 @@ describe("skill package format", () => {
 			"maestro skill install npm:@test/maestro-review-skills@1.0.0",
 		);
 		expect(payload.issues).toEqual([]);
+	});
+
+	it('emits one issue when the "maestro-package" keyword is missing', async () => {
+		const workspace = tempRoot();
+		const packageDir = await writeOssSkillPackage(workspace);
+		writeFileSync(
+			join(packageDir, "package.json"),
+			JSON.stringify(
+				{
+					name: "@test/maestro-review-skills",
+					version: "1.0.0",
+					keywords: ["maestro-skill-package"],
+					maestro: {
+						skills: ["./skills"],
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const contract = await buildSkillPackagePublishContract(
+			"./vendor/review-skills",
+			{ cwd: workspace },
+		);
+
+		expect(contract.issues).toEqual([
+			{
+				code: "missing_maestro_package_keyword",
+				message: 'Missing "maestro-package" keyword.',
+			},
+		]);
 	});
 
 	it("installs validated OSS skill packages into the selected config scope", async () => {

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -40,6 +40,56 @@ function tempRoot(): string {
 	return dir;
 }
 
+async function writeOssSkillPackage(workspace: string): Promise<string> {
+	const packageDir = join(workspace, "vendor", "review-skills");
+	const skillDir = join(packageDir, "skills", "reviewing-prs");
+	await mkdir(skillDir, { recursive: true });
+	writeFileSync(
+		join(packageDir, "package.json"),
+		JSON.stringify(
+			{
+				name: "@test/maestro-review-skills",
+				version: "1.0.0",
+				keywords: ["maestro-package", "maestro-skill-package"],
+				maestro: {
+					skills: ["./skills"],
+				},
+			},
+			null,
+			2,
+		),
+	);
+	writeFileSync(
+		join(skillDir, "SKILL.md"),
+		`---\nname: reviewing-prs\ndescription: "Review pull requests. Use when the user asks for PR review."\nallowed-tools:\n  - read\nbuiltin-tools:\n  - read\nisolatedContext: true\n---\n\n# Reviewing PRs\n\nKeep findings first and cite exact files.\n`,
+	);
+	return packageDir;
+}
+
+async function captureSkillCommand(
+	subcommand: string,
+	args: string[],
+	workspaceDir: string,
+): Promise<{ logs: string[]; errors: string[] }> {
+	const originalLog = console.log;
+	const originalError = console.error;
+	const logs: string[] = [];
+	const errors: string[] = [];
+	console.log = (...values: unknown[]) => {
+		logs.push(values.map((value) => String(value)).join(" "));
+	};
+	console.error = (...values: unknown[]) => {
+		errors.push(values.map((value) => String(value)).join(" "));
+	};
+	try {
+		await handleSkillCommand(subcommand, args, { workspaceDir });
+	} finally {
+		console.log = originalLog;
+		console.error = originalError;
+	}
+	return { logs, errors };
+}
+
 afterEach(() => {
 	for (const dir of tempDirs.splice(0)) {
 		rmSync(dir, { recursive: true, force: true });
@@ -255,6 +305,71 @@ describe("skill package format", () => {
 				process.env.MAESTRO_SYSTEM_SKILLS_DIR = originalSystemSkills;
 			}
 		}
+	});
+
+	it("emits the OSS skill package publish/install contract", async () => {
+		const workspace = tempRoot();
+		await writeOssSkillPackage(workspace);
+
+		const { logs, errors } = await captureSkillCommand(
+			"publish-check",
+			["./vendor/review-skills", "--json"],
+			workspace,
+		);
+
+		expect(errors).toEqual([]);
+		const payload = JSON.parse(logs.join("\n")) as {
+			schemaVersion: string;
+			package: { name: string; version: string };
+			resources: { skills: string[] };
+			install: { npm?: string };
+			issues: unknown[];
+		};
+		expect(payload.schemaVersion).toBe(
+			"evalops.maestro.skill-package-publish-contract.v1",
+		);
+		expect(payload.package).toMatchObject({
+			name: "@test/maestro-review-skills",
+			version: "1.0.0",
+		});
+		expect(payload.resources.skills).toHaveLength(1);
+		expect(payload.install.npm).toBe(
+			"maestro skill install npm:@test/maestro-review-skills@1.0.0",
+		);
+		expect(payload.issues).toEqual([]);
+	});
+
+	it("installs validated OSS skill packages into the selected config scope", async () => {
+		const workspace = tempRoot();
+		await mkdir(join(workspace, ".maestro"), { recursive: true });
+		await writeOssSkillPackage(workspace);
+
+		const { logs, errors } = await captureSkillCommand(
+			"install",
+			["./vendor/review-skills", "--scope", "project", "--json"],
+			workspace,
+		);
+
+		expect(errors).toEqual([]);
+		const payload = JSON.parse(logs.join("\n")) as {
+			installed: boolean;
+			config: { path: string; scope: string };
+		};
+		expect(payload.installed).toBe(true);
+		expect(payload.config).toMatchObject({
+			path: join(workspace, ".maestro", "config.toml"),
+			scope: "project",
+		});
+		expect(readFileSync(payload.config.path, "utf8")).toContain(
+			"../vendor/review-skills",
+		);
+
+		const loaded = loadSkills(workspace, { includeSystem: false });
+		expect(loaded.errors).toEqual([]);
+		expect(loaded.skills.map((skill) => skill.name)).toContain("reviewing-prs");
+		expect(
+			loaded.skills.find((skill) => skill.name === "reviewing-prs")?.sourceType,
+		).toBe("project");
 	});
 
 	it("accepts quoted isolatedContext consistently across load and lint", async () => {

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -390,6 +390,23 @@ describe("skill package format", () => {
 		expect(contract.issues).toEqual([]);
 	});
 
+	it("uses Windows command quoting for install source hints on win32", async () => {
+		const workspace = tempRoot();
+		const packageDir = join(workspace, "My Skills", "review-pack");
+		await writeOssSkillPackageAt(packageDir);
+
+		const contract = await buildSkillPackagePublishContract(
+			"./My Skills/review-pack",
+			{ cwd: workspace, platform: "win32" },
+		);
+
+		expect(contract.install.source).toBe(
+			'maestro skill install "local:./My Skills/review-pack"',
+		);
+		expect(contract.install.local).toBe(contract.install.source);
+		expect(contract.issues).toEqual([]);
+	});
+
 	it("keeps publish-check install hints tied to the inspected source type", async () => {
 		const workspace = tempRoot();
 		const packageDir = await writeOssSkillPackage(workspace);

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -61,7 +61,10 @@ function createCommittedGitRepo(dir: string): void {
 }
 
 async function writeOssSkillPackage(workspace: string): Promise<string> {
-	const packageDir = join(workspace, "vendor", "review-skills");
+	return writeOssSkillPackageAt(join(workspace, "vendor", "review-skills"));
+}
+
+async function writeOssSkillPackageAt(packageDir: string): Promise<string> {
 	const skillDir = join(packageDir, "skills", "reviewing-prs");
 	await mkdir(skillDir, { recursive: true });
 	writeFileSync(
@@ -368,6 +371,23 @@ describe("skill package format", () => {
 				"C:\\workspace",
 			),
 		).toBe("local:D:\\skills\\review-pack");
+	});
+
+	it("quotes install commands when local sources contain spaces", async () => {
+		const workspace = tempRoot();
+		const packageDir = join(workspace, "My Skills", "review-pack");
+		await writeOssSkillPackageAt(packageDir);
+
+		const contract = await buildSkillPackagePublishContract(
+			"./My Skills/review-pack",
+			{ cwd: workspace },
+		);
+
+		expect(contract.install.source).toBe(
+			"maestro skill install 'local:./My Skills/review-pack'",
+		);
+		expect(contract.install.local).toBe(contract.install.source);
+		expect(contract.issues).toEqual([]);
 	});
 
 	it("keeps publish-check install hints tied to the inspected source type", async () => {

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -364,7 +364,11 @@ describe("skill package format", () => {
 			{ cwd: workspace },
 		);
 
-		expect(contract.issues).toEqual([
+		expect(
+			contract.issues.filter(
+				(item) => item.code === "missing_maestro_package_keyword",
+			),
+		).toEqual([
 			{
 				code: "missing_maestro_package_keyword",
 				message: 'Missing "maestro-package" keyword.',


### PR DESCRIPTION
## Summary
- add a `SkillPackagePublishContract` projection for local/npm/git skill packages, including package metadata, resources, eval report, install commands, and blocking lint issues
- add `maestro skill publish-check` and `maestro skill install` CLI commands so OSS packages can validate before publication and install into local/project/user scope
- document the required npm keywords, package entrypoints, validation command, and install flow

## Source of Truth
- evalops/maestro-internal#1984

## Verification
- `npm run test -- test/skill-package-format.test.ts test/skill-eval-harness.test.ts test/packages/maestro-packages.test.ts`
- `npm run evals:skill-package`
- `bunx biome check docs/cookbook/skills/README.md src/cli/commands/skill.ts src/cli/help.ts src/skills/index.ts src/skills/package-contract.ts test/skill-package-format.test.ts`
- `bunx tsc -p tsconfig.build.json --noEmit`
- `npm run lint:evals`
- `git diff --check`

## Staged Rollout
- Staging is unnecessary: this adds explicit operator-invoked `maestro skill publish-check` and `maestro skill install` commands, not ambient runtime activation. `install` validates the publish contract before writing config, and scope is explicit (`local`, `project`, or `user`).