### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/a2a-fleet-delegation.md
+++ b/docs/protocols/a2a-fleet-delegation.md
@@ -10,6 +10,7 @@ back.
 ```sh
 maestro a2a fleet [--json] [--registry <path>] [--tasks <path>]
 maestro a2a delegate <peer> <text> [--role <role>] [--cwd <path>] [--wait]
+maestro a2a reply <peer> <task-id> <text> [--wait]
 maestro a2a tasks [peer] [--json] [--refresh]
 maestro a2a wait <peer> <task-id>
 ```
@@ -22,6 +23,10 @@ registry URL and a bounded error.
 `delegate` sends a normal A2A `message:send` request with Maestro delegation
 metadata: origin, peer name, role, and working directory. The resulting task is
 recorded in the local ledger before optional waiting begins.
+
+`reply` continues an existing remote A2A task by sending `message.taskId` and
+the durable ledger `contextId` when available. It appends the operator's reply
+to the same local transcript and can wait for the peer's follow-up result.
 
 `tasks` reads the durable ledger and can refresh known task IDs from their
 registered peers. This gives the operator a single place to see outstanding work
@@ -50,6 +55,7 @@ Before this feature, the following tests fail:
 
 ```sh
 npm run test:fast -- test/cli/commands/a2a-fleet-delegation.test.ts test/cli-tui/commands/a2a-handlers.test.ts
+npm run test:fast -- test/cli/commands/a2a.test.ts test/platform/a2a-task-ledger.test.ts
 cargo test -p maestro-tui commands::registry::tests::a2a_command_parses_peer_actions
 ```
 
@@ -57,10 +63,12 @@ After implementation, they must pass and prove:
 
 - `maestro a2a delegate <peer> <text> --wait` sends real HTTP+JSON A2A traffic,
   records the task, updates the final state, and stores a transcript.
+- `maestro a2a reply <peer> <task-id> <text> --wait` sends a follow-up message
+  with the original task id and context id, appends to the same transcript, and
+  does not mark `INPUT_REQUIRED` or `AUTH_REQUIRED` tasks as completed.
 - `maestro a2a fleet --json` shows peer health, Agent Card capabilities, and the
   peer's most recent ledger task without leaking token values.
 - `maestro a2a tasks --json` reads the ledger and can be used as a fleet task
   view.
-- TypeScript and Rust TUIs both recognize `/a2a fleet`, `/a2a tasks`, and
-  `/a2a delegate`.
-
+- TypeScript and Rust TUIs both recognize `/a2a fleet`, `/a2a tasks`,
+  `/a2a delegate`, and `/a2a reply`.

--- a/packages/tui-rs/src/app.rs
+++ b/packages/tui-rs/src/app.rs
@@ -3376,6 +3376,7 @@ Add the required fields and retry.",
                         "/a2a tasks [peer]",
                         "/a2a accept <pairing-code>",
                         "/a2a delegate <peer> <text>",
+                        "/a2a reply <peer> <task-id> <text>",
                         "/a2a send <peer> <text>",
                         "",
                         "Native pairing codes, fleet views, and delegation ledgers are shared with the TypeScript CLI/TUI.",
@@ -3410,6 +3411,16 @@ Add the required fields and retry.",
             A2aAction::Delegate { peer, text } => {
                 self.state.add_system_message(format!(
                     "A2A delegation prepared for `{peer}` ({} chars). Run `maestro a2a delegate {peer} <text> --wait` while the Rust delegation controller is connected to the shared A2A client.",
+                    text.len()
+                ));
+            }
+            A2aAction::Reply {
+                peer,
+                task_id,
+                text,
+            } => {
+                self.state.add_system_message(format!(
+                    "A2A task reply prepared for `{peer}` task `{task_id}` ({} chars). Run `maestro a2a reply {peer} {task_id} <text> --wait` while the Rust task-continuation controller is connected to the shared A2A client.",
                     text.len()
                 ));
             }

--- a/packages/tui-rs/src/commands/registry.rs
+++ b/packages/tui-rs/src/commands/registry.rs
@@ -535,6 +535,23 @@ fn parse_a2a_action(raw: &str) -> Result<A2aAction, CommandError> {
                 text,
             })
         }
+        "reply" | "continue" => {
+            let peer = tokens
+                .get(1)
+                .ok_or_else(|| CommandError::new("Usage: /a2a reply <peer> <task-id> <text>"))?;
+            let task_id = tokens
+                .get(2)
+                .ok_or_else(|| CommandError::new("Usage: /a2a reply <peer> <task-id> <text>"))?;
+            let text = tokens.get(3..).unwrap_or(&[]).join(" ");
+            if text.trim().is_empty() {
+                return Err(CommandError::new("Usage: /a2a reply <peer> <task-id> <text>"));
+            }
+            Ok(A2aAction::Reply {
+                peer: peer.clone(),
+                task_id: task_id.clone(),
+                text,
+            })
+        }
         "send" => {
             let peer = tokens
                 .get(1)
@@ -550,7 +567,7 @@ fn parse_a2a_action(raw: &str) -> Result<A2aAction, CommandError> {
         }
         _ => Err(
             CommandError::new(format!("Unknown A2A subcommand: {subcommand}"))
-                .with_hint("Usage: /a2a [fleet|peers|tasks|accept <code>|delegate <peer> <text>|send <peer> <text>]"),
+                .with_hint("Usage: /a2a [fleet|peers|tasks|accept <code>|delegate <peer> <text>|reply <peer> <task-id> <text>|send <peer> <text>]"),
         ),
     }
 }
@@ -779,7 +796,7 @@ pub fn build_command_registry() -> CommandRegistry {
                 )?)))
             }),
         )
-        .usage("/a2a [fleet|peers|tasks|accept <code>|delegate <peer> <text>|send <peer> <text>]"),
+        .usage("/a2a [fleet|peers|tasks|accept <code>|delegate <peer> <text>|reply <peer> <task-id> <text>|send <peer> <text>]"),
     );
 
     // Queue command
@@ -2008,6 +2025,27 @@ mod tests {
                 assert_eq!(code, "maestro-pair-v1.payload.checksum");
             }
             other => panic!("expected a2a accept action, got {other:?}"),
+        }
+
+        match registry
+            .execute(
+                "/a2a reply mac-mini task-1 use the short smoke",
+                "/tmp",
+                None,
+                None,
+            )
+            .expect("a2a reply should parse")
+        {
+            CommandOutput::Action(CommandAction::A2a(A2aAction::Reply {
+                peer,
+                task_id,
+                text,
+            })) => {
+                assert_eq!(peer, "mac-mini");
+                assert_eq!(task_id, "task-1");
+                assert_eq!(text, "use the short smoke");
+            }
+            other => panic!("expected a2a reply action, got {other:?}"),
         }
 
         match registry

--- a/packages/tui-rs/src/commands/types.rs
+++ b/packages/tui-rs/src/commands/types.rs
@@ -367,6 +367,12 @@ pub enum A2aAction {
     Accept { code: String },
     /// Delegate work to a peer.
     Delegate { peer: String, text: String },
+    /// Continue an existing A2A task.
+    Reply {
+        peer: String,
+        task_id: String,
+        text: String,
+    },
     /// Send a message to a peer.
     Send { peer: String, text: String },
 }

--- a/src/cli-tui/commands/a2a-handlers.ts
+++ b/src/cli-tui/commands/a2a-handlers.ts
@@ -130,6 +130,12 @@ export async function handleA2ATuiCommand(
 		);
 		return;
 	}
+	if (subcommand === "reply" || subcommand === "continue") {
+		context.showInfo(
+			"Use `maestro a2a reply <peer> <task-id> <text> --wait` to continue an actionable A2A task while the TUI task panel is being wired.",
+		);
+		return;
+	}
 	if (subcommand === "delegate") {
 		context.showInfo(
 			"Use `maestro a2a delegate <peer> <text> --wait` for native A2A delegation while the TUI task panel is being wired.",
@@ -142,6 +148,7 @@ export async function handleA2ATuiCommand(
 			"/a2a fleet",
 			"/a2a peers",
 			"/a2a delegate <peer> <text>",
+			"/a2a reply <peer> <task-id> <text>",
 			"/a2a tasks [peer]",
 			"/a2a send <peer> <text>",
 		].join("\n"),

--- a/src/cli-tui/commands/command-catalog.ts
+++ b/src/cli-tui/commands/command-catalog.ts
@@ -180,13 +180,15 @@ export const PRIMARY_COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
 	}),
 	withArgs("a2a", "a2a", {
 		description: "Pair, inspect, and delegate to A2A peer agents",
-		usage: "/a2a [accept <code>|fleet|peers|tasks|delegate <peer> <text>]",
+		usage:
+			"/a2a [accept <code>|fleet|peers|tasks|delegate <peer> <text>|reply <peer> <task-id> <text>]",
 		tags: ["tools", "agents"],
 		examples: [
 			"/a2a fleet",
 			"/a2a peers",
 			"/a2a tasks",
 			"/a2a delegate mac-mini run workspace smoke",
+			"/a2a reply mac-mini task-123 use the short smoke",
 			"/a2a accept maestro-pair-v1.payload.checksum --name mac-mini",
 		],
 	}),

--- a/src/cli/commands/a2a.ts
+++ b/src/cli/commands/a2a.ts
@@ -23,11 +23,13 @@ import {
 	upsertA2APeerFromPairingPayload,
 } from "../../platform/a2a-peer-registry.js";
 import {
+	type A2ATaskLedgerEntry,
 	extractA2ATaskText,
 	getA2ATaskLedgerPath,
 	isTerminalA2AState,
 	listA2ATaskEntries,
 	loadA2ATaskLedger,
+	recordA2ATaskReply,
 	recordA2ATaskStart,
 	updateA2ATaskInLedger,
 } from "../../platform/a2a-task-ledger.js";
@@ -65,6 +67,13 @@ const A2A_VALUE_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> = {
 		"--url",
 	],
 	peers: ["--registry"],
+	reply: [
+		"--interval-ms",
+		"--max-wait-ms",
+		"--registry",
+		"--tasks",
+		"--timeout-ms",
+	],
 	send: ["--interval-ms", "--max-wait-ms", "--registry", "--timeout-ms"],
 	tasks: ["--registry", "--tasks", "--timeout-ms"],
 	wait: [
@@ -79,6 +88,7 @@ const A2A_BOOLEAN_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> = {
 	accept: ["--default"],
 	delegate: ["--wait"],
 	fleet: ["--json"],
+	reply: ["--wait"],
 	send: ["--wait"],
 	tasks: ["--json", "--refresh"],
 };
@@ -122,6 +132,10 @@ export async function handleA2ACommand(args: string[]): Promise<void> {
 		case "delegate":
 		case "delegation":
 			await handleA2ADelegate(parsed);
+			return;
+		case "reply":
+		case "continue":
+			await handleA2AReply(parsed);
 			return;
 		case "tasks":
 			await handleA2ATasks(parsed);
@@ -230,6 +244,8 @@ function canonicalA2ASubcommand(input: string | undefined): string {
 			return "peers";
 		case "delegation":
 			return "delegate";
+		case "continue":
+			return "reply";
 		default:
 			return input?.toLowerCase() ?? "help";
 	}
@@ -502,6 +518,94 @@ async function handleA2ADelegate(parsed: ParsedA2AArgs): Promise<void> {
 	printTask(task);
 }
 
+async function handleA2AReply(parsed: ParsedA2AArgs): Promise<void> {
+	const peerName =
+		parsed.positionals.shift() ??
+		fail("Usage: maestro a2a reply <peer> <task-id> <text>");
+	const taskId =
+		parsed.positionals.shift() ??
+		fail("Usage: maestro a2a reply <peer> <task-id> <text>");
+	const text = parsed.positionals.join(" ").trim();
+	if (!text) {
+		fail("Usage: maestro a2a reply <peer> <task-id> <text>");
+	}
+	const peer = await resolveA2APeer(peerName, {
+		path: stringFlag(parsed, "--registry"),
+		timeoutMs: numberFlag(parsed, "--timeout-ms"),
+	});
+	const existing = await loadA2AReplyLedgerEntry(parsed, peer.name, taskId);
+	const wait = booleanFlag(parsed, "--wait");
+	const messageId = `maestro-a2a-message-${randomUUID()}`;
+	const sent = await sendA2AMessage(peer.config, {
+		message: buildA2AUserMessage({
+			messageId,
+			contextId: existing?.contextId,
+			taskId,
+			text,
+			metadata: {
+				requestKind: "maestro-peer-task-reply",
+				relayPeer: peer.name,
+				referencedTaskId: taskId,
+			},
+		}),
+		configuration: { returnImmediately: true },
+	});
+	console.log(`Replied to ${chalk.bold(peer.name)} task ${sent.task.id}`);
+	await persistA2ALedgerBestEffort("record task reply locally", () =>
+		recordA2ATaskReply({
+			path: stringFlag(parsed, "--tasks"),
+			peer: peer.name,
+			peerDisplayName: peer.entry.displayName,
+			task: sent.task,
+			text,
+			messageId,
+			metadata: {
+				requestKind: "maestro-peer-task-reply",
+				relayPeer: peer.name,
+				referencedTaskId: taskId,
+			},
+		}),
+	);
+	const task = wait
+		? await waitForA2ATask(peer.config, sent.task.id, parsed)
+		: sent.task;
+	if (wait) {
+		await persistA2ALedgerBestEffort("sync replied task result locally", () =>
+			updateA2ATaskInLedger({
+				path: stringFlag(parsed, "--tasks"),
+				peer: peer.name,
+				task,
+			}),
+		);
+	}
+	printTask(task);
+}
+
+async function loadA2AReplyLedgerEntry(
+	parsed: ParsedA2AArgs,
+	peerName: string,
+	taskId: string,
+): Promise<A2ATaskLedgerEntry | undefined> {
+	try {
+		const ledger = await loadA2ATaskLedger({
+			path: stringFlag(parsed, "--tasks"),
+		});
+		return listA2ATaskEntries(ledger, { peer: peerName }).find(
+			(entry) => entry.taskId === taskId,
+		);
+	} catch (error) {
+		if (isAbortError(error)) {
+			throw error;
+		}
+		console.error(
+			chalk.yellow(
+				`A2A task ledger warning: could not load task reply context: ${errorMessage(error)}`,
+			),
+		);
+		return undefined;
+	}
+}
+
 async function handleA2ATasks(parsed: ParsedA2AArgs): Promise<void> {
 	const peerName = parsed.positionals.shift();
 	if (booleanFlag(parsed, "--refresh")) {
@@ -708,6 +812,7 @@ function printA2AHelp(): void {
   maestro a2a fleet [--json]
   maestro a2a card <peer>
   maestro a2a delegate <peer> <text> [--role <role>] [--cwd <path>] [--wait]
+  maestro a2a reply <peer> <task-id> <text> [--wait]
   maestro a2a send <peer> <text> [--wait]
   maestro a2a tasks [peer] [--json] [--refresh]
   maestro a2a wait <peer> <task-id>

--- a/src/platform/a2a-task-ledger.ts
+++ b/src/platform/a2a-task-ledger.ts
@@ -63,8 +63,22 @@ export interface UpdateA2ATaskInput extends A2ATaskLedgerOptions {
 	task: A2ATask;
 }
 
-const TERMINAL_STATE_PATTERN =
-	/(COMPLETED|FAILED|CANCELED|CANCELLED|REJECTED|INPUT_REQUIRED|AUTH_REQUIRED)/u;
+export interface RecordA2ATaskReplyInput extends A2ATaskLedgerOptions {
+	peer: string;
+	peerDisplayName?: string;
+	task: A2ATask;
+	text: string;
+	messageId: string;
+	metadata?: Record<string, string | number | boolean | undefined>;
+}
+
+interface A2ATaskResponseText {
+	text: string;
+	messageId?: string;
+}
+
+const FINAL_STATE_PATTERN = /(COMPLETED|FAILED|CANCELED|CANCELLED|REJECTED)/u;
+const ACTION_REQUIRED_STATE_PATTERN = /(INPUT_REQUIRED|AUTH_REQUIRED)/u;
 const LEDGER_LOCK_RETRY_MS = 25;
 const LEDGER_LOCK_HEARTBEAT_MS = 10_000;
 const LEDGER_LOCK_STALE_MS = 30_000;
@@ -321,19 +335,99 @@ export async function recordA2ATaskStart(
 				existingIndex >= 0 ? ledger.tasks[existingIndex]!.createdAt : now,
 			updatedAt: now,
 		};
-		const taskText = extractA2ATaskText(input.task);
-		if (taskText) {
-			entry.responseText = taskText;
+		const taskResponse = extractA2ATaskResponse(input.task);
+		if (taskResponse) {
+			entry.responseText = taskResponse.text;
 			entry.transcript.push({
 				at: now,
 				role: "agent",
-				text: taskText,
+				text: taskResponse.text,
 				state: input.task.status.state,
-				messageId: input.task.status.message?.messageId,
+				messageId: taskResponse.messageId,
 			});
 		}
-		if (isTerminalA2AState(entry.state)) {
+		if (isFinalA2AState(entry.state)) {
 			entry.completedAt = now;
+		} else {
+			delete entry.completedAt;
+		}
+		if (existingIndex >= 0) {
+			ledger.tasks[existingIndex] = entry;
+		} else {
+			ledger.tasks.push(entry);
+		}
+		const path = await writeA2ATaskLedger(ledger, input);
+		return { entry, path };
+	});
+}
+
+export async function recordA2ATaskReply(
+	input: RecordA2ATaskReplyInput,
+): Promise<{ entry: A2ATaskLedgerEntry; path: string }> {
+	return withA2ATaskLedgerLock(input, async () => {
+		const ledger = await loadA2ATaskLedger(input);
+		const now = (input.now ?? new Date()).toISOString();
+		const taskId = trimString(input.task.id) ?? fail("A2A task id is required");
+		const existingIndex = ledger.tasks.findIndex(
+			(entry) => entry.peer === input.peer && entry.taskId === taskId,
+		);
+		const previous =
+			existingIndex >= 0 ? ledger.tasks[existingIndex] : undefined;
+		const metadata = cleanMetadata({
+			...(previous?.metadata ?? {}),
+			...(input.metadata ?? {}),
+		});
+		const userText = input.text.trim();
+		const taskResponse = extractA2ATaskResponse(input.task);
+		const responseText = taskResponse?.text ?? previous?.responseText;
+		const entry: A2ATaskLedgerEntry = {
+			...(previous ?? {}),
+			id: previous?.id ?? `maestro-a2a-task-${randomUUID()}`,
+			kind: previous?.kind ?? "message",
+			peer: input.peer,
+			...((input.peerDisplayName ?? previous?.peerDisplayName)
+				? {
+						peerDisplayName: input.peerDisplayName ?? previous?.peerDisplayName,
+					}
+				: {}),
+			taskId,
+			...(trimString(input.task.contextId ?? previous?.contextId)
+				? { contextId: trimString(input.task.contextId ?? previous?.contextId) }
+				: {}),
+			messageId: input.messageId,
+			text: previous?.text ?? userText,
+			...(previous?.role ? { role: previous.role } : {}),
+			...(previous?.cwd ? { cwd: previous.cwd } : {}),
+			state: input.task.status.state,
+			...(responseText ? { responseText } : {}),
+			...(metadata ? { metadata } : {}),
+			transcript: [
+				...(previous?.transcript ?? []),
+				{
+					at: now,
+					role: "user",
+					text: userText,
+					messageId: input.messageId,
+				},
+			],
+			createdAt: previous?.createdAt ?? now,
+			updatedAt: now,
+			...(previous?.completedAt ? { completedAt: previous.completedAt } : {}),
+		};
+		if (taskResponse && shouldAppendAgentTranscript(entry, taskResponse)) {
+			entry.transcript = [
+				...entry.transcript,
+				{
+					at: now,
+					role: "agent",
+					text: taskResponse.text,
+					state: input.task.status.state,
+					messageId: taskResponse.messageId,
+				},
+			];
+		}
+		if (isFinalA2AState(input.task.status.state)) {
+			entry.completedAt = previous?.completedAt ?? now;
 		} else {
 			delete entry.completedAt;
 		}
@@ -362,8 +456,8 @@ export async function updateA2ATaskInLedger(
 		}
 		const now = (input.now ?? new Date()).toISOString();
 		const previous = ledger.tasks[index]!;
-		const responseText =
-			extractA2ATaskText(input.task) ?? previous.responseText;
+		const taskResponse = extractA2ATaskResponse(input.task);
+		const responseText = taskResponse?.text ?? previous.responseText;
 		const entry: A2ATaskLedgerEntry = {
 			...previous,
 			state: input.task.status.state,
@@ -372,24 +466,22 @@ export async function updateA2ATaskInLedger(
 				: {}),
 			...(responseText ? { responseText } : {}),
 			updatedAt: now,
-			...(isTerminalA2AState(input.task.status.state)
+			...(isFinalA2AState(input.task.status.state)
 				? { completedAt: previous.completedAt ?? now }
 				: {}),
 		};
-		if (
-			responseText &&
-			!entry.transcript.some(
-				(item) => item.role === "agent" && item.text === responseText,
-			)
-		) {
+		if (!isFinalA2AState(input.task.status.state)) {
+			delete entry.completedAt;
+		}
+		if (taskResponse && shouldAppendAgentTranscript(entry, taskResponse)) {
 			entry.transcript = [
 				...entry.transcript,
 				{
 					at: now,
 					role: "agent",
-					text: responseText,
+					text: taskResponse.text,
 					state: input.task.status.state,
-					messageId: input.task.status.message?.messageId,
+					messageId: taskResponse.messageId,
 				},
 			];
 		}
@@ -417,21 +509,60 @@ export function latestA2ATaskForPeer(
 }
 
 export function extractA2ATaskText(task: A2ATask): string | undefined {
-	return (
-		firstMessageText(task.status.message) ??
-		task.artifacts
-			?.flatMap((artifact) => artifact.parts)
-			.map((part) => trimString(part.text))
-			.find((text): text is string => Boolean(text)) ??
-		task.history
-			?.filter(isAgentMessage)
-			.map(firstMessageText)
-			.find((text): text is string => Boolean(text))
-	);
+	return extractA2ATaskResponse(task)?.text;
+}
+
+function extractA2ATaskResponse(
+	task: A2ATask,
+): A2ATaskResponseText | undefined {
+	const statusText = firstMessageText(task.status.message);
+	if (statusText) {
+		return {
+			text: statusText,
+			messageId: task.status.message?.messageId,
+		};
+	}
+	const artifactText = task.artifacts
+		?.flatMap((artifact) => artifact.parts)
+		.map((part) => trimString(part.text))
+		.find((text): text is string => Boolean(text));
+	if (artifactText) {
+		return { text: artifactText };
+	}
+	const latestAgentMessage = latestAgentMessageInHistory(task.history);
+	const historyText = firstMessageText(latestAgentMessage);
+	if (historyText) {
+		return {
+			text: historyText,
+			messageId: latestAgentMessage?.messageId,
+		};
+	}
+	return undefined;
+}
+
+function shouldAppendAgentTranscript(
+	entry: A2ATaskLedgerEntry,
+	response: A2ATaskResponseText,
+): boolean {
+	if (response.messageId) {
+		return !entry.transcript.some(
+			(item) => item.role === "agent" && item.messageId === response.messageId,
+		);
+	}
+	const last = entry.transcript.at(-1);
+	return !last || last.role !== "agent" || last.text !== response.text;
 }
 
 export function isTerminalA2AState(state: string): boolean {
-	return TERMINAL_STATE_PATTERN.test(
+	return isFinalA2AState(state) || isActionRequiredA2AState(state);
+}
+
+export function isFinalA2AState(state: string): boolean {
+	return FINAL_STATE_PATTERN.test(state.toUpperCase().replace(/[\s-]+/gu, "_"));
+}
+
+export function isActionRequiredA2AState(state: string): boolean {
+	return ACTION_REQUIRED_STATE_PATTERN.test(
 		state.toUpperCase().replace(/[\s-]+/gu, "_"),
 	);
 }
@@ -443,6 +574,23 @@ function firstMessageText(message: A2AMessage | undefined): string | undefined {
 function isAgentMessage(message: A2AMessage): boolean {
 	const role = message.role.toUpperCase();
 	return role === "ROLE_AGENT" || role === "AGENT";
+}
+
+function latestAgentMessageInHistory(
+	history: A2AMessage[] | undefined,
+): A2AMessage | undefined {
+	if (!history) {
+		return undefined;
+	}
+	for (const message of [...history].reverse()) {
+		if (!isAgentMessage(message)) {
+			continue;
+		}
+		if (firstMessageText(message)) {
+			return message;
+		}
+	}
+	return undefined;
 }
 
 function normalizeLedgerEntry(

--- a/test/cli/commands/a2a-fleet-delegation.test.ts
+++ b/test/cli/commands/a2a-fleet-delegation.test.ts
@@ -304,6 +304,125 @@ describe("A2A fleet delegation CLI", () => {
 		expect(plainLogs(errors)).not.toContain("super-secret-token");
 	});
 
+	it("replies to an existing task using the durable context", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-reply-"));
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks.json");
+		await writeRegistry(registryPath, baseUrl);
+		await writeFile(
+			tasksPath,
+			JSON.stringify({
+				tasks: [
+					{
+						id: "maestro-a2a-ledger-1",
+						kind: "delegation",
+						peer: "mac-mini",
+						taskId: "task-mac-mini-1",
+						contextId: "maestro-a2a-context-test",
+						messageId: "message-1",
+						text: "review the branch",
+						state: "TASK_STATE_INPUT_REQUIRED",
+						transcript: [
+							{
+								at: "2026-05-16T00:00:00.000Z",
+								role: "user",
+								text: "review the branch",
+								messageId: "message-1",
+							},
+						],
+						createdAt: "2026-05-16T00:00:00.000Z",
+						updatedAt: "2026-05-16T00:00:00.000Z",
+					},
+				],
+			}),
+		);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+
+		await handleA2ACommand([
+			"reply",
+			"mac-mini",
+			"task-mac-mini-1",
+			"use",
+			"the",
+			"short",
+			"smoke",
+			"--wait",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--max-wait-ms",
+			"1000",
+			"--interval-ms",
+			"10",
+			"--timeout-ms",
+			"1000",
+		]);
+
+		expect(requests).toHaveLength(1);
+		expect(recordValue(requests[0]!.body, "message.taskId")).toBe(
+			"task-mac-mini-1",
+		);
+		expect(recordValue(requests[0]!.body, "message.contextId")).toBe(
+			"maestro-a2a-context-test",
+		);
+		expect(recordValue(requests[0]!.body, "message.metadata")).toMatchObject({
+			requestKind: "maestro-peer-task-reply",
+			referencedTaskId: "task-mac-mini-1",
+			relayPeer: "mac-mini",
+		});
+		expect(plainLogs(logs)).toContain(
+			"Replied to mac-mini task task-mac-mini-1",
+		);
+		expect(plainLogs(logs)).toContain("mac mini finished the smoke plan");
+
+		const ledgerRaw = await readFile(tasksPath, "utf8");
+		expect(ledgerRaw).toContain("review the branch");
+		expect(ledgerRaw).toContain("use the short smoke");
+		expect(ledgerRaw).toContain("mac mini finished the smoke plan");
+		expect(ledgerRaw).not.toContain("super-secret-token");
+		expect(errors.join("\n")).toBe("");
+	});
+
+	it("replies by task id when the local ledger context cannot be loaded", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-reply-no-ledger-"));
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks-as-dir");
+		await writeRegistry(registryPath, baseUrl);
+		await mkdir(tasksPath);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+
+		await expect(
+			handleA2ACommand([
+				"reply",
+				"mac-mini",
+				"task-mac-mini-1",
+				"use",
+				"the",
+				"short",
+				"smoke",
+				"--registry",
+				registryPath,
+				"--tasks",
+				tasksPath,
+				"--timeout-ms",
+				"1000",
+			]),
+		).resolves.toBeUndefined();
+
+		expect(requests).toHaveLength(1);
+		expect(recordValue(requests[0]!.body, "message.taskId")).toBe(
+			"task-mac-mini-1",
+		);
+		expect(recordValue(requests[0]!.body, "message.contextId")).toBeUndefined();
+		expect(plainLogs(logs)).toContain(
+			"Replied to mac-mini task task-mac-mini-1",
+		);
+		expect(plainLogs(errors)).toContain("could not load task reply context");
+		expect(plainLogs(errors)).toContain("A2A task ledger warning");
+		expect(plainLogs(errors)).not.toContain("super-secret-token");
+	});
+
 	it("reports wait completion when local ledger update fails", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-wait-ledger-fail-"));
 		const registryPath = join(dir, "peers.json");

--- a/test/cli/commands/a2a.test.ts
+++ b/test/cli/commands/a2a.test.ts
@@ -60,6 +60,29 @@ describe("A2A CLI command helpers", () => {
 		expect(parsed.flags.get("--timeout-ms")).toBe("1000");
 	});
 
+	it("parses task reply flags without swallowing reply text", () => {
+		const parsed = parseA2AArgs([
+			"reply",
+			"mac-mini",
+			"task-1",
+			"use",
+			"--json",
+			"--wait",
+			"--tasks",
+			"/tmp/tasks.json",
+		]);
+
+		expect(parsed.positionals).toEqual([
+			"reply",
+			"mac-mini",
+			"task-1",
+			"use",
+			"--json",
+		]);
+		expect(parsed.flags.get("--wait")).toBe(true);
+		expect(parsed.flags.get("--tasks")).toBe("/tmp/tasks.json");
+	});
+
 	it("scopes json and refresh flags to fleet task views", () => {
 		const delegate = parseA2AArgs([
 			"delegate",

--- a/test/platform/a2a-task-ledger.test.ts
+++ b/test/platform/a2a-task-ledger.test.ts
@@ -11,7 +11,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	getA2ATaskLedgerPath,
+	isFinalA2AState,
+	isTerminalA2AState,
 	loadA2ATaskLedger,
+	recordA2ATaskReply,
 	recordA2ATaskStart,
 	updateA2ATaskInLedger,
 } from "../../src/platform/a2a-task-ledger.js";
@@ -110,6 +113,294 @@ describe("A2A task ledger", () => {
 			expect.objectContaining({
 				role: "user",
 				text: "run --json checks",
+			}),
+		]);
+	});
+
+	it("records task replies without marking action-required states completed", async () => {
+		const path = join(
+			await mkdtemp(join(tmpdir(), "maestro-a2a-ledger-reply-")),
+			"tasks.json",
+		);
+
+		await recordA2ATaskStart({
+			path,
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-2",
+				contextId: "context-dev-2",
+				status: { state: "TASK_STATE_INPUT_REQUIRED" },
+			},
+			text: "review the branch",
+			messageId: "message-1",
+			now: NOW,
+		});
+		await recordA2ATaskReply({
+			path,
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-2",
+				contextId: "context-dev-2",
+				status: { state: "TASK_STATE_WORKING" },
+				history: [
+					{
+						messageId: "agent-message-old",
+						role: "ROLE_AGENT",
+						parts: [{ text: "old agent result", mediaType: "text/plain" }],
+					},
+					{
+						messageId: "agent-message-new",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "latest agent continuation",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				],
+			},
+			text: "use the smaller smoke suite",
+			messageId: "message-2",
+			now: LATER,
+		});
+
+		const ledger = await loadA2ATaskLedger({ path });
+		expect(ledger.tasks[0]).toMatchObject({
+			peer: "dev-desktop",
+			taskId: "task-dev-2",
+			contextId: "context-dev-2",
+			state: "TASK_STATE_WORKING",
+			text: "review the branch",
+			responseText: "latest agent continuation",
+			transcript: [
+				{ role: "user", text: "review the branch" },
+				{ role: "user", text: "use the smaller smoke suite" },
+				{ role: "agent", text: "latest agent continuation" },
+			],
+		});
+		expect(ledger.tasks[0]?.completedAt).toBeUndefined();
+		expect(isTerminalA2AState("TASK_STATE_INPUT_REQUIRED")).toBe(true);
+		expect(isFinalA2AState("TASK_STATE_INPUT_REQUIRED")).toBe(false);
+	});
+
+	it("clears stale completedAt when re-recording a task in a non-final state", async () => {
+		const path = join(
+			await mkdtemp(join(tmpdir(), "maestro-a2a-ledger-restart-")),
+			"tasks.json",
+		);
+
+		await recordA2ATaskStart({
+			path,
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-3",
+				status: { state: "TASK_STATE_COMPLETED" },
+			},
+			text: "finish the smoke",
+			now: NOW,
+		});
+		await recordA2ATaskStart({
+			path,
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-3",
+				status: { state: "TASK_STATE_INPUT_REQUIRED" },
+			},
+			text: "restart with more input",
+			now: LATER,
+		});
+
+		const ledger = await loadA2ATaskLedger({ path });
+		expect(ledger.tasks[0]).toMatchObject({
+			peer: "dev-desktop",
+			taskId: "task-dev-3",
+			state: "TASK_STATE_INPUT_REQUIRED",
+			text: "restart with more input",
+		});
+		expect(ledger.tasks[0]?.completedAt).toBeUndefined();
+	});
+
+	it("records the latest agent history response for continued tasks", async () => {
+		const path = join(
+			await mkdtemp(join(tmpdir(), "maestro-a2a-ledger-history-reply-")),
+			"tasks.json",
+		);
+
+		await recordA2ATaskStart({
+			path,
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-4",
+				contextId: "context-dev-4",
+				status: { state: "TASK_STATE_INPUT_REQUIRED" },
+				history: [
+					{
+						messageId: "message-1",
+						role: "ROLE_USER",
+						parts: [{ text: "review the branch", mediaType: "text/plain" }],
+					},
+					{
+						messageId: "agent-message-1",
+						role: "ROLE_AGENT",
+						parts: [{ text: "which suite?", mediaType: "text/plain" }],
+					},
+				],
+			},
+			text: "review the branch",
+			messageId: "message-1",
+			now: NOW,
+		});
+		await recordA2ATaskReply({
+			path,
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-4",
+				contextId: "context-dev-4",
+				status: { state: "TASK_STATE_COMPLETED" },
+				history: [
+					{
+						messageId: "message-1",
+						role: "ROLE_USER",
+						parts: [{ text: "review the branch", mediaType: "text/plain" }],
+					},
+					{
+						messageId: "agent-message-1",
+						role: "ROLE_AGENT",
+						parts: [{ text: "which suite?", mediaType: "text/plain" }],
+					},
+					{
+						messageId: "message-2",
+						role: "ROLE_USER",
+						parts: [{ text: "short smoke", mediaType: "text/plain" }],
+					},
+					{
+						messageId: "agent-message-2",
+						role: "ROLE_AGENT",
+						parts: [{ text: "short smoke passed", mediaType: "text/plain" }],
+					},
+				],
+			},
+			text: "short smoke",
+			messageId: "message-2",
+			now: LATER,
+		});
+
+		const ledger = await loadA2ATaskLedger({ path });
+		expect(ledger.tasks[0]).toMatchObject({
+			responseText: "short smoke passed",
+			transcript: [
+				{ role: "user", text: "review the branch" },
+				{ role: "agent", text: "which suite?" },
+				{ role: "user", text: "short smoke" },
+				{ role: "agent", text: "short smoke passed" },
+			],
+		});
+	});
+
+	it("keeps repeated agent reply text when message ids differ", async () => {
+		const path = join(
+			await mkdtemp(join(tmpdir(), "maestro-a2a-ledger-repeat-reply-")),
+			"tasks.json",
+		);
+
+		await recordA2ATaskStart({
+			path,
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-repeat",
+				contextId: "context-dev-repeat",
+				status: { state: "TASK_STATE_INPUT_REQUIRED" },
+				history: [
+					{
+						messageId: "message-1",
+						role: "ROLE_USER",
+						parts: [{ text: "start", mediaType: "text/plain" }],
+					},
+					{
+						messageId: "agent-message-1",
+						role: "ROLE_AGENT",
+						parts: [{ text: "Done", mediaType: "text/plain" }],
+					},
+				],
+			},
+			text: "start",
+			messageId: "message-1",
+			now: NOW,
+		});
+		await recordA2ATaskReply({
+			path,
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-repeat",
+				contextId: "context-dev-repeat",
+				status: { state: "TASK_STATE_INPUT_REQUIRED" },
+				history: [
+					{
+						messageId: "message-1",
+						role: "ROLE_USER",
+						parts: [{ text: "start", mediaType: "text/plain" }],
+					},
+					{
+						messageId: "agent-message-1",
+						role: "ROLE_AGENT",
+						parts: [{ text: "Done", mediaType: "text/plain" }],
+					},
+					{
+						messageId: "message-2",
+						role: "ROLE_USER",
+						parts: [{ text: "continue", mediaType: "text/plain" }],
+					},
+					{
+						messageId: "agent-message-2",
+						role: "ROLE_AGENT",
+						parts: [{ text: "Done", mediaType: "text/plain" }],
+					},
+				],
+			},
+			text: "continue",
+			messageId: "message-2",
+			now: LATER,
+		});
+		await updateA2ATaskInLedger({
+			path,
+			peer: "dev-desktop",
+			task: {
+				id: "task-dev-repeat",
+				contextId: "context-dev-repeat",
+				status: { state: "TASK_STATE_INPUT_REQUIRED" },
+				history: [
+					{
+						messageId: "agent-message-2",
+						role: "ROLE_AGENT",
+						parts: [{ text: "Done", mediaType: "text/plain" }],
+					},
+				],
+			},
+			now: new Date("2026-05-16T00:02:00.000Z"),
+		});
+
+		const ledger = await loadA2ATaskLedger({ path });
+		expect(ledger.tasks[0]?.transcript).toEqual([
+			expect.objectContaining({
+				role: "user",
+				text: "start",
+				messageId: "message-1",
+			}),
+			expect.objectContaining({
+				role: "agent",
+				text: "Done",
+				messageId: "agent-message-1",
+			}),
+			expect.objectContaining({
+				role: "user",
+				text: "continue",
+				messageId: "message-2",
+			}),
+			expect.objectContaining({
+				role: "agent",
+				text: "Done",
+				messageId: "agent-message-2",
 			}),
 		]);
 	});


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `48cd79ffef40dea72c71f6cc59ba01210d2ed346`
- last generated public sync base: `7d2a4205e30bd877c42b4191c600849762cd39e7`
- previewed public-tree drift: `11` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (48cd79ffef40)`
- public projection: `https://github.com/evalops/maestro@main (59d8ba1f37ef)`
- files to copy or update: `11`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update packages/tui-rs/src/app.rs
- copy/update packages/tui-rs/src/commands/registry.rs
- copy/update packages/tui-rs/src/commands/types.rs
- copy/update src/cli-tui/commands/a2a-handlers.ts
- copy/update src/cli-tui/commands/command-catalog.ts
- copy/update src/cli/commands/a2a.ts
- copy/update src/platform/a2a-task-ledger.ts
- copy/update test/cli/commands/a2a-fleet-delegation.test.ts
- copy/update test/cli/commands/a2a.test.ts
- copy/update test/platform/a2a-task-ledger.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update packages/tui-rs/src/app.rs
- copy/update packages/tui-rs/src/commands/registry.rs
- copy/update packages/tui-rs/src/commands/types.rs
- copy/update src/cli-tui/commands/a2a-handlers.ts
- copy/update src/cli-tui/commands/command-catalog.ts
- copy/update src/cli/commands/a2a.ts
- copy/update src/platform/a2a-task-ledger.ts
- copy/update test/cli/commands/a2a-fleet-delegation.test.ts
- copy/update test/cli/commands/a2a.test.ts
- copy/update test/platform/a2a-task-ledger.test.ts

## Public-only commits since last generated sync

- 59d8ba1f feat: add first-party operational skill packages (#425)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@48cd79ffef40dea72c71f6cc59ba01210d2ed346`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.