### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/a2a-fleet-delegation.md
+++ b/docs/protocols/a2a-fleet-delegation.md
@@ -9,10 +9,11 @@ back.
 
 ```sh
 maestro a2a fleet [--json] [--registry <path>] [--tasks <path>]
-maestro a2a delegate <peer> <text> [--role <role>] [--cwd <path>] [--wait]
-maestro a2a reply <peer> <task-id> <text> [--wait]
-maestro a2a tasks [peer] [--json] [--refresh]
-maestro a2a wait <peer> <task-id>
+maestro a2a delegate <peer> <text> [--role <role>] [--cwd <path>] [--wait] [--work-graph]
+maestro a2a reply <peer> <task-id> <text> [--wait] [--work-graph]
+maestro a2a tasks [peer] [--json] [--refresh] [--work-graph]
+maestro a2a coordinate [peer] [--json] [--refresh] [--reply <text>] [--wait] [--work-graph]
+maestro a2a wait <peer> <task-id> [--work-graph]
 ```
 
 `fleet` reads the native peer registry, fetches each peer Agent Card when
@@ -35,6 +36,23 @@ to the same local transcript and can wait for the peer's follow-up result.
 `tasks` reads the durable ledger and can refresh known task IDs from their
 registered peers. This gives the operator a single place to see outstanding work
 across the Mac mini, dev desktop, and local Maestro instances.
+
+When a peer exposes Platform A2A `metadata.workGraph`, Maestro stores a
+sanitized work graph with counts and IDs for active items, blocked items, child
+runs, tool executions, waits, the correlation path, and `codexSubagents`
+edges. Human task views show the compact summary by default; `--work-graph`
+also shows Codex child-run/tool/thread IDs and the correlation breadcrumb. JSON
+views include the normalized `workGraph` object for automation.
+
+`coordinate` is the operator loop for actionable fleet work. It refreshes
+non-final ledger tasks from their registered peers, filters the tasks that need
+operator action such as `INPUT_REQUIRED` or `AUTH_REQUIRED`, and renders the
+peer, task id, state, prompt, and next command. With `--reply <text>`, it replies
+to the selected actionable task using the task id and durable `contextId`. Add
+`--wait` when you want the command to refresh the ledger again and show whether
+the task moved forward or still needs operator input. If more than one actionable
+task matches the requested scope, use `maestro a2a reply <peer> <task-id> <text>`
+to choose the task explicitly.
 
 ## Native Control-Plane Surface
 
@@ -134,6 +152,7 @@ Before this feature, the following tests fail:
 npm run test:fast -- test/cli/commands/a2a-fleet-delegation.test.ts test/cli-tui/commands/a2a-handlers.test.ts
 npm run test:fast -- test/cli/commands/a2a.test.ts test/platform/a2a-task-ledger.test.ts
 cargo test -p maestro-tui commands::registry::tests::a2a_command_parses_peer_actions
+npm run smoke:a2a-input-required
 ```
 
 After implementation, they must pass and prove:
@@ -143,9 +162,17 @@ After implementation, they must pass and prove:
 - `maestro a2a reply <peer> <task-id> <text> --wait` sends a follow-up message
   with the original task id and context id, appends to the same transcript, and
   does not mark `INPUT_REQUIRED` or `AUTH_REQUIRED` tasks as completed.
+- `npm run smoke:a2a-input-required` launches `scripts/codex-a2a-bridge.py` on a
+  random localhost port with `CODEX_A2A_FIXTURE_MODE=input-required-once`,
+  writes isolated `peers.json` and `tasks.json`, delegates with `--wait`, replies
+  with `--wait`, and proves the same `taskId`/`contextId` moves
+  `INPUT_REQUIRED` to `COMPLETED` with a four-turn transcript:
+  user request, agent question, user reply, agent final.
 - `maestro a2a fleet --json` shows peer health, Agent Card capabilities, and the
-  peer's most recent ledger task without leaking token values.
+  peer's most recent ledger task plus any normalized Platform work graph without
+  leaking token values.
 - `maestro a2a tasks --json` reads the ledger and can be used as a fleet task
-  view.
+  view with the normalized `workGraph` object when a peer exposes it.
 - TypeScript and Rust TUIs both recognize `/a2a fleet`, `/a2a tasks`,
-  `/a2a delegate`, and `/a2a reply`.
+  `/a2a tasks --work-graph`, `/a2a delegate`, `/a2a reply`, and
+  `/a2a coordinate --work-graph`.

--- a/docs/protocols/codex-operating-layer.json
+++ b/docs/protocols/codex-operating-layer.json
@@ -169,7 +169,10 @@
 				"collabAgentToolCall",
 				"codex.subagent.",
 				"spawnAgent",
-				"wait"
+				"sendInput",
+				"resumeAgent",
+				"wait",
+				"closeAgent"
 			]
 		},
 		{
@@ -231,6 +234,9 @@
 				"codex_work_graph",
 				"recordCodexSubagentWorkItem",
 				"updateCodexSubagentWorkItem",
+				"sendInput",
+				"resumeAgent",
+				"closeAgent",
 				"PlatformAgentWorkItemKindValue.ChildRun",
 				"PlatformAgentWorkItemKindValue.Wait"
 			]
@@ -268,6 +274,7 @@
 				"records Codex spawn handoffs as Platform agent-registry delegations",
 				"links follow-up Codex subagent tools to the spawned child work item",
 				"codex.subagent.spawnAgent",
+				"codex.subagent.sendInput",
 				"ownerChildRunId",
 				"parentWorkItemId",
 				"codex_work_graph",
@@ -283,7 +290,48 @@
 				"evalops.remote-runner.work-continuity.v1",
 				"collectHostedRunnerWorkContinuity",
 				"codex_subagent_child_run_ids",
-				"codex_subagent_thread_ids"
+				"codex_subagent_thread_ids",
+				"codex_subagent_edges",
+				"collectCodexSubagentEdgesFromSource",
+				"codexSubagentOperation"
+			]
+		},
+		{
+			"area": "remote-runner-continuity",
+			"evidenceType": "source",
+			"path": "src/cli/headless-protocol.ts",
+			"anchors": [
+				"HeadlessCodexSubagentContinuityEdge",
+				"buildCodexSubagentContinuityEdges",
+				"codexSubagentOperation",
+				"spawn_agent",
+				"send_input",
+				"resume_agent",
+				"wait_agent",
+				"close_agent"
+			]
+		},
+		{
+			"area": "remote-runner-continuity",
+			"evidenceType": "source",
+			"path": "packages/tui-rs/src/hosted_runner.rs",
+			"anchors": [
+				"evalops.remote-runner.work-continuity.v1",
+				"CodexSubagentContinuityEdge",
+				"codex_subagent_edges",
+				"close_agent"
+			]
+		},
+		{
+			"area": "remote-runner-continuity",
+			"evidenceType": "source",
+			"path": "packages/tui-rs/src/headless/messages.rs",
+			"anchors": [
+				"CodexSubagentContinuityEdge",
+				"codex_subagent_edges",
+				"send_input",
+				"resume_agent",
+				"close_agent"
 			]
 		},
 		{
@@ -292,8 +340,11 @@
 			"path": "test/server/hosted-runner-drain.test.ts",
 			"anchors": [
 				"records Codex subagent continuity without copying prompt payloads into manifest metadata",
+				"records Codex subagent edge lifecycle from restored runtime state",
 				"HOSTED_RUNNER_WORK_CONTINUITY_VERSION",
-				"codex_subagent_child_run_ids"
+				"codex_subagent_child_run_ids",
+				"codex_subagent_edges",
+				"close_agent"
 			]
 		},
 		{

--- a/docs/protocols/codex-operating-layer.md
+++ b/docs/protocols/codex-operating-layer.md
@@ -29,8 +29,8 @@ npm run check:codex-operating-layer
   parent/child work can be inspected, resumed, scored, and restored remotely.
   Spawned children also become Platform agent-registry delegations so ownership,
   routing capability, resolution, and evidence refs survive remote execution.
-  TS and Rust both normalize child run ids, and follow-up subagent tools link
-  back to the spawned child work item.
+  TS and Rust both normalize child run ids and persist subagent edge lifecycle
+  state, so spawn/send/resume/wait/close edges survive drain and restore.
 - Rust can expose the same Codex models through the control plane, bridge
   Codex headless runs, stream SSE/WebSocket events, handle approval requests,
   and preserve sandbox policy.
@@ -52,6 +52,7 @@ npm run check:codex-operating-layer
 | approvals and sandbox policy | `approvals-sandbox-policy` | `src/agent/transport.ts`, `test/agent/provider-transport-provider-tools.test.ts`, `packages/control-plane-rs/src/main.rs`, `docs/protocols/pending-requests.md` |
 | subagents | `subagents` | `src/agent/providers/codex-app-server.ts`, `test/agent/provider-transport-provider-tools.test.ts` |
 | multi-agent work graph | `multi-agent-workgraph` | `src/platform/agent-runtime-client.ts`, `src/platform/agent-registry-client.ts`, `src/agent/providers/codex-app-server.ts`, `packages/control-plane-rs/src/main.rs`, `src/server/hosted-agent-runtime-progress.ts`, `test/server/hosted-agent-runtime-progress.test.ts` |
+| remote runner continuity | `remote-runner-continuity` | `src/server/handlers/hosted-runner-drain.ts`, `packages/tui-rs/src/hosted_runner.rs`, `packages/tui-rs/src/headless/messages.rs`, `test/server/hosted-runner-drain.test.ts` |
 | realtime streaming | `realtime-streaming` | `src/server/handlers/runtime-app-server-ws.ts`, `test/server/runtime-app-server-ws.test.ts` |
 | TypeScript runtime | `typescript-runtime` | `src/agent/providers/codex-app-server.ts`, `test/agent/codex-app-server.test.ts` |
 | Rust runtime | `rust-control-plane` | `packages/control-plane-rs/src/model_catalog.rs`, `packages/control-plane-rs/src/main.rs` |
@@ -71,8 +72,8 @@ npm run check:codex-parity
 Use the runtime gate before merging changes that affect Codex execution:
 
 ```bash
-npm test -- test/agent/codex-app-server.test.ts test/agent/provider-transport-provider-tools.test.ts test/codex/app-server-client.test.ts test/codex/compatibility.test.ts test/cli/codex-command.test.ts test/scripts/codex-operating-layer-conformance.test.ts test/scripts/codex-parity-conformance.test.ts test/server/runtime-app-server-ws.test.ts test/headless/runtime-conformance.test.ts
-cargo test codex_ --no-default-features
+npm test -- test/agent/codex-app-server.test.ts test/agent/provider-transport-provider-tools.test.ts test/codex/app-server-client.test.ts test/codex/compatibility.test.ts test/cli/codex-command.test.ts test/scripts/codex-operating-layer-conformance.test.ts test/scripts/codex-parity-conformance.test.ts test/server/runtime-app-server-ws.test.ts test/server/hosted-runner-drain.test.ts test/headless/runtime-conformance.test.ts
+npm run tui-rs:test -- hosted_runner
 npm run smoke:codex-app-server-live
 ```
 
@@ -83,7 +84,9 @@ temporary workspace, and enforces bounded dynamic tool calls with
 `MAESTRO_CODEX_LIVE_SMOKE_MAX_TOTAL_TOOL_CALLS` and
 `MAESTRO_CODEX_LIVE_SMOKE_MAX_IDENTICAL_TOOL_CALLS`. It also runs real Codex
 subagent spawn/wait inference and requires `codexWorkGraph` evidence on both
-`codex.subagent.spawnAgent` and `codex.subagent.wait`.
+`codex.subagent.spawnAgent` and `codex.subagent.wait`; the remote-runner drain
+tests then require lifecycle-edge continuity for spawn/send/resume/wait/close
+without copying child prompts into manifest metadata.
 
 ## Completion Bar
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "smoke:codex-app-server-live": "node scripts/smoke-codex-app-server-live.mjs",
     "smoke:event-bus": "tsx scripts/smoke-maestro-event-bus.ts",
     "smoke:a2a-local": "tsx scripts/smoke-maestro-a2a-local.ts",
+    "smoke:a2a-input-required": "tsx scripts/smoke-maestro-a2a-input-required.ts",
     "smoke:a2a-tmux": "bash scripts/smoke-maestro-a2a-tmux.sh",
     "a2a": "tsx src/cli.ts a2a",
     "a2a:codex-bridge": "python3 scripts/codex-a2a-bridge.py",

--- a/packages/contracts/schema/headless/payload-schemas.json
+++ b/packages/contracts/schema/headless/payload-schemas.json
@@ -1628,6 +1628,34 @@
 				}
 			}
 		},
+		"HeadlessCodexSubagentContinuityEdgeSchema": {
+			"kind": "object",
+			"additionalProperties": false,
+			"properties": {
+				"spawn_tool_call_id": {
+					"kind": "string",
+					"optional": true
+				},
+				"wait_tool_call_id": {
+					"kind": "string",
+					"optional": true
+				},
+				"child_run_id": {
+					"kind": "string",
+					"optional": true
+				},
+				"thread_id": {
+					"kind": "string",
+					"optional": true
+				},
+				"operation": {
+					"kind": "string"
+				},
+				"status": {
+					"kind": "string"
+				}
+			}
+		},
 		"HeadlessStreamingResponseStateSchema": {
 			"kind": "object",
 			"additionalProperties": false,
@@ -1915,6 +1943,14 @@
 					"items": {
 						"kind": "ref",
 						"name": "HeadlessPendingToolStateSchema"
+					}
+				},
+				"codex_subagent_edges": {
+					"kind": "array",
+					"optional": true,
+					"items": {
+						"kind": "ref",
+						"name": "HeadlessCodexSubagentContinuityEdgeSchema"
 					}
 				},
 				"last_error": {

--- a/packages/contracts/src/headless-protocol-payloads.manifest.json
+++ b/packages/contracts/src/headless-protocol-payloads.manifest.json
@@ -957,6 +957,18 @@
 				"output": { "kind": "string" }
 			}
 		},
+		"HeadlessCodexSubagentContinuityEdgeSchema": {
+			"kind": "object",
+			"additionalProperties": false,
+			"properties": {
+				"spawn_tool_call_id": { "kind": "string", "optional": true },
+				"wait_tool_call_id": { "kind": "string", "optional": true },
+				"child_run_id": { "kind": "string", "optional": true },
+				"thread_id": { "kind": "string", "optional": true },
+				"operation": { "kind": "string" },
+				"status": { "kind": "string" }
+			}
+		},
 		"HeadlessStreamingResponseStateSchema": {
 			"kind": "object",
 			"additionalProperties": false,
@@ -1142,6 +1154,14 @@
 				"tracked_tools": {
 					"kind": "array",
 					"items": { "kind": "ref", "name": "HeadlessPendingToolStateSchema" }
+				},
+				"codex_subagent_edges": {
+					"kind": "array",
+					"optional": true,
+					"items": {
+						"kind": "ref",
+						"name": "HeadlessCodexSubagentContinuityEdgeSchema"
+					}
 				},
 				"last_error": { "kind": "string", "optional": true },
 				"last_error_type": {

--- a/packages/contracts/src/headless-protocol-schemas.generated.ts
+++ b/packages/contracts/src/headless-protocol-schemas.generated.ts
@@ -816,6 +816,18 @@ export const HeadlessActiveToolStateSchema = Type.Object(
 	{ additionalProperties: false },
 );
 
+export const HeadlessCodexSubagentContinuityEdgeSchema = Type.Object(
+	{
+		spawn_tool_call_id: Type.Optional(Type.String()),
+		wait_tool_call_id: Type.Optional(Type.String()),
+		child_run_id: Type.Optional(Type.String()),
+		thread_id: Type.Optional(Type.String()),
+		operation: Type.String(),
+		status: Type.String(),
+	},
+	{ additionalProperties: false },
+);
+
 export const HeadlessStreamingResponseStateSchema = Type.Object(
 	{
 		response_id: Type.String(),
@@ -894,6 +906,9 @@ export const HeadlessRuntimeStateSchema = Type.Object(
 		),
 		active_file_watches: Type.Array(HeadlessActiveFileWatchStateSchema),
 		tracked_tools: Type.Array(HeadlessPendingToolStateSchema),
+		codex_subagent_edges: Type.Optional(
+			Type.Array(HeadlessCodexSubagentContinuityEdgeSchema),
+		),
 		last_error: Type.Optional(Type.String()),
 		last_error_type: Type.Optional(stringLiteralUnion(headlessErrorTypes)),
 		last_status: Type.Optional(Type.String()),

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -11503,20 +11503,6 @@ setTimeout(() => {
             &config
         )
         .is_err());
-        assert!(validate_csrf(
-            &csrf_head_for_path(
-                "POST",
-                "/tasks/maestro-task-1:subscribe",
-                Some("csrf-token")
-            ),
-            &config,
-        )
-        .is_ok());
-        assert!(validate_csrf(
-            &csrf_head_for_path("POST", "/tasks/maestro-task-1:subscribe", None),
-            &config
-        )
-        .is_err());
         assert!(validate_csrf(&csrf_head("GET", None), &config).is_ok());
     }
 

--- a/packages/tui-rs/src/app.rs
+++ b/packages/tui-rs/src/app.rs
@@ -3373,7 +3373,8 @@ Add the required fields and retry.",
                         "",
                         "/a2a fleet",
                         "/a2a peers",
-                        "/a2a tasks [peer]",
+                        "/a2a tasks [peer] [--work-graph]",
+                        "/a2a coordinate [peer] [--reply <text>] [--work-graph]",
                         "/a2a accept <pairing-code>",
                         "/a2a delegate <peer> <text>",
                         "/a2a reply <peer> <task-id> <text>",
@@ -3396,10 +3397,47 @@ Add the required fields and retry.",
                         .to_string(),
                 );
             }
-            A2aAction::Tasks { peer } => {
+            A2aAction::Tasks {
+                peer,
+                include_work_graph,
+            } => {
                 let scope = peer.as_deref().unwrap_or("all peers");
+                let graph_hint = if include_work_graph {
+                    " with Platform work graph and Codex subagent summaries"
+                } else {
+                    ""
+                };
+                let graph_flag = if include_work_graph {
+                    " --work-graph"
+                } else {
+                    ""
+                };
                 self.state.add_system_message(format!(
-                    "A2A task ledger requested for {scope}. Run `maestro a2a tasks` for the current durable ledger until the Rust task reader is wired into this view."
+                    "A2A task ledger requested for {scope}{graph_hint}. Run `maestro a2a tasks{graph_flag}` for the current durable ledger until the Rust task reader is wired into this view."
+                ));
+            }
+            A2aAction::Coordinate {
+                peer,
+                reply,
+                include_work_graph,
+            } => {
+                let scope = peer.as_deref().unwrap_or("all peers");
+                let reply_hint = reply
+                    .as_ref()
+                    .map(|value| format!(" with a {} character reply", value.len()))
+                    .unwrap_or_default();
+                let graph_hint = if include_work_graph {
+                    " and Platform work graph context"
+                } else {
+                    ""
+                };
+                let graph_flag = if include_work_graph {
+                    " --work-graph"
+                } else {
+                    ""
+                };
+                self.state.add_system_message(format!(
+                    "A2A coordination requested for {scope}{reply_hint}{graph_hint}. Run `maestro a2a coordinate [peer] --reply <text> --wait{graph_flag}` while the Rust coordination controller is connected to the shared A2A client."
                 ));
             }
             A2aAction::Accept { code } => {

--- a/packages/tui-rs/src/commands/registry.rs
+++ b/packages/tui-rs/src/commands/registry.rs
@@ -514,8 +514,42 @@ fn parse_a2a_action(raw: &str) -> Result<A2aAction, CommandError> {
         "fleet" => Ok(A2aAction::Fleet),
         "peers" | "list" => Ok(A2aAction::Peers),
         "tasks" => Ok(A2aAction::Tasks {
-            peer: tokens.get(1).cloned(),
+            peer: first_a2a_positional(&tokens, 1),
+            include_work_graph: has_a2a_flag(&tokens, "--work-graph"),
         }),
+        "coordinate" => {
+            let reply_index = tokens.iter().position(|value| value == "--reply");
+            let peer = first_a2a_positional(
+                reply_index
+                    .map(|index| &tokens[..index])
+                    .unwrap_or_else(|| tokens.as_slice()),
+                1,
+            );
+            let include_work_graph = has_a2a_flag(&tokens, "--work-graph");
+            let reply = reply_index.map(|index| {
+                tokens
+                    .get(index + 1..)
+                    .unwrap_or(&[])
+                    .iter()
+                    .take_while(|value| !value.starts_with("--"))
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            });
+            let reply = reply.and_then(|value| {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            });
+            Ok(A2aAction::Coordinate {
+                peer,
+                reply,
+                include_work_graph,
+            })
+        }
         "accept" => {
             let code = tokens
                 .get(1)
@@ -565,11 +599,44 @@ fn parse_a2a_action(raw: &str) -> Result<A2aAction, CommandError> {
                 text,
             })
         }
-        _ => Err(
-            CommandError::new(format!("Unknown A2A subcommand: {subcommand}"))
-                .with_hint("Usage: /a2a [fleet|peers|tasks|accept <code>|delegate <peer> <text>|reply <peer> <task-id> <text>|send <peer> <text>]"),
-        ),
+        _ => Err(CommandError::new(format!("Unknown A2A subcommand: {subcommand}")).with_hint(
+            "Usage: /a2a [fleet|peers|tasks [--work-graph]|coordinate [--work-graph]|accept <code>|delegate <peer> <text>|reply <peer> <task-id> <text>|send <peer> <text>]",
+        )),
     }
+}
+
+fn has_a2a_flag(tokens: &[String], flag: &str) -> bool {
+    tokens.iter().any(|value| value == flag)
+}
+
+fn first_a2a_positional(tokens: &[String], start: usize) -> Option<String> {
+    let mut index = start;
+    while index < tokens.len() {
+        let token = &tokens[index];
+        if token.starts_with("--") {
+            if a2a_value_flag(token) && !token.contains('=') {
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        return Some(token.clone());
+    }
+    None
+}
+
+fn a2a_value_flag(token: &str) -> bool {
+    matches!(
+        token,
+        "--registry"
+            | "--tasks"
+            | "--timeout-ms"
+            | "--interval-ms"
+            | "--max-wait-ms"
+            | "--role"
+            | "--cwd"
+    )
 }
 
 /// Build the default command registry with all built-in commands
@@ -796,7 +863,7 @@ pub fn build_command_registry() -> CommandRegistry {
                 )?)))
             }),
         )
-        .usage("/a2a [fleet|peers|tasks|accept <code>|delegate <peer> <text>|reply <peer> <task-id> <text>|send <peer> <text>]"),
+        .usage("/a2a [fleet|peers|tasks [--work-graph]|coordinate [--work-graph]|accept <code>|delegate <peer> <text>|reply <peer> <task-id> <text>|send <peer> <text>]"),
     );
 
     // Queue command
@@ -1996,6 +2063,12 @@ mod tests {
         assert!(registry.execute("/a2a fleet", "/tmp", None, None).is_ok());
         assert!(registry.execute("/a2a tasks", "/tmp", None, None).is_ok());
         assert!(registry
+            .execute("/a2a tasks --work-graph mac-mini", "/tmp", None, None)
+            .is_ok());
+        assert!(registry
+            .execute("/a2a coordinate", "/tmp", None, None)
+            .is_ok());
+        assert!(registry
             .execute(
                 "/a2a delegate mac-mini run workspace smoke",
                 "/tmp",
@@ -2010,6 +2083,20 @@ mod tests {
         {
             CommandOutput::Action(CommandAction::A2a(A2aAction::Peers)) => {}
             other => panic!("expected a2a peers action, got {other:?}"),
+        }
+
+        match registry
+            .execute("/a2a tasks --work-graph mac-mini", "/tmp", None, None)
+            .expect("a2a task work graph view should parse")
+        {
+            CommandOutput::Action(CommandAction::A2a(A2aAction::Tasks {
+                peer,
+                include_work_graph,
+            })) => {
+                assert_eq!(peer.as_deref(), Some("mac-mini"));
+                assert!(include_work_graph);
+            }
+            other => panic!("expected a2a tasks action, got {other:?}"),
         }
 
         match registry
@@ -2046,6 +2133,48 @@ mod tests {
                 assert_eq!(text, "use the short smoke");
             }
             other => panic!("expected a2a reply action, got {other:?}"),
+        }
+
+        match registry
+            .execute(
+                "/a2a coordinate mac-mini --work-graph --reply use the short smoke",
+                "/tmp",
+                None,
+                None,
+            )
+            .expect("a2a coordinate should parse")
+        {
+            CommandOutput::Action(CommandAction::A2a(A2aAction::Coordinate {
+                peer,
+                reply,
+                include_work_graph,
+            })) => {
+                assert_eq!(peer.as_deref(), Some("mac-mini"));
+                assert_eq!(reply.as_deref(), Some("use the short smoke"));
+                assert!(include_work_graph);
+            }
+            other => panic!("expected a2a coordinate action, got {other:?}"),
+        }
+
+        match registry
+            .execute(
+                "/a2a coordinate --work-graph mac-mini --reply use the short smoke",
+                "/tmp",
+                None,
+                None,
+            )
+            .expect("a2a coordinate should parse work-graph before peer")
+        {
+            CommandOutput::Action(CommandAction::A2a(A2aAction::Coordinate {
+                peer,
+                reply,
+                include_work_graph,
+            })) => {
+                assert_eq!(peer.as_deref(), Some("mac-mini"));
+                assert_eq!(reply.as_deref(), Some("use the short smoke"));
+                assert!(include_work_graph);
+            }
+            other => panic!("expected a2a coordinate action, got {other:?}"),
         }
 
         match registry

--- a/packages/tui-rs/src/commands/types.rs
+++ b/packages/tui-rs/src/commands/types.rs
@@ -362,7 +362,16 @@ pub enum A2aAction {
     /// List paired peers.
     Peers,
     /// List delegated A2A tasks.
-    Tasks { peer: Option<String> },
+    Tasks {
+        peer: Option<String>,
+        include_work_graph: bool,
+    },
+    /// Coordinate actionable A2A tasks.
+    Coordinate {
+        peer: Option<String>,
+        reply: Option<String>,
+        include_work_graph: bool,
+    },
     /// Accept a pairing code.
     Accept { code: String },
     /// Delegate work to a peer.

--- a/packages/tui-rs/src/headless/messages.rs
+++ b/packages/tui-rs/src/headless/messages.rs
@@ -93,6 +93,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+pub(crate) const CODEX_SUBAGENT_TOOL_PREFIX: &str = "codex.subagent.";
+pub(crate) const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA: &str =
+    "evalops.maestro.codex.subagent-workgraph.v1";
+
 /// Current headless protocol version shared with the TypeScript runtime.
 pub use super::generated_protocol::HEADLESS_PROTOCOL_VERSION;
 
@@ -914,6 +918,8 @@ pub struct AgentState {
     pub active_file_watches: HashMap<String, ActiveFileWatch>,
     /// Tracks tool metadata until a tool run completes, even when approval is not required.
     pub tracked_tools: HashMap<String, PendingApproval>,
+    /// Durable Codex app-server subagent edge metadata for restore/drain continuity.
+    pub codex_subagent_edges: Vec<CodexSubagentContinuityEdge>,
     /// Last error message
     pub last_error: Option<String>,
     /// Last structured error type
@@ -985,6 +991,21 @@ pub struct PendingApproval {
     pub started_at_ms: Option<u64>,
 }
 
+/// Durable edge metadata for Codex app-server subagent tools.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CodexSubagentContinuityEdge {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spawn_tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wait_tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    pub operation: String,
+    pub status: String,
+}
+
 /// A tool currently executing
 #[derive(Debug, Clone, PartialEq)]
 pub struct ActiveTool {
@@ -1020,7 +1041,287 @@ pub struct ActiveFileWatch {
     pub owner_connection_id: Option<String>,
 }
 
+pub(crate) fn codex_subagent_operation(tool: &str) -> Option<&'static str> {
+    let suffix = tool
+        .strip_prefix(CODEX_SUBAGENT_TOOL_PREFIX)
+        .unwrap_or(tool);
+    match suffix {
+        "spawnAgent" | "spawn_agent" => Some("spawn_agent"),
+        "sendInput" | "send_input" => Some("send_input"),
+        "resumeAgent" | "resume_agent" => Some("resume_agent"),
+        "wait" | "waitAgent" | "wait_agent" => Some("wait_agent"),
+        "closeAgent" | "close_agent" => Some("close_agent"),
+        _ => None,
+    }
+}
+
+pub(crate) fn active_codex_subagent_status(operation: &str) -> &'static str {
+    match operation {
+        "send_input" => "waiting_for_input_ack",
+        "wait_agent" => "wait_pending",
+        "close_agent" => "waiting_for_close",
+        "resume_agent" => "restoring",
+        _ => "waiting_for_restore",
+    }
+}
+
+fn terminal_codex_subagent_status(operation: &str, success: bool) -> &'static str {
+    if !success {
+        return "failed";
+    }
+    match operation {
+        "spawn_agent" => "spawned",
+        "send_input" => "acknowledged",
+        "resume_agent" => "resumed",
+        "close_agent" => "closed",
+        _ => "completed",
+    }
+}
+
+pub(crate) fn codex_subagent_status_is_terminal(status: &str) -> bool {
+    let normalized = status
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|ch| if ch == '-' || ch == ' ' { '_' } else { ch })
+        .collect::<String>();
+    matches!(
+        normalized.as_str(),
+        "closed"
+            | "explicitly_closed"
+            | "succeeded"
+            | "success"
+            | "completed"
+            | "complete"
+            | "done"
+            | "acknowledged"
+            | "failed"
+            | "failure"
+            | "error"
+            | "cancelled"
+            | "canceled"
+    )
+}
+
+pub(crate) fn json_string_from_object(
+    object: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Option<String> {
+    keys.iter().find_map(|key| {
+        object
+            .get(*key)
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    })
+}
+
+pub(crate) fn json_string_array_from_object(
+    object: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Vec<String> {
+    keys.iter()
+        .find_map(|key| object.get(*key).and_then(serde_json::Value::as_array))
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn has_codex_work_graph(args: Option<&serde_json::Value>) -> bool {
+    let Some(args) = args.and_then(serde_json::Value::as_object) else {
+        return false;
+    };
+    let Some(graph) = args
+        .get("codexWorkGraph")
+        .or_else(|| args.get("codex_work_graph"))
+        .and_then(serde_json::Value::as_object)
+    else {
+        return false;
+    };
+    json_string_from_object(graph, &["schemaVersion", "schema_version"]).as_deref()
+        == Some(CODEX_SUBAGENT_WORK_GRAPH_SCHEMA)
+}
+
+pub(crate) fn codex_subagent_child_runs(
+    args: Option<&serde_json::Value>,
+) -> Vec<(Option<String>, Option<String>)> {
+    let Some(args) = args.and_then(serde_json::Value::as_object) else {
+        return Vec::new();
+    };
+    let child_run_ids = json_string_array_from_object(args, &["childRunIds", "child_run_ids"]);
+    let thread_ids =
+        json_string_array_from_object(args, &["receiverThreadIds", "receiver_thread_ids"]);
+    let graph = args
+        .get("codexWorkGraph")
+        .or_else(|| args.get("codex_work_graph"));
+    let mut graph_runs = Vec::new();
+    if let Some(graph) = graph.and_then(serde_json::Value::as_object) {
+        if let Some(child_runs) = graph
+            .get("childRuns")
+            .or_else(|| graph.get("child_runs"))
+            .and_then(serde_json::Value::as_array)
+        {
+            for child_run in child_runs {
+                let Some(child_run) = child_run.as_object() else {
+                    continue;
+                };
+                graph_runs.push((
+                    json_string_from_object(child_run, &["childRunId", "child_run_id"]),
+                    json_string_from_object(child_run, &["threadId", "thread_id"]),
+                ));
+            }
+        }
+    }
+    let count = child_run_ids
+        .len()
+        .max(thread_ids.len())
+        .max(graph_runs.len())
+        .max(1);
+    let mut runs = Vec::new();
+    for index in 0..count {
+        let child_run_id = child_run_ids
+            .get(index)
+            .cloned()
+            .or_else(|| graph_runs.get(index).and_then(|run| run.0.clone()));
+        let thread_id = thread_ids
+            .get(index)
+            .cloned()
+            .or_else(|| graph_runs.get(index).and_then(|run| run.1.clone()));
+        if child_run_id.is_some() || thread_id.is_some() {
+            runs.push((child_run_id, thread_id));
+        }
+    }
+    runs
+}
+
+pub(crate) fn codex_subagent_edge_key(edge: &CodexSubagentContinuityEdge) -> String {
+    [
+        edge.spawn_tool_call_id.as_deref().unwrap_or_default(),
+        edge.wait_tool_call_id.as_deref().unwrap_or_default(),
+        edge.child_run_id.as_deref().unwrap_or_default(),
+        edge.thread_id.as_deref().unwrap_or_default(),
+        edge.operation.as_str(),
+    ]
+    .join("\0")
+}
+
 impl AgentState {
+    fn upsert_codex_subagent_edges(
+        &mut self,
+        call_id: &str,
+        tool: &str,
+        args: Option<&serde_json::Value>,
+        status: &str,
+    ) {
+        let Some(operation) = codex_subagent_operation(tool) else {
+            return;
+        };
+        if !tool.starts_with(CODEX_SUBAGENT_TOOL_PREFIX) && !has_codex_work_graph(args) {
+            return;
+        }
+        let child_runs = codex_subagent_child_runs(args);
+        let mut edges = Vec::new();
+        if child_runs.is_empty() {
+            edges.push(CodexSubagentContinuityEdge {
+                spawn_tool_call_id: (operation == "spawn_agent").then(|| call_id.to_string()),
+                wait_tool_call_id: (operation != "spawn_agent").then(|| call_id.to_string()),
+                child_run_id: None,
+                thread_id: None,
+                operation: operation.to_string(),
+                status: status.to_string(),
+            });
+        } else {
+            for (child_run_id, thread_id) in child_runs {
+                edges.push(CodexSubagentContinuityEdge {
+                    spawn_tool_call_id: (operation == "spawn_agent").then(|| call_id.to_string()),
+                    wait_tool_call_id: (operation != "spawn_agent").then(|| call_id.to_string()),
+                    child_run_id,
+                    thread_id,
+                    operation: operation.to_string(),
+                    status: status.to_string(),
+                });
+            }
+        }
+
+        let mut existing = self
+            .codex_subagent_edges
+            .iter()
+            .cloned()
+            .map(|edge| (codex_subagent_edge_key(&edge), edge))
+            .collect::<HashMap<_, _>>();
+        for edge in &edges {
+            existing.insert(codex_subagent_edge_key(edge), edge.clone());
+        }
+        if matches!(status, "closed" | "completed")
+            && matches!(operation, "close_agent" | "wait_agent")
+        {
+            for edge in existing.values_mut() {
+                if edge.operation == operation || codex_subagent_status_is_terminal(&edge.status) {
+                    continue;
+                }
+                let same_child = edge.child_run_id.as_ref().is_some_and(|child_run_id| {
+                    edges
+                        .iter()
+                        .any(|closed_edge| closed_edge.child_run_id.as_ref() == Some(child_run_id))
+                }) || edge.thread_id.as_ref().is_some_and(|thread_id| {
+                    edges
+                        .iter()
+                        .any(|closed_edge| closed_edge.thread_id.as_ref() == Some(thread_id))
+                });
+                if same_child {
+                    edge.status = "completed".to_string();
+                }
+            }
+        }
+        let mut sorted_edges = existing.into_values().collect::<Vec<_>>();
+        sorted_edges.sort_by(|left, right| {
+            codex_subagent_edge_key(left).cmp(&codex_subagent_edge_key(right))
+        });
+        self.codex_subagent_edges = sorted_edges;
+    }
+
+    fn mark_codex_subagent_edges_failed_for_call(&mut self, call_id: &str) {
+        if call_id.is_empty() {
+            return;
+        }
+        let mut changed = false;
+        for edge in &mut self.codex_subagent_edges {
+            let matches = edge.spawn_tool_call_id.as_deref() == Some(call_id)
+                || edge.wait_tool_call_id.as_deref() == Some(call_id);
+            if matches && !codex_subagent_status_is_terminal(&edge.status) {
+                edge.status = "failed".to_string();
+                changed = true;
+            }
+        }
+        if changed {
+            self.codex_subagent_edges.sort_by(|left, right| {
+                codex_subagent_edge_key(left).cmp(&codex_subagent_edge_key(right))
+            });
+        }
+    }
+
+    fn fail_codex_subagent_edge(&mut self, call_id: &str) {
+        if let Some(source) = self.tracked_tools.get(call_id).cloned() {
+            if let Some(operation) = codex_subagent_operation(&source.tool) {
+                self.upsert_codex_subagent_edges(
+                    call_id,
+                    &source.tool,
+                    Some(&source.args),
+                    terminal_codex_subagent_status(operation, false),
+                );
+            }
+        }
+        self.mark_codex_subagent_edges_failed_for_call(call_id);
+    }
+
     /// Clear volatile runtime activity that can become stale across transport gaps.
     pub fn clear_transient_progress(&mut self) {
         self.current_response = None;
@@ -1098,6 +1399,9 @@ impl AgentState {
             ToAgentMessage::ToolResponse {
                 call_id, approved, ..
             } => {
+                if !approved {
+                    self.fail_codex_subagent_edge(call_id);
+                }
                 let _ = self.remove_pending_approval(call_id);
                 if !approved {
                     self.tracked_tools.remove(call_id);
@@ -1114,9 +1418,19 @@ impl AgentState {
                 ..
             } => match request_type {
                 ServerRequestType::Approval => {
+                    let call_id = self
+                        .pending_approvals
+                        .iter()
+                        .find(|p| pending_request_matches(p, request_id))
+                        .map(|p| p.call_id.clone())
+                        .unwrap_or_else(|| request_id.clone());
+                    if approved != &Some(true) {
+                        self.fail_codex_subagent_edge(&call_id);
+                    }
                     self.pending_approvals
                         .retain(|p| !pending_request_matches(p, request_id));
                     if approved != &Some(true) {
+                        self.tracked_tools.remove(&call_id);
                         self.tracked_tools.remove(request_id);
                     }
                 }
@@ -1385,6 +1699,14 @@ impl AgentState {
                         started_at_ms: None,
                     },
                 );
+                if let Some(operation) = codex_subagent_operation(&tool) {
+                    self.upsert_codex_subagent_edges(
+                        &call_id,
+                        &tool,
+                        Some(&args),
+                        active_codex_subagent_status(operation),
+                    );
+                }
                 if requires_approval {
                     self.pending_approvals.push(PendingApproval {
                         call_id: call_id.clone(),
@@ -1433,8 +1755,27 @@ impl AgentState {
             }
 
             FromAgentMessage::ToolEnd { call_id, success } => {
-                let tool = self.active_tools.remove(&call_id);
-                self.tracked_tools.remove(&call_id);
+                let active_tool = self.active_tools.remove(&call_id);
+                let tracked_tool = self.tracked_tools.remove(&call_id);
+                if let Some(source) = tracked_tool.as_ref() {
+                    if let Some(operation) = codex_subagent_operation(&source.tool) {
+                        self.upsert_codex_subagent_edges(
+                            &call_id,
+                            &source.tool,
+                            Some(&source.args),
+                            terminal_codex_subagent_status(operation, success),
+                        );
+                    }
+                } else if let Some(source) = active_tool.as_ref() {
+                    if let Some(operation) = codex_subagent_operation(&source.tool) {
+                        self.upsert_codex_subagent_edges(
+                            &call_id,
+                            &source.tool,
+                            None,
+                            terminal_codex_subagent_status(operation, success),
+                        );
+                    }
+                }
                 self.pending_approvals.retain(|p| p.call_id != call_id);
                 self.pending_client_tools.retain(|p| p.call_id != call_id);
                 self.pending_user_inputs.retain(|p| p.call_id != call_id);
@@ -1442,7 +1783,7 @@ impl AgentState {
                 Some(AgentEvent::ToolEnd {
                     call_id,
                     success,
-                    duration: tool.map(|t| t.started.elapsed()),
+                    duration: active_tool.map(|t| t.started.elapsed()),
                 })
             }
 
@@ -1461,6 +1802,14 @@ impl AgentState {
                         started_at_ms: None,
                     },
                 );
+                if let Some(operation) = codex_subagent_operation(&tool) {
+                    self.upsert_codex_subagent_edges(
+                        &call_id,
+                        &tool,
+                        Some(&args),
+                        active_codex_subagent_status(operation),
+                    );
+                }
                 if tool == "ask_user" {
                     self.pending_user_inputs.retain(|p| p.call_id != call_id);
                     self.pending_user_inputs.push(PendingApproval {
@@ -1504,6 +1853,14 @@ impl AgentState {
                             args: args.clone(),
                             started_at_ms,
                         },
+                    );
+                }
+                if let Some(operation) = codex_subagent_operation(&tool) {
+                    self.upsert_codex_subagent_edges(
+                        &call_id,
+                        &tool,
+                        Some(&args),
+                        active_codex_subagent_status(operation),
                     );
                 }
                 let request_id = if request_id == call_id {
@@ -1568,6 +1925,7 @@ impl AgentState {
                         self.pending_approvals
                             .retain(|p| !pending_request_matches(p, &request_id));
                         if resolution != ServerRequestResolutionStatus::Approved {
+                            self.fail_codex_subagent_edge(&call_id);
                             self.tracked_tools.remove(&call_id);
                         }
                     }
@@ -1575,6 +1933,7 @@ impl AgentState {
                         self.pending_client_tools
                             .retain(|p| !pending_request_matches(p, &request_id));
                         if resolution == ServerRequestResolutionStatus::Cancelled {
+                            self.fail_codex_subagent_edge(&call_id);
                             self.tracked_tools.remove(&call_id);
                         }
                     }
@@ -1582,6 +1941,7 @@ impl AgentState {
                         self.pending_user_inputs
                             .retain(|p| !pending_request_matches(p, &request_id));
                         if resolution != ServerRequestResolutionStatus::Answered {
+                            self.fail_codex_subagent_edge(&call_id);
                             self.tracked_tools.remove(&call_id);
                         }
                     }
@@ -2881,5 +3241,76 @@ mod tests {
         assert!(resolved.is_none());
         assert!(state.pending_client_tools.is_empty());
         assert!(!state.tracked_tools.contains_key("call_client"));
+    }
+
+    #[test]
+    fn state_preserves_codex_subagent_edges_across_runtime_reset_messages() {
+        let mut state = AgentState::default();
+        let edge = CodexSubagentContinuityEdge {
+            spawn_tool_call_id: Some("collab-spawn-reset".to_string()),
+            wait_tool_call_id: None,
+            child_run_id: Some("agent-run-child-reset".to_string()),
+            thread_id: Some("child-thread-reset".to_string()),
+            operation: "spawn_agent".to_string(),
+            status: "waiting_for_restore".to_string(),
+        };
+        state.codex_subagent_edges = vec![edge.clone()];
+
+        state.clear_pending_request_state();
+        assert_eq!(state.codex_subagent_edges, vec![edge.clone()]);
+
+        state.handle_sent_message(&ToAgentMessage::Interrupt);
+        assert_eq!(state.codex_subagent_edges, vec![edge.clone()]);
+
+        state.handle_sent_message(&ToAgentMessage::Cancel);
+        assert_eq!(state.codex_subagent_edges, vec![edge.clone()]);
+
+        state.handle_sent_message(&ToAgentMessage::Shutdown);
+        assert_eq!(state.codex_subagent_edges, vec![edge]);
+    }
+
+    #[test]
+    fn state_marks_denied_restored_codex_subagent_edges_failed_without_tracked_source() {
+        let mut state = AgentState {
+            codex_subagent_edges: vec![CodexSubagentContinuityEdge {
+                spawn_tool_call_id: Some("collab-spawn-denied".to_string()),
+                wait_tool_call_id: None,
+                child_run_id: Some("agent-run-child-denied".to_string()),
+                thread_id: Some("child-thread-denied".to_string()),
+                operation: "spawn_agent".to_string(),
+                status: "waiting_for_restore".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        let resolved = state.handle_message(FromAgentMessage::ServerRequestResolved {
+            request_id: "approval-denied".to_string(),
+            request_type: ServerRequestType::Approval,
+            call_id: "collab-spawn-denied".to_string(),
+            resolution: ServerRequestResolutionStatus::Denied,
+            reason: Some("Denied by policy".to_string()),
+            resolved_by: ServerRequestResolvedBy::Policy,
+            started_at_ms: Some(1_771_000_000_000),
+            resolved_at_ms: Some(1_771_000_000_123),
+        });
+
+        assert!(resolved.is_none());
+        assert_eq!(
+            state.codex_subagent_edges,
+            vec![CodexSubagentContinuityEdge {
+                spawn_tool_call_id: Some("collab-spawn-denied".to_string()),
+                wait_tool_call_id: None,
+                child_run_id: Some("agent-run-child-denied".to_string()),
+                thread_id: Some("child-thread-denied".to_string()),
+                operation: "spawn_agent".to_string(),
+                status: "failed".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn codex_subagent_terminal_statuses_include_send_input_acknowledged() {
+        assert!(codex_subagent_status_is_terminal("acknowledged"));
+        assert!(codex_subagent_status_is_terminal("Acknowledged"));
     }
 }

--- a/packages/tui-rs/src/headless/remote_transport.rs
+++ b/packages/tui-rs/src/headless/remote_transport.rs
@@ -21,9 +21,10 @@ use tokio_util::sync::CancellationToken;
 use super::async_transport::{AsyncTransportError, RemoteErrorKind};
 use super::messages::{
     ActiveFileWatch, ActiveUtilityCommand, AgentState, ApprovalMode, ClientCapabilities,
-    ClientInfo, ConnectionRole, ConnectionState, FromAgentMessage, HeadlessErrorType, InitConfig,
-    PendingApproval, ServerRequestType, StreamingResponse, ThinkingLevel, ToAgentMessage,
-    UtilityCommandShellMode, UtilityCommandTerminalMode, UtilityOperation,
+    ClientInfo, CodexSubagentContinuityEdge, ConnectionRole, ConnectionState, FromAgentMessage,
+    HeadlessErrorType, InitConfig, PendingApproval, ServerRequestType, StreamingResponse,
+    ThinkingLevel, ToAgentMessage, UtilityCommandShellMode, UtilityCommandTerminalMode,
+    UtilityOperation,
 };
 
 const MESSAGE_POST_MAX_RETRIES: u32 = 10;
@@ -313,6 +314,8 @@ struct RemoteRuntimeStateSnapshot {
     #[serde(default)]
     active_tools: Vec<RemoteActiveToolState>,
     #[serde(default)]
+    codex_subagent_edges: Vec<CodexSubagentContinuityEdge>,
+    #[serde(default)]
     active_utility_commands: Vec<RemoteActiveUtilityCommandState>,
     #[serde(default)]
     active_file_watches: Vec<RemoteActiveFileWatchState>,
@@ -376,6 +379,7 @@ impl RemoteRuntimeStateSnapshot {
                     )
                 })
                 .collect(),
+            codex_subagent_edges: self.codex_subagent_edges,
             active_utility_commands: self
                 .active_utility_commands
                 .into_iter()
@@ -1978,6 +1982,14 @@ mod tests {
                 tool: "read".to_string(),
                 output: "partial".to_string(),
             }],
+            codex_subagent_edges: vec![CodexSubagentContinuityEdge {
+                spawn_tool_call_id: Some("collab-spawn-remote".to_string()),
+                wait_tool_call_id: None,
+                child_run_id: Some("agent-run-child-remote".to_string()),
+                thread_id: Some("child-thread-remote".to_string()),
+                operation: "spawn_agent".to_string(),
+                status: "waiting_for_restore".to_string(),
+            }],
             active_utility_commands: vec![RemoteActiveUtilityCommandState {
                 command_id: "cmd-1".to_string(),
                 command: "echo hi".to_string(),
@@ -2033,6 +2045,11 @@ mod tests {
         );
         assert_eq!(state.tracked_tools.len(), 1);
         assert_eq!(state.active_tools.len(), 1);
+        assert_eq!(state.codex_subagent_edges.len(), 1);
+        assert_eq!(
+            state.codex_subagent_edges[0].child_run_id.as_deref(),
+            Some("agent-run-child-remote")
+        );
         assert_eq!(state.active_utility_commands.len(), 1);
         assert_eq!(state.active_file_watches.len(), 1);
         assert_eq!(

--- a/packages/tui-rs/src/headless/session.rs
+++ b/packages/tui-rs/src/headless/session.rs
@@ -91,8 +91,8 @@ use std::time::SystemTime;
 use serde::{Deserialize, Serialize};
 
 use super::messages::{
-    ActiveFileWatch, ActiveTool, AgentState, FromAgentMessage, InitConfig, PendingApproval,
-    StreamingResponse, ToAgentMessage, TokenUsage,
+    ActiveFileWatch, ActiveTool, AgentState, CodexSubagentContinuityEdge, FromAgentMessage,
+    InitConfig, PendingApproval, StreamingResponse, ToAgentMessage, TokenUsage,
 };
 
 /// A recorded session entry (either a sent or received message).
@@ -247,6 +247,8 @@ pub struct AgentStateCheckpoint {
     #[serde(default)]
     pub active_tools: Vec<ActiveToolCheckpoint>,
     #[serde(default)]
+    pub codex_subagent_edges: Vec<CodexSubagentContinuityEdge>,
+    #[serde(default)]
     pub active_utility_commands: Vec<ActiveUtilityCommandCheckpoint>,
     #[serde(default)]
     pub active_file_watches: Vec<ActiveFileWatchCheckpoint>,
@@ -302,6 +304,7 @@ impl AgentStateCheckpoint {
                     elapsed_ms: tool.started.elapsed().as_millis() as u64,
                 })
                 .collect(),
+            codex_subagent_edges: state.codex_subagent_edges.clone(),
             active_utility_commands: state
                 .active_utility_commands
                 .values()
@@ -387,6 +390,7 @@ impl AgentStateCheckpoint {
                     )
                 })
                 .collect(),
+            codex_subagent_edges: self.codex_subagent_edges,
             active_utility_commands: self
                 .active_utility_commands
                 .into_iter()

--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -25,10 +25,12 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::headless::messages::{
-    ApprovalMode, ClientCapabilities, ClientInfo, ConnectionRole, ConnectionState,
-    FromAgentMessage, InitConfig, ServerRequestType, ThinkingLevel, ToAgentMessage,
-    UtilityCommandShellMode, UtilityCommandStream, UtilityCommandTerminalMode,
-    UtilityFileSearchMatch, UtilityOperation, HEADLESS_PROTOCOL_VERSION,
+    active_codex_subagent_status, codex_subagent_child_runs, codex_subagent_edge_key,
+    codex_subagent_operation, codex_subagent_status_is_terminal, ApprovalMode, ClientCapabilities,
+    ClientInfo, CodexSubagentContinuityEdge, ConnectionRole, ConnectionState, FromAgentMessage,
+    InitConfig, ServerRequestType, ThinkingLevel, ToAgentMessage, UtilityCommandShellMode,
+    UtilityCommandStream, UtilityCommandTerminalMode, UtilityFileSearchMatch, UtilityOperation,
+    CODEX_SUBAGENT_TOOL_PREFIX, CODEX_SUBAGENT_WORK_GRAPH_SCHEMA, HEADLESS_PROTOCOL_VERSION,
 };
 use crate::headless::{AgentState, AgentSupervisor, AsyncTransportError};
 
@@ -47,9 +49,6 @@ const DEFAULT_LISTEN_PORT: u16 = 8080;
 const DEFAULT_HEARTBEAT_INTERVAL_MS: u64 = 15_000;
 const CONNECTION_IDLE_MS: i64 = (DEFAULT_HEARTBEAT_INTERVAL_MS as i64) * 3;
 const MAX_EVENTS: usize = 1024;
-const CODEX_SUBAGENT_TOOL_PREFIX: &str = "codex.subagent.";
-const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA: &str = "evalops.maestro.codex.subagent-workgraph.v1";
-
 #[derive(Debug, Clone)]
 pub struct HostedRunnerConfig {
     pub runner_session_id: String,
@@ -549,6 +548,8 @@ struct RuntimeStateSnapshot {
     pending_tool_retries: Vec<serde_json::Value>,
     tracked_tools: Vec<serde_json::Value>,
     active_tools: Vec<serde_json::Value>,
+    #[serde(default)]
+    codex_subagent_edges: Vec<CodexSubagentContinuityEdge>,
     active_utility_commands: Vec<ActiveUtilityCommandSnapshot>,
     active_file_watches: Vec<ActiveFileWatchSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -622,6 +623,8 @@ struct WorkContinuityManifest {
     codex_subagent_tool_call_ids: Vec<String>,
     codex_subagent_child_run_ids: Vec<String>,
     codex_subagent_thread_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    codex_subagent_edges: Vec<CodexSubagentContinuityEdge>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -672,16 +675,85 @@ fn default_retention_policy_manifest() -> RetentionPolicyManifest {
     }
 }
 
+fn add_codex_subagent_edge(
+    edges: &mut BTreeSet<CodexSubagentContinuityEdge>,
+    edge: CodexSubagentContinuityEdge,
+) {
+    let key = codex_subagent_edge_key(&edge);
+    edges.retain(|existing| codex_subagent_edge_key(existing) != key);
+    edges.insert(edge);
+}
+
+fn collect_codex_subagent_edges_from_source(
+    source: &serde_json::Value,
+    edges: &mut BTreeSet<CodexSubagentContinuityEdge>,
+) {
+    let tool = json_string_field(source, &["tool"]).unwrap_or_default();
+    let Some(operation) = codex_subagent_operation(&tool) else {
+        return;
+    };
+    let call_id = json_string_field(source, &["call_id", "callId", "tool_call_id", "toolCallId"])
+        .unwrap_or_default();
+    if call_id.is_empty() {
+        return;
+    }
+    let child_runs = codex_subagent_child_runs(source.get("args"));
+    if child_runs.is_empty() {
+        add_codex_subagent_edge(
+            edges,
+            CodexSubagentContinuityEdge {
+                spawn_tool_call_id: (operation == "spawn_agent").then(|| call_id.clone()),
+                wait_tool_call_id: (operation != "spawn_agent").then(|| call_id.clone()),
+                child_run_id: None,
+                thread_id: None,
+                operation: operation.to_string(),
+                status: active_codex_subagent_status(operation).to_string(),
+            },
+        );
+        return;
+    }
+    for (child_run_id, thread_id) in child_runs {
+        add_codex_subagent_edge(
+            edges,
+            CodexSubagentContinuityEdge {
+                spawn_tool_call_id: (operation == "spawn_agent").then(|| call_id.clone()),
+                wait_tool_call_id: (operation != "spawn_agent").then(|| call_id.clone()),
+                child_run_id,
+                thread_id,
+                operation: operation.to_string(),
+                status: active_codex_subagent_status(operation).to_string(),
+            },
+        );
+    }
+}
+
 fn default_work_continuity_manifest(snapshot: &RuntimeSnapshot) -> WorkContinuityManifest {
     let state = &snapshot.state;
     let mut tool_call_ids = BTreeSet::new();
     let mut child_run_ids = BTreeSet::new();
     let mut thread_ids = BTreeSet::new();
+    let mut codex_subagent_edges = BTreeSet::new();
+    let mut codex_tracked_source_call_ids = BTreeSet::new();
     let pending_request_count = state.pending_approvals.len()
         + state.pending_client_tools.len()
         + state.pending_mcp_elicitations.len()
         + state.pending_user_inputs.len()
         + state.pending_tool_retries.len();
+    for edge in &state.codex_subagent_edges {
+        if let Some(call_id) = edge.spawn_tool_call_id.as_ref() {
+            tool_call_ids.insert(call_id.clone());
+        }
+        if let Some(call_id) = edge.wait_tool_call_id.as_ref() {
+            tool_call_ids.insert(call_id.clone());
+        }
+        if let Some(child_run_id) = edge.child_run_id.as_ref() {
+            child_run_ids.insert(child_run_id.clone());
+        }
+        if let Some(thread_id) = edge.thread_id.as_ref() {
+            thread_ids.insert(thread_id.clone());
+        }
+        add_codex_subagent_edge(&mut codex_subagent_edges, edge.clone());
+    }
     for source in state
         .tracked_tools
         .iter()
@@ -703,8 +775,10 @@ fn default_work_continuity_manifest(snapshot: &RuntimeSnapshot) -> WorkContinuit
             if let Some(call_id) =
                 json_string_field(source, &["call_id", "callId", "tool_call_id", "toolCallId"])
             {
+                codex_tracked_source_call_ids.insert(call_id.clone());
                 tool_call_ids.insert(call_id);
             }
+            collect_codex_subagent_edges_from_source(source, &mut codex_subagent_edges);
         }
     }
     for active_tool in &state.active_tools {
@@ -714,18 +788,59 @@ fn default_work_continuity_manifest(snapshot: &RuntimeSnapshot) -> WorkContinuit
                 active_tool,
                 &["call_id", "callId", "tool_call_id", "toolCallId"],
             ) {
+                let has_tracked_source = tool_call_ids.contains(&call_id);
                 tool_call_ids.insert(call_id);
+                if !has_tracked_source {
+                    collect_codex_subagent_edges_from_source(
+                        active_tool,
+                        &mut codex_subagent_edges,
+                    );
+                }
             }
         }
     }
+    let codex_subagent_edges = codex_subagent_edges.into_iter().collect::<Vec<_>>();
+    let active_codex_subagent_edge_count = codex_subagent_edges
+        .iter()
+        .filter(|edge| !codex_subagent_status_is_terminal(&edge.status))
+        .count();
+    let non_codex_active_tool_count = state
+        .active_tools
+        .iter()
+        .filter(|tool| {
+            !json_string_field(tool, &["tool"])
+                .unwrap_or_default()
+                .starts_with(CODEX_SUBAGENT_TOOL_PREFIX)
+        })
+        .count();
+    let non_codex_tracked_tool_count = state
+        .tracked_tools
+        .iter()
+        .filter(|tool| {
+            !json_string_field(tool, &["call_id", "callId", "tool_call_id", "toolCallId"])
+                .is_some_and(|call_id| codex_tracked_source_call_ids.contains(&call_id))
+        })
+        .count();
+    let tracked_codex_subagent_count = tool_call_ids.len().max(codex_subagent_edges.len());
+    let active_tool_count = if codex_subagent_edges.is_empty() {
+        state.active_tools.len()
+    } else {
+        non_codex_active_tool_count + active_codex_subagent_edge_count
+    };
+    let tracked_tool_count = if codex_subagent_edges.is_empty() {
+        state.tracked_tools.len()
+    } else {
+        non_codex_tracked_tool_count + tracked_codex_subagent_count
+    };
     WorkContinuityManifest {
         protocol_version: HOSTED_RUNNER_WORK_CONTINUITY_VERSION.to_string(),
-        active_tool_count: state.active_tools.len(),
-        tracked_tool_count: state.tracked_tools.len(),
+        active_tool_count,
+        tracked_tool_count,
         pending_request_count,
         codex_subagent_tool_call_ids: tool_call_ids.into_iter().collect(),
         codex_subagent_child_run_ids: child_run_ids.into_iter().collect(),
         codex_subagent_thread_ids: thread_ids.into_iter().collect(),
+        codex_subagent_edges,
     }
 }
 
@@ -1532,6 +1647,10 @@ impl SharedRunner {
                             .collect()
                     })
                     .or_else(|| restored_state.map(|state| state.active_tools.clone()))
+                    .unwrap_or_default(),
+                codex_subagent_edges: agent_state
+                    .map(|state| state.codex_subagent_edges.clone())
+                    .or_else(|| restored_state.map(|state| state.codex_subagent_edges.clone()))
                     .unwrap_or_default(),
                 active_utility_commands: state.active_utility_commands.values().cloned().collect(),
                 active_file_watches: state.active_file_watches.values().cloned().collect(),
@@ -4207,6 +4326,60 @@ mod tests {
     }
 
     #[test]
+    fn runtime_state_snapshot_serializes_empty_codex_subagent_edges() {
+        let snapshot = RuntimeSnapshot {
+            protocol_version: HEADLESS_PROTOCOL_VERSION.to_string(),
+            session_id: "session_empty_edges".to_string(),
+            cursor: 0,
+            last_init: None,
+            state: RuntimeStateSnapshot {
+                protocol_version: Some(HEADLESS_PROTOCOL_VERSION.to_string()),
+                client_protocol_version: None,
+                client_info: None,
+                capabilities: None,
+                opt_out_notifications: None,
+                connection_role: None,
+                connection_count: 0,
+                subscriber_count: 0,
+                controller_subscription_id: None,
+                controller_connection_id: None,
+                connections: Vec::new(),
+                model: Some("gpt-5.4".to_string()),
+                provider: Some("rust".to_string()),
+                session_id: Some("session_empty_edges".to_string()),
+                cwd: None,
+                git_branch: None,
+                current_response: None,
+                pending_approvals: Vec::new(),
+                pending_client_tools: Vec::new(),
+                pending_mcp_elicitations: Vec::new(),
+                pending_user_inputs: Vec::new(),
+                pending_tool_retries: Vec::new(),
+                tracked_tools: Vec::new(),
+                active_tools: Vec::new(),
+                codex_subagent_edges: Vec::new(),
+                active_utility_commands: Vec::new(),
+                active_file_watches: Vec::new(),
+                last_error: None,
+                last_error_type: None,
+                last_status: Some("Ready".to_string()),
+                last_response_duration_ms: None,
+                last_ttft_ms: None,
+                is_ready: true,
+                is_responding: false,
+            },
+        };
+
+        let value = serde_json::to_value(&snapshot).expect("snapshot json");
+        let empty_edges = json!([]);
+
+        assert_eq!(
+            value.pointer("/state/codex_subagent_edges"),
+            Some(&empty_edges)
+        );
+    }
+
+    #[test]
     fn work_continuity_manifest_extracts_codex_subagent_ids() {
         let snapshot: RuntimeSnapshot = serde_json::from_value(json!({
             "protocolVersion": HEADLESS_PROTOCOL_VERSION,
@@ -4281,8 +4454,226 @@ mod tests {
             continuity.codex_subagent_thread_ids,
             vec!["child-thread-rust".to_string()]
         );
+        assert_eq!(
+            continuity.codex_subagent_edges,
+            vec![CodexSubagentContinuityEdge {
+                spawn_tool_call_id: Some("collab-spawn-rust".to_string()),
+                wait_tool_call_id: None,
+                child_run_id: Some("agent-run-child-rust".to_string()),
+                thread_id: Some("child-thread-rust".to_string()),
+                operation: "spawn_agent".to_string(),
+                status: "waiting_for_restore".to_string(),
+            }]
+        );
         let continuity_json = serde_json::to_string(&continuity).expect("continuity json");
         assert!(!continuity_json.contains("Sensitive Rust subagent prompt"));
+    }
+
+    #[test]
+    fn work_continuity_manifest_preserves_restored_codex_subagent_edges() {
+        let snapshot: RuntimeSnapshot = serde_json::from_value(json!({
+            "protocolVersion": HEADLESS_PROTOCOL_VERSION,
+            "session_id": "session_rust_restored",
+            "cursor": 10,
+            "last_init": null,
+            "state": {
+                "protocol_version": HEADLESS_PROTOCOL_VERSION,
+                "connection_count": 0,
+                "subscriber_count": 0,
+                "connections": [],
+                "model": "gpt-5.4",
+                "provider": "rust",
+                "session_id": "session_rust_restored",
+                "pending_approvals": [],
+                "pending_client_tools": [],
+                "pending_mcp_elicitations": [],
+                "pending_user_inputs": [],
+                "pending_tool_retries": [],
+                "tracked_tools": [],
+                "active_tools": [],
+                "codex_subagent_edges": [
+                    {
+                        "spawn_tool_call_id": "collab-spawn-rust-restored",
+                        "child_run_id": "agent-run-child-rust-restored",
+                        "thread_id": "child-thread-rust-restored",
+                        "operation": "spawn_agent",
+                        "status": "completed"
+                    },
+                    {
+                        "wait_tool_call_id": "collab-close-rust-restored",
+                        "child_run_id": "agent-run-child-rust-restored",
+                        "thread_id": "child-thread-rust-restored",
+                        "operation": "close_agent",
+                        "status": "closed"
+                    }
+                ],
+                "active_utility_commands": [],
+                "active_file_watches": [],
+                "is_ready": true,
+                "is_responding": false
+            }
+        }))
+        .expect("runtime snapshot");
+
+        let continuity = default_work_continuity_manifest(&snapshot);
+
+        assert_eq!(continuity.active_tool_count, 0);
+        assert_eq!(continuity.tracked_tool_count, 2);
+        assert_eq!(continuity.pending_request_count, 0);
+        assert_eq!(
+            continuity.codex_subagent_tool_call_ids,
+            vec![
+                "collab-close-rust-restored".to_string(),
+                "collab-spawn-rust-restored".to_string(),
+            ]
+        );
+        assert_eq!(
+            continuity.codex_subagent_child_run_ids,
+            vec!["agent-run-child-rust-restored".to_string()]
+        );
+        assert_eq!(
+            continuity.codex_subagent_thread_ids,
+            vec!["child-thread-rust-restored".to_string()]
+        );
+        assert_eq!(
+            continuity.codex_subagent_edges,
+            vec![
+                CodexSubagentContinuityEdge {
+                    spawn_tool_call_id: None,
+                    wait_tool_call_id: Some("collab-close-rust-restored".to_string()),
+                    child_run_id: Some("agent-run-child-rust-restored".to_string()),
+                    thread_id: Some("child-thread-rust-restored".to_string()),
+                    operation: "close_agent".to_string(),
+                    status: "closed".to_string(),
+                },
+                CodexSubagentContinuityEdge {
+                    spawn_tool_call_id: Some("collab-spawn-rust-restored".to_string()),
+                    wait_tool_call_id: None,
+                    child_run_id: Some("agent-run-child-rust-restored".to_string()),
+                    thread_id: Some("child-thread-rust-restored".to_string()),
+                    operation: "spawn_agent".to_string(),
+                    status: "completed".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn work_continuity_manifest_counts_mixed_codex_and_regular_tools() {
+        let snapshot: RuntimeSnapshot = serde_json::from_value(json!({
+            "protocolVersion": HEADLESS_PROTOCOL_VERSION,
+            "session_id": "session_rust_mixed",
+            "cursor": 11,
+            "last_init": null,
+            "state": {
+                "protocol_version": HEADLESS_PROTOCOL_VERSION,
+                "connection_count": 0,
+                "subscriber_count": 0,
+                "connections": [],
+                "model": "gpt-5.4",
+                "provider": "rust",
+                "session_id": "session_rust_mixed",
+                "pending_approvals": [],
+                "pending_client_tools": [],
+                "pending_mcp_elicitations": [],
+                "pending_user_inputs": [],
+                "pending_tool_retries": [],
+                "tracked_tools": [{
+                    "call_id": "regular-tracked-rust",
+                    "tool": "shell.exec",
+                    "args": {
+                        "command": "pwd"
+                    }
+                }],
+                "active_tools": [{
+                    "call_id": "regular-active-rust",
+                    "tool": "shell.exec",
+                    "output": "running"
+                }],
+                "codex_subagent_edges": [
+                    {
+                        "spawn_tool_call_id": "collab-spawn-mixed",
+                        "child_run_id": "agent-run-child-mixed",
+                        "thread_id": "child-thread-mixed",
+                        "operation": "spawn_agent",
+                        "status": "completed"
+                    },
+                    {
+                        "wait_tool_call_id": "collab-wait-mixed",
+                        "child_run_id": "agent-run-child-mixed",
+                        "thread_id": "child-thread-mixed",
+                        "operation": "wait_agent",
+                        "status": "wait_pending"
+                    }
+                ],
+                "active_utility_commands": [],
+                "active_file_watches": [],
+                "is_ready": true,
+                "is_responding": false
+            }
+        }))
+        .expect("runtime snapshot");
+
+        let continuity = default_work_continuity_manifest(&snapshot);
+
+        assert_eq!(continuity.active_tool_count, 2);
+        assert_eq!(continuity.tracked_tool_count, 3);
+        assert_eq!(
+            continuity.codex_subagent_tool_call_ids,
+            vec![
+                "collab-spawn-mixed".to_string(),
+                "collab-wait-mixed".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn work_continuity_manifest_treats_acknowledged_send_input_as_terminal() {
+        let snapshot: RuntimeSnapshot = serde_json::from_value(json!({
+            "protocolVersion": HEADLESS_PROTOCOL_VERSION,
+            "session_id": "session_rust_acknowledged",
+            "cursor": 12,
+            "last_init": null,
+            "state": {
+                "protocol_version": HEADLESS_PROTOCOL_VERSION,
+                "connection_count": 0,
+                "subscriber_count": 0,
+                "connections": [],
+                "model": "gpt-5.4",
+                "provider": "rust",
+                "session_id": "session_rust_acknowledged",
+                "pending_approvals": [],
+                "pending_client_tools": [],
+                "pending_mcp_elicitations": [],
+                "pending_user_inputs": [],
+                "pending_tool_retries": [],
+                "tracked_tools": [],
+                "active_tools": [],
+                "codex_subagent_edges": [
+                    {
+                        "wait_tool_call_id": "collab-send-ack",
+                        "child_run_id": "agent-run-child-ack",
+                        "thread_id": "child-thread-ack",
+                        "operation": "send_input",
+                        "status": "acknowledged"
+                    }
+                ],
+                "active_utility_commands": [],
+                "active_file_watches": [],
+                "is_ready": true,
+                "is_responding": false
+            }
+        }))
+        .expect("runtime snapshot");
+
+        let continuity = default_work_continuity_manifest(&snapshot);
+
+        assert_eq!(continuity.active_tool_count, 0);
+        assert_eq!(continuity.tracked_tool_count, 1);
+        assert_eq!(
+            continuity.codex_subagent_tool_call_ids,
+            vec!["collab-send-ack".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/scripts/codex-a2a-bridge.py
+++ b/scripts/codex-a2a-bridge.py
@@ -43,6 +43,9 @@ SAFE_PROMPT_METADATA_KEYS = {
     "sessionId",
     "workspaceId",
 }
+INPUT_REQUIRED_ONCE_FIXTURE_MODE = "input-required-once"
+INPUT_REQUIRED_ONCE_FIXTURE_TASK_ID = "codex-a2a-fixture-task-input-required-once"
+INPUT_REQUIRED_ONCE_FIXTURE_CONTEXT_ID = "codex-a2a-fixture-context-input-required-once"
 
 
 def env(name: str, default: str) -> str:
@@ -97,6 +100,10 @@ def terminal(state: str | None) -> bool:
         "TASK_STATE_CANCELED",
         "TASK_STATE_REJECTED",
     }
+
+
+def fixture_mode() -> str:
+    return os.environ.get("CODEX_A2A_FIXTURE_MODE", "").strip()
 
 
 def prune_terminal_tasks_locked(protected_task_id: str | None = None) -> None:
@@ -241,6 +248,15 @@ def user_message(message: dict[str, Any], context_id: str) -> dict[str, Any]:
     return copied
 
 
+def fixture_agent_message(context_id: str, suffix: str, text: str) -> dict[str, Any]:
+    return {
+        "messageId": f"codex-a2a-fixture-message-{suffix}",
+        "contextId": context_id,
+        "role": "ROLE_AGENT",
+        "parts": [{"text": text, "mediaType": "text/plain"}],
+    }
+
+
 def task_value(
     task_id: str,
     context_id: str,
@@ -262,6 +278,101 @@ def task_value(
         "artifacts": artifacts or [],
         "metadata": metadata or {},
     }
+
+
+def input_required_once_fixture_task(
+    message: dict[str, Any],
+    prompt_text: str,
+    requested_task_id: str,
+    requested_context_id: str,
+) -> tuple[int, dict[str, Any]]:
+    task_id = requested_task_id or INPUT_REQUIRED_ONCE_FIXTURE_TASK_ID
+    context_id = requested_context_id or INPUT_REQUIRED_ONCE_FIXTURE_CONTEXT_ID
+    with LOCK:
+        existing = TASKS.get(task_id)
+        if requested_task_id:
+            if not existing:
+                return 404, {"error": {"code": "TASK_NOT_FOUND", "message": "A2A task not found"}}
+            existing_state = existing.get("status", {}).get("state")
+            if terminal(existing_state):
+                return (
+                    400,
+                    {
+                        "error": {
+                            "code": "UNSUPPORTED_OPERATION",
+                            "message": "A2A terminal tasks cannot accept more messages",
+                        }
+                    },
+                )
+            if not accepts_message(existing_state):
+                return (
+                    409,
+                    {
+                        "error": {
+                            "code": "UNSUPPORTED_OPERATION",
+                            "message": "A2A task is not ready to accept another message",
+                        }
+                    },
+                )
+            existing_context_id = str(existing.get("contextId") or "").strip()
+            if (
+                requested_context_id
+                and existing_context_id
+                and requested_context_id != existing_context_id
+            ):
+                return (
+                    400,
+                    {
+                        "error": {
+                            "code": "INVALID_REQUEST",
+                            "message": "A2A message contextId must match the referenced task",
+                        }
+                    },
+                )
+            context_id = (
+                requested_context_id
+                or existing_context_id
+                or INPUT_REQUIRED_ONCE_FIXTURE_CONTEXT_ID
+            )
+            normalized_message = user_message(message, context_id)
+            final_text = f"Fixture completed after user reply: {prompt_text}"
+            final_message = fixture_agent_message(context_id, "completed", final_text)
+            task = task_value(
+                task_id,
+                context_id,
+                "TASK_STATE_COMPLETED",
+                final_message,
+                [*copy.deepcopy(existing.get("history") or []), normalized_message, final_message],
+                artifacts=[
+                    {
+                        "artifactId": f"{task_id}-fixture-response",
+                        "name": "fixture-response",
+                        "parts": [{"text": final_text, "mediaType": "text/plain"}],
+                    }
+                ],
+                metadata={
+                    "backend": "codex-a2a-fixture",
+                    "fixtureMode": INPUT_REQUIRED_ONCE_FIXTURE_MODE,
+                },
+            )
+            store_task_locked(task_id, task)
+            return 200, {"task": task}
+        question = "What do you need to continue this A2A task?"
+        question_message = fixture_agent_message(context_id, "input-required", question)
+        normalized_message = user_message(message, context_id)
+        task = task_value(
+            task_id,
+            context_id,
+            "TASK_STATE_INPUT_REQUIRED",
+            question_message,
+            [normalized_message, question_message],
+            metadata={
+                "backend": "codex-a2a-fixture",
+                "fixtureMode": INPUT_REQUIRED_ONCE_FIXTURE_MODE,
+            },
+        )
+        store_task_locked(task_id, task)
+        return 200, {"task": task}
 
 
 def json_bytes(value: Any) -> bytes:
@@ -617,6 +728,15 @@ class Handler(BaseHTTPRequestHandler):
                     "INVALID_REQUEST",
                     "A2A configuration returnImmediately must be a boolean",
                 )
+                return
+            if fixture_mode() == INPUT_REQUIRED_ONCE_FIXTURE_MODE:
+                status, response = input_required_once_fixture_task(
+                    message,
+                    prompt_text,
+                    requested_task_id,
+                    requested_context_id,
+                )
+                self.send_json(status, response)
                 return
             immediate = return_immediately is True
             error: tuple[int, str, str] | None = None

--- a/scripts/smoke-maestro-a2a-input-required.ts
+++ b/scripts/smoke-maestro-a2a-input-required.ts
@@ -1,0 +1,458 @@
+import { once } from "node:events";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+interface TranscriptEntry {
+	role: string;
+	text: string;
+	state?: string;
+}
+
+interface LedgerEntry {
+	taskId: string;
+	contextId?: string;
+	state: string;
+	text: string;
+	responseText?: string;
+	transcript: TranscriptEntry[];
+}
+
+interface LedgerFile {
+	tasks: LedgerEntry[];
+}
+
+const PEER_NAME = "codex-input-required";
+const TOKEN = "test-token";
+const FIRST_USER_TEXT = "Run the deterministic input-required A2A fixture smoke.";
+const USER_REPLY_TEXT = "Use the deterministic reply and complete the fixture task.";
+const READY_TIMEOUT_MS = positiveIntEnv(
+	"MAESTRO_A2A_INPUT_REQUIRED_SMOKE_READY_TIMEOUT_MS",
+	30_000,
+);
+const CLI_TIMEOUT_MS = positiveIntEnv(
+	"MAESTRO_A2A_INPUT_REQUIRED_SMOKE_CLI_TIMEOUT_MS",
+	15_000,
+);
+const PROCESS_EXIT_GRACE_MS = 2_000;
+const BRIDGE_START_ATTEMPTS = 5;
+
+function positiveIntEnv(name: string, fallback: number): number {
+	const parsed = Number.parseInt(process.env[name] ?? "", 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function openPort(): Promise<number> {
+	const server = net.createServer();
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	if (address === null || typeof address === "string") {
+		server.close();
+		throw new Error("failed to allocate a local TCP port");
+	}
+	const port = address.port;
+	await new Promise<void>((resolve, reject) => {
+		server.close((error) => (error ? reject(error) : resolve()));
+	});
+	return port;
+}
+
+async function waitForHealth(
+	baseUrl: string,
+	stderr: () => string,
+	child?: ChildProcess,
+): Promise<void> {
+	const deadline = Date.now() + READY_TIMEOUT_MS;
+	while (Date.now() < deadline) {
+		if (
+			child &&
+			(child.exitCode !== null || child.signalCode !== null)
+		) {
+			throw new Error(
+				`Codex A2A bridge exited before health check passed:\n${stderr()}`,
+			);
+		}
+		try {
+			const response = await fetch(`${baseUrl}/healthz`);
+			if (response.ok) {
+				return;
+			}
+		} catch {
+			// Bridge process is still starting.
+		}
+		await delay(100);
+	}
+	throw new Error(`Codex A2A bridge did not become ready:\n${stderr()}`);
+}
+
+async function stopProcess(child: ChildProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) {
+		return;
+	}
+	child.kill("SIGTERM");
+	await Promise.race([once(child, "exit"), delay(PROCESS_EXIT_GRACE_MS)]);
+	if (child.exitCode === null && child.signalCode === null) {
+		child.kill("SIGKILL");
+	}
+}
+
+async function runMaestroA2A(
+	args: string[],
+	env: NodeJS.ProcessEnv,
+): Promise<string> {
+	const child = spawn("bun", ["run", "a2a", "--", ...args], {
+		env,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	let stdout = "";
+	let stderr = "";
+	child.stdout?.on("data", (chunk: Buffer) => {
+		stdout += chunk.toString("utf8");
+	});
+	child.stderr?.on("data", (chunk: Buffer) => {
+		stderr += chunk.toString("utf8");
+	});
+	const [code, signal] = await waitForChildExit(
+		child,
+		CLI_TIMEOUT_MS + PROCESS_EXIT_GRACE_MS,
+		`maestro a2a ${args[0] ?? "command"}`,
+	);
+	if (code !== 0) {
+		throw new Error(
+			`maestro a2a ${args[0] ?? "command"} failed with ${code ?? signal ?? "unknown"}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`,
+		);
+	}
+	return stdout;
+}
+
+async function waitForChildExit(
+	child: ChildProcess,
+	timeoutMs: number,
+	label: string,
+): Promise<[number | null, NodeJS.Signals | null]> {
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		const timeout = setTimeout(() => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			void stopProcess(child).finally(() => {
+				reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+			});
+		}, timeoutMs);
+		child.once("error", (error) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			clearTimeout(timeout);
+			reject(error);
+		});
+		child.once("close", (code, signal) => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			clearTimeout(timeout);
+			resolve([code, signal]);
+		});
+	});
+}
+
+async function loadLedger(path: string): Promise<LedgerFile> {
+	const raw = await readFile(path, "utf8");
+	const parsed = JSON.parse(raw) as unknown;
+	if (!isRecord(parsed) || !Array.isArray(parsed.tasks)) {
+		throw new Error(`A2A task ledger at ${path} did not contain a tasks array`);
+	}
+	return {
+		tasks: parsed.tasks.map((entry, index) =>
+			normalizeLedgerEntry(entry, `tasks[${index}]`),
+		),
+	};
+}
+
+function normalizeLedgerEntry(input: unknown, label: string): LedgerEntry {
+	if (!isRecord(input)) {
+		throw new Error(`${label} must be an object`);
+	}
+	const taskId = requiredString(input.taskId, `${label}.taskId`);
+	const state = requiredString(input.state, `${label}.state`);
+	const text = requiredString(input.text, `${label}.text`);
+	const transcriptInput = input.transcript;
+	if (!Array.isArray(transcriptInput)) {
+		throw new Error(`${label}.transcript must be an array`);
+	}
+	return {
+		taskId,
+		state,
+		text,
+		...(typeof input.contextId === "string" ? { contextId: input.contextId } : {}),
+		...(typeof input.responseText === "string"
+			? { responseText: input.responseText }
+			: {}),
+		transcript: transcriptInput.map((entry, index) =>
+			normalizeTranscriptEntry(entry, `${label}.transcript[${index}]`),
+		),
+	};
+}
+
+function normalizeTranscriptEntry(input: unknown, label: string): TranscriptEntry {
+	if (!isRecord(input)) {
+		throw new Error(`${label} must be an object`);
+	}
+	return {
+		role: requiredString(input.role, `${label}.role`),
+		text: requiredString(input.text, `${label}.text`),
+		...(typeof input.state === "string" ? { state: input.state } : {}),
+	};
+}
+
+function requiredString(input: unknown, label: string): string {
+	if (typeof input !== "string" || !input.trim()) {
+		throw new Error(`${label} must be a non-empty string`);
+	}
+	return input;
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+	return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+
+function assertState(value: string, expected: "INPUT_REQUIRED" | "COMPLETED"): void {
+	const normalized = value.toUpperCase().replace(/[\s-]+/gu, "_");
+	if (!normalized.includes(expected)) {
+		throw new Error(`expected state ${expected}, got ${value}`);
+	}
+}
+
+function assertTranscript(
+	entry: LedgerEntry,
+	expected:
+		| readonly ["user", "agent"]
+		| readonly ["user", "agent", "user", "agent"],
+): void {
+	const roles = entry.transcript.map((item) => item.role);
+	if (JSON.stringify(roles) !== JSON.stringify(expected)) {
+		throw new Error(
+			`unexpected transcript roles for ${entry.taskId}: ${roles.join(" -> ")}`,
+		);
+	}
+}
+
+function latestLedgerEntry(ledger: LedgerFile): LedgerEntry {
+	if (ledger.tasks.length !== 1 || !ledger.tasks[0]) {
+		throw new Error(`expected exactly one A2A task, found ${ledger.tasks.length}`);
+	}
+	return ledger.tasks[0];
+}
+
+async function main(): Promise<void> {
+	const workDir = await mkdtemp(join(tmpdir(), "maestro-a2a-input-required-"));
+	const peersPath = join(workDir, "peers.json");
+	const tasksPath = join(workDir, "tasks.json");
+	const runtimeDir = join(workDir, "runtime");
+	let bridgeStderr = "";
+	let bridgeStdout = "";
+	let bridge: ChildProcess | undefined;
+	let baseUrl = "";
+
+	try {
+		for (let attempt = 1; attempt <= BRIDGE_START_ATTEMPTS; attempt += 1) {
+			const port = await openPort();
+			baseUrl = `http://127.0.0.1:${port}`;
+			await writePeerRegistry(peersPath, baseUrl);
+			bridgeStdout = "";
+			bridgeStderr = "";
+			bridge = spawnBridge(port, baseUrl, runtimeDir);
+			bridge.stdout?.on("data", (chunk: Buffer) => {
+				bridgeStdout += chunk.toString("utf8");
+			});
+			bridge.stderr?.on("data", (chunk: Buffer) => {
+				bridgeStderr += chunk.toString("utf8");
+			});
+			try {
+				await waitForHealth(
+					baseUrl,
+					() => `${bridgeStdout}\n${bridgeStderr}`,
+					bridge,
+				);
+				break;
+			} catch (error) {
+				await stopProcess(bridge);
+				bridge = undefined;
+				if (attempt >= BRIDGE_START_ATTEMPTS) {
+					throw error;
+				}
+			}
+		}
+		if (!bridge) {
+			throw new Error("Codex A2A bridge did not start");
+		}
+		const cliEnv = {
+			...process.env,
+			CODEX_A2A_TOKEN: TOKEN,
+			MAESTRO_A2A_PEERS_FILE: peersPath,
+			MAESTRO_A2A_TASKS_FILE: tasksPath,
+		};
+		const commonFlags = [
+			"--registry",
+			peersPath,
+			"--tasks",
+			tasksPath,
+			"--max-wait-ms",
+			String(CLI_TIMEOUT_MS),
+			"--interval-ms",
+			"100",
+			"--timeout-ms",
+			"3000",
+		];
+
+		await runMaestroA2A(
+			[
+				"delegate",
+				PEER_NAME,
+				FIRST_USER_TEXT,
+				"--role",
+				"background-worker",
+				"--cwd",
+				process.cwd(),
+				"--wait",
+				...commonFlags,
+			],
+			cliEnv,
+		);
+		const inputRequired = latestLedgerEntry(await loadLedger(tasksPath));
+		assertState(inputRequired.state, "INPUT_REQUIRED");
+		assertTranscript(inputRequired, ["user", "agent"]);
+		if (inputRequired.text !== FIRST_USER_TEXT) {
+			throw new Error(`unexpected delegated text: ${inputRequired.text}`);
+		}
+		const taskId = inputRequired.taskId;
+		const contextId = requiredString(
+			inputRequired.contextId,
+			"inputRequired.contextId",
+		);
+		if (!inputRequired.transcript[1]?.text.includes("?")) {
+			throw new Error(
+				`expected input-required agent turn to ask a question, got: ${inputRequired.transcript[1]?.text ?? "<missing>"}`,
+			);
+		}
+
+		await runMaestroA2A(
+			["reply", PEER_NAME, taskId, USER_REPLY_TEXT, "--wait", ...commonFlags],
+			cliEnv,
+		);
+		const completed = latestLedgerEntry(await loadLedger(tasksPath));
+		assertState(completed.state, "COMPLETED");
+		assertTranscript(completed, ["user", "agent", "user", "agent"]);
+		if (completed.taskId !== taskId) {
+			throw new Error(`reply changed taskId from ${taskId} to ${completed.taskId}`);
+		}
+		if (completed.contextId !== contextId) {
+			throw new Error(
+				`reply changed contextId from ${contextId} to ${completed.contextId ?? "<missing>"}`,
+			);
+		}
+		if (completed.transcript[0]?.text !== FIRST_USER_TEXT) {
+			throw new Error("final transcript did not preserve the original user turn");
+		}
+		if (completed.transcript[2]?.text !== USER_REPLY_TEXT) {
+			throw new Error("final transcript did not record the user reply");
+		}
+		if (!completed.responseText) {
+			throw new Error("completed A2A ledger entry did not record a final response");
+		}
+
+		console.log(
+			JSON.stringify(
+				{
+					ok: true,
+					peer: PEER_NAME,
+					taskId,
+					contextId,
+					initialState: inputRequired.state,
+					finalState: completed.state,
+					transcript: completed.transcript.map((item) => ({
+						role: item.role,
+						text: item.text,
+						...(item.state ? { state: item.state } : {}),
+					})),
+					peersPath,
+					tasksPath,
+				},
+				null,
+				2,
+			),
+		);
+	} finally {
+		if (bridge) {
+			await stopProcess(bridge);
+		}
+		if (process.env.MAESTRO_A2A_INPUT_REQUIRED_SMOKE_KEEP_WORKDIR !== "1") {
+			await rm(workDir, { force: true, recursive: true });
+		}
+	}
+}
+
+async function writePeerRegistry(path: string, baseUrl: string): Promise<void> {
+	await writeFile(
+		path,
+		`${JSON.stringify(
+			{
+				defaultPeer: PEER_NAME,
+				peers: {
+					[PEER_NAME]: {
+						url: baseUrl,
+						displayName: "Codex input-required fixture",
+						agentCardUrl: `${baseUrl}/.well-known/agent-card.json`,
+						tokenEnv: "CODEX_A2A_TOKEN",
+						workspaceId: "maestro-a2a-input-required-smoke",
+						agentId: "maestro-a2a-input-required-smoke",
+						timeoutMs: 3_000,
+						maxAttempts: 1,
+					},
+				},
+			},
+			null,
+			2,
+		)}\n`,
+		{ mode: 0o600 },
+	);
+}
+
+function spawnBridge(port: number, baseUrl: string, runtimeDir: string): ChildProcess {
+	return spawn("python3", ["scripts/codex-a2a-bridge.py"], {
+		env: {
+			...process.env,
+			CODEX_A2A_ACCESS_LOG: "0",
+			CODEX_A2A_BIND: "127.0.0.1",
+			CODEX_A2A_CODEX_BIN: "__maestro_fixture_mode_should_not_call_codex__",
+			CODEX_A2A_FIXTURE_MODE: "input-required-once",
+			CODEX_A2A_HOST: "127.0.0.1",
+			CODEX_A2A_PORT: String(port),
+			CODEX_A2A_PUBLIC_URL: baseUrl,
+			CODEX_A2A_RUNTIME_DIR: runtimeDir,
+			CODEX_A2A_TOKEN: TOKEN,
+			CODEX_A2A_TURN_TIMEOUT_MS: "5000",
+			CODEX_A2A_WORKDIR: process.cwd(),
+			PYTHONUNBUFFERED: "1",
+		},
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+}
+
+main().catch((error: unknown) => {
+	console.error(error instanceof Error ? error.stack : String(error));
+	process.exit(1);
+});

--- a/src/cli-tui/commands/a2a-handlers.ts
+++ b/src/cli-tui/commands/a2a-handlers.ts
@@ -10,6 +10,10 @@ import {
 	listA2ATaskEntries,
 	loadA2ATaskLedger,
 } from "../../platform/a2a-task-ledger.js";
+import {
+	formatA2AWorkGraphCodexSubagents,
+	formatA2AWorkGraphSummary,
+} from "../../platform/a2a-work-graph.js";
 import type { CommandExecutionContext } from "./types.js";
 
 export interface A2ACommandHandlerDeps {
@@ -78,6 +82,7 @@ export async function handleA2ATuiCommand(
 	if (subcommand === "tasks") {
 		const peer = parsed.positionals.shift();
 		const tasksPath = stringFlag(parsed.flags, "--tasks");
+		const includeWorkGraphDetails = parsed.flags.get("--work-graph") === true;
 		const ledger = await loadA2ATaskLedger({ path: tasksPath });
 		const entries = listA2ATaskEntries(ledger, { peer });
 		deps.addContent(
@@ -86,9 +91,19 @@ export async function handleA2ATuiCommand(
 				entries.length === 0
 					? "No delegated tasks recorded yet."
 					: entries
-							.map(
-								(entry) =>
+							.map((entry) =>
+								[
 									`${entry.peer} ${entry.taskId} ${entry.state} ${entry.text}`,
+									formatA2AWorkGraphSummary(entry.workGraph),
+									includeWorkGraphDetails
+										? formatA2AWorkGraphCodexSubagents(entry.workGraph)
+										: undefined,
+									includeWorkGraphDetails && entry.workGraph?.correlationPath
+										? `Correlation: ${entry.workGraph.correlationPath}`
+										: undefined,
+								]
+									.filter(Boolean)
+									.join("\n  "),
 							)
 							.join("\n"),
 			].join("\n"),
@@ -130,6 +145,12 @@ export async function handleA2ATuiCommand(
 		);
 		return;
 	}
+	if (subcommand === "coordinate") {
+		context.showInfo(
+			"Use `maestro a2a coordinate [peer] --refresh` to refresh actionable A2A tasks, or add `--reply <text>` to answer the selected task while the TUI coordination panel is being wired.",
+		);
+		return;
+	}
 	if (subcommand === "reply" || subcommand === "continue") {
 		context.showInfo(
 			"Use `maestro a2a reply <peer> <task-id> <text> --wait` to continue an actionable A2A task while the TUI task panel is being wired.",
@@ -149,6 +170,7 @@ export async function handleA2ATuiCommand(
 			"/a2a peers",
 			"/a2a delegate <peer> <text>",
 			"/a2a reply <peer> <task-id> <text>",
+			"/a2a coordinate [peer] [--reply <text>]",
 			"/a2a tasks [peer]",
 			"/a2a send <peer> <text>",
 		].join("\n"),

--- a/src/cli/commands/a2a.ts
+++ b/src/cli/commands/a2a.ts
@@ -26,6 +26,8 @@ import {
 	type A2ATaskLedgerEntry,
 	extractA2ATaskText,
 	getA2ATaskLedgerPath,
+	isActionRequiredA2AState,
+	isFinalA2AState,
 	isTerminalA2AState,
 	listA2ATaskEntries,
 	loadA2ATaskLedger,
@@ -33,6 +35,11 @@ import {
 	recordA2ATaskStart,
 	updateA2ATaskInLedger,
 } from "../../platform/a2a-task-ledger.js";
+import {
+	extractA2AWorkGraphMetadata,
+	formatA2AWorkGraphCodexSubagents,
+	formatA2AWorkGraphSummary,
+} from "../../platform/a2a-work-graph.js";
 import { getEnvValue } from "../../platform/client.js";
 import { isAbortError } from "../../utils/abort-error.js";
 
@@ -54,6 +61,14 @@ const A2A_VALUE_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> = {
 		"--max-wait-ms",
 		"--registry",
 		"--role",
+		"--tasks",
+		"--timeout-ms",
+	],
+	coordinate: [
+		"--interval-ms",
+		"--max-wait-ms",
+		"--registry",
+		"--reply",
 		"--tasks",
 		"--timeout-ms",
 	],
@@ -86,12 +101,18 @@ const A2A_VALUE_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> = {
 };
 const A2A_BOOLEAN_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> = {
 	accept: ["--default"],
-	delegate: ["--wait"],
+	coordinate: ["--json", "--refresh", "--wait", "--work-graph"],
+	delegate: ["--wait", "--work-graph"],
 	fleet: ["--json"],
-	reply: ["--wait"],
-	send: ["--wait"],
-	tasks: ["--json", "--refresh"],
+	reply: ["--wait", "--work-graph"],
+	send: ["--wait", "--work-graph"],
+	tasks: ["--json", "--refresh", "--work-graph"],
+	wait: ["--work-graph"],
 };
+const A2A_COLLECT_VALUE_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> =
+	{
+		coordinate: ["--reply"],
+	};
 const A2A_LEADING_VALUE_FLAGS = new Set(
 	Object.values(A2A_VALUE_FLAGS_BY_SUBCOMMAND).flat(),
 );
@@ -137,6 +158,9 @@ export async function handleA2ACommand(args: string[]): Promise<void> {
 		case "continue":
 			await handleA2AReply(parsed);
 			return;
+		case "coordinate":
+			await handleA2ACoordinate(parsed);
+			return;
 		case "tasks":
 			await handleA2ATasks(parsed);
 			return;
@@ -159,6 +183,9 @@ export function parseA2AArgs(args: string[]): ParsedA2AArgs {
 	const valueFlags = new Set(A2A_VALUE_FLAGS_BY_SUBCOMMAND[subcommand] ?? []);
 	const booleanFlags = new Set(
 		A2A_BOOLEAN_FLAGS_BY_SUBCOMMAND[subcommand] ?? [],
+	);
+	const collectValueFlags = new Set(
+		A2A_COLLECT_VALUE_FLAGS_BY_SUBCOMMAND[subcommand] ?? [],
 	);
 	for (let index = 0; index < args.length; index++) {
 		const arg = args[index];
@@ -189,11 +216,36 @@ export function parseA2AArgs(args: string[]): ParsedA2AArgs {
 				continue;
 			}
 			if (inlineValue !== undefined) {
+				if (collectValueFlags.has(flag) && !inlineValue.trim()) {
+					throw new Error(collectValueFlagMissingTextMessage(flag, subcommand));
+				}
 				flags.set(flag, inlineValue);
 				continue;
 			}
 			if (booleanFlags.has(flag)) {
 				flags.set(flag, true);
+				continue;
+			}
+			if (collectValueFlags.has(flag)) {
+				const values: string[] = [];
+				while (args[index + 1] && args[index + 1] !== "--") {
+					const next = args[index + 1]!;
+					const [nextFlag] = next.split("=", 2);
+					if (
+						next.startsWith("--") &&
+						nextFlag &&
+						(valueFlags.has(nextFlag) || booleanFlags.has(nextFlag))
+					) {
+						break;
+					}
+					values.push(next);
+					index++;
+				}
+				const value = values.join(" ").trim();
+				if (!value) {
+					throw new Error(collectValueFlagMissingTextMessage(flag, subcommand));
+				}
+				flags.set(flag, value);
 				continue;
 			}
 			const next = args[index + 1];
@@ -208,6 +260,17 @@ export function parseA2AArgs(args: string[]): ParsedA2AArgs {
 		positionals.push(arg);
 	}
 	return { flags, positionals };
+}
+
+function collectValueFlagMissingTextMessage(
+	flag: string,
+	subcommand: string,
+): string {
+	const usage =
+		subcommand === "coordinate" && flag === "--reply"
+			? "\nUsage: maestro a2a coordinate [peer] --reply <text> [--wait]"
+			: "";
+	return `${flag} requires text${usage}`;
 }
 
 function findA2ASubcommandIndex(args: readonly string[]): number {
@@ -448,7 +511,9 @@ async function handleA2ASend(parsed: ParsedA2AArgs): Promise<void> {
 	const task = wait
 		? await waitForA2ATask(peer.config, sent.task.id, parsed)
 		: sent.task;
-	printTask(task);
+	printTask(task, {
+		includeWorkGraphDetails: booleanFlag(parsed, "--work-graph"),
+	});
 }
 
 async function handleA2ADelegate(parsed: ParsedA2AArgs): Promise<void> {
@@ -515,7 +580,9 @@ async function handleA2ADelegate(parsed: ParsedA2AArgs): Promise<void> {
 			}),
 		);
 	}
-	printTask(task);
+	printTask(task, {
+		includeWorkGraphDetails: booleanFlag(parsed, "--work-graph"),
+	});
 }
 
 async function handleA2AReply(parsed: ParsedA2AArgs): Promise<void> {
@@ -578,7 +645,171 @@ async function handleA2AReply(parsed: ParsedA2AArgs): Promise<void> {
 			}),
 		);
 	}
-	printTask(task);
+	printTask(task, {
+		includeWorkGraphDetails: booleanFlag(parsed, "--work-graph"),
+	});
+}
+
+async function handleA2ACoordinate(parsed: ParsedA2AArgs): Promise<void> {
+	const peerName = parsed.positionals.shift();
+	if (parsed.positionals.length > 0) {
+		fail("Usage: maestro a2a coordinate [peer] [--reply <text>] [--wait]");
+	}
+	const replyText = stringFlag(parsed, "--reply");
+	if (parsed.flags.has("--reply") && !replyText) {
+		fail("Usage: maestro a2a coordinate [peer] --reply <text> [--wait]");
+	}
+	if (replyText) {
+		await handleA2ACoordinateReply(parsed, peerName, replyText);
+		return;
+	}
+	await refreshA2ANonFinalTaskLedger(parsed, peerName);
+	const ledger = await loadA2ATaskLedger({
+		path: stringFlag(parsed, "--tasks"),
+	});
+	const tasks = actionableA2ATaskEntries(ledger, peerName);
+	if (booleanFlag(parsed, "--json")) {
+		console.log(
+			JSON.stringify(
+				{
+					path: getA2ATaskLedgerPath(stringFlag(parsed, "--tasks")),
+					tasks: tasks.map((entry) => ({
+						id: entry.id,
+						kind: entry.kind,
+						peer: entry.peer,
+						taskId: entry.taskId,
+						contextId: entry.contextId,
+						state: entry.state,
+						text: entry.text,
+						responseText: entry.responseText,
+						workGraph: entry.workGraph,
+						updatedAt: entry.updatedAt,
+					})),
+				},
+				null,
+				2,
+			),
+		);
+		return;
+	}
+	console.log(
+		`A2A coordinate (${getA2ATaskLedgerPath(stringFlag(parsed, "--tasks"))})`,
+	);
+	if (tasks.length === 0) {
+		console.log(chalk.dim("  No actionable A2A tasks require coordination."));
+		return;
+	}
+	for (const task of tasks) {
+		console.log(
+			`${task.peer} ${chalk.bold(task.taskId)} ${task.state} ${chalk.dim(task.updatedAt)}`,
+		);
+		console.log(chalk.dim(`  ${task.text}`));
+		if (task.responseText) {
+			console.log(`  ${task.responseText}`);
+		}
+		printLedgerWorkGraph(task, booleanFlag(parsed, "--work-graph"));
+	}
+}
+
+async function handleA2ACoordinateReply(
+	parsed: ParsedA2AArgs,
+	peerName: string | undefined,
+	text: string,
+): Promise<void> {
+	await refreshA2ANonFinalTaskLedger(parsed, peerName);
+	const ledger = await loadA2ATaskLedger({
+		path: stringFlag(parsed, "--tasks"),
+	});
+	const entry = selectCoordinateReplyTask(ledger, peerName);
+	if (!entry) {
+		fail("No actionable A2A task is waiting for coordinator input.");
+	}
+	const peer = await resolveA2APeer(entry.peer, {
+		path: stringFlag(parsed, "--registry"),
+		timeoutMs: numberFlag(parsed, "--timeout-ms"),
+	});
+	const messageId = `maestro-a2a-message-${randomUUID()}`;
+	const sent = await sendA2AMessage(peer.config, {
+		message: buildA2AUserMessage({
+			messageId,
+			contextId: entry.contextId,
+			taskId: entry.taskId,
+			text,
+			metadata: {
+				requestKind: "maestro-peer-coordinate-reply",
+				relayPeer: peer.name,
+				referencedTaskId: entry.taskId,
+			},
+		}),
+		configuration: { returnImmediately: true },
+	});
+	const replyTask: A2ATask = {
+		...sent.task,
+		id: entry.taskId,
+		contextId: sent.task.contextId ?? entry.contextId,
+	};
+	const json = booleanFlag(parsed, "--json");
+	if (!json) {
+		console.log(`Coordinated ${chalk.bold(peer.name)} task ${entry.taskId}`);
+	}
+	await persistA2ALedgerBestEffort("record coordinate reply locally", () =>
+		recordA2ATaskReply({
+			path: stringFlag(parsed, "--tasks"),
+			peer: peer.name,
+			peerDisplayName: peer.entry.displayName,
+			task: replyTask,
+			text,
+			messageId,
+			metadata: {
+				requestKind: "maestro-peer-coordinate-reply",
+				relayPeer: peer.name,
+				referencedTaskId: entry.taskId,
+			},
+		}),
+	);
+	const task = booleanFlag(parsed, "--wait")
+		? await waitForA2ATask(peer.config, entry.taskId, parsed)
+		: replyTask;
+	if (booleanFlag(parsed, "--wait")) {
+		await persistA2ALedgerBestEffort(
+			"sync coordinate task result locally",
+			() =>
+				updateA2ATaskInLedger({
+					path: stringFlag(parsed, "--tasks"),
+					peer: peer.name,
+					task,
+				}),
+		);
+	}
+	if (json) {
+		console.log(JSON.stringify({ peer: peer.name, task }, null, 2));
+		return;
+	}
+	printTask(task, {
+		includeWorkGraphDetails: booleanFlag(parsed, "--work-graph"),
+	});
+}
+
+function actionableA2ATaskEntries(
+	ledger: { tasks: A2ATaskLedgerEntry[] },
+	peerName: string | undefined,
+): A2ATaskLedgerEntry[] {
+	return listA2ATaskEntries(ledger, { peer: peerName }).filter((entry) =>
+		isActionRequiredA2AState(entry.state),
+	);
+}
+
+function selectCoordinateReplyTask(
+	ledger: { tasks: A2ATaskLedgerEntry[] },
+	peerName: string | undefined,
+): A2ATaskLedgerEntry | undefined {
+	const tasks = actionableA2ATaskEntries(ledger, peerName);
+	if (tasks.length > 1) {
+		fail(
+			"Multiple actionable A2A tasks found; use `maestro a2a reply <peer> <task-id> <text>`.",
+		);
+	}
+	return tasks[0];
 }
 
 async function loadA2AReplyLedgerEntry(
@@ -628,6 +859,7 @@ async function handleA2ATasks(parsed: ParsedA2AArgs): Promise<void> {
 						state: entry.state,
 						text: entry.text,
 						responseText: entry.responseText,
+						workGraph: entry.workGraph,
 						updatedAt: entry.updatedAt,
 					})),
 				},
@@ -652,6 +884,7 @@ async function handleA2ATasks(parsed: ParsedA2AArgs): Promise<void> {
 		if (task.responseText) {
 			console.log(`  ${task.responseText}`);
 		}
+		printLedgerWorkGraph(task, booleanFlag(parsed, "--work-graph"));
 	}
 }
 
@@ -674,7 +907,9 @@ async function handleA2AWait(parsed: ParsedA2AArgs): Promise<void> {
 			task,
 		}),
 	);
-	printTask(task);
+	printTask(task, {
+		includeWorkGraphDetails: booleanFlag(parsed, "--work-graph"),
+	});
 }
 
 async function refreshA2ATaskLedger(
@@ -701,6 +936,41 @@ async function refreshA2ATaskLedger(
 	}
 }
 
+async function refreshA2ANonFinalTaskLedger(
+	parsed: ParsedA2AArgs,
+	peerFilter: string | undefined,
+): Promise<void> {
+	const ledger = await loadA2ATaskLedger({
+		path: stringFlag(parsed, "--tasks"),
+	});
+	for (const entry of listA2ATaskEntries(ledger, { peer: peerFilter })) {
+		if (isFinalA2AState(entry.state)) {
+			continue;
+		}
+		try {
+			const peer = await resolveA2APeer(entry.peer, {
+				path: stringFlag(parsed, "--registry"),
+				timeoutMs: numberFlag(parsed, "--timeout-ms"),
+			});
+			const task = await getA2ATask(peer.config, entry.taskId);
+			await updateA2ATaskInLedger({
+				path: stringFlag(parsed, "--tasks"),
+				peer: entry.peer,
+				task,
+			});
+		} catch (error) {
+			if (isAbortError(error)) {
+				throw error;
+			}
+			console.error(
+				chalk.yellow(
+					`A2A coordinate warning: could not refresh ${entry.peer} task ${entry.taskId}: ${errorMessage(error)}`,
+				),
+			);
+		}
+	}
+}
+
 async function waitForA2ATask(
 	config: A2AServiceConfig,
 	taskId: string,
@@ -723,16 +993,51 @@ async function waitForA2ATask(
 	return lastTask;
 }
 
-function printTask(task: A2ATask): void {
+function printTask(
+	task: A2ATask,
+	options: { includeWorkGraphDetails?: boolean } = {},
+): void {
 	console.log(`Task ${task.id}: ${task.status.state}`);
 	const text = a2aTaskText(task);
 	if (text) {
 		console.log(text);
 	}
+	printTaskWorkGraph(task, Boolean(options.includeWorkGraphDetails));
 }
 
 function a2aTaskText(task: A2ATask): string | undefined {
 	return extractA2ATaskText(task);
+}
+
+function printTaskWorkGraph(task: A2ATask, includeDetails: boolean): void {
+	printWorkGraphLines(extractA2AWorkGraphMetadata(task), includeDetails);
+}
+
+function printLedgerWorkGraph(
+	entry: A2ATaskLedgerEntry,
+	includeDetails: boolean,
+): void {
+	printWorkGraphLines(entry.workGraph, includeDetails);
+}
+
+function printWorkGraphLines(
+	workGraph: A2ATaskLedgerEntry["workGraph"],
+	includeDetails: boolean,
+): void {
+	const summary = formatA2AWorkGraphSummary(workGraph);
+	if (summary) {
+		console.log(chalk.dim(`  ${summary}`));
+	}
+	if (!includeDetails) {
+		return;
+	}
+	const codexSubagents = formatA2AWorkGraphCodexSubagents(workGraph);
+	if (codexSubagents) {
+		console.log(chalk.dim(`  ${codexSubagents}`));
+	}
+	if (workGraph?.correlationPath) {
+		console.log(chalk.dim(`  Correlation: ${workGraph.correlationPath}`));
+	}
 }
 
 export const isA2AWaitCompletionState = isTerminalA2AState;
@@ -811,11 +1116,12 @@ function printA2AHelp(): void {
   maestro a2a peers
   maestro a2a fleet [--json]
   maestro a2a card <peer>
-  maestro a2a delegate <peer> <text> [--role <role>] [--cwd <path>] [--wait]
-  maestro a2a reply <peer> <task-id> <text> [--wait]
-  maestro a2a send <peer> <text> [--wait]
-  maestro a2a tasks [peer] [--json] [--refresh]
-  maestro a2a wait <peer> <task-id>
+  maestro a2a coordinate [peer] [--reply <text>] [--wait] [--json] [--work-graph]
+  maestro a2a delegate <peer> <text> [--role <role>] [--cwd <path>] [--wait] [--work-graph]
+  maestro a2a reply <peer> <task-id> <text> [--wait] [--work-graph]
+  maestro a2a send <peer> <text> [--wait] [--work-graph]
+  maestro a2a tasks [peer] [--json] [--refresh] [--work-graph]
+  maestro a2a wait <peer> <task-id> [--work-graph]
 
 Pairing codes carry Agent Card and transport coordinates only. Configure auth with
 --token-env or --token-file when accepting a peer; bearer tokens are never embedded.`);

--- a/src/cli/headless-protocol.ts
+++ b/src/cli/headless-protocol.ts
@@ -561,6 +561,15 @@ export interface HeadlessActiveToolState {
 	output: string;
 }
 
+export interface HeadlessCodexSubagentContinuityEdge {
+	spawn_tool_call_id?: string;
+	wait_tool_call_id?: string;
+	child_run_id?: string;
+	thread_id?: string;
+	operation: string;
+	status: string;
+}
+
 export interface HeadlessActiveUtilityCommandState {
 	command_id: string;
 	command: string;
@@ -626,6 +635,7 @@ export interface HeadlessRuntimeState {
 	active_utility_commands: HeadlessActiveUtilityCommandState[];
 	active_file_watches: HeadlessActiveFileWatchState[];
 	tracked_tools: HeadlessPendingApprovalState[];
+	codex_subagent_edges: HeadlessCodexSubagentContinuityEdge[];
 	last_error?: string;
 	last_error_type?: HeadlessErrorMessage["error_type"];
 	last_status?: string;
@@ -662,6 +672,7 @@ export function createHeadlessRuntimeState(): HeadlessRuntimeState {
 		active_utility_commands: [],
 		active_file_watches: [],
 		tracked_tools: [],
+		codex_subagent_edges: [],
 		is_ready: false,
 		is_responding: false,
 	};
@@ -719,6 +730,317 @@ export function syncHeadlessPendingRequests(
 		),
 	];
 	return state.pending_requests;
+}
+
+export const CODEX_SUBAGENT_TOOL_PREFIX = "codex.subagent.";
+export const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA =
+	"evalops.maestro.codex.subagent-workgraph.v1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function stringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter(
+				(item): item is string => typeof item === "string" && item.length > 0,
+			)
+		: [];
+}
+
+export function codexSubagentOperation(tool: string): string | undefined {
+	const suffix = tool.startsWith(CODEX_SUBAGENT_TOOL_PREFIX)
+		? tool.slice(CODEX_SUBAGENT_TOOL_PREFIX.length)
+		: tool;
+	switch (suffix) {
+		case "spawnAgent":
+		case "spawn_agent":
+			return "spawn_agent";
+		case "sendInput":
+		case "send_input":
+			return "send_input";
+		case "resumeAgent":
+		case "resume_agent":
+			return "resume_agent";
+		case "wait":
+		case "waitAgent":
+		case "wait_agent":
+			return "wait_agent";
+		case "closeAgent":
+		case "close_agent":
+			return "close_agent";
+		default:
+			return undefined;
+	}
+}
+
+export function activeCodexSubagentStatus(operation: string): string {
+	switch (operation) {
+		case "send_input":
+			return "waiting_for_input_ack";
+		case "wait_agent":
+			return "wait_pending";
+		case "close_agent":
+			return "waiting_for_close";
+		case "resume_agent":
+			return "restoring";
+		default:
+			return "waiting_for_restore";
+	}
+}
+
+export function codexSubagentStatusIsTerminal(
+	status: string | undefined,
+): boolean {
+	switch ((status ?? "").toLowerCase().replace(/[-\s]+/g, "_")) {
+		case "closed":
+		case "explicitly_closed":
+		case "succeeded":
+		case "success":
+		case "completed":
+		case "complete":
+		case "done":
+		case "acknowledged":
+		case "failed":
+		case "failure":
+		case "error":
+		case "cancelled":
+		case "canceled":
+			return true;
+		default:
+			return false;
+	}
+}
+
+function terminalCodexSubagentStatus(
+	operation: string,
+	success: boolean,
+): string {
+	if (!success) {
+		return "failed";
+	}
+	switch (operation) {
+		case "spawn_agent":
+			return "spawned";
+		case "send_input":
+			return "acknowledged";
+		case "resume_agent":
+			return "resumed";
+		case "close_agent":
+			return "closed";
+		default:
+			return "completed";
+	}
+}
+
+export function collectCodexChildRuns(args: unknown): Array<{
+	child_run_id?: string;
+	thread_id?: string;
+}> {
+	if (!isRecord(args)) {
+		return [];
+	}
+	const childRunIds = stringArray(args.childRunIds ?? args.child_run_ids);
+	const threadIds = stringArray(
+		args.receiverThreadIds ?? args.receiver_thread_ids,
+	);
+	const graph = args.codexWorkGraph ?? args.codex_work_graph;
+	const graphRuns: Array<{ child_run_id?: string; thread_id?: string }> = [];
+	if (isRecord(graph)) {
+		const graphChildRuns = graph.childRuns ?? graph.child_runs;
+		for (const childRun of Array.isArray(graphChildRuns)
+			? graphChildRuns
+			: []) {
+			if (!isRecord(childRun)) {
+				continue;
+			}
+			graphRuns.push({
+				child_run_id: nonEmptyString(
+					childRun.childRunId ?? childRun.child_run_id,
+				),
+				thread_id: nonEmptyString(childRun.threadId ?? childRun.thread_id),
+			});
+		}
+	}
+	const count = Math.max(
+		childRunIds.length,
+		threadIds.length,
+		graphRuns.length,
+		1,
+	);
+	const runs: Array<{ child_run_id?: string; thread_id?: string }> = [];
+	for (let index = 0; index < count; index += 1) {
+		runs.push({
+			child_run_id: childRunIds[index] ?? graphRuns[index]?.child_run_id,
+			thread_id: threadIds[index] ?? graphRuns[index]?.thread_id,
+		});
+	}
+	return runs.filter((run) => run.child_run_id || run.thread_id);
+}
+
+function hasCodexWorkGraph(args: unknown): boolean {
+	if (!isRecord(args)) {
+		return false;
+	}
+	const graph = args.codexWorkGraph ?? args.codex_work_graph;
+	return (
+		isRecord(graph) &&
+		(graph.schemaVersion === CODEX_SUBAGENT_WORK_GRAPH_SCHEMA ||
+			graph.schema_version === CODEX_SUBAGENT_WORK_GRAPH_SCHEMA)
+	);
+}
+
+export function codexSubagentEdgeKey(
+	edge: HeadlessCodexSubagentContinuityEdge,
+): string {
+	return [
+		edge.spawn_tool_call_id ?? "",
+		edge.wait_tool_call_id ?? "",
+		edge.child_run_id ?? "",
+		edge.thread_id ?? "",
+		edge.operation,
+	].join("\u0000");
+}
+
+export function buildCodexSubagentContinuityEdges(input: {
+	call_id: string;
+	tool: string;
+	args?: unknown;
+	status: string;
+}): HeadlessCodexSubagentContinuityEdge[] {
+	const operation = codexSubagentOperation(input.tool);
+	if (!operation) {
+		return [];
+	}
+	const base: Omit<
+		HeadlessCodexSubagentContinuityEdge,
+		"child_run_id" | "thread_id"
+	> = {
+		operation,
+		status: input.status,
+		...(operation === "spawn_agent"
+			? { spawn_tool_call_id: input.call_id }
+			: { wait_tool_call_id: input.call_id }),
+	};
+	const childRuns = collectCodexChildRuns(input.args);
+	return childRuns.length > 0
+		? childRuns.map((childRun) => ({
+				...base,
+				...(childRun.child_run_id
+					? { child_run_id: childRun.child_run_id }
+					: {}),
+				...(childRun.thread_id ? { thread_id: childRun.thread_id } : {}),
+			}))
+		: [base];
+}
+
+function upsertCodexSubagentContinuityEdges(
+	state: HeadlessRuntimeState,
+	input: {
+		call_id: string;
+		tool: string;
+		args?: unknown;
+		status: string;
+	},
+): void {
+	const operation = codexSubagentOperation(input.tool);
+	if (
+		!operation ||
+		(!input.tool.startsWith(CODEX_SUBAGENT_TOOL_PREFIX) &&
+			!hasCodexWorkGraph(input.args))
+	) {
+		return;
+	}
+	const edges = buildCodexSubagentContinuityEdges(input);
+	state.codex_subagent_edges ??= [];
+	const existing = new Map<string, HeadlessCodexSubagentContinuityEdge>(
+		state.codex_subagent_edges.map((edge) => [
+			codexSubagentEdgeKey(edge),
+			edge,
+		]),
+	);
+	for (const edge of edges) {
+		existing.set(codexSubagentEdgeKey(edge), edge);
+	}
+	if (
+		(input.status === "closed" || input.status === "completed") &&
+		(operation === "close_agent" || operation === "wait_agent")
+	) {
+		const closedChildIds = new Set(
+			edges.map((edge) => edge.child_run_id).filter(Boolean),
+		);
+		const closedThreadIds = new Set(
+			edges.map((edge) => edge.thread_id).filter(Boolean),
+		);
+		for (const [key, edge] of existing) {
+			if (
+				edge.operation === operation ||
+				codexSubagentStatusIsTerminal(edge.status)
+			) {
+				continue;
+			}
+			const sameChild =
+				(edge.child_run_id && closedChildIds.has(edge.child_run_id)) ||
+				(edge.thread_id && closedThreadIds.has(edge.thread_id));
+			if (sameChild) {
+				existing.set(key, { ...edge, status: "completed" });
+			}
+		}
+	}
+	state.codex_subagent_edges = [...existing.values()].sort((left, right) =>
+		codexSubagentEdgeKey(left).localeCompare(codexSubagentEdgeKey(right)),
+	);
+}
+
+function markCodexSubagentEdgesFailedForCall(
+	state: HeadlessRuntimeState,
+	callId: string,
+): void {
+	if (!callId) {
+		return;
+	}
+	state.codex_subagent_edges ??= [];
+	state.codex_subagent_edges = state.codex_subagent_edges
+		.map((edge) => {
+			const matches =
+				edge.spawn_tool_call_id === callId || edge.wait_tool_call_id === callId;
+			if (!matches || codexSubagentStatusIsTerminal(edge.status)) {
+				return edge;
+			}
+			return { ...edge, status: "failed" };
+		})
+		.sort((left, right) =>
+			codexSubagentEdgeKey(left).localeCompare(codexSubagentEdgeKey(right)),
+		);
+}
+
+function failCodexSubagentContinuityEdge(
+	state: HeadlessRuntimeState,
+	callId: string,
+): void {
+	const source =
+		state.tracked_tools.find((tool) => tool.call_id === callId) ??
+		state.pending_approvals.find((approval) => approval.call_id === callId) ??
+		state.pending_client_tools.find((request) => request.call_id === callId) ??
+		state.pending_mcp_elicitations.find(
+			(request) => request.call_id === callId,
+		) ??
+		state.pending_user_inputs.find((request) => request.call_id === callId) ??
+		state.pending_tool_retries.find((request) => request.call_id === callId);
+	const operation = source ? codexSubagentOperation(source.tool) : undefined;
+	if (source && operation) {
+		upsertCodexSubagentContinuityEdges(state, {
+			call_id: callId,
+			tool: source.tool,
+			args: source.args,
+			status: terminalCodexSubagentStatus(operation, false),
+		});
+	}
+	markCodexSubagentEdgesFailedForCall(state, callId);
 }
 
 export function headlessViewerCanSend(msg: HeadlessToAgentMessage): boolean {
@@ -1496,6 +1818,9 @@ function applyOutgoingHeadlessMessageInner(
 			state.is_responding = true;
 			return;
 		case "tool_response":
+			if (!msg.approved) {
+				failCodexSubagentContinuityEdge(state, msg.call_id);
+			}
 			state.pending_approvals = state.pending_approvals.filter(
 				(approval) => approval.call_id !== msg.call_id,
 			);
@@ -1524,12 +1849,20 @@ function applyOutgoingHeadlessMessageInner(
 			return;
 		case "server_request_response":
 			if (msg.request_type === "approval") {
+				const pendingApproval = state.pending_approvals.find(
+					(approval) => getPendingRequestId(approval) === msg.request_id,
+				);
+				const callId = pendingApproval?.call_id ?? msg.request_id;
+				if (!msg.approved) {
+					failCodexSubagentContinuityEdge(state, callId);
+				}
 				state.pending_approvals = state.pending_approvals.filter(
 					(approval) => getPendingRequestId(approval) !== msg.request_id,
 				);
 				if (!msg.approved) {
 					state.tracked_tools = state.tracked_tools.filter(
-						(tool) => tool.call_id !== msg.request_id,
+						(tool) =>
+							tool.call_id !== callId && tool.call_id !== msg.request_id,
 					);
 				}
 			} else if (msg.request_type === "client_tool") {
@@ -1656,6 +1989,14 @@ function applyIncomingHeadlessMessageInner(
 			state.is_responding = false;
 			return;
 		case "tool_call":
+			upsertCodexSubagentContinuityEdges(state, {
+				call_id: msg.call_id,
+				tool: msg.tool,
+				args: msg.args,
+				status: activeCodexSubagentStatus(
+					codexSubagentOperation(msg.tool) ?? "",
+				),
+			});
 			state.tracked_tools = [
 				...state.tracked_tools.filter((tool) => tool.call_id !== msg.call_id),
 				{
@@ -1720,7 +2061,35 @@ function applyIncomingHeadlessMessageInner(
 					: tool,
 			);
 			return;
-		case "tool_end":
+		case "tool_end": {
+			const source =
+				state.tracked_tools.find((tool) => tool.call_id === msg.call_id) ??
+				state.pending_approvals.find(
+					(approval) => approval.call_id === msg.call_id,
+				) ??
+				state.pending_client_tools.find(
+					(request) => request.call_id === msg.call_id,
+				) ??
+				state.pending_mcp_elicitations.find(
+					(request) => request.call_id === msg.call_id,
+				) ??
+				state.pending_user_inputs.find(
+					(request) => request.call_id === msg.call_id,
+				) ??
+				state.pending_tool_retries.find(
+					(request) => request.call_id === msg.call_id,
+				);
+			if (source) {
+				const operation = codexSubagentOperation(source.tool);
+				if (operation) {
+					upsertCodexSubagentContinuityEdges(state, {
+						call_id: msg.call_id,
+						tool: source.tool,
+						args: source.args,
+						status: terminalCodexSubagentStatus(operation, msg.success),
+					});
+				}
+			}
 			state.active_tools = state.active_tools.filter(
 				(tool) => tool.call_id !== msg.call_id,
 			);
@@ -1743,6 +2112,7 @@ function applyIncomingHeadlessMessageInner(
 				(tool) => tool.call_id !== msg.call_id,
 			);
 			return;
+		}
 		case "client_tool_request":
 			state.tracked_tools = [
 				...state.tracked_tools.filter((tool) => tool.call_id !== msg.call_id),
@@ -1752,6 +2122,14 @@ function applyIncomingHeadlessMessageInner(
 					args: msg.args,
 				},
 			];
+			upsertCodexSubagentContinuityEdges(state, {
+				call_id: msg.call_id,
+				tool: msg.tool,
+				args: msg.args,
+				status: activeCodexSubagentStatus(
+					codexSubagentOperation(msg.tool) ?? "",
+				),
+			});
 			if (msg.tool === "ask_user") {
 				state.pending_user_inputs = [
 					...state.pending_user_inputs.filter(
@@ -1790,6 +2168,14 @@ function applyIncomingHeadlessMessageInner(
 					},
 				];
 			}
+			upsertCodexSubagentContinuityEdges(state, {
+				call_id: msg.call_id,
+				tool: msg.tool,
+				args: msg.args,
+				status: activeCodexSubagentStatus(
+					codexSubagentOperation(msg.tool) ?? "",
+				),
+			});
 			if (msg.request_type === "approval") {
 				state.pending_approvals = [
 					...state.pending_approvals.filter(
@@ -1866,6 +2252,7 @@ function applyIncomingHeadlessMessageInner(
 					(approval) => getPendingRequestId(approval) !== msg.request_id,
 				);
 				if (msg.resolution !== "approved") {
+					failCodexSubagentContinuityEdge(state, msg.call_id);
 					state.tracked_tools = state.tracked_tools.filter(
 						(tool) => tool.call_id !== msg.call_id,
 					);
@@ -1875,6 +2262,7 @@ function applyIncomingHeadlessMessageInner(
 					(request) => getPendingRequestId(request) !== msg.request_id,
 				);
 				if (msg.resolution === "cancelled") {
+					failCodexSubagentContinuityEdge(state, msg.call_id);
 					state.tracked_tools = state.tracked_tools.filter(
 						(tool) => tool.call_id !== msg.call_id,
 					);
@@ -1888,6 +2276,7 @@ function applyIncomingHeadlessMessageInner(
 					(request) => getPendingRequestId(request) !== msg.request_id,
 				);
 				if (msg.resolution !== "answered") {
+					failCodexSubagentContinuityEdge(state, msg.call_id);
 					state.tracked_tools = state.tracked_tools.filter(
 						(tool) => tool.call_id !== msg.call_id,
 					);

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -700,8 +700,8 @@ function normalizeA2AStreamEvent(
 			: payload;
 		return {
 			...statusUpdatePayload,
-			type: "statusUpdate",
 			status: statusUpdatePayload.status as A2ATaskStatus,
+			type: "statusUpdate",
 		};
 	}
 	const artifactUpdatePayload = isRecord(payload.artifactUpdate)
@@ -709,8 +709,8 @@ function normalizeA2AStreamEvent(
 		: payload;
 	return {
 		...artifactUpdatePayload,
-		type: "artifactUpdate",
 		artifact: artifactUpdatePayload.artifact as A2AArtifact,
+		type: "artifactUpdate",
 	};
 }
 

--- a/src/platform/a2a-fleet.ts
+++ b/src/platform/a2a-fleet.ts
@@ -11,6 +11,7 @@ import {
 	latestA2ATaskForPeer,
 	loadA2ATaskLedger,
 } from "./a2a-task-ledger.js";
+import type { A2AWorkGraphMetadata } from "./a2a-work-graph.js";
 
 const DEFAULT_A2A_FLEET_PROBE_TIMEOUT_MS = 10_000;
 
@@ -51,6 +52,7 @@ export interface A2AFleetTaskSummary {
 	state: string;
 	text: string;
 	responseText?: string;
+	workGraph?: A2AWorkGraphMetadata;
 	updatedAt: string;
 }
 
@@ -91,6 +93,7 @@ function fleetTaskSummary(
 		state: entry.state,
 		text: entry.text,
 		...(entry.responseText ? { responseText: entry.responseText } : {}),
+		...(entry.workGraph ? { workGraph: entry.workGraph } : {}),
 		updatedAt: entry.updatedAt,
 	};
 }

--- a/src/platform/a2a-task-ledger.ts
+++ b/src/platform/a2a-task-ledger.ts
@@ -3,6 +3,11 @@ import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { A2AMessage, A2ATask } from "./a2a-client.js";
+import {
+	type A2AWorkGraphMetadata,
+	extractA2AWorkGraphMetadata,
+	normalizeA2AWorkGraphMetadata,
+} from "./a2a-work-graph.js";
 import { getEnvValue, trimString } from "./client.js";
 
 export type A2ATaskKind = "delegation" | "message";
@@ -30,6 +35,7 @@ export interface A2ATaskLedgerEntry {
 	state: string;
 	responseText?: string;
 	metadata?: Record<string, string | number | boolean>;
+	workGraph?: A2AWorkGraphMetadata;
 	transcript: A2ATaskTranscriptEntry[];
 	createdAt: string;
 	updatedAt: string;
@@ -297,6 +303,7 @@ export async function recordA2ATaskStart(
 			(entry) => entry.peer === input.peer && entry.taskId === taskId,
 		);
 		const metadata = cleanMetadata(input.metadata);
+		const workGraph = extractA2AWorkGraphMetadata(input.task);
 		const userText = input.text.trim();
 		const entry: A2ATaskLedgerEntry = {
 			...(existingIndex >= 0 ? ledger.tasks[existingIndex] : {}),
@@ -321,6 +328,7 @@ export async function recordA2ATaskStart(
 			...(trimString(input.cwd) ? { cwd: trimString(input.cwd) } : {}),
 			state: input.task.status.state,
 			...(metadata ? { metadata } : {}),
+			...(workGraph ? { workGraph } : {}),
 			transcript: [
 				{
 					at: now,
@@ -377,6 +385,8 @@ export async function recordA2ATaskReply(
 			...(previous?.metadata ?? {}),
 			...(input.metadata ?? {}),
 		});
+		const workGraph =
+			extractA2AWorkGraphMetadata(input.task) ?? previous?.workGraph;
 		const userText = input.text.trim();
 		const taskResponse = extractA2ATaskResponse(input.task);
 		const responseText = taskResponse?.text ?? previous?.responseText;
@@ -401,6 +411,7 @@ export async function recordA2ATaskReply(
 			state: input.task.status.state,
 			...(responseText ? { responseText } : {}),
 			...(metadata ? { metadata } : {}),
+			...(workGraph ? { workGraph } : {}),
 			transcript: [
 				...(previous?.transcript ?? []),
 				{
@@ -458,6 +469,8 @@ export async function updateA2ATaskInLedger(
 		const previous = ledger.tasks[index]!;
 		const taskResponse = extractA2ATaskResponse(input.task);
 		const responseText = taskResponse?.text ?? previous.responseText;
+		const workGraph =
+			extractA2AWorkGraphMetadata(input.task) ?? previous.workGraph;
 		const entry: A2ATaskLedgerEntry = {
 			...previous,
 			state: input.task.status.state,
@@ -465,6 +478,7 @@ export async function updateA2ATaskInLedger(
 				? { contextId: trimString(input.task.contextId) }
 				: {}),
 			...(responseText ? { responseText } : {}),
+			...(workGraph ? { workGraph } : {}),
 			updatedAt: now,
 			...(isFinalA2AState(input.task.status.state)
 				? { completedAt: previous.completedAt ?? now }
@@ -639,6 +653,10 @@ function normalizeLedgerEntry(
 	}
 	if (isRecord(input.metadata)) {
 		entry.metadata = cleanMetadata(input.metadata);
+	}
+	const workGraph = normalizeA2AWorkGraphMetadata(input.workGraph);
+	if (workGraph) {
+		entry.workGraph = workGraph;
 	}
 	return entry;
 }

--- a/src/platform/a2a-work-graph.ts
+++ b/src/platform/a2a-work-graph.ts
@@ -1,0 +1,358 @@
+export interface A2ACodexSubagentEdgeMetadata {
+	spawnToolCallId?: string;
+	waitToolCallId?: string;
+	childRunId?: string;
+	threadId?: string;
+	operation?: string;
+	status?: string;
+	role?: string;
+	workItemState?: string;
+	completionGate?: string;
+	workItemId?: string;
+}
+
+export interface A2ACodexSubagentWorkGraphMetadata {
+	toolCallIds: string[];
+	childRunIds: string[];
+	threadIds: string[];
+	edgeCount?: number;
+	edges?: A2ACodexSubagentEdgeMetadata[];
+}
+
+export interface A2AWorkGraphMetadata {
+	state?: string;
+	itemCount?: number;
+	activeItemCount?: number;
+	blockedItemCount?: number;
+	waitingItemCount?: number;
+	childRunCount?: number;
+	childRunIds: string[];
+	toolCallCount?: number;
+	pendingToolCallCount?: number;
+	toolExecutionIds: string[];
+	waitItemCount?: number;
+	waitIds: string[];
+	stateCounts?: Record<string, number>;
+	correlationPath?: string;
+	codexSubagents?: A2ACodexSubagentWorkGraphMetadata;
+}
+
+export function extractA2AWorkGraphMetadata(
+	task: { metadata?: Record<string, unknown> } | undefined,
+): A2AWorkGraphMetadata | undefined {
+	return normalizeA2AWorkGraphMetadata(task?.metadata?.workGraph);
+}
+
+export function normalizeA2AWorkGraphMetadata(
+	input: unknown,
+): A2AWorkGraphMetadata | undefined {
+	if (!isRecord(input)) {
+		return undefined;
+	}
+	const codexSubagents = normalizeCodexSubagents(input.codexSubagents);
+	const stateCounts = normalizeNumberRecord(input.stateCounts);
+	const graph: A2AWorkGraphMetadata = {
+		...(stringValue(input.state) ? { state: stringValue(input.state) } : {}),
+		...(numberValue(input.itemCount) !== undefined
+			? { itemCount: numberValue(input.itemCount) }
+			: {}),
+		...(numberValue(input.activeItemCount) !== undefined
+			? { activeItemCount: numberValue(input.activeItemCount) }
+			: {}),
+		...(numberValue(input.blockedItemCount) !== undefined
+			? { blockedItemCount: numberValue(input.blockedItemCount) }
+			: {}),
+		...(numberValue(input.waitingItemCount) !== undefined
+			? { waitingItemCount: numberValue(input.waitingItemCount) }
+			: {}),
+		...(numberValue(input.childRunCount) !== undefined
+			? { childRunCount: numberValue(input.childRunCount) }
+			: {}),
+		childRunIds: stringList(input.childRunIds),
+		...(numberValue(input.toolCallCount) !== undefined
+			? { toolCallCount: numberValue(input.toolCallCount) }
+			: {}),
+		...(numberValue(input.pendingToolCallCount) !== undefined
+			? { pendingToolCallCount: numberValue(input.pendingToolCallCount) }
+			: {}),
+		toolExecutionIds: stringList(input.toolExecutionIds),
+		...(numberValue(input.waitItemCount) !== undefined
+			? { waitItemCount: numberValue(input.waitItemCount) }
+			: {}),
+		waitIds: stringList(input.waitIds),
+		...(stateCounts ? { stateCounts } : {}),
+		...(stringValue(input.correlationPath)
+			? { correlationPath: stringValue(input.correlationPath) }
+			: {}),
+		...(codexSubagents ? { codexSubagents } : {}),
+	};
+	return hasWorkGraphSignal(graph) ? graph : undefined;
+}
+
+export function formatA2AWorkGraphSummary(
+	graph: A2AWorkGraphMetadata | undefined,
+): string | undefined {
+	if (!graph) {
+		return undefined;
+	}
+	const parts = [
+		graph.state,
+		countPart("items", graph.itemCount),
+		countPart("active", graph.activeItemCount),
+		positiveCountPart("blocked", graph.blockedItemCount),
+		positiveCountPart("waiting", graph.waitingItemCount),
+		countPart("child runs", graph.childRunCount),
+		countPart("tools", graph.toolCallCount),
+		positiveCountPart("pending tools", graph.pendingToolCallCount),
+		countPart("waits", graph.waitItemCount),
+	].filter((part): part is string => Boolean(part));
+	if (parts.length === 0) {
+		return undefined;
+	}
+	return `Work graph: ${parts.join(" | ")}`;
+}
+
+export function formatA2AWorkGraphCodexSubagents(
+	graph: A2AWorkGraphMetadata | undefined,
+): string | undefined {
+	const subagents = graph?.codexSubagents;
+	if (!subagents) {
+		return undefined;
+	}
+	const parts = [
+		countPart("edges", subagents.edgeCount),
+		edgeLifecyclePart(subagents.edges),
+		idListPart("child runs", subagents.childRunIds),
+		idListPart("tools", subagents.toolCallIds),
+		idListPart("threads", subagents.threadIds),
+	].filter((part): part is string => Boolean(part));
+	if (parts.length === 0) {
+		return undefined;
+	}
+	return `Codex subagents: ${parts.join(" | ")}`;
+}
+
+function normalizeCodexSubagents(
+	input: unknown,
+): A2ACodexSubagentWorkGraphMetadata | undefined {
+	if (!isRecord(input)) {
+		return undefined;
+	}
+	const edges = normalizeCodexSubagentEdges(input.edges);
+	const subagents: A2ACodexSubagentWorkGraphMetadata = {
+		toolCallIds: stringList(input.toolCallIds),
+		childRunIds: stringList(input.childRunIds),
+		threadIds: stringList(input.threadIds),
+		...(numberValue(input.edgeCount) !== undefined
+			? { edgeCount: numberValue(input.edgeCount) }
+			: {}),
+		...(edges.length > 0 ? { edges } : {}),
+	};
+	return subagents.toolCallIds.length > 0 ||
+		subagents.childRunIds.length > 0 ||
+		subagents.threadIds.length > 0 ||
+		edges.length > 0 ||
+		subagents.edgeCount !== undefined
+		? subagents
+		: undefined;
+}
+
+function normalizeCodexSubagentEdges(
+	input: unknown,
+): A2ACodexSubagentEdgeMetadata[] {
+	if (!Array.isArray(input)) {
+		return [];
+	}
+	const edges: A2ACodexSubagentEdgeMetadata[] = [];
+	for (const value of input) {
+		if (!isRecord(value)) {
+			continue;
+		}
+		const edge: A2ACodexSubagentEdgeMetadata = {};
+		const spawnToolCallId = stringValue(value.spawnToolCallId);
+		const waitToolCallId = stringValue(value.waitToolCallId);
+		const childRunId = stringValue(value.childRunId);
+		const threadId = stringValue(value.threadId);
+		const operation = stringValue(value.operation);
+		const status = stringValue(value.status);
+		const role = stringValue(value.role);
+		const workItemState = stringValue(value.workItemState);
+		const completionGate = stringValue(value.completionGate);
+		const workItemId = stringValue(value.workItemId);
+		if (spawnToolCallId) {
+			edge.spawnToolCallId = spawnToolCallId;
+		}
+		if (waitToolCallId) {
+			edge.waitToolCallId = waitToolCallId;
+		}
+		if (childRunId) {
+			edge.childRunId = childRunId;
+		}
+		if (threadId) {
+			edge.threadId = threadId;
+		}
+		if (operation) {
+			edge.operation = operation;
+		}
+		if (status) {
+			edge.status = status;
+		}
+		if (role) {
+			edge.role = role;
+		}
+		if (workItemState) {
+			edge.workItemState = workItemState;
+		}
+		if (completionGate) {
+			edge.completionGate = completionGate;
+		}
+		if (workItemId) {
+			edge.workItemId = workItemId;
+		}
+		if (
+			!edge.spawnToolCallId &&
+			!edge.waitToolCallId &&
+			!edge.childRunId &&
+			!edge.threadId
+		) {
+			continue;
+		}
+		if (
+			!edges.some(
+				(existing) =>
+					existing.spawnToolCallId === edge.spawnToolCallId &&
+					existing.waitToolCallId === edge.waitToolCallId &&
+					existing.childRunId === edge.childRunId &&
+					existing.threadId === edge.threadId &&
+					existing.operation === edge.operation &&
+					existing.status === edge.status,
+			)
+		) {
+			edges.push(edge);
+		}
+	}
+	return edges;
+}
+
+function normalizeNumberRecord(
+	input: unknown,
+): Record<string, number> | undefined {
+	if (!isRecord(input)) {
+		return undefined;
+	}
+	const entries = Object.entries(input)
+		.map(([key, value]) => [key, numberValue(value)] as const)
+		.filter((entry): entry is [string, number] => entry[1] !== undefined);
+	return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function hasWorkGraphSignal(graph: A2AWorkGraphMetadata): boolean {
+	return Boolean(
+		graph.state ||
+			graph.itemCount !== undefined ||
+			graph.activeItemCount !== undefined ||
+			graph.blockedItemCount !== undefined ||
+			graph.waitingItemCount !== undefined ||
+			graph.childRunCount !== undefined ||
+			graph.childRunIds.length > 0 ||
+			graph.toolCallCount !== undefined ||
+			graph.pendingToolCallCount !== undefined ||
+			graph.toolExecutionIds.length > 0 ||
+			graph.waitItemCount !== undefined ||
+			graph.waitIds.length > 0 ||
+			graph.stateCounts ||
+			graph.correlationPath ||
+			graph.codexSubagents,
+	);
+}
+
+function countPart(
+	label: string,
+	value: number | undefined,
+): string | undefined {
+	return value === undefined ? undefined : `${label} ${value}`;
+}
+
+function positiveCountPart(
+	label: string,
+	value: number | undefined,
+): string | undefined {
+	return value && value > 0 ? `${label} ${value}` : undefined;
+}
+
+function idListPart(
+	label: string,
+	values: readonly string[],
+): string | undefined {
+	if (values.length === 0) {
+		return undefined;
+	}
+	const visible = values.slice(0, 3).join(", ");
+	const hidden = values.length > 3 ? ` (+${values.length - 3} more)` : "";
+	return `${label} ${visible}${hidden}`;
+}
+
+function edgeLifecyclePart(
+	edges: readonly A2ACodexSubagentEdgeMetadata[] | undefined,
+): string | undefined {
+	if (!edges || edges.length === 0) {
+		return undefined;
+	}
+	const values = edges
+		.map(formatCodexSubagentEdge)
+		.filter((value): value is string => Boolean(value));
+	if (values.length === 0) {
+		return undefined;
+	}
+	const visible = values.slice(0, 3).join(", ");
+	const hidden = values.length > 3 ? ` (+${values.length - 3} more)` : "";
+	return `lifecycle ${visible}${hidden}`;
+}
+
+function formatCodexSubagentEdge(
+	edge: A2ACodexSubagentEdgeMetadata,
+): string | undefined {
+	const lifecycle = [edge.operation, edge.status].filter(Boolean).join(":");
+	const subject =
+		edge.childRunId ??
+		edge.threadId ??
+		edge.spawnToolCallId ??
+		edge.waitToolCallId;
+	if (!lifecycle) {
+		return subject;
+	}
+	return subject ? `${lifecycle}(${subject})` : lifecycle;
+}
+
+function stringList(input: unknown): string[] {
+	if (!Array.isArray(input)) {
+		return [];
+	}
+	const values: string[] = [];
+	for (const value of input) {
+		const text = stringValue(value);
+		if (text && !values.includes(text)) {
+			values.push(text);
+		}
+	}
+	return values;
+}
+
+function stringValue(input: unknown): string | undefined {
+	return typeof input === "string" && input.trim() ? input.trim() : undefined;
+}
+
+function numberValue(input: unknown): number | undefined {
+	if (typeof input === "number" && Number.isFinite(input)) {
+		return input;
+	}
+	if (typeof input !== "string" || !input.trim()) {
+		return undefined;
+	}
+	const parsed = Number(input);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/remote-runner/attach-client.ts
+++ b/src/remote-runner/attach-client.ts
@@ -150,6 +150,7 @@ function normalizeState(value: unknown): HeadlessRuntimeState {
 		return createHeadlessRuntimeState();
 	}
 	const state = structuredClone(value as HeadlessRuntimeState);
+	state.codex_subagent_edges ??= [];
 	syncHeadlessPendingRequests(state);
 	return state;
 }

--- a/src/server/handlers/hosted-runner-drain.ts
+++ b/src/server/handlers/hosted-runner-drain.ts
@@ -4,8 +4,17 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 import {
+	CODEX_SUBAGENT_TOOL_PREFIX,
+	CODEX_SUBAGENT_WORK_GRAPH_SCHEMA,
 	HEADLESS_PROTOCOL_VERSION,
+	type HeadlessCodexSubagentContinuityEdge,
+	activeCodexSubagentStatus,
+	buildCodexSubagentContinuityEdges,
+	codexSubagentEdgeKey,
+	codexSubagentOperation,
+	codexSubagentStatusIsTerminal,
 	createHeadlessRuntimeState,
+	stringArray,
 } from "../../cli/headless-protocol.js";
 import type { HostedRunnerContext, WebServerContext } from "../app-context.js";
 import type { HeadlessRuntimeSnapshot } from "../headless-runtime-service.js";
@@ -27,10 +36,6 @@ export const HOSTED_RUNNER_RETENTION_POLICY_VERSION =
 
 export const HOSTED_RUNNER_WORK_CONTINUITY_VERSION =
 	"evalops.remote-runner.work-continuity.v1";
-
-const CODEX_SUBAGENT_TOOL_PREFIX = "codex.subagent.";
-const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA =
-	"evalops.maestro.codex.subagent-workgraph.v1";
 
 export enum HostedRunnerDrainStatusValue {
 	Drained = "drained",
@@ -177,6 +182,7 @@ export interface HostedRunnerWorkContinuity {
 	codex_subagent_tool_call_ids: string[];
 	codex_subagent_child_run_ids: string[];
 	codex_subagent_thread_ids: string[];
+	codex_subagent_edges?: HeadlessCodexSubagentContinuityEdge[];
 }
 
 export interface HostedRunnerDrainResult {
@@ -452,12 +458,23 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
-function stringArray(value: unknown): string[] {
-	return Array.isArray(value)
-		? value.filter(
-				(item): item is string => typeof item === "string" && item.length > 0,
-			)
-		: [];
+function collectCodexSubagentEdgesFromSource(
+	source: { call_id: string; tool: string; args?: unknown },
+	edges: Map<string, HeadlessCodexSubagentContinuityEdge>,
+): void {
+	const operation = codexSubagentOperation(source.tool);
+	if (!operation) {
+		return;
+	}
+	const status = activeCodexSubagentStatus(operation);
+	for (const edge of buildCodexSubagentContinuityEdges({
+		call_id: source.call_id,
+		tool: source.tool,
+		args: source.args,
+		status,
+	})) {
+		edges.set(codexSubagentEdgeKey(edge), edge);
+	}
 }
 
 function collectCodexWorkArgs(
@@ -515,6 +532,25 @@ function collectHostedRunnerWorkContinuity(
 	const codexToolCallIds = new Set<string>();
 	const childRunIds = new Set<string>();
 	const threadIds = new Set<string>();
+	const codexSubagentEdges = new Map<
+		string,
+		HeadlessCodexSubagentContinuityEdge
+	>();
+	for (const edge of state.codex_subagent_edges ?? []) {
+		codexSubagentEdges.set(codexSubagentEdgeKey(edge), edge);
+		if (edge.spawn_tool_call_id) {
+			codexToolCallIds.add(edge.spawn_tool_call_id);
+		}
+		if (edge.wait_tool_call_id) {
+			codexToolCallIds.add(edge.wait_tool_call_id);
+		}
+		if (edge.child_run_id) {
+			childRunIds.add(edge.child_run_id);
+		}
+		if (edge.thread_id) {
+			threadIds.add(edge.thread_id);
+		}
+	}
 	const trackedSources = [
 		...state.tracked_tools,
 		...state.pending_approvals,
@@ -523,6 +559,7 @@ function collectHostedRunnerWorkContinuity(
 		...state.pending_user_inputs,
 		...state.pending_tool_retries,
 	];
+	const codexTrackedSourceCallIds = new Set<string>();
 	for (const source of trackedSources) {
 		const tool = source.tool;
 		const isCodexSubagentTool = tool.startsWith(CODEX_SUBAGENT_TOOL_PREFIX);
@@ -533,18 +570,49 @@ function collectHostedRunnerWorkContinuity(
 			isCodexSubagentTool,
 		);
 		if (isCodexSubagentTool || hasCodexWorkArgs) {
+			codexTrackedSourceCallIds.add(source.call_id);
 			codexToolCallIds.add(source.call_id);
+			collectCodexSubagentEdgesFromSource(source, codexSubagentEdges);
 		}
 	}
 	for (const activeTool of state.active_tools) {
 		if (activeTool.tool.startsWith(CODEX_SUBAGENT_TOOL_PREFIX)) {
+			const hasTrackedSource = codexToolCallIds.has(activeTool.call_id);
 			codexToolCallIds.add(activeTool.call_id);
+			if (!hasTrackedSource) {
+				collectCodexSubagentEdgesFromSource(
+					{ call_id: activeTool.call_id, tool: activeTool.tool },
+					codexSubagentEdges,
+				);
+			}
 		}
 	}
+	const sortedEdges = [...codexSubagentEdges.values()].sort((left, right) =>
+		codexSubagentEdgeKey(left).localeCompare(codexSubagentEdgeKey(right)),
+	);
+	const activeCodexSubagentEdgeCount = sortedEdges.filter(
+		(edge) => !codexSubagentStatusIsTerminal(edge.status),
+	).length;
+	const nonCodexActiveToolCount = state.active_tools.filter(
+		(tool) => !tool.tool.startsWith(CODEX_SUBAGENT_TOOL_PREFIX),
+	).length;
+	const nonCodexTrackedToolCount = state.tracked_tools.filter(
+		(tool) => !codexTrackedSourceCallIds.has(tool.call_id),
+	).length;
+	const trackedCodexSubagentCount = Math.max(
+		codexToolCallIds.size,
+		sortedEdges.length,
+	);
 	return {
 		protocol_version: HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
-		active_tool_count: state.active_tools.length,
-		tracked_tool_count: state.tracked_tools.length,
+		active_tool_count:
+			sortedEdges.length > 0
+				? nonCodexActiveToolCount + activeCodexSubagentEdgeCount
+				: state.active_tools.length,
+		tracked_tool_count:
+			sortedEdges.length > 0
+				? nonCodexTrackedToolCount + trackedCodexSubagentCount
+				: state.tracked_tools.length,
 		pending_request_count:
 			state.pending_approvals.length +
 			state.pending_client_tools.length +
@@ -554,6 +622,7 @@ function collectHostedRunnerWorkContinuity(
 		codex_subagent_tool_call_ids: [...codexToolCallIds].sort(),
 		codex_subagent_child_run_ids: [...childRunIds].sort(),
 		codex_subagent_thread_ids: [...threadIds].sort(),
+		...(sortedEdges.length > 0 ? { codex_subagent_edges: sortedEdges } : {}),
 	};
 }
 

--- a/src/skills/package-contract.ts
+++ b/src/skills/package-contract.ts
@@ -82,6 +82,19 @@ function mapValidationIssue(message: string): SkillPackageContractIssue {
 		: issue("package_validation", message);
 }
 
+export function quoteSkillPackageInstallSourceArg(
+	value: string,
+	platform = process.platform,
+): string {
+	if (SHELL_SAFE_INSTALL_SOURCE_REGEX.test(value)) {
+		return value;
+	}
+	if (platform === "win32") {
+		return `"${value.replace(/"/g, '\\"')}"`;
+	}
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 function buildInstallCommands(input: {
 	cwd: string;
 	platform: NodeJS.Platform;
@@ -91,7 +104,7 @@ function buildInstallCommands(input: {
 		input.source,
 		input.cwd,
 	);
-	const command = `maestro skill install ${quoteShellArg(installSource, input.platform)}`;
+	const command = `maestro skill install ${quoteSkillPackageInstallSourceArg(installSource, input.platform)}`;
 	switch (input.source.type) {
 		case "local":
 			return { source: command, local: command };
@@ -100,16 +113,6 @@ function buildInstallCommands(input: {
 		case "npm":
 			return { source: command, npm: command };
 	}
-}
-
-function quoteShellArg(value: string, platform: NodeJS.Platform): string {
-	if (SHELL_SAFE_INSTALL_SOURCE_REGEX.test(value)) {
-		return value;
-	}
-	if (platform === "win32") {
-		return `"${value.replace(/"/g, '\\"')}"`;
-	}
-	return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 export function formatSkillPackageInstallSource(
@@ -239,8 +242,8 @@ export function formatSkillPackagePublishContract(
 		`Source: ${contract.resolvedSource}`,
 		`Skills: ${contract.resources.skills.length}`,
 		"Install:",
-		...installCommands.map((command) => `  ${command}`),
 	];
+	lines.push(...installCommands.map((command) => `  ${command}`));
 	if (contract.evalReport) {
 		lines.push("", "Eval:", formatSkillEvalText(contract.evalReport));
 	}

--- a/test/cli-tui/commands/a2a-handlers.test.ts
+++ b/test/cli-tui/commands/a2a-handlers.test.ts
@@ -29,6 +29,34 @@ describe("A2A TUI command handler", () => {
 						taskId: "task-dev-1",
 						text: "run full workspace checks",
 						state: "TASK_STATE_WORKING",
+						workGraph: {
+							state: "waiting",
+							itemCount: 3,
+							activeItemCount: 3,
+							childRunCount: 1,
+							childRunIds: ["agent_run_child_1"],
+							toolCallCount: 2,
+							pendingToolCallCount: 1,
+							toolExecutionIds: ["tool_exec_1"],
+							waitItemCount: 1,
+							waitIds: ["thread_child_1"],
+							codexSubagents: {
+								edgeCount: 1,
+								edges: [
+									{
+										spawnToolCallId: "toolu_spawn_child",
+										childRunId: "agent_run_child_1",
+										operation: "spawn_agent",
+										status: "running",
+									},
+								],
+								childRunIds: ["agent_run_child_1"],
+								toolCallIds: ["toolu_spawn_child"],
+								threadIds: ["thread_child_1"],
+							},
+							correlationPath:
+								"platform_agent_run_id=run_1 active_work_items=3 blocked_work_items=0 child_runs=1",
+						},
 						createdAt: "2026-05-16T00:00:00.000Z",
 						updatedAt: "2026-05-16T00:00:00.000Z",
 					},
@@ -37,7 +65,7 @@ describe("A2A TUI command handler", () => {
 		);
 		vi.stubEnv("MAESTRO_A2A_TASKS_FILE", tasksPath);
 		const content: string[] = [];
-		const context = createContext("tasks");
+		const context = createContext("tasks --work-graph");
 
 		await handleA2ATuiCommand(context, {
 			addContent(text) {
@@ -50,6 +78,14 @@ describe("A2A TUI command handler", () => {
 		expect(content.join("\n")).toContain("dev-desktop");
 		expect(content.join("\n")).toContain("task-dev-1");
 		expect(content.join("\n")).toContain("TASK_STATE_WORKING");
+		expect(content.join("\n")).toContain("Work graph: waiting");
+		expect(content.join("\n")).toContain("Codex subagents: edges 1");
+		expect(content.join("\n")).toContain(
+			"lifecycle spawn_agent:running(agent_run_child_1)",
+		);
+		expect(content.join("\n")).toContain(
+			"Correlation: platform_agent_run_id=run_1 active_work_items=3 blocked_work_items=0 child_runs=1",
+		);
 		expect(context.showError).not.toHaveBeenCalled();
 	});
 
@@ -78,6 +114,25 @@ describe("A2A TUI command handler", () => {
 			timeoutMs: 2500,
 		});
 		expect(content.join("\n")).toContain("A2A fleet");
+		expect(context.showError).not.toHaveBeenCalled();
+	});
+
+	it("renders coordinate as a TUI-aware CLI placeholder", async () => {
+		const context = createContext(
+			"coordinate mac-mini --reply use the short smoke",
+		);
+
+		await handleA2ATuiCommand(context, {
+			addContent: vi.fn(),
+			requestRender: vi.fn(),
+		});
+
+		expect(context.showInfo).toHaveBeenCalledWith(
+			expect.stringContaining("maestro a2a coordinate [peer] --refresh"),
+		);
+		expect(context.showInfo).toHaveBeenCalledWith(
+			expect.stringContaining("--reply <text>"),
+		);
 		expect(context.showError).not.toHaveBeenCalled();
 	});
 });

--- a/test/cli-tui/commands/command-registry-integration.test.ts
+++ b/test/cli-tui/commands/command-registry-integration.test.ts
@@ -212,6 +212,18 @@ describe("command-registry-integration", () => {
 		);
 	});
 
+	it("advertises /a2a coordinate in the TUI command catalog", () => {
+		const opts = createMockOptions();
+		const { commands } = buildCommandRegistry(opts);
+		const a2a = commands.find((command) => command.name === "a2a");
+
+		expect(a2a?.usage).toContain("coordinate");
+		expect(a2a?.examples).toContain("/a2a coordinate");
+		expect(a2a?.examples).toContain(
+			"/a2a coordinate mac-mini --work-graph --reply use the short smoke",
+		);
+	});
+
 	it("every entry has a valid command with name and description", () => {
 		const opts = createMockOptions();
 		const { entries } = buildCommandRegistry(opts);

--- a/test/cli/commands/a2a-fleet-delegation.test.ts
+++ b/test/cli/commands/a2a-fleet-delegation.test.ts
@@ -22,12 +22,14 @@ describe("A2A fleet delegation CLI", () => {
 	let baseUrl: string;
 	let requests: RequestRecord[];
 	let taskFetches: number;
+	let taskResponses: unknown[];
 	let logs: string[];
 	let errors: string[];
 
 	beforeEach(async () => {
 		requests = [];
 		taskFetches = 0;
+		taskResponses = [];
 		logs = [];
 		errors = [];
 		vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
@@ -80,12 +82,13 @@ describe("A2A fleet delegation CLI", () => {
 			}
 			if (request.method === "POST" && request.url === "/message:send") {
 				const body = await readJson(request);
+				const taskId = recordValue(body, "message.taskId") ?? "task-mac-mini-1";
 				requests.push({ method: request.method, url: request.url, body });
 				response.writeHead(200, { "Content-Type": "application/json" });
 				response.end(
 					JSON.stringify({
 						task: {
-							id: "task-mac-mini-1",
+							id: taskId,
 							contextId:
 								recordValue(body, "message.contextId") ??
 								"maestro-a2a-context-test",
@@ -101,15 +104,19 @@ describe("A2A fleet delegation CLI", () => {
 				);
 				return;
 			}
-			if (
-				request.method === "GET" &&
-				request.url === "/tasks/task-mac-mini-1"
-			) {
+			if (request.method === "GET" && request.url?.startsWith("/tasks/")) {
+				const taskId = decodeURIComponent(request.url.slice("/tasks/".length));
 				taskFetches += 1;
+				const taskResponse = taskResponses.shift();
+				if (taskResponse) {
+					response.writeHead(200, { "Content-Type": "application/json" });
+					response.end(JSON.stringify(taskResponse));
+					return;
+				}
 				response.writeHead(200, { "Content-Type": "application/json" });
 				response.end(
 					JSON.stringify({
-						id: "task-mac-mini-1",
+						id: taskId,
 						contextId: "maestro-a2a-context-test",
 						status: {
 							state: "TASK_STATE_COMPLETED",
@@ -135,6 +142,9 @@ describe("A2A fleet delegation CLI", () => {
 								],
 							},
 						],
+						metadata: {
+							workGraph: workGraphMetadata(),
+						},
 					}),
 				);
 				return;
@@ -194,6 +204,9 @@ describe("A2A fleet delegation CLI", () => {
 		});
 		expect(plainLogs(logs)).toContain("Delegated to mac-mini");
 		expect(plainLogs(logs)).toContain("mac mini finished the smoke plan");
+		expect(plainLogs(logs)).toContain("Work graph: waiting");
+		expect(plainLogs(logs)).not.toContain("Codex subagents:");
+		expect(plainLogs(logs)).not.toContain("Correlation:");
 
 		const ledgerRaw = await readFile(tasksPath, "utf8");
 		expect(ledgerRaw).toContain("task-mac-mini-1");
@@ -230,6 +243,20 @@ describe("A2A fleet delegation CLI", () => {
 				lastTask: expect.objectContaining({
 					id: "task-mac-mini-1",
 					state: "TASK_STATE_COMPLETED",
+					workGraph: expect.objectContaining({
+						state: "waiting",
+						childRunIds: ["agent_run_child_1"],
+						codexSubagents: expect.objectContaining({
+							threadIds: ["thread_child_1"],
+							edges: [
+								expect.objectContaining({
+									childRunId: "agent_run_child_1",
+									operation: "spawn_agent",
+									status: "running",
+								}),
+							],
+						}),
+					}),
 				}),
 			}),
 		]);
@@ -238,15 +265,68 @@ describe("A2A fleet delegation CLI", () => {
 		logs = [];
 		await handleA2ACommand(["tasks", "--json", "--tasks", tasksPath]);
 		const taskView = JSON.parse(logs.join("\n")) as {
-			tasks: Array<{ peer: string; taskId: string; state: string }>;
+			tasks: Array<{
+				peer: string;
+				taskId: string;
+				state: string;
+				workGraph?: {
+					state?: string;
+					codexSubagents?: { threadIds?: string[] };
+				};
+			}>;
 		};
 		expect(taskView.tasks).toEqual([
 			expect.objectContaining({
 				peer: "mac-mini",
 				taskId: "task-mac-mini-1",
 				state: "TASK_STATE_COMPLETED",
+				workGraph: expect.objectContaining({
+					state: "waiting",
+					codexSubagents: expect.objectContaining({
+						threadIds: ["thread_child_1"],
+						edges: [
+							expect.objectContaining({
+								childRunId: "agent_run_child_1",
+								operation: "spawn_agent",
+								status: "running",
+							}),
+						],
+					}),
+				}),
 			}),
 		]);
+		logs = [];
+		await handleA2ACommand(["tasks", "--work-graph", "--tasks", tasksPath]);
+		expect(plainLogs(logs)).toContain("Work graph: waiting");
+		expect(plainLogs(logs)).toContain("Codex subagents: edges 1");
+		expect(plainLogs(logs)).toContain(
+			"lifecycle spawn_agent:running(agent_run_child_1)",
+		);
+		expect(plainLogs(logs)).toContain(
+			"Correlation: platform_agent_run_id=run_1 active_work_items=3 blocked_work_items=0 child_runs=1",
+		);
+
+		logs = [];
+		await handleA2ACommand([
+			"wait",
+			"mac-mini",
+			"task-mac-mini-1",
+			"--work-graph",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--max-wait-ms",
+			"1000",
+			"--interval-ms",
+			"10",
+			"--timeout-ms",
+			"1000",
+		]);
+		expect(plainLogs(logs)).toContain("Codex subagents: edges 1");
+		expect(plainLogs(logs)).toContain(
+			"Correlation: platform_agent_run_id=run_1",
+		);
 		const fetchesAfterCompletion = taskFetches;
 
 		logs = [];
@@ -262,6 +342,877 @@ describe("A2A fleet delegation CLI", () => {
 		]);
 		expect(taskFetches).toBe(fetchesAfterCompletion);
 		expect(errors.join("\n")).toBe("");
+	});
+
+	it("preserves an input-required delegated task and completes it after an operator reply", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-input-required-"));
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks.json");
+		await writeRegistry(registryPath, baseUrl);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+		taskResponses = [
+			{
+				id: "task-mac-mini-1",
+				contextId: "maestro-a2a-context-test",
+				status: {
+					state: "TASK_STATE_INPUT_REQUIRED",
+					message: {
+						messageId: "agent-input-required-1",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "Which smoke profile should I run?",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+			},
+			{
+				id: "task-mac-mini-1",
+				contextId: "maestro-a2a-context-test",
+				status: {
+					state: "TASK_STATE_COMPLETED",
+					message: {
+						messageId: "agent-message-2",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "short smoke passed after operator reply",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+				artifacts: [
+					{
+						artifactId: "result",
+						parts: [
+							{
+								text: "short smoke passed after operator reply",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				],
+			},
+		];
+
+		await handleA2ACommand([
+			"delegate",
+			"mac-mini",
+			"review",
+			"the",
+			"release",
+			"branch",
+			"--wait",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--max-wait-ms",
+			"1000",
+			"--interval-ms",
+			"10",
+			"--timeout-ms",
+			"1000",
+		]);
+
+		const inputRequiredLedger = JSON.parse(
+			await readFile(tasksPath, "utf8"),
+		) as {
+			tasks: Array<{
+				completedAt?: string;
+				contextId?: string;
+				responseText?: string;
+				state: string;
+				taskId: string;
+			}>;
+		};
+		expect(inputRequiredLedger.tasks).toHaveLength(1);
+		expect(inputRequiredLedger.tasks[0]).toMatchObject({
+			taskId: "task-mac-mini-1",
+			contextId: "maestro-a2a-context-test",
+			state: "TASK_STATE_INPUT_REQUIRED",
+			responseText: "Which smoke profile should I run?",
+		});
+		expect(inputRequiredLedger.tasks[0]!.completedAt).toBeUndefined();
+
+		logs = [];
+		await handleA2ACommand([
+			"reply",
+			"mac-mini",
+			"task-mac-mini-1",
+			"use",
+			"the",
+			"short",
+			"smoke",
+			"profile",
+			"--wait",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--max-wait-ms",
+			"1000",
+			"--interval-ms",
+			"10",
+			"--timeout-ms",
+			"1000",
+		]);
+
+		expect(requests).toHaveLength(2);
+		expect(recordValue(requests[1]!.body, "message.taskId")).toBe(
+			"task-mac-mini-1",
+		);
+		expect(recordValue(requests[1]!.body, "message.contextId")).toBe(
+			"maestro-a2a-context-test",
+		);
+		expect(plainLogs(logs)).toContain(
+			"short smoke passed after operator reply",
+		);
+		const completedLedger = JSON.parse(await readFile(tasksPath, "utf8")) as {
+			tasks: Array<{
+				completedAt?: string;
+				contextId?: string;
+				responseText?: string;
+				state: string;
+				taskId: string;
+				transcript: Array<{
+					messageId?: string;
+					role: string;
+					state?: string;
+					text: string;
+				}>;
+			}>;
+		};
+		expect(completedLedger.tasks).toHaveLength(1);
+		expect(completedLedger.tasks[0]).toMatchObject({
+			taskId: "task-mac-mini-1",
+			contextId: "maestro-a2a-context-test",
+			state: "TASK_STATE_COMPLETED",
+			responseText: "short smoke passed after operator reply",
+		});
+		expect(completedLedger.tasks[0]!.completedAt).toEqual(expect.any(String));
+		expect(completedLedger.tasks[0]!.transcript).toEqual([
+			expect.objectContaining({
+				role: "user",
+				text: "review the release branch",
+			}),
+			expect.objectContaining({
+				messageId: "agent-input-required-1",
+				role: "agent",
+				state: "TASK_STATE_INPUT_REQUIRED",
+				text: "Which smoke profile should I run?",
+			}),
+			expect.objectContaining({
+				role: "user",
+				text: "use the short smoke profile",
+			}),
+			expect.objectContaining({
+				messageId: "agent-message-2",
+				role: "agent",
+				state: "TASK_STATE_COMPLETED",
+				text: "short smoke passed after operator reply",
+			}),
+		]);
+		expect(JSON.stringify(completedLedger)).not.toContain("super-secret-token");
+		expect(errors.join("\n")).toBe("");
+	});
+
+	it("coordinates pending tasks by refreshing input-required work without replying", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-coordinate-"));
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks.json");
+		await writeRegistry(registryPath, baseUrl);
+		await writeFile(
+			tasksPath,
+			JSON.stringify({
+				tasks: [
+					{
+						id: "maestro-a2a-ledger-1",
+						kind: "delegation",
+						peer: "mac-mini",
+						taskId: "task-mac-mini-1",
+						contextId: "maestro-a2a-context-test",
+						messageId: "message-1",
+						text: "review the release branch",
+						state: "TASK_STATE_SUBMITTED",
+						transcript: [
+							{
+								at: "2026-05-16T00:00:00.000Z",
+								role: "user",
+								text: "review the release branch",
+								messageId: "message-1",
+							},
+						],
+						createdAt: "2026-05-16T00:00:00.000Z",
+						updatedAt: "2026-05-16T00:00:00.000Z",
+					},
+				],
+			}),
+		);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+		taskResponses = [
+			{
+				id: "task-mac-mini-1",
+				contextId: "maestro-a2a-context-test",
+				status: {
+					state: "TASK_STATE_INPUT_REQUIRED",
+					message: {
+						messageId: "agent-input-required-1",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "Which smoke profile should I run?",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+				metadata: {
+					workGraph: workGraphMetadata({
+						state: "blocked",
+						blockedItemCount: 1,
+					}),
+				},
+			},
+		];
+
+		await handleA2ACommand([
+			"coordinate",
+			"mac-mini",
+			"--work-graph",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--timeout-ms",
+			"1000",
+		]);
+
+		expect(requests).toHaveLength(0);
+		expect(taskFetches).toBe(1);
+		expect(plainLogs(logs)).toContain("A2A coordinate");
+		expect(plainLogs(logs)).toContain("TASK_STATE_INPUT_REQUIRED");
+		expect(plainLogs(logs)).toContain("Which smoke profile should I run?");
+		expect(plainLogs(logs)).toContain("Work graph: blocked");
+		expect(plainLogs(logs)).toContain("Codex subagents: edges 1");
+		const ledger = JSON.parse(await readFile(tasksPath, "utf8")) as {
+			tasks: Array<{
+				contextId?: string;
+				responseText?: string;
+				state: string;
+				taskId: string;
+				transcript: Array<{ role: string; text: string }>;
+				workGraph?: { state?: string; blockedItemCount?: number };
+			}>;
+		};
+		expect(ledger.tasks).toHaveLength(1);
+		expect(ledger.tasks[0]).toMatchObject({
+			taskId: "task-mac-mini-1",
+			contextId: "maestro-a2a-context-test",
+			state: "TASK_STATE_INPUT_REQUIRED",
+			responseText: "Which smoke profile should I run?",
+			workGraph: expect.objectContaining({
+				state: "blocked",
+				blockedItemCount: 1,
+			}),
+		});
+		expect(ledger.tasks[0]!.transcript).toEqual([
+			expect.objectContaining({
+				role: "user",
+				text: "review the release branch",
+			}),
+			expect.objectContaining({
+				role: "agent",
+				text: "Which smoke profile should I run?",
+			}),
+		]);
+		expect(JSON.stringify(ledger)).not.toContain("super-secret-token");
+		expect(errors.join("\n")).toBe("");
+	});
+
+	it("continues coordinate refresh when one non-final peer task cannot be refreshed", async () => {
+		const dir = await mkdtemp(
+			join(tmpdir(), "maestro-a2a-coordinate-partial-refresh-"),
+		);
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks.json");
+		await writeRegistry(registryPath, baseUrl);
+		await writeFile(
+			tasksPath,
+			JSON.stringify({
+				tasks: [
+					{
+						id: "maestro-a2a-ledger-missing",
+						kind: "delegation",
+						peer: "offline-peer",
+						taskId: "task-offline-1",
+						contextId: "maestro-a2a-context-offline",
+						text: "check the offline peer",
+						state: "TASK_STATE_SUBMITTED",
+						transcript: [
+							{
+								at: "2026-05-16T00:00:00.000Z",
+								role: "user",
+								text: "check the offline peer",
+							},
+						],
+						createdAt: "2026-05-16T00:00:00.000Z",
+						updatedAt: "2026-05-16T00:02:00.000Z",
+					},
+					{
+						id: "maestro-a2a-ledger-1",
+						kind: "delegation",
+						peer: "mac-mini",
+						taskId: "task-mac-mini-1",
+						contextId: "maestro-a2a-context-test",
+						messageId: "message-1",
+						text: "review the release branch",
+						state: "TASK_STATE_SUBMITTED",
+						transcript: [
+							{
+								at: "2026-05-16T00:00:00.000Z",
+								role: "user",
+								text: "review the release branch",
+								messageId: "message-1",
+							},
+						],
+						createdAt: "2026-05-16T00:00:00.000Z",
+						updatedAt: "2026-05-16T00:01:00.000Z",
+					},
+				],
+			}),
+		);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+		taskResponses = [
+			{
+				id: "task-mac-mini-1",
+				contextId: "maestro-a2a-context-test",
+				status: {
+					state: "TASK_STATE_INPUT_REQUIRED",
+					message: {
+						messageId: "agent-input-required-1",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "Which smoke profile should I run?",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+			},
+		];
+
+		await handleA2ACommand([
+			"coordinate",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--timeout-ms",
+			"1000",
+		]);
+
+		expect(taskFetches).toBe(1);
+		expect(requests).toHaveLength(0);
+		expect(plainLogs(logs)).toContain("task-mac-mini-1");
+		expect(plainLogs(logs)).toContain("TASK_STATE_INPUT_REQUIRED");
+		expect(errors.join("\n")).toContain(
+			"could not refresh offline-peer task task-offline-1",
+		);
+		expect(errors.join("\n")).not.toContain("super-secret-token");
+	});
+
+	it("rejects coordinate reply flags without reply text", async () => {
+		await expect(
+			handleA2ACommand(["coordinate", "mac-mini", "--reply", "--wait"]),
+		).rejects.toThrow("--reply requires text");
+
+		expect(requests).toHaveLength(0);
+		expect(taskFetches).toBe(0);
+	});
+
+	it("coordinates an input-required task by replying and waiting on the same ledger entry", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-coordinate-reply-"));
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks.json");
+		await writeRegistry(registryPath, baseUrl);
+		await writeFile(
+			tasksPath,
+			JSON.stringify({
+				tasks: [
+					{
+						id: "maestro-a2a-ledger-1",
+						kind: "delegation",
+						peer: "mac-mini",
+						taskId: "task-mac-mini-1",
+						contextId: "maestro-a2a-context-test",
+						messageId: "message-1",
+						text: "review the release branch",
+						state: "TASK_STATE_INPUT_REQUIRED",
+						responseText: "Which smoke profile should I run?",
+						transcript: [
+							{
+								at: "2026-05-16T00:00:00.000Z",
+								role: "user",
+								text: "review the release branch",
+								messageId: "message-1",
+							},
+							{
+								at: "2026-05-16T00:01:00.000Z",
+								role: "agent",
+								text: "Which smoke profile should I run?",
+								state: "TASK_STATE_INPUT_REQUIRED",
+								messageId: "agent-input-required-1",
+							},
+						],
+						createdAt: "2026-05-16T00:00:00.000Z",
+						updatedAt: "2026-05-16T00:01:00.000Z",
+					},
+				],
+			}),
+		);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+		taskResponses = [
+			{
+				id: "task-mac-mini-1",
+				contextId: "maestro-a2a-context-test",
+				status: {
+					state: "TASK_STATE_INPUT_REQUIRED",
+					message: {
+						messageId: "agent-input-required-1",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "Which smoke profile should I run?",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+			},
+			{
+				id: "task-mac-mini-1",
+				contextId: "maestro-a2a-context-test",
+				status: {
+					state: "TASK_STATE_COMPLETED",
+					message: {
+						messageId: "agent-message-2",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "short smoke passed after operator reply",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+				artifacts: [
+					{
+						artifactId: "result",
+						parts: [
+							{
+								text: "short smoke passed after operator reply",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				],
+			},
+		];
+
+		await handleA2ACommand([
+			"coordinate",
+			"mac-mini",
+			"--reply",
+			"use the short smoke profile",
+			"--wait",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--max-wait-ms",
+			"1000",
+			"--interval-ms",
+			"10",
+			"--timeout-ms",
+			"1000",
+		]);
+
+		expect(requests).toHaveLength(1);
+		expect(recordValue(requests[0]!.body, "message.taskId")).toBe(
+			"task-mac-mini-1",
+		);
+		expect(recordValue(requests[0]!.body, "message.contextId")).toBe(
+			"maestro-a2a-context-test",
+		);
+		expect(plainLogs(logs)).toContain(
+			"Coordinated mac-mini task task-mac-mini-1",
+		);
+		expect(plainLogs(logs)).toContain(
+			"short smoke passed after operator reply",
+		);
+		const ledger = JSON.parse(await readFile(tasksPath, "utf8")) as {
+			tasks: Array<{
+				completedAt?: string;
+				contextId?: string;
+				id: string;
+				responseText?: string;
+				state: string;
+				taskId: string;
+				transcript: Array<{
+					messageId?: string;
+					role: string;
+					state?: string;
+					text: string;
+				}>;
+			}>;
+		};
+		expect(ledger.tasks).toHaveLength(1);
+		expect(ledger.tasks[0]).toMatchObject({
+			id: "maestro-a2a-ledger-1",
+			taskId: "task-mac-mini-1",
+			contextId: "maestro-a2a-context-test",
+			state: "TASK_STATE_COMPLETED",
+			responseText: "short smoke passed after operator reply",
+		});
+		expect(ledger.tasks[0]!.completedAt).toEqual(expect.any(String));
+		expect(ledger.tasks[0]!.transcript).toEqual([
+			expect.objectContaining({
+				role: "user",
+				text: "review the release branch",
+			}),
+			expect.objectContaining({
+				messageId: "agent-input-required-1",
+				role: "agent",
+				state: "TASK_STATE_INPUT_REQUIRED",
+				text: "Which smoke profile should I run?",
+			}),
+			expect.objectContaining({
+				role: "user",
+				text: "use the short smoke profile",
+			}),
+			expect.objectContaining({
+				messageId: "agent-message-2",
+				role: "agent",
+				state: "TASK_STATE_COMPLETED",
+				text: "short smoke passed after operator reply",
+			}),
+		]);
+		expect(JSON.stringify(ledger)).not.toContain("super-secret-token");
+		expect(errors.join("\n")).toBe("");
+	});
+
+	it("refreshes stale actionable tasks before choosing a coordinate reply target", async () => {
+		const dir = await mkdtemp(
+			join(tmpdir(), "maestro-a2a-coordinate-stale-ambiguous-"),
+		);
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks.json");
+		await writeRegistry(registryPath, baseUrl);
+		await writeFile(
+			tasksPath,
+			JSON.stringify({
+				tasks: [
+					{
+						id: "maestro-a2a-ledger-1",
+						kind: "delegation",
+						peer: "mac-mini",
+						taskId: "task-mac-mini-1",
+						contextId: "maestro-a2a-context-1",
+						text: "review the release branch",
+						state: "TASK_STATE_INPUT_REQUIRED",
+						responseText: "Which smoke profile should I run?",
+						transcript: [
+							{
+								at: "2026-05-16T00:00:00.000Z",
+								role: "user",
+								text: "review the release branch",
+							},
+							{
+								at: "2026-05-16T00:01:00.000Z",
+								role: "agent",
+								text: "Which smoke profile should I run?",
+								state: "TASK_STATE_INPUT_REQUIRED",
+							},
+						],
+						createdAt: "2026-05-16T00:00:00.000Z",
+						updatedAt: "2026-05-16T00:03:00.000Z",
+					},
+					{
+						id: "maestro-a2a-ledger-2",
+						kind: "delegation",
+						peer: "mac-mini",
+						taskId: "task-mac-mini-2",
+						contextId: "maestro-a2a-context-2",
+						text: "review the docs branch",
+						state: "TASK_STATE_INPUT_REQUIRED",
+						responseText: "Which docs scope should I run?",
+						transcript: [
+							{
+								at: "2026-05-16T00:02:00.000Z",
+								role: "user",
+								text: "review the docs branch",
+							},
+							{
+								at: "2026-05-16T00:03:00.000Z",
+								role: "agent",
+								text: "Which docs scope should I run?",
+								state: "TASK_STATE_INPUT_REQUIRED",
+							},
+						],
+						createdAt: "2026-05-16T00:02:00.000Z",
+						updatedAt: "2026-05-16T00:01:00.000Z",
+					},
+				],
+			}),
+		);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+		taskResponses = [
+			{
+				id: "task-mac-mini-1",
+				contextId: "maestro-a2a-context-1",
+				status: {
+					state: "TASK_STATE_COMPLETED",
+					message: {
+						messageId: "agent-completed-1",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "release branch smoke already passed",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+			},
+			{
+				id: "task-mac-mini-2",
+				contextId: "maestro-a2a-context-2",
+				status: {
+					state: "TASK_STATE_INPUT_REQUIRED",
+					message: {
+						messageId: "agent-input-required-2",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "Which docs scope should I run?",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+			},
+			{
+				id: "task-mac-mini-2",
+				contextId: "maestro-a2a-context-2",
+				status: {
+					state: "TASK_STATE_COMPLETED",
+					message: {
+						messageId: "agent-completed-2",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "docs smoke passed",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+				artifacts: [
+					{
+						artifactId: "result",
+						parts: [
+							{
+								text: "docs smoke passed",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				],
+			},
+		];
+
+		await handleA2ACommand([
+			"coordinate",
+			"mac-mini",
+			"--reply",
+			"use the docs smoke scope",
+			"--wait",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--max-wait-ms",
+			"1000",
+			"--interval-ms",
+			"10",
+			"--timeout-ms",
+			"1000",
+		]);
+
+		expect(taskFetches).toBe(3);
+		expect(requests).toHaveLength(1);
+		expect(recordValue(requests[0]!.body, "message.taskId")).toBe(
+			"task-mac-mini-2",
+		);
+		expect(recordValue(requests[0]!.body, "message.contextId")).toBe(
+			"maestro-a2a-context-2",
+		);
+		expect(plainLogs(logs)).toContain(
+			"Coordinated mac-mini task task-mac-mini-2",
+		);
+		expect(plainLogs(logs)).toContain("docs smoke passed");
+		const ledger = JSON.parse(await readFile(tasksPath, "utf8")) as {
+			tasks: Array<{
+				completedAt?: string;
+				responseText?: string;
+				state: string;
+				taskId: string;
+			}>;
+		};
+		expect(ledger.tasks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					taskId: "task-mac-mini-1",
+					state: "TASK_STATE_COMPLETED",
+					responseText: "release branch smoke already passed",
+					completedAt: expect.any(String),
+				}),
+				expect.objectContaining({
+					taskId: "task-mac-mini-2",
+					state: "TASK_STATE_COMPLETED",
+					responseText: "docs smoke passed",
+					completedAt: expect.any(String),
+				}),
+			]),
+		);
+		expect(errors.join("\n")).toBe("");
+	});
+
+	it("refuses coordinate replies when more than one actionable task matches", async () => {
+		const dir = await mkdtemp(
+			join(tmpdir(), "maestro-a2a-coordinate-ambiguous-"),
+		);
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks.json");
+		await writeRegistry(registryPath, baseUrl);
+		await writeFile(
+			tasksPath,
+			JSON.stringify({
+				tasks: [
+					{
+						id: "maestro-a2a-ledger-1",
+						kind: "delegation",
+						peer: "mac-mini",
+						taskId: "task-mac-mini-1",
+						contextId: "maestro-a2a-context-1",
+						text: "review the release branch",
+						state: "TASK_STATE_INPUT_REQUIRED",
+						responseText: "Which smoke profile should I run?",
+						transcript: [
+							{
+								at: "2026-05-16T00:00:00.000Z",
+								role: "user",
+								text: "review the release branch",
+							},
+							{
+								at: "2026-05-16T00:01:00.000Z",
+								role: "agent",
+								text: "Which smoke profile should I run?",
+								state: "TASK_STATE_INPUT_REQUIRED",
+							},
+						],
+						createdAt: "2026-05-16T00:00:00.000Z",
+						updatedAt: "2026-05-16T00:01:00.000Z",
+					},
+					{
+						id: "maestro-a2a-ledger-2",
+						kind: "delegation",
+						peer: "mac-mini",
+						taskId: "task-mac-mini-2",
+						contextId: "maestro-a2a-context-2",
+						text: "review the docs branch",
+						state: "TASK_STATE_INPUT_REQUIRED",
+						responseText: "Which docs scope should I run?",
+						transcript: [
+							{
+								at: "2026-05-16T00:02:00.000Z",
+								role: "user",
+								text: "review the docs branch",
+							},
+							{
+								at: "2026-05-16T00:03:00.000Z",
+								role: "agent",
+								text: "Which docs scope should I run?",
+								state: "TASK_STATE_INPUT_REQUIRED",
+							},
+						],
+						createdAt: "2026-05-16T00:02:00.000Z",
+						updatedAt: "2026-05-16T00:03:00.000Z",
+					},
+				],
+			}),
+		);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+		taskResponses = [
+			{
+				id: "task-mac-mini-2",
+				contextId: "maestro-a2a-context-2",
+				status: {
+					state: "TASK_STATE_INPUT_REQUIRED",
+					message: {
+						messageId: "agent-input-required-2",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "Which docs scope should I run?",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+			},
+			{
+				id: "task-mac-mini-1",
+				contextId: "maestro-a2a-context-1",
+				status: {
+					state: "TASK_STATE_INPUT_REQUIRED",
+					message: {
+						messageId: "agent-input-required-1",
+						role: "ROLE_AGENT",
+						parts: [
+							{
+								text: "Which smoke profile should I run?",
+								mediaType: "text/plain",
+							},
+						],
+					},
+				},
+			},
+		];
+
+		await expect(
+			handleA2ACommand([
+				"coordinate",
+				"mac-mini",
+				"--reply",
+				"use the short smoke profile",
+				"--registry",
+				registryPath,
+				"--tasks",
+				tasksPath,
+				"--timeout-ms",
+				"1000",
+			]),
+		).rejects.toThrow("Multiple actionable A2A tasks found");
+
+		expect(requests).toHaveLength(0);
+		expect(taskFetches).toBe(2);
+		expect(errors.join("\n")).not.toContain("super-secret-token");
 	});
 
 	it("reports delegation success when local ledger persistence fails", async () => {
@@ -479,6 +1430,48 @@ function recordValue(input: unknown, path: string): unknown {
 
 function plainLogs(entries: string[]): string {
 	return entries.join("\n").replace(ANSI_ESCAPE_PATTERN, "");
+}
+
+function workGraphMetadata(
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		state: "waiting",
+		itemCount: 3,
+		activeItemCount: 3,
+		blockedItemCount: 0,
+		waitingItemCount: 1,
+		childRunCount: 1,
+		childRunIds: ["agent_run_child_1"],
+		toolCallCount: 2,
+		pendingToolCallCount: 1,
+		toolExecutionIds: ["tool_exec_1"],
+		waitItemCount: 1,
+		waitIds: ["thread_child_1"],
+		stateCounts: {
+			AGENT_WORK_ITEM_STATE_WAITING: 1,
+			AGENT_WORK_ITEM_STATE_RUNNING: 2,
+		},
+		correlationPath:
+			"platform_agent_run_id=run_1 active_work_items=3 blocked_work_items=0 child_runs=1",
+		codexSubagents: {
+			edgeCount: 1,
+			edges: [
+				{
+					spawnToolCallId: "toolu_spawn_child",
+					waitToolCallId: "toolu_wait_child",
+					childRunId: "agent_run_child_1",
+					threadId: "thread_child_1",
+					operation: "spawn_agent",
+					status: "running",
+				},
+			],
+			childRunIds: ["agent_run_child_1"],
+			toolCallIds: ["toolu_spawn_child", "toolu_wait_child"],
+			threadIds: ["thread_child_1"],
+		},
+		...overrides,
+	};
 }
 
 async function writeRegistry(path: string, baseUrl: string): Promise<void> {

--- a/test/cli/commands/a2a.test.ts
+++ b/test/cli/commands/a2a.test.ts
@@ -51,13 +51,42 @@ describe("A2A CLI command helpers", () => {
 			"mac-mini",
 			"ping",
 			"--wait",
+			"--work-graph",
 			"--timeout-ms",
 			"1000",
 		]);
 
 		expect(parsed.positionals).toEqual(["send", "mac-mini", "ping"]);
 		expect(parsed.flags.get("--wait")).toBe(true);
+		expect(parsed.flags.get("--work-graph")).toBe(true);
 		expect(parsed.flags.get("--timeout-ms")).toBe("1000");
+	});
+
+	it("parses direct task output work graph flags", () => {
+		const reply = parseA2AArgs([
+			"reply",
+			"mac-mini",
+			"task-1",
+			"use",
+			"the",
+			"short",
+			"smoke",
+			"--work-graph",
+		]);
+		expect(reply.positionals).toEqual([
+			"reply",
+			"mac-mini",
+			"task-1",
+			"use",
+			"the",
+			"short",
+			"smoke",
+		]);
+		expect(reply.flags.get("--work-graph")).toBe(true);
+
+		const wait = parseA2AArgs(["wait", "mac-mini", "task-1", "--work-graph"]);
+		expect(wait.positionals).toEqual(["wait", "mac-mini", "task-1"]);
+		expect(wait.flags.get("--work-graph")).toBe(true);
 	});
 
 	it("parses task reply flags without swallowing reply text", () => {
@@ -104,6 +133,43 @@ describe("A2A CLI command helpers", () => {
 		expect(tasks.positionals).toEqual(["tasks"]);
 		expect(tasks.flags.get("--json")).toBe(true);
 		expect(tasks.flags.get("--refresh")).toBe(true);
+
+		const workGraph = parseA2AArgs(["tasks", "mac-mini", "--work-graph"]);
+		expect(workGraph.positionals).toEqual(["tasks", "mac-mini"]);
+		expect(workGraph.flags.get("--work-graph")).toBe(true);
+	});
+
+	it("parses coordinate flags without swallowing reply text", () => {
+		const parsed = parseA2AArgs([
+			"coordinate",
+			"mac-mini",
+			"--refresh",
+			"--reply",
+			"use",
+			"the",
+			"short",
+			"smoke",
+			"--wait",
+			"--json",
+			"--tasks",
+			"/tmp/tasks.json",
+		]);
+
+		expect(parsed.positionals).toEqual(["coordinate", "mac-mini"]);
+		expect(parsed.flags.get("--refresh")).toBe(true);
+		expect(parsed.flags.get("--reply")).toBe("use the short smoke");
+		expect(parsed.flags.get("--wait")).toBe(true);
+		expect(parsed.flags.get("--json")).toBe(true);
+		expect(parsed.flags.get("--tasks")).toBe("/tmp/tasks.json");
+	});
+
+	it("rejects coordinate reply flags without reply text", () => {
+		expect(() =>
+			parseA2AArgs(["coordinate", "mac-mini", "--reply", "--wait"]),
+		).toThrow("--reply requires text");
+		expect(() => parseA2AArgs(["coordinate", "mac-mini", "--reply="])).toThrow(
+			"Usage: maestro a2a coordinate [peer] --reply <text> [--wait]",
+		);
 	});
 
 	it("parses leading flags after locating the subcommand", () => {

--- a/test/cli/headless.test.ts
+++ b/test/cli/headless.test.ts
@@ -616,6 +616,207 @@ describe("headless protocol helpers", () => {
 		]);
 	});
 
+	it("preserves Codex subagent lifecycle edges without prompt payloads", () => {
+		const state = createHeadlessRuntimeState();
+		const spawnArgs = {
+			prompt: "Sensitive child task prompt",
+			codexWorkGraph: {
+				schemaVersion: "evalops.maestro.codex.subagent-workgraph.v1",
+				childRuns: [
+					{
+						threadId: "child-thread-1",
+						childRunId: "agent-run-child-1",
+						operation: "spawnAgent",
+					},
+				],
+			},
+		};
+
+		applyIncomingHeadlessMessage(state, {
+			type: "tool_call",
+			call_id: "collab-spawn-1",
+			tool: "codex.subagent.spawnAgent",
+			args: spawnArgs,
+			requires_approval: false,
+		});
+		expect(state.codex_subagent_edges).toEqual([
+			{
+				spawn_tool_call_id: "collab-spawn-1",
+				child_run_id: "agent-run-child-1",
+				thread_id: "child-thread-1",
+				operation: "spawn_agent",
+				status: "waiting_for_restore",
+			},
+		]);
+
+		applyIncomingHeadlessMessage(state, {
+			type: "tool_end",
+			call_id: "collab-spawn-1",
+			success: true,
+		});
+		applyIncomingHeadlessMessage(state, {
+			type: "tool_call",
+			call_id: "collab-close-1",
+			tool: "codex.subagent.closeAgent",
+			args: {
+				receiverThreadIds: ["child-thread-1"],
+				childRunIds: ["agent-run-child-1"],
+			},
+			requires_approval: false,
+		});
+		applyIncomingHeadlessMessage(state, {
+			type: "tool_end",
+			call_id: "collab-close-1",
+			success: true,
+		});
+
+		expect(state.codex_subagent_edges).toEqual([
+			{
+				wait_tool_call_id: "collab-close-1",
+				child_run_id: "agent-run-child-1",
+				thread_id: "child-thread-1",
+				operation: "close_agent",
+				status: "closed",
+			},
+			{
+				spawn_tool_call_id: "collab-spawn-1",
+				child_run_id: "agent-run-child-1",
+				thread_id: "child-thread-1",
+				operation: "spawn_agent",
+				status: "completed",
+			},
+		]);
+		expect(JSON.stringify(state.codex_subagent_edges)).not.toContain(
+			"Sensitive child task prompt",
+		);
+	});
+
+	it("keeps durable Codex subagent edges across runtime reset messages", () => {
+		const state = createHeadlessRuntimeState();
+		const edge = {
+			spawn_tool_call_id: "collab-spawn-reset",
+			child_run_id: "agent-run-child-reset",
+			thread_id: "child-thread-reset",
+			operation: "spawn_agent",
+			status: "waiting_for_restore",
+		};
+		state.codex_subagent_edges = [edge];
+
+		applyOutgoingHeadlessMessage(state, { type: "interrupt" });
+		expect(state.codex_subagent_edges).toEqual([edge]);
+
+		applyOutgoingHeadlessMessage(state, { type: "cancel" });
+		expect(state.codex_subagent_edges).toEqual([edge]);
+
+		applyOutgoingHeadlessMessage(state, { type: "shutdown" });
+		expect(state.codex_subagent_edges).toEqual([edge]);
+	});
+
+	it("preserves restored terminal Codex subagent statuses during close propagation", () => {
+		const state = createHeadlessRuntimeState();
+		state.codex_subagent_edges = [
+			{
+				spawn_tool_call_id: "collab-spawn-restored",
+				child_run_id: "agent-run-child-restored",
+				thread_id: "child-thread-restored",
+				operation: "spawn_agent",
+				status: "cancelled",
+			},
+		];
+
+		applyIncomingHeadlessMessage(state, {
+			type: "tool_call",
+			call_id: "collab-close-restored",
+			tool: "codex.subagent.closeAgent",
+			args: {
+				receiverThreadIds: ["child-thread-restored"],
+				childRunIds: ["agent-run-child-restored"],
+			},
+			requires_approval: false,
+		});
+		applyIncomingHeadlessMessage(state, {
+			type: "tool_end",
+			call_id: "collab-close-restored",
+			success: true,
+		});
+
+		expect(state.codex_subagent_edges).toEqual([
+			{
+				wait_tool_call_id: "collab-close-restored",
+				child_run_id: "agent-run-child-restored",
+				thread_id: "child-thread-restored",
+				operation: "close_agent",
+				status: "closed",
+			},
+			{
+				spawn_tool_call_id: "collab-spawn-restored",
+				child_run_id: "agent-run-child-restored",
+				thread_id: "child-thread-restored",
+				operation: "spawn_agent",
+				status: "cancelled",
+			},
+		]);
+	});
+
+	it("normalizes older restored states before tracking Codex subagent edges", () => {
+		const state = createHeadlessRuntimeState();
+		delete (state as Partial<ReturnType<typeof createHeadlessRuntimeState>>)
+			.codex_subagent_edges;
+
+		applyIncomingHeadlessMessage(state, {
+			type: "tool_call",
+			call_id: "collab-spawn-legacy",
+			tool: "codex.subagent.spawnAgent",
+			args: {
+				childRunIds: ["agent-run-child-legacy"],
+				receiverThreadIds: ["child-thread-legacy"],
+			},
+			requires_approval: false,
+		});
+
+		expect(state.codex_subagent_edges).toEqual([
+			{
+				spawn_tool_call_id: "collab-spawn-legacy",
+				child_run_id: "agent-run-child-legacy",
+				thread_id: "child-thread-legacy",
+				operation: "spawn_agent",
+				status: "waiting_for_restore",
+			},
+		]);
+	});
+
+	it("marks denied restored Codex subagent edges failed after tracked source cleanup", () => {
+		const state = createHeadlessRuntimeState();
+		state.codex_subagent_edges = [
+			{
+				spawn_tool_call_id: "collab-spawn-denied",
+				child_run_id: "agent-run-child-denied",
+				thread_id: "child-thread-denied",
+				operation: "spawn_agent",
+				status: "waiting_for_restore",
+			},
+		];
+
+		applyIncomingHeadlessMessage(state, {
+			type: "server_request_resolved",
+			request_id: "approval-denied",
+			request_type: "approval",
+			call_id: "collab-spawn-denied",
+			resolution: "denied",
+			resolved_by: "policy",
+		});
+
+		expect(state.codex_subagent_edges).toEqual([
+			{
+				spawn_tool_call_id: "collab-spawn-denied",
+				child_run_id: "agent-run-child-denied",
+				thread_id: "child-thread-denied",
+				operation: "spawn_agent",
+				status: "failed",
+			},
+		]);
+	});
+
 	it("tracks approval server requests in the runtime state", () => {
 		const state = createHeadlessRuntimeState();
 

--- a/test/contracts/contract-validators.test.ts
+++ b/test/contracts/contract-validators.test.ts
@@ -36,6 +36,7 @@ import {
 	isComposerAgentEvent,
 	validateSchema,
 } from "../../packages/contracts/src/validators.js";
+import { createHeadlessRuntimeState } from "../../src/cli/headless-protocol.js";
 
 describe("contracts validators", () => {
 	it("accepts a minimal chat request", () => {
@@ -145,6 +146,25 @@ describe("contracts validators", () => {
 			assertHeadlessRuntimeStreamEnvelope({
 				type: "heartbeat",
 				cursor: 3,
+			}),
+		).not.toThrow();
+	});
+
+	it("accepts legacy headless runtime snapshots without Codex subagent edge state", () => {
+		const state = createHeadlessRuntimeState();
+		delete (state as Partial<typeof state>).codex_subagent_edges;
+
+		expect(() =>
+			assertHeadlessRuntimeStreamEnvelope({
+				type: "reset",
+				reason: "restored_from_snapshot",
+				snapshot: {
+					protocolVersion: "2026-04-02",
+					session_id: "sess_legacy_edges",
+					cursor: 4,
+					last_init: null,
+					state,
+				},
 			}),
 		).not.toThrow();
 	});

--- a/test/platform/a2a-task-ledger.test.ts
+++ b/test/platform/a2a-task-ledger.test.ts
@@ -40,6 +40,45 @@ describe("A2A task ledger", () => {
 			task: {
 				id: "task-dev-1",
 				status: { state: "TASK_STATE_SUBMITTED" },
+				metadata: {
+					workGraph: {
+						state: "waiting",
+						itemCount: "3",
+						activeItemCount: 3,
+						childRunCount: 1,
+						childRunIds: ["agent_run_child_1", ""],
+						toolCallCount: 2,
+						pendingToolCallCount: 1,
+						toolExecutionIds: ["tool_exec_1"],
+						waitItemCount: 1,
+						waitIds: ["thread_child_1"],
+						stateCounts: {
+							AGENT_WORK_ITEM_STATE_WAITING: "1",
+						},
+						correlationPath:
+							"platform_agent_run_id=run_1 active_work_items=3 blocked_work_items=0 child_runs=1",
+						codexSubagents: {
+							edgeCount: "1",
+							edges: [
+								{
+									spawnToolCallId: "toolu_spawn_child",
+									waitToolCallId: "toolu_wait_child",
+									childRunId: "agent_run_child_1",
+									threadId: "thread_child_1",
+									operation: "spawn_agent",
+									status: "running",
+								},
+								{
+									operation: "missing_ids",
+									status: "ignored",
+								},
+							],
+							childRunIds: ["agent_run_child_1"],
+							toolCallIds: ["toolu_spawn_child", "toolu_wait_child"],
+							threadIds: ["thread_child_1"],
+						},
+					},
+				},
 			},
 			text: "run the full checks",
 			messageId: "message-1",
@@ -76,6 +115,22 @@ describe("A2A task ledger", () => {
 						{ role: "user", text: "run the full checks" },
 						{ role: "agent", text: "checks passed" },
 					],
+					workGraph: {
+						state: "waiting",
+						itemCount: 3,
+						childRunIds: ["agent_run_child_1"],
+						codexSubagents: {
+							edgeCount: 1,
+							threadIds: ["thread_child_1"],
+							edges: [
+								{
+									childRunId: "agent_run_child_1",
+									operation: "spawn_agent",
+									status: "running",
+								},
+							],
+						},
+					},
 				},
 			],
 		});

--- a/test/scripts/codex-a2a-bridge.test.ts
+++ b/test/scripts/codex-a2a-bridge.test.ts
@@ -29,9 +29,139 @@ print(json.dumps({
 }, sort_keys=True))
 `;
 
+const fixtureHelperCode = `
+import importlib.util
+import json
+import os
+import sys
+import threading
+import urllib.error
+import urllib.request
+
+script_path = json.loads(sys.argv[1])
+scenario = sys.argv[2]
+
+fixture_token = "-".join(["test", "token"])
+os.environ["CODEX_A2A_TOKEN"] = fixture_token
+os.environ["CODEX_A2A_FIXTURE_MODE"] = "input-required-once"
+os.environ["CODEX_A2A_CODEX_BIN"] = "/tmp/codex-a2a-fixture-mode-must-not-run-codex"
+
+spec = importlib.util.spec_from_file_location("codex_a2a_bridge", script_path)
+bridge = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(bridge)
+
+with bridge.LOCK:
+    bridge.TASKS.clear()
+    bridge.PROCESSES.clear()
+
+server = bridge.ThreadingHTTPServer(("127.0.0.1", 0), bridge.Handler)
+thread = threading.Thread(target=server.serve_forever, daemon=True)
+thread.start()
+
+def message(text, task_id=None, context_id=None):
+    value = {
+        "message": {
+            "messageId": "user-message-" + text.lower().replace(" ", "-"),
+            "parts": [{"text": text, "mediaType": "text/plain"}],
+            "role": "ROLE_USER",
+        }
+    }
+    if task_id is not None:
+        value["message"]["taskId"] = task_id
+    if context_id is not None:
+        value["message"]["contextId"] = context_id
+    return value
+
+def post(body):
+    data = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{server.server_port}/message:send",
+        data=data,
+        headers={
+            "Authorization": " ".join(["Bearer", fixture_token]),
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return {
+                "status": response.status,
+                "body": json.loads(response.read().decode("utf-8")),
+            }
+    except urllib.error.HTTPError as error:
+        return {
+            "status": error.code,
+            "body": json.loads(error.read().decode("utf-8")),
+        }
+
+try:
+    responses = []
+    initial = post(message("Please prepare the deployment summary"))
+    responses.append(initial)
+    task = initial.get("body", {}).get("task", {})
+    task_id = task.get("id")
+    context_id = task.get("contextId")
+    if scenario == "initial":
+        pass
+    elif scenario == "follow-up":
+        responses.append(post(message("The deploy target is staging.", task_id, context_id)))
+    elif scenario == "context-mismatch":
+        responses.append(post(message("The deploy target is staging.", task_id, "wrong-context")))
+    elif scenario == "terminal-rejects":
+        responses.append(post(message("The deploy target is staging.", task_id, context_id)))
+        responses.append(post(message("One more update.", task_id, context_id)))
+    else:
+        raise AssertionError(f"unknown scenario: {scenario}")
+    print(json.dumps({"responses": responses}, sort_keys=True))
+finally:
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+`;
+
 type HelperResult = {
 	metadata: Record<string, unknown>;
 	prompt: string;
+};
+
+type BridgeResponse = {
+	status: number;
+	body: {
+		error?: {
+			code: string;
+			message: string;
+		};
+		task?: {
+			id: string;
+			contextId: string;
+			status: {
+				state: string;
+				message: {
+					contextId: string;
+					role: string;
+					parts: Array<{ text: string; mediaType: string }>;
+				};
+			};
+			history: Array<{
+				messageId: string;
+				contextId: string;
+				role: string;
+				parts: Array<{ text: string; mediaType: string }>;
+			}>;
+			artifacts: Array<{
+				artifactId: string;
+				name: string;
+				parts: Array<{ text: string; mediaType: string }>;
+			}>;
+			metadata: Record<string, unknown>;
+		};
+	};
+};
+
+type FixtureScenarioResult = {
+	responses: BridgeResponse[];
 };
 
 const mockToken = ["super", "secret", "token"].join("-");
@@ -54,6 +184,25 @@ async function buildPromptFromPayloadJson(payloadJson: string) {
 		{ encoding: "utf8" },
 	);
 	return JSON.parse(stdout) as HelperResult;
+}
+
+async function runFixtureScenario(scenario: string) {
+	const { stdout } = await execFileAsync(
+		"python3",
+		["-c", fixtureHelperCode, JSON.stringify(bridgePath), scenario],
+		{ encoding: "utf8" },
+	);
+	return JSON.parse(stdout) as FixtureScenarioResult;
+}
+
+function taskFrom(response: BridgeResponse) {
+	expect(response.status).toBe(200);
+	expect(response.body.task).toBeDefined();
+	return response.body.task;
+}
+
+function textFrom(parts: Array<{ text: string }>) {
+	return parts.map((part) => part.text).join("\n");
 }
 
 function parsePromptEnvelope(prompt: string) {
@@ -247,5 +396,78 @@ describe("codex-a2a-bridge prompt metadata", () => {
 			expect.stringMatching(/^codex-a2a-message-/),
 		);
 		expect(envelope.metadata.relayPeer).toBe("mac-mini");
+	});
+});
+
+describe("codex-a2a-bridge input-required fixture", () => {
+	it("stores and returns a stable input-required task with an agent question", async () => {
+		const { responses } = await runFixtureScenario("initial");
+		const task = taskFrom(responses[0]);
+
+		expect(task?.id).toBe("codex-a2a-fixture-task-input-required-once");
+		expect(task?.contextId).toBe(
+			"codex-a2a-fixture-context-input-required-once",
+		);
+		expect(task?.status.state).toBe("TASK_STATE_INPUT_REQUIRED");
+		expect(task?.status.message.contextId).toBe(task?.contextId);
+		expect(task?.status.message.role).toBe("ROLE_AGENT");
+		expect(textFrom(task?.status.message.parts ?? [])).toMatch(/what .*need/i);
+		expect(task?.history).toHaveLength(2);
+		expect(task?.history[0]).toMatchObject({
+			contextId: task?.contextId,
+			role: "ROLE_USER",
+		});
+		expect(task?.history[1]).toEqual(task?.status.message);
+		expect(task?.artifacts).toEqual([]);
+		expect(task?.metadata).toMatchObject({
+			backend: "codex-a2a-fixture",
+			fixtureMode: "input-required-once",
+		});
+	});
+
+	it("accepts a same-context follow-up and completes the same task with an artifact", async () => {
+		const { responses } = await runFixtureScenario("follow-up");
+		const initialTask = taskFrom(responses[0]);
+		const completedTask = taskFrom(responses[1]);
+
+		expect(completedTask?.id).toBe(initialTask?.id);
+		expect(completedTask?.contextId).toBe(initialTask?.contextId);
+		expect(completedTask?.status.state).toBe("TASK_STATE_COMPLETED");
+		expect(completedTask?.history).toHaveLength(4);
+		expect(completedTask?.history[0]).toEqual(initialTask?.history[0]);
+		expect(completedTask?.history[1]).toEqual(initialTask?.history[1]);
+		expect(textFrom(completedTask?.history[2].parts ?? [])).toContain(
+			"The deploy target is staging.",
+		);
+		expect(completedTask?.artifacts).toHaveLength(1);
+		expect(textFrom(completedTask?.artifacts[0].parts ?? [])).toContain(
+			"The deploy target is staging.",
+		);
+	});
+
+	it("rejects a follow-up when the context does not match the task", async () => {
+		const { responses } = await runFixtureScenario("context-mismatch");
+		const initialTask = taskFrom(responses[0]);
+		const mismatch = responses[1];
+
+		expect(initialTask?.status.state).toBe("TASK_STATE_INPUT_REQUIRED");
+		expect(mismatch.status).toBe(400);
+		expect(mismatch.body.error).toMatchObject({
+			code: "INVALID_REQUEST",
+			message: "A2A message contextId must match the referenced task",
+		});
+	});
+
+	it("rejects additional messages after the fixture task reaches a terminal state", async () => {
+		const { responses } = await runFixtureScenario("terminal-rejects");
+		const completedTask = taskFrom(responses[1]);
+		const terminalFollowUp = responses[2];
+
+		expect(completedTask?.status.state).toBe("TASK_STATE_COMPLETED");
+		expect(terminalFollowUp.status).toBe(400);
+		expect(terminalFollowUp.body.error).toMatchObject({
+			code: "UNSUPPORTED_OPERATION",
+			message: "A2A terminal tasks cannot accept more messages",
+		});
 	});
 });

--- a/test/server/hosted-runner-drain.test.ts
+++ b/test/server/hosted-runner-drain.test.ts
@@ -331,6 +331,15 @@ describe("hosted runner drain", () => {
 			codex_subagent_tool_call_ids: ["collab-spawn-1"],
 			codex_subagent_child_run_ids: ["agent-run-child-1"],
 			codex_subagent_thread_ids: ["child-thread-1"],
+			codex_subagent_edges: [
+				{
+					spawn_tool_call_id: "collab-spawn-1",
+					child_run_id: "agent-run-child-1",
+					thread_id: "child-thread-1",
+					operation: "spawn_agent",
+					status: "waiting_for_restore",
+				},
+			],
 		});
 		const manifestWithoutSnapshot = {
 			...result!.manifest,
@@ -395,6 +404,162 @@ describe("hosted runner drain", () => {
 			codex_subagent_tool_call_ids: ["collab-spawn-2"],
 			codex_subagent_child_run_ids: ["agent-run-child-2"],
 			codex_subagent_thread_ids: ["child-thread-2"],
+			codex_subagent_edges: [
+				{
+					spawn_tool_call_id: "collab-spawn-2",
+					child_run_id: "agent-run-child-2",
+					thread_id: "child-thread-2",
+					operation: "spawn_agent",
+					status: "waiting_for_restore",
+				},
+			],
+		});
+	});
+
+	it("records Codex subagent edge lifecycle from restored runtime state", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const context = hostedRunnerContext(workspaceRoot);
+		const snapshot = runtimeSnapshot(workspaceRoot);
+		snapshot.state.codex_subagent_edges = [
+			{
+				spawn_tool_call_id: "collab-spawn-restored",
+				child_run_id: "agent-run-child-restored",
+				thread_id: "child-thread-restored",
+				operation: "spawn_agent",
+				status: "completed",
+			},
+			{
+				wait_tool_call_id: "collab-close-restored",
+				child_run_id: "agent-run-child-restored",
+				thread_id: "child-thread-restored",
+				operation: "close_agent",
+				status: "closed",
+			},
+		];
+
+		const result = await drainHostedRunner(
+			{ reason: "ttl_expired" },
+			{
+				hostedRunner: context,
+				drainRuntime: vi.fn().mockResolvedValue({
+					sessionId: "session_123",
+					snapshot,
+				}),
+				now: () => new Date("2026-04-23T00:05:00.000Z"),
+			},
+		);
+
+		expect(result?.manifest.work_continuity).toEqual({
+			protocol_version: HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
+			active_tool_count: 0,
+			tracked_tool_count: 2,
+			pending_request_count: 0,
+			codex_subagent_tool_call_ids: [
+				"collab-close-restored",
+				"collab-spawn-restored",
+			],
+			codex_subagent_child_run_ids: ["agent-run-child-restored"],
+			codex_subagent_thread_ids: ["child-thread-restored"],
+			codex_subagent_edges: [
+				{
+					wait_tool_call_id: "collab-close-restored",
+					child_run_id: "agent-run-child-restored",
+					thread_id: "child-thread-restored",
+					operation: "close_agent",
+					status: "closed",
+				},
+				{
+					spawn_tool_call_id: "collab-spawn-restored",
+					child_run_id: "agent-run-child-restored",
+					thread_id: "child-thread-restored",
+					operation: "spawn_agent",
+					status: "completed",
+				},
+			],
+		});
+	});
+
+	it("preserves regular tool counts when Codex subagent edges are present", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const context = hostedRunnerContext(workspaceRoot);
+		const snapshot = runtimeSnapshot(workspaceRoot);
+		snapshot.state.active_tools = [
+			{
+				call_id: "regular-active-tool",
+				tool: "shell.exec",
+				output: "still running",
+			},
+		];
+		snapshot.state.tracked_tools = [
+			{
+				call_id: "regular-tracked-tool",
+				tool: "shell.exec",
+				args: { command: "npm test" },
+			},
+		];
+		snapshot.state.codex_subagent_edges = [
+			{
+				spawn_tool_call_id: "collab-spawn-restored",
+				child_run_id: "agent-run-child-restored",
+				thread_id: "child-thread-restored",
+				operation: "spawn_agent",
+				status: "waiting_for_restore",
+			},
+		];
+
+		const result = await drainHostedRunner(
+			{ reason: "ttl_expired" },
+			{
+				hostedRunner: context,
+				drainRuntime: vi.fn().mockResolvedValue({
+					sessionId: "session_123",
+					snapshot,
+				}),
+				now: () => new Date("2026-04-23T00:05:30.000Z"),
+			},
+		);
+
+		expect(result?.manifest.work_continuity).toMatchObject({
+			active_tool_count: 2,
+			tracked_tool_count: 2,
+			codex_subagent_tool_call_ids: ["collab-spawn-restored"],
+			codex_subagent_child_run_ids: ["agent-run-child-restored"],
+			codex_subagent_thread_ids: ["child-thread-restored"],
+		});
+	});
+
+	it("treats acknowledged Codex send input edges as terminal continuity", async () => {
+		const workspaceRoot = await createTempWorkspace();
+		const context = hostedRunnerContext(workspaceRoot);
+		const snapshot = runtimeSnapshot(workspaceRoot);
+		snapshot.state.codex_subagent_edges = [
+			{
+				wait_tool_call_id: "collab-send-ack",
+				child_run_id: "agent-run-child-ack",
+				thread_id: "child-thread-ack",
+				operation: "send_input",
+				status: "acknowledged",
+			},
+		];
+
+		const result = await drainHostedRunner(
+			{ reason: "ttl_expired" },
+			{
+				hostedRunner: context,
+				drainRuntime: vi.fn().mockResolvedValue({
+					sessionId: "session_123",
+					snapshot,
+				}),
+				now: () => new Date("2026-04-23T00:05:40.000Z"),
+			},
+		);
+
+		expect(result?.manifest.work_continuity).toMatchObject({
+			active_tool_count: 0,
+			tracked_tool_count: 1,
+			codex_subagent_tool_call_ids: ["collab-send-ack"],
+			codex_subagent_child_run_ids: ["agent-run-child-ack"],
+			codex_subagent_thread_ids: ["child-thread-ack"],
 		});
 	});
 
@@ -569,6 +734,15 @@ describe("hosted runner drain", () => {
 			codex_subagent_tool_call_ids: ["collab-spawn-interrupted"],
 			codex_subagent_child_run_ids: ["agent-run-child-interrupted"],
 			codex_subagent_thread_ids: ["child-thread-interrupted"],
+			codex_subagent_edges: [
+				{
+					spawn_tool_call_id: "collab-spawn-interrupted",
+					child_run_id: "agent-run-child-interrupted",
+					thread_id: "child-thread-interrupted",
+					operation: "spawn_agent",
+					status: "waiting_for_restore",
+				},
+			],
 		});
 	});
 


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `51302f2dc9472c7ee2c5ba266de7234807072524`
- last generated public sync base: `2eb62cdb238ba7a6210ff9dee88d1dd16ce4c1f5`
- previewed public-tree drift: `36` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `6`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (51302f2dc947)`
- public projection: `https://github.com/evalops/maestro@main (b1446f6126e3)`
- files to copy or update: `36`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update docs/protocols/codex-operating-layer.json
- copy/update docs/protocols/codex-operating-layer.md
- copy/update package.json
- copy/update packages/contracts/schema/headless/payload-schemas.json
- copy/update packages/contracts/src/headless-protocol-payloads.manifest.json
- copy/update packages/contracts/src/headless-protocol-schemas.generated.ts
- copy/update packages/control-plane-rs/src/main.rs
- copy/update packages/tui-rs/src/app.rs
- copy/update packages/tui-rs/src/commands/registry.rs
- copy/update packages/tui-rs/src/commands/types.rs
- copy/update packages/tui-rs/src/headless/messages.rs
- copy/update packages/tui-rs/src/headless/remote_transport.rs
- copy/update packages/tui-rs/src/headless/session.rs
- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update scripts/codex-a2a-bridge.py
- copy/update scripts/smoke-maestro-a2a-input-required.ts
- copy/update src/cli-tui/commands/a2a-handlers.ts
- copy/update src/cli/commands/a2a.ts
- copy/update src/cli/headless-protocol.ts
- copy/update src/platform/a2a-client.ts
- copy/update src/platform/a2a-fleet.ts
- copy/update src/platform/a2a-task-ledger.ts
- copy/update src/platform/a2a-work-graph.ts
- copy/update src/remote-runner/attach-client.ts
- ... 11 more

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update docs/protocols/codex-operating-layer.json
- copy/update docs/protocols/codex-operating-layer.md
- copy/update package.json
- copy/update packages/contracts/schema/headless/payload-schemas.json
- copy/update packages/contracts/src/headless-protocol-payloads.manifest.json
- copy/update packages/contracts/src/headless-protocol-schemas.generated.ts
- copy/update packages/control-plane-rs/src/main.rs
- copy/update packages/tui-rs/src/app.rs
- copy/update packages/tui-rs/src/commands/registry.rs
- copy/update packages/tui-rs/src/commands/types.rs
- copy/update packages/tui-rs/src/headless/messages.rs
- copy/update packages/tui-rs/src/headless/remote_transport.rs
- copy/update packages/tui-rs/src/headless/session.rs
- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update scripts/codex-a2a-bridge.py
- copy/update scripts/smoke-maestro-a2a-input-required.ts
- copy/update src/cli-tui/commands/a2a-handlers.ts
- copy/update src/cli/commands/a2a.ts
- copy/update src/cli/headless-protocol.ts

## Public-only commits since last generated sync

- b1446f61 fix: unwrap a2a jsonrpc stream envelopes (#439)
- f41b5827 Fix mixed-newline A2A SSE parsing (#438)
- ee4271f4 fix: handle mixed-newline A2A SSE frames (#437)
- 2fbfb687 Harden Maestro A2A fleet streaming (#436)
- aadd04ff feat: add agent operating plane telemetry context (#435)
- d738fce8 feat: add OSS skill publish install contract (#431)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@51302f2dc9472c7ee2c5ba266de7234807072524`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #433 to internal source `51302f2dc9472c7ee2c5ba266de7234807072524`