### PR TITLE
telemetry: add agent operating-plane context

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -657,9 +657,22 @@ function eventCorrelationOverrides(
 			"tool_call_id",
 		]),
 		agent_id: metadataString(metadata, ["agentId", "agent_id"]),
+		actor_id: metadataString(metadata, ["actorId", "actor_id"]),
+		principal_id: metadataString(metadata, ["principalId", "principal_id"]),
 		trace_id:
 			topLevelTraceId ?? metadataString(metadata, ["traceId", "trace_id"]),
+		traceparent: metadataString(metadata, ["traceparent", "trace_parent"]),
+		tracestate: metadataString(metadata, ["tracestate", "trace_state"]),
 		request_id: metadataString(metadata, ["requestId", "request_id"]),
+		remote_runner_session_id: metadataString(metadata, [
+			"remoteRunnerSessionId",
+			"remote_runner_session_id",
+		]),
+		objective_id: metadataString(metadata, ["objectiveId", "objective_id"]),
+		conversation_id: metadataString(metadata, [
+			"conversationId",
+			"conversation_id",
+		]),
 	};
 }
 
@@ -687,10 +700,17 @@ function maestroCorrelationSpanAttributes(
 		"evalops.workspace_id": correlation.workspace_id ?? principal?.workspace_id,
 		"maestro.session_id": correlation.session_id,
 		"agent.id": correlation.agent_id,
+		"agent.actor.id": correlation.actor_id,
+		"evalops.principal_id": correlation.principal_id,
 		"maestro.agent_run_id": correlation.agent_run_id,
 		"maestro.agent_run_step_id": correlation.agent_run_step_id,
 		"trace.id": correlation.trace_id,
+		traceparent: correlation.traceparent,
+		tracestate: correlation.tracestate,
 		"request.id": correlation.request_id,
+		"evalops.remote_runner_session_id": correlation.remote_runner_session_id,
+		"evalops.objective_id": correlation.objective_id,
+		"evalops.conversation_id": correlation.conversation_id,
 		"maestro.surface": config.defaultSurface,
 	};
 

--- a/src/telemetry/agent-operating-plane-context.ts
+++ b/src/telemetry/agent-operating-plane-context.ts
@@ -1,0 +1,99 @@
+import type { MaestroCorrelation } from "./maestro-event-bus.js";
+
+export type AgentOperatingPlaneDataClassification =
+	| "public"
+	| "internal"
+	| "customer"
+	| "restricted";
+
+export type AgentOperatingPlaneRetentionClass =
+	| "ephemeral"
+	| "operational_audit"
+	| "security_audit"
+	| "legal_hold";
+
+export interface AgentOperatingPlaneCorrelationInput
+	extends Partial<MaestroCorrelation> {
+	workspace_id: string;
+	session_id: string;
+}
+
+export interface AgentOperatingPlaneMetadataInput {
+	dataClassification?: AgentOperatingPlaneDataClassification;
+	retentionClass?: AgentOperatingPlaneRetentionClass;
+	safeSummary?: string;
+}
+
+export interface AgentOperatingPlaneContextInput {
+	correlation: AgentOperatingPlaneCorrelationInput;
+	metadata?: AgentOperatingPlaneMetadataInput;
+}
+
+export interface AgentOperatingPlaneContext {
+	correlation: MaestroCorrelation;
+	metadata: Record<string, string>;
+}
+
+function cleanString(value: string | undefined): string | undefined {
+	const cleanValue = value?.trim();
+	return cleanValue ? cleanValue : undefined;
+}
+
+function compactStringRecord(
+	record: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+	if (!record) return undefined;
+	const compacted = Object.fromEntries(
+		Object.entries(record)
+			.map(([key, value]) => [key, cleanString(value)] as const)
+			.filter((entry): entry is readonly [string, string] => Boolean(entry[1])),
+	);
+	return Object.keys(compacted).length > 0 ? compacted : undefined;
+}
+
+export function buildAgentOperatingPlaneCorrelation(
+	input: AgentOperatingPlaneCorrelationInput,
+): MaestroCorrelation {
+	return {
+		organization_id: cleanString(input.organization_id),
+		user_id: cleanString(input.user_id),
+		workspace_id: cleanString(input.workspace_id) ?? "unknown",
+		session_id: cleanString(input.session_id) ?? "unknown",
+		agent_run_id: cleanString(input.agent_run_id),
+		agent_run_step_id: cleanString(input.agent_run_step_id),
+		agent_id: cleanString(input.agent_id),
+		actor_id: cleanString(input.actor_id),
+		principal_id: cleanString(input.principal_id),
+		trace_id: cleanString(input.trace_id),
+		traceparent: cleanString(input.traceparent),
+		tracestate: cleanString(input.tracestate),
+		request_id: cleanString(input.request_id),
+		parent_event_id: cleanString(input.parent_event_id),
+		remote_runner_session_id: cleanString(input.remote_runner_session_id),
+		objective_id: cleanString(input.objective_id),
+		conversation_id: cleanString(input.conversation_id),
+		attributes: compactStringRecord(input.attributes),
+	};
+}
+
+export function buildAgentOperatingPlaneMetadata(
+	input: AgentOperatingPlaneMetadataInput = {},
+): Record<string, string> {
+	const metadata: Record<string, string> = {};
+	const dataClassification = cleanString(input.dataClassification);
+	const retentionClass = cleanString(input.retentionClass);
+	const safeSummary = cleanString(input.safeSummary);
+	if (dataClassification) metadata.data_classification = dataClassification;
+	if (retentionClass) metadata.retention_class = retentionClass;
+	if (safeSummary) metadata.safe_summary = safeSummary;
+	return metadata;
+}
+
+export function buildAgentOperatingPlaneContext(
+	input: AgentOperatingPlaneContextInput,
+): AgentOperatingPlaneContext {
+	return {
+		correlation: buildAgentOperatingPlaneCorrelation(input.correlation),
+		metadata: buildAgentOperatingPlaneMetadata(input.metadata),
+	};
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -122,6 +122,18 @@ export {
 	type MaestroPlatformReplayFixtureEvent,
 } from "./maestro-platform-replay-fixture.js";
 
+export {
+	buildAgentOperatingPlaneContext,
+	buildAgentOperatingPlaneCorrelation,
+	buildAgentOperatingPlaneMetadata,
+	type AgentOperatingPlaneContext,
+	type AgentOperatingPlaneContextInput,
+	type AgentOperatingPlaneCorrelationInput,
+	type AgentOperatingPlaneDataClassification,
+	type AgentOperatingPlaneMetadataInput,
+	type AgentOperatingPlaneRetentionClass,
+} from "./agent-operating-plane-context.js";
+
 // Wide events (canonical turn events)
 export {
 	TurnCollector,

--- a/src/telemetry/maestro-event-bus.ts
+++ b/src/telemetry/maestro-event-bus.ts
@@ -82,6 +82,7 @@ export interface MaestroCorrelation {
 	principal_id?: string;
 	trace_id?: string;
 	traceparent?: string;
+	tracestate?: string;
 	request_id?: string;
 	parent_event_id?: string;
 	remote_runner_session_id?: string;
@@ -148,6 +149,7 @@ export interface ApprovalHitEventData extends Record<string, unknown> {
 	policy_id?: string;
 	reason?: string;
 	context?: Record<string, unknown>;
+	metadata?: Record<string, unknown>;
 	occurred_at: string;
 }
 
@@ -191,6 +193,7 @@ export interface ToolCallAttemptEventData extends Record<string, unknown> {
 	safe_arguments?: Record<string, unknown>;
 	redactions?: string[];
 	idempotency_key?: string;
+	metadata?: Record<string, unknown>;
 	attempted_at: string;
 }
 
@@ -208,6 +211,7 @@ export interface ToolCallResultEventData extends Record<string, unknown> {
 	redactions?: string[];
 	error_code?: string;
 	error_message?: string;
+	metadata?: Record<string, unknown>;
 	completed_at: string;
 }
 
@@ -307,6 +311,7 @@ export interface SkillOutcomeEventData extends Record<string, unknown> {
 	evaluation_assertion_count?: number;
 	evaluation_rationale?: string;
 	stop_reason?: string;
+	metadata?: Record<string, unknown>;
 	outcome_at: string;
 }
 
@@ -360,6 +365,7 @@ export interface RecordMaestroApprovalHitInput {
 	policy_id?: string;
 	reason?: string;
 	context?: Record<string, unknown>;
+	metadata?: Record<string, unknown>;
 	correlation?: Partial<MaestroCorrelation>;
 	occurred_at?: string;
 	env?: Env;
@@ -395,6 +401,7 @@ export interface RecordMaestroToolCallAttemptInput {
 	safe_arguments?: Record<string, unknown>;
 	redactions?: string[];
 	idempotency_key?: string;
+	metadata?: Record<string, unknown>;
 	correlation?: Partial<MaestroCorrelation>;
 	attempted_at?: string;
 	env?: Env;
@@ -414,6 +421,7 @@ export interface RecordMaestroToolCallCompletedInput {
 	redactions?: string[];
 	error_code?: string;
 	error_message?: string;
+	metadata?: Record<string, unknown>;
 	correlation?: Partial<MaestroCorrelation>;
 	completed_at?: string;
 	env?: Env;
@@ -480,6 +488,7 @@ export interface RecordMaestroSkillOutcomeInput {
 	evaluation_assertion_count?: number;
 	evaluation_rationale?: string;
 	stop_reason?: string;
+	metadata?: Record<string, unknown>;
 	correlation?: Partial<MaestroCorrelation>;
 	outcome_at?: string;
 	env?: Env;
@@ -608,6 +617,7 @@ function defaultCorrelation(
 		principal_id: readEnv(env, ["MAESTRO_PRINCIPAL_ID"]),
 		trace_id: readEnv(env, ["TRACE_ID", "OTEL_TRACE_ID"]),
 		traceparent: readEnv(env, ["TRACEPARENT", "TRACE_PARENT"]),
+		tracestate: readEnv(env, ["TRACESTATE", "TRACE_STATE"]),
 		request_id: readEnv(env, ["MAESTRO_REQUEST_ID"]),
 		remote_runner_session_id: readEnv(env, [
 			"MAESTRO_REMOTE_RUNNER_SESSION_ID",
@@ -862,6 +872,7 @@ export function maestroCorrelationToChronicleMetadata(
 	putCanonicalMetadata("principal_id", correlation.principal_id);
 	putCanonicalMetadata("trace_id", correlation.trace_id);
 	putCanonicalMetadata("traceparent", correlation.traceparent);
+	putCanonicalMetadata("tracestate", correlation.tracestate);
 	putCanonicalMetadata("request_id", correlation.request_id);
 	putCanonicalMetadata(
 		"remote_runner_session_id",
@@ -951,7 +962,11 @@ export function buildMaestroCloudEvent<TData extends Record<string, unknown>>(
 function maestroDataCorrelation(
 	correlation: MaestroCorrelation,
 ): MaestroCorrelation {
-	const { traceparent: _traceparent, ...dataCorrelation } = correlation;
+	const {
+		traceparent: _traceparent,
+		tracestate: _tracestate,
+		...dataCorrelation
+	} = correlation;
 	return dataCorrelation;
 }
 
@@ -968,6 +983,7 @@ function maestroContextExtensions(
 	putMetadata(extensions, "agent_run_step_id", correlation.agent_run_step_id);
 	putMetadata(extensions, "trace_id", correlation.trace_id);
 	putMetadata(extensions, "traceparent", correlation.traceparent);
+	putMetadata(extensions, "tracestate", correlation.tracestate);
 	putMetadata(extensions, "request_id", correlation.request_id);
 	putMetadata(extensions, "source_issue", correlation.attributes?.source_issue);
 	putMetadata(extensions, "task_id", correlation.attributes?.task_id);
@@ -1068,6 +1084,78 @@ function correlationFromMetadata(
 				? record.toolCallId
 				: typeof record.tool_call_id === "string"
 					? record.tool_call_id
+					: undefined,
+		organization_id:
+			typeof record.organizationId === "string"
+				? record.organizationId
+				: typeof record.organization_id === "string"
+					? record.organization_id
+					: undefined,
+		user_id:
+			typeof record.userId === "string"
+				? record.userId
+				: typeof record.user_id === "string"
+					? record.user_id
+					: undefined,
+		agent_id:
+			typeof record.agentId === "string"
+				? record.agentId
+				: typeof record.agent_id === "string"
+					? record.agent_id
+					: undefined,
+		actor_id:
+			typeof record.actorId === "string"
+				? record.actorId
+				: typeof record.actor_id === "string"
+					? record.actor_id
+					: undefined,
+		principal_id:
+			typeof record.principalId === "string"
+				? record.principalId
+				: typeof record.principal_id === "string"
+					? record.principal_id
+					: undefined,
+		trace_id:
+			typeof record.traceId === "string"
+				? record.traceId
+				: typeof record.trace_id === "string"
+					? record.trace_id
+					: undefined,
+		traceparent:
+			typeof record.traceparent === "string"
+				? record.traceparent
+				: typeof record.trace_parent === "string"
+					? record.trace_parent
+					: undefined,
+		tracestate:
+			typeof record.tracestate === "string"
+				? record.tracestate
+				: typeof record.trace_state === "string"
+					? record.trace_state
+					: undefined,
+		request_id:
+			typeof record.requestId === "string"
+				? record.requestId
+				: typeof record.request_id === "string"
+					? record.request_id
+					: undefined,
+		remote_runner_session_id:
+			typeof record.remoteRunnerSessionId === "string"
+				? record.remoteRunnerSessionId
+				: typeof record.remote_runner_session_id === "string"
+					? record.remote_runner_session_id
+					: undefined,
+		objective_id:
+			typeof record.objectiveId === "string"
+				? record.objectiveId
+				: typeof record.objective_id === "string"
+					? record.objective_id
+					: undefined,
+		conversation_id:
+			typeof record.conversationId === "string"
+				? record.conversationId
+				: typeof record.conversation_id === "string"
+					? record.conversation_id
 					: undefined,
 	};
 }
@@ -1204,6 +1292,7 @@ export function recordMaestroApprovalHit(
 			policy_id: event.policy_id,
 			reason: event.reason,
 			context: event.context,
+			metadata: event.metadata,
 			occurred_at: occurredAt,
 		},
 		{ env: event.env, eventId: event.event_id, time: occurredAt },
@@ -1259,6 +1348,7 @@ export function recordMaestroToolCallAttempt(
 			safe_arguments: event.safe_arguments,
 			redactions: event.redactions,
 			idempotency_key: event.idempotency_key,
+			metadata: event.metadata,
 			attempted_at: attemptedAt,
 		},
 		{ env: event.env, eventId: event.event_id, time: attemptedAt },
@@ -1288,6 +1378,7 @@ export function recordMaestroToolCallCompleted(
 			redactions: event.redactions,
 			error_code: event.error_code,
 			error_message: event.error_message,
+			metadata: event.metadata,
 			completed_at: completedAt,
 		},
 		{ env: event.env, eventId: event.event_id, time: completedAt },
@@ -1406,6 +1497,7 @@ export function recordMaestroSkillOutcome(
 			evaluation_assertion_count: event.evaluation_assertion_count,
 			evaluation_rationale: event.evaluation_rationale,
 			stop_reason: event.stop_reason,
+			metadata: event.metadata,
 			outcome_at: outcomeAt,
 		},
 		{ env: event.env, eventId: event.event_id, time: outcomeAt },

--- a/src/telemetry/maestro-platform-replay-fixture.ts
+++ b/src/telemetry/maestro-platform-replay-fixture.ts
@@ -1,4 +1,8 @@
 import {
+	buildAgentOperatingPlaneContext,
+	buildAgentOperatingPlaneCorrelation,
+} from "./agent-operating-plane-context.js";
+import {
 	MaestroBusEventType,
 	type MaestroCloudEvent,
 	type MaestroCorrelation,
@@ -19,6 +23,8 @@ const SKILL_TOOL_CALL_ID = "tool_call_platform_replay_skill_001";
 const SKILL_TOOL_EXECUTION_ID = "tool_exec_platform_replay_skill_001";
 const APPROVAL_REQUEST_ID = "approval_platform_replay_001";
 const SKILL_ID = "skill_incident_review";
+const DATA_CLASSIFICATION = "internal";
+const RETENTION_CLASS = "operational_audit";
 
 const promptMetadata = {
 	name: "maestro-system",
@@ -38,25 +44,28 @@ const skillMetadata = {
 	version: "3",
 };
 
-const baseCorrelation: MaestroCorrelation = {
-	organization_id: ORGANIZATION_ID,
-	workspace_id: WORKSPACE_ID,
-	session_id: SESSION_ID,
-	agent_run_id: AGENT_RUN_ID,
-	agent_run_step_id: "agent_run_step_platform_replay_001",
-	agent_id: "agent_maestro_platform_replay",
-	actor_id: "user_platform_replay",
-	principal_id: "principal_platform_replay",
-	trace_id: "trace_platform_replay_001",
-	request_id: "request_platform_replay_001",
-	remote_runner_session_id: "remote_runner_platform_replay_001",
-	objective_id: "objective_platform_replay_001",
-	conversation_id: "conversation_platform_replay_001",
-	attributes: {
-		fixture: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
-		scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+const baseCorrelation: MaestroCorrelation = buildAgentOperatingPlaneCorrelation(
+	{
+		organization_id: ORGANIZATION_ID,
+		workspace_id: WORKSPACE_ID,
+		session_id: SESSION_ID,
+		agent_run_id: AGENT_RUN_ID,
+		agent_run_step_id: "agent_run_step_platform_replay_001",
+		agent_id: "agent_maestro_platform_replay",
+		actor_id: "user_platform_replay",
+		principal_id: "principal_platform_replay",
+		trace_id: "trace_platform_replay_001",
+		request_id: "request_platform_replay_001",
+		remote_runner_session_id: "remote_runner_platform_replay_001",
+		objective_id: "objective_platform_replay_001",
+		conversation_id: "conversation_platform_replay_001",
+		tracestate: "evalops=maestro-platform-replay",
+		attributes: {
+			fixture: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+			scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
+		},
 	},
-};
+);
 
 const principal: MaestroPrincipal = {
 	subject: "user:platform-replay@example.com",
@@ -84,6 +93,7 @@ const fixtureEnv: NodeJS.ProcessEnv = {
 	MAESTRO_REMOTE_RUNNER_SESSION_ID: baseCorrelation.remote_runner_session_id,
 	MAESTRO_OBJECTIVE_ID: baseCorrelation.objective_id,
 	MAESTRO_CONVERSATION_ID: baseCorrelation.conversation_id,
+	TRACESTATE: baseCorrelation.tracestate,
 	MAESTRO_SURFACE: "web",
 	MAESTRO_RUNTIME_MODE: "hosted",
 };
@@ -198,12 +208,12 @@ function eventFor(
 	return buildMaestroCloudEvent(
 		type,
 		{
-			correlation: {
+			...withOperatingPlaneContext(type, data, {
 				...baseCorrelation,
 				agent_run_step_id: stepId,
 				traceparent: fixtureTraceparent(index),
-			},
-			...data,
+				tracestate: fixtureTracestate(index),
+			}),
 		},
 		{
 			env: fixtureEnv,
@@ -215,6 +225,63 @@ function eventFor(
 
 function fixtureTraceparent(index: number): string {
 	return `00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-${String(index + 1).padStart(16, "0")}-01`;
+}
+
+function fixtureTracestate(index: number): string {
+	return `evalops=maestro-platform-replay-${String(index + 1).padStart(2, "0")}`;
+}
+
+function withOperatingPlaneContext(
+	type: MaestroBusEventType,
+	data: Record<string, unknown>,
+	correlation: MaestroCorrelation,
+): Record<string, unknown> {
+	const { metadata, ...eventData } = data;
+	const context = buildAgentOperatingPlaneContext({
+		correlation,
+		metadata: {
+			dataClassification: DATA_CLASSIFICATION,
+			retentionClass: RETENTION_CLASS,
+			safeSummary: safeSummaryFor(type),
+		},
+	});
+	return {
+		correlation: context.correlation,
+		metadata: {
+			...context.metadata,
+			...(isRecord(metadata) ? metadata : {}),
+		},
+		...eventData,
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function safeSummaryFor(type: MaestroBusEventType): string {
+	switch (type) {
+		case MaestroBusEventType.SessionStarted:
+			return "Hosted Maestro session started";
+		case MaestroBusEventType.PromptVariantSelected:
+			return "Prompt variant selected by stable artifact identity";
+		case MaestroBusEventType.ToolCallAttempted:
+			return "Tool call attempt recorded with safe argument summary";
+		case MaestroBusEventType.ToolCallCompleted:
+			return "Tool call completed with safe output summary";
+		case MaestroBusEventType.SkillInvoked:
+			return "Skill invocation linked to tool execution";
+		case MaestroBusEventType.ApprovalHit:
+			return "Governance approval requested for workspace command";
+		case MaestroBusEventType.EvalScored:
+			return "Evaluation result linked to tool execution";
+		case MaestroBusEventType.SkillFailed:
+			return "Skill outcome failed the evaluation threshold";
+		case MaestroBusEventType.SessionClosed:
+			return "Hosted Maestro session closed";
+		default:
+			return "Maestro operating-plane event recorded";
+	}
 }
 
 function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
@@ -305,7 +372,7 @@ function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
 				approval_request_id: APPROVAL_REQUEST_ID,
 				governance_decision_id: "governance_decision_platform_replay_001",
 				action: "Run workspace test command",
-				command: "bunx vitest --run test/telemetry",
+				command: "workspace test command",
 				risk_level: "RISK_LEVEL_MEDIUM",
 				decision_mode: "MAESTRO_DECISION_MODE_REQUIRE_APPROVAL",
 				policy_id: "policy_workspace_test_approval",
@@ -314,8 +381,8 @@ function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
 					tool_name: "Bash",
 					display_name: "Bash",
 					summary_label: "Bash",
-					args: {
-						command: "bunx vitest --run test/telemetry",
+					safe_arguments: {
+						command_summary: "Run telemetry test suite",
 					},
 				},
 				occurred_at: eventPlan[5].time,
@@ -336,7 +403,7 @@ function buildEvents(): MaestroPlatformReplayFixtureEvent[] {
 				mutates_resource: false,
 				risk_level: "RISK_LEVEL_MEDIUM",
 				safe_arguments: {
-					command_summary: "bunx vitest --run test/telemetry",
+					command_summary: "Run telemetry test suite",
 				},
 				redactions: ["raw_command"],
 				idempotency_key: "idempotency_platform_replay_bash_001",
@@ -439,6 +506,13 @@ export function buildCanonicalMaestroPlatformReplayFixture(): MaestroPlatformRep
 			workspace_id: WORKSPACE_ID,
 			session_id: SESSION_ID,
 			agent_run_id: AGENT_RUN_ID,
+			agent_id: baseCorrelation.agent_id ?? "",
+			actor_id: baseCorrelation.actor_id ?? "",
+			principal_id: baseCorrelation.principal_id ?? "",
+			request_id: baseCorrelation.request_id ?? "",
+			remote_runner_session_id: baseCorrelation.remote_runner_session_id ?? "",
+			objective_id: baseCorrelation.objective_id ?? "",
+			conversation_id: baseCorrelation.conversation_id ?? "",
 			tool_call_id: BASH_TOOL_CALL_ID,
 			tool_execution_id: BASH_TOOL_EXECUTION_ID,
 			skill_tool_call_id: SKILL_TOOL_CALL_ID,

--- a/src/telemetry/maestro-publisher-conformance-fixture.ts
+++ b/src/telemetry/maestro-publisher-conformance-fixture.ts
@@ -1,6 +1,10 @@
 import type { PromptMetadata } from "../prompts/types.js";
 import type { SkillArtifactMetadata } from "../skills/artifact-metadata.js";
 import {
+	buildAgentOperatingPlaneCorrelation,
+	buildAgentOperatingPlaneMetadata,
+} from "./agent-operating-plane-context.js";
+import {
 	MaestroBusEventType,
 	type MaestroCloudEvent,
 	type MaestroCorrelation,
@@ -27,6 +31,8 @@ const SKILL_TOOL_EXECUTION_ID = "tool_exec_publisher_fixture_skill_001";
 const APPROVAL_REQUEST_ID = "approval_publisher_fixture_001";
 const SKILL_INVOCATION_ID = "skill_invocation_publisher_fixture_001";
 const SKILL_ID = "skill_incident_review";
+const DATA_CLASSIFICATION = "internal";
+const RETENTION_CLASS = "operational_audit";
 
 const promptMetadata = {
 	name: "maestro-system",
@@ -56,25 +62,37 @@ const fixtureEnv: NodeJS.ProcessEnv = {
 	MAESTRO_AGENT_ID: "agent_maestro_publisher_fixture",
 	MAESTRO_ACTOR_ID: "user_publisher_fixture",
 	MAESTRO_PRINCIPAL_ID: "principal_publisher_fixture",
+	MAESTRO_REQUEST_ID: "request_publisher_fixture_001",
+	MAESTRO_REMOTE_RUNNER_SESSION_ID: "remote_runner_publisher_fixture_001",
+	MAESTRO_OBJECTIVE_ID: "objective_publisher_fixture_001",
+	MAESTRO_CONVERSATION_ID: "conversation_publisher_fixture_001",
 	TRACE_ID: "trace_publisher_fixture_001",
+	TRACESTATE: "evalops=maestro-publisher-fixture",
 	MAESTRO_EVENT_BUS_ATTR_FIXTURE: "maestro-publisher-conformance",
 	MAESTRO_EVENT_BUS_ATTR_PUBLISHER_CONTRACT: "maestro.v1",
 };
 
-const baseCorrelation: MaestroCorrelation = {
-	organization_id: ORGANIZATION_ID,
-	workspace_id: WORKSPACE_ID,
-	session_id: SESSION_ID,
-	agent_run_id: AGENT_RUN_ID,
-	agent_id: "agent_maestro_publisher_fixture",
-	actor_id: "user_publisher_fixture",
-	principal_id: "principal_publisher_fixture",
-	trace_id: "trace_publisher_fixture_001",
-	attributes: {
-		fixture: "maestro-publisher-conformance",
-		publisher_contract: "maestro.v1",
+const baseCorrelation: MaestroCorrelation = buildAgentOperatingPlaneCorrelation(
+	{
+		organization_id: ORGANIZATION_ID,
+		workspace_id: WORKSPACE_ID,
+		session_id: SESSION_ID,
+		agent_run_id: AGENT_RUN_ID,
+		agent_id: "agent_maestro_publisher_fixture",
+		actor_id: "user_publisher_fixture",
+		principal_id: "principal_publisher_fixture",
+		trace_id: "trace_publisher_fixture_001",
+		request_id: "request_publisher_fixture_001",
+		remote_runner_session_id: "remote_runner_publisher_fixture_001",
+		objective_id: "objective_publisher_fixture_001",
+		conversation_id: "conversation_publisher_fixture_001",
+		tracestate: "evalops=maestro-publisher-fixture",
+		attributes: {
+			fixture: "maestro-publisher-conformance",
+			publisher_contract: "maestro.v1",
+		},
 	},
-};
+);
 
 const eventPlan = [
 	{
@@ -113,7 +131,7 @@ export interface MaestroPublisherConformanceFixture {
 	event_count: number;
 	origin: {
 		repository: "evalops/maestro";
-		issue: "evalops/maestro#49";
+		issue: "evalops/maestro#434";
 		publisher_package: "packages/ai";
 		source_paths: string[];
 		generated_by: "scripts/generate-maestro-publisher-conformance-fixture.ts";
@@ -128,18 +146,38 @@ export interface MaestroPublisherConformanceFixture {
 	events: MaestroPublisherConformanceFixtureEvent[];
 }
 
-function bashCorrelation(): MaestroCorrelation {
+function bashCorrelation(index: number): MaestroCorrelation {
 	return {
 		...baseCorrelation,
 		agent_run_step_id: BASH_AGENT_RUN_STEP_ID,
+		traceparent: fixtureTraceparent(index),
+		tracestate: fixtureTracestate(index),
 	};
 }
 
-function skillCorrelation(): MaestroCorrelation {
+function skillCorrelation(index: number): MaestroCorrelation {
 	return {
 		...baseCorrelation,
 		agent_run_step_id: SKILL_AGENT_RUN_STEP_ID,
+		traceparent: fixtureTraceparent(index),
+		tracestate: fixtureTracestate(index),
 	};
+}
+
+function fixtureTraceparent(index: number): string {
+	return `00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-${String(index + 1).padStart(16, "0")}-01`;
+}
+
+function fixtureTracestate(index: number): string {
+	return `evalops=maestro-publisher-${String(index + 1).padStart(2, "0")}`;
+}
+
+function operatingPlaneMetadata(safeSummary: string): Record<string, string> {
+	return buildAgentOperatingPlaneMetadata({
+		dataClassification: DATA_CLASSIFICATION,
+		retentionClass: RETENTION_CLASS,
+		safeSummary,
+	});
 }
 
 async function flushPublisherTasks(): Promise<void> {
@@ -179,12 +217,15 @@ async function buildPublisherEvents(): Promise<
 					approval_request_id: APPROVAL_REQUEST_ID,
 					governance_decision_id: "governance_decision_publisher_fixture_001",
 					action: "Run workspace test command",
-					command: "bunx vitest --run test/telemetry",
+					command: "workspace test command",
 					risk_level: "RISK_LEVEL_MEDIUM",
 					decision_mode: "MAESTRO_DECISION_MODE_REQUIRE_APPROVAL",
 					policy_id: "policy_workspace_test_approval",
 					reason: "publisher fixture approval path",
-					correlation: bashCorrelation(),
+					metadata: operatingPlaneMetadata(
+						"Governance approval requested for workspace command",
+					),
+					correlation: bashCorrelation(0),
 					occurred_at: eventPlan[0].time,
 					env: fixtureEnv,
 				});
@@ -200,10 +241,13 @@ async function buildPublisherEvents(): Promise<
 					capability: "workspace:test",
 					risk_level: "RISK_LEVEL_MEDIUM",
 					safe_arguments: {
-						command_summary: "bunx vitest --run test/telemetry",
+						command_summary: "Run telemetry test suite",
 					},
 					prompt_metadata: promptMetadata,
-					correlation: bashCorrelation(),
+					metadata: operatingPlaneMetadata(
+						"Tool call attempt recorded with safe argument summary",
+					),
+					correlation: bashCorrelation(1),
 					attempted_at: eventPlan[1].time,
 					env: fixtureEnv,
 				});
@@ -221,7 +265,10 @@ async function buildPublisherEvents(): Promise<
 					},
 					prompt_metadata: promptMetadata,
 					skill_metadata: skillMetadata,
-					correlation: bashCorrelation(),
+					metadata: operatingPlaneMetadata(
+						"Tool call completed with safe output summary",
+					),
+					correlation: bashCorrelation(2),
 					completed_at: eventPlan[2].time,
 					env: fixtureEnv,
 				});
@@ -246,7 +293,10 @@ async function buildPublisherEvents(): Promise<
 					evaluation_rationale: "formatting checks failed",
 					prompt_metadata: promptMetadata,
 					skill_metadata: skillMetadata,
-					correlation: skillCorrelation(),
+					metadata: operatingPlaneMetadata(
+						"Skill outcome failed the evaluation threshold",
+					),
+					correlation: skillCorrelation(3),
 					outcome_at: eventPlan[3].time,
 					env: fixtureEnv,
 				});
@@ -267,7 +317,7 @@ export async function buildCanonicalMaestroPublisherConformanceFixture(
 		event_count: events.length,
 		origin: {
 			repository: "evalops/maestro",
-			issue: "evalops/maestro#49",
+			issue: "evalops/maestro#434",
 			publisher_package: "packages/ai",
 			source_paths: [
 				"packages/ai/src/telemetry/index.ts",
@@ -290,6 +340,7 @@ export async function buildCanonicalMaestroPublisherConformanceFixture(
 				"versionId",
 			],
 			skill_metadata: ["artifactId", "hash", "name", "source", "version"],
+			metadata: ["data_classification", "retention_class", "safe_summary"],
 			safe_arguments: ["command_summary"],
 			safe_output: ["exit_code", "summary"],
 		},

--- a/test/telemetry/maestro-event-bus.test.ts
+++ b/test/telemetry/maestro-event-bus.test.ts
@@ -300,6 +300,9 @@ describe("maestro event bus", () => {
 				correlation: {
 					workspace_id: "workspace_123",
 					session_id: "session_123",
+					traceparent:
+						"00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+					tracestate: "evalops=maestro-test",
 				},
 				tool_call_id: "tool_1",
 				tool_name: "bash",
@@ -331,8 +334,12 @@ describe("maestro event bus", () => {
 				user_id: "user_123",
 				workspace_id: "workspace_123",
 				maestro_session_id: "session_123",
+				traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+				tracestate: "evalops=maestro-test",
 			},
 		});
+		expect(event.data.correlation).not.toHaveProperty("traceparent");
+		expect(event.data.correlation).not.toHaveProperty("tracestate");
 		expect(event.data["@type"]).toBe(
 			"type.googleapis.com/maestro.v1.ToolCallAttempt",
 		);
@@ -438,6 +445,7 @@ describe("maestro event bus", () => {
 			principal_id: "principal_123",
 			trace_id: "trace_123",
 			traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+			tracestate: "evalops=maestro-test",
 			request_id: "request_123",
 			parent_event_id: "event_parent",
 			attributes: {
@@ -463,6 +471,7 @@ describe("maestro event bus", () => {
 			principal_id: "principal_123",
 			trace_id: "trace_123",
 			traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+			tracestate: "evalops=maestro-test",
 			request_id: "request_123",
 			parent_event_id: "event_parent",
 			task_id: "task_123",

--- a/test/telemetry/maestro-platform-replay-fixture.test.ts
+++ b/test/telemetry/maestro-platform-replay-fixture.test.ts
@@ -9,6 +9,38 @@ import {
 	canonicalMaestroPlatformReplayFixtureJson,
 } from "../../src/telemetry/maestro-platform-replay-fixture.js";
 
+const FORBIDDEN_FIXTURE_KEYS = new Set([
+	"raw_prompt",
+	"prompt",
+	"messages",
+	"tool_args",
+	"tool_arguments",
+	"args",
+	"stdout",
+	"stderr",
+	"credentials",
+	"api_key",
+	"access_token",
+	"withheld_content",
+	"withheld_vfs_bytes",
+]);
+
+function collectObjectKeys(
+	value: unknown,
+	keys = new Set<string>(),
+): Set<string> {
+	if (!value || typeof value !== "object") return keys;
+	if (Array.isArray(value)) {
+		for (const item of value) collectObjectKeys(item, keys);
+		return keys;
+	}
+	for (const [key, child] of Object.entries(value)) {
+		keys.add(key);
+		collectObjectKeys(child, keys);
+	}
+	return keys;
+}
+
 describe("canonical Maestro Platform replay fixture", () => {
 	const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
@@ -24,6 +56,13 @@ describe("canonical Maestro Platform replay fixture", () => {
 				workspace_id: "workspace_platform_replay",
 				session_id: "session_platform_replay_001",
 				agent_run_id: "agent_run_platform_replay_001",
+				agent_id: "agent_maestro_platform_replay",
+				actor_id: "user_platform_replay",
+				principal_id: "principal_platform_replay",
+				request_id: "request_platform_replay_001",
+				remote_runner_session_id: "remote_runner_platform_replay_001",
+				objective_id: "objective_platform_replay_001",
+				conversation_id: "conversation_platform_replay_001",
 				tool_call_id: "tool_call_platform_replay_bash_001",
 				tool_execution_id: "tool_exec_platform_replay_bash_001",
 				skill_tool_call_id: "tool_call_platform_replay_skill_001",
@@ -75,9 +114,17 @@ describe("canonical Maestro Platform replay fixture", () => {
 						agent_run_id: "agent_run_platform_replay_001",
 						trace_id: "trace_platform_replay_001",
 						request_id: "request_platform_replay_001",
+						remote_runner_session_id: "remote_runner_platform_replay_001",
+						objective_id: "objective_platform_replay_001",
+						conversation_id: "conversation_platform_replay_001",
 						attributes: {
 							scenario_id: CANONICAL_MAESTRO_PLATFORM_REPLAY_FIXTURE_NAME,
 						},
+					},
+					metadata: {
+						data_classification: "internal",
+						retention_class: "operational_audit",
+						safe_summary: expect.any(String),
 					},
 				},
 			});
@@ -88,7 +135,11 @@ describe("canonical Maestro Platform replay fixture", () => {
 			expect(event.extensions.traceparent).toBe(
 				`00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-${String(index + 1).padStart(16, "0")}-01`,
 			);
+			expect(event.extensions.tracestate).toBe(
+				`evalops=maestro-platform-replay-${String(index + 1).padStart(2, "0")}`,
+			);
 			expect(event.data.correlation).not.toHaveProperty("traceparent");
+			expect(event.data.correlation).not.toHaveProperty("tracestate");
 			expect(event.time).toMatch(/^2026-04-23T18:/);
 		}
 	});
@@ -138,6 +189,14 @@ describe("canonical Maestro Platform replay fixture", () => {
 			tool_call_id: "tool_call_platform_replay_skill_001",
 			tool_execution_id: "tool_exec_platform_replay_skill_001",
 			tool_name: "Skill",
+			metadata: {
+				data_classification: "internal",
+				retention_class: "operational_audit",
+				safe_summary: "Tool call attempt recorded with safe argument summary",
+			},
+			safe_arguments: {
+				skill_id: "skill_incident_review",
+			},
 			prompt_metadata: {
 				name: "maestro-system",
 				label: "production",
@@ -217,12 +276,13 @@ describe("canonical Maestro Platform replay fixture", () => {
 			byType.get(MaestroBusEventType.ToolCallCompleted)?.data,
 		).not.toHaveProperty("estimated_cost");
 		expect(byType.get(MaestroBusEventType.ApprovalHit)?.data).toMatchObject({
+			command: "workspace test command",
 			context: {
 				tool_name: "Bash",
 				display_name: "Bash",
 				summary_label: "Bash",
-				args: {
-					command: "bunx vitest --run test/telemetry",
+				safe_arguments: {
+					command_summary: "Run telemetry test suite",
 				},
 			},
 		});
@@ -329,6 +389,18 @@ describe("canonical Maestro Platform replay fixture", () => {
 		});
 		expect(parsed.events.map((event: { type: string }) => event.type)).toEqual(
 			parsed.subjects,
+		);
+	});
+
+	it("keeps replay fixtures free of raw prompts, tool args, and withheld payloads", () => {
+		const fixture = buildCanonicalMaestroPlatformReplayFixture();
+		const keys = collectObjectKeys(fixture);
+
+		expect([...keys].filter((key) => FORBIDDEN_FIXTURE_KEYS.has(key))).toEqual(
+			[],
+		);
+		expect(JSON.stringify(fixture)).not.toMatch(
+			/(Bearer\s+|sk-[A-Za-z0-9]|api[_-]?key|authorization)/i,
 		);
 	});
 

--- a/test/telemetry/maestro-publisher-conformance-fixture.test.ts
+++ b/test/telemetry/maestro-publisher-conformance-fixture.test.ts
@@ -21,6 +21,38 @@ function toolCallId(value: unknown): string | undefined {
 		: undefined;
 }
 
+const FORBIDDEN_FIXTURE_KEYS = new Set([
+	"raw_prompt",
+	"prompt",
+	"messages",
+	"tool_args",
+	"tool_arguments",
+	"args",
+	"stdout",
+	"stderr",
+	"credentials",
+	"api_key",
+	"access_token",
+	"withheld_content",
+	"withheld_vfs_bytes",
+]);
+
+function collectObjectKeys(
+	value: unknown,
+	keys = new Set<string>(),
+): Set<string> {
+	if (!value || typeof value !== "object") return keys;
+	if (Array.isArray(value)) {
+		for (const item of value) collectObjectKeys(item, keys);
+		return keys;
+	}
+	for (const [key, child] of Object.entries(value)) {
+		keys.add(key);
+		collectObjectKeys(child, keys);
+	}
+	return keys;
+}
+
 describe("canonical Maestro publisher conformance fixture", () => {
 	const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
@@ -35,7 +67,7 @@ describe("canonical Maestro publisher conformance fixture", () => {
 			event_count: 4,
 			origin: {
 				repository: "evalops/maestro",
-				issue: "evalops/maestro#49",
+				issue: "evalops/maestro#434",
 				publisher_package: "packages/ai",
 				generated_by:
 					"scripts/generate-maestro-publisher-conformance-fixture.ts",
@@ -56,7 +88,7 @@ describe("canonical Maestro publisher conformance fixture", () => {
 			"evt_maestro_publisher_004_skill_failed",
 		]);
 
-		for (const event of fixture.events) {
+		for (const [index, event] of fixture.events.entries()) {
 			expect(event).toMatchObject({
 				spec_version: "1.0",
 				source: "maestro-publisher-fixture",
@@ -73,16 +105,33 @@ describe("canonical Maestro publisher conformance fixture", () => {
 						actor_id: "user_publisher_fixture",
 						principal_id: "principal_publisher_fixture",
 						trace_id: "trace_publisher_fixture_001",
+						request_id: "request_publisher_fixture_001",
+						remote_runner_session_id: "remote_runner_publisher_fixture_001",
+						objective_id: "objective_publisher_fixture_001",
+						conversation_id: "conversation_publisher_fixture_001",
 						attributes: {
 							fixture: "maestro-publisher-conformance",
 							publisher_contract: "maestro.v1",
 						},
+					},
+					metadata: {
+						data_classification: "internal",
+						retention_class: "operational_audit",
+						safe_summary: expect.any(String),
 					},
 				},
 			});
 			expect(event.extensions.dataschema).toMatch(
 				/^buf\.build\/evalops\/proto\/maestro\.v1\./,
 			);
+			expect(event.extensions.traceparent).toBe(
+				`00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-${String(index + 1).padStart(16, "0")}-01`,
+			);
+			expect(event.extensions.tracestate).toBe(
+				`evalops=maestro-publisher-${String(index + 1).padStart(2, "0")}`,
+			);
+			expect(event.data.correlation).not.toHaveProperty("traceparent");
+			expect(event.data.correlation).not.toHaveProperty("tracestate");
 		}
 	});
 
@@ -96,7 +145,7 @@ describe("canonical Maestro publisher conformance fixture", () => {
 			approval_request_id: "approval_publisher_fixture_001",
 			governance_decision_id: "governance_decision_publisher_fixture_001",
 			action: "Run workspace test command",
-			command: "bunx vitest --run test/telemetry",
+			command: "workspace test command",
 			risk_level: "RISK_LEVEL_MEDIUM",
 			decision_mode: "MAESTRO_DECISION_MODE_REQUIRE_APPROVAL",
 			policy_id: "policy_workspace_test_approval",
@@ -114,7 +163,7 @@ describe("canonical Maestro publisher conformance fixture", () => {
 			capability: "workspace:test",
 			risk_level: "RISK_LEVEL_MEDIUM",
 			safe_arguments: {
-				command_summary: "bunx vitest --run test/telemetry",
+				command_summary: "Run telemetry test suite",
 			},
 			prompt_metadata: {
 				name: "maestro-system",
@@ -181,10 +230,25 @@ describe("canonical Maestro publisher conformance fixture", () => {
 		expect(sortedKeys(toolCompleted?.safe_output)).toEqual(
 			fixture.stable_untyped_keys.safe_output,
 		);
+		expect(sortedKeys(toolAttempt?.metadata)).toEqual(
+			fixture.stable_untyped_keys.metadata,
+		);
 		expect(fixture.expected_assertions).toMatchObject({
 			required_event_types: fixture.subjects,
 			required_subjects: fixture.subjects,
 		});
+	});
+
+	it("keeps publisher fixtures free of raw prompts, tool args, and withheld payloads", async () => {
+		const fixture = await buildCanonicalMaestroPublisherConformanceFixture();
+		const keys = collectObjectKeys(fixture);
+
+		expect([...keys].filter((key) => FORBIDDEN_FIXTURE_KEYS.has(key))).toEqual(
+			[],
+		);
+		expect(JSON.stringify(fixture)).not.toMatch(
+			/(Bearer\s+|sk-[A-Za-z0-9]|api[_-]?key|authorization)/i,
+		);
 	});
 
 	it("uses standalone agent run step ids instead of aliasing tool call ids", async () => {

--- a/test/telemetry/opentelemetry-correlation.test.ts
+++ b/test/telemetry/opentelemetry-correlation.test.ts
@@ -139,12 +139,28 @@ describe("OpenTelemetry correlation", () => {
 			traceId: "  ",
 			metadata: {
 				traceId: "trace_metadata",
+				traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+				tracestate: "evalops=maestro-test",
+				actorId: "user_metadata",
+				principalId: "principal_metadata",
+				requestId: "request_metadata",
+				remoteRunnerSessionId: "remote_runner_metadata",
+				objectiveId: "objective_metadata",
+				conversationId: "conversation_metadata",
 			},
 		});
 
 		expect(spanAttributes).toHaveLength(1);
 		expect(spanAttributes[0]).toMatchObject({
 			"trace.id": "trace_metadata",
+			traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+			tracestate: "evalops=maestro-test",
+			"agent.actor.id": "user_metadata",
+			"evalops.principal_id": "principal_metadata",
+			"request.id": "request_metadata",
+			"evalops.remote_runner_session_id": "remote_runner_metadata",
+			"evalops.objective_id": "objective_metadata",
+			"evalops.conversation_id": "conversation_metadata",
 			"maestro.turn.id": "turn_event",
 		});
 	});


### PR DESCRIPTION
## Summary
- adds a reusable agent operating-plane correlation/metadata helper for canonical run, step, actor, principal, request, remote-runner, objective, conversation, trace, retention, and safe-summary fields
- carries tracestate through Maestro CloudEvent extensions and Chronicle metadata while keeping trace context out of data.correlation payloads
- upgrades publisher and Platform replay fixtures to assert the canonical envelope, data handling metadata, and no raw prompt/tool-arg/withheld payload keys
- extends canonical-turn/tool-execution telemetry correlation into OTel span attributes and event-bus metadata extraction

Source-of-truth PR: evalops/maestro-internal#1987

Closes #434.

## Verification
- node ./scripts/run-vitest.js --run test/telemetry/maestro-event-bus.test.ts test/telemetry/maestro-publisher-conformance-fixture.test.ts test/telemetry/maestro-platform-replay-fixture.test.ts test/telemetry/opentelemetry-correlation.test.ts
- bunx biome check src/telemetry.ts src/telemetry/index.ts src/telemetry/agent-operating-plane-context.ts src/telemetry/maestro-event-bus.ts src/telemetry/maestro-platform-replay-fixture.ts src/telemetry/maestro-publisher-conformance-fixture.ts test/telemetry/maestro-event-bus.test.ts test/telemetry/maestro-platform-replay-fixture.test.ts test/telemetry/maestro-publisher-conformance-fixture.test.ts test/telemetry/opentelemetry-correlation.test.ts
- bunx tsc -p tsconfig.build.json --noEmit
- npm run developer-surface:check
- npm run check:codex-operating-layer
- npm run check:session-replay-fixtures
- npm run lint
- npm run test
- npm run build
