### PR TITLE
Harden Maestro A2A fleet streaming

### DIFF
--- a/docs/protocols/a2a-fleet-delegation.md
+++ b/docs/protocols/a2a-fleet-delegation.md
@@ -32,6 +32,37 @@ to the same local transcript and can wait for the peer's follow-up result.
 registered peers. This gives the operator a single place to see outstanding work
 across the Mac mini, dev desktop, and local Maestro instances.
 
+## Native Control-Plane Surface
+
+The Rust control-plane A2A server uses the same task ledger path as the CLI. On
+startup it restores known tasks from the ledger, and each task state transition
+is written back to disk before being published to local subscribers.
+
+Supported A2A HTTP+JSON operations:
+
+```text
+GET  /.well-known/agent-card.json
+GET  /extendedAgentCard
+POST /message:send
+POST /message:stream
+GET  /tasks
+GET  /tasks/{id}
+GET  /tasks/{id}:subscribe
+POST /tasks/{id}:subscribe
+POST /tasks/{id}:cancel
+```
+
+`GET /tasks` accepts the spec-shaped fleet filters `contextId`, `status`,
+`statusTimestampAfter`, `pageSize`, `pageToken`, `historyLength`, and
+`includeArtifacts`. List responses include `nextPageToken`, `pageSize`, and
+`totalSize`.
+
+`POST /message:stream` and `tasks/{id}:subscribe` use Server-Sent Events with A2A
+`StreamResponse` payloads (`task`, `statusUpdate`, and `artifactUpdate`). The
+public Agent Card advertises streaming plus authenticated extended-card support,
+and the extended card declares Maestro's EvalOps operating-plane extension for
+workspace/session/trace/retention correlation metadata.
+
 ## Files
 
 The peer registry remains:

--- a/docs/protocols/a2a-fleet-delegation.md
+++ b/docs/protocols/a2a-fleet-delegation.md
@@ -22,7 +22,11 @@ registry URL and a bounded error.
 
 `delegate` sends a normal A2A `message:send` request with Maestro delegation
 metadata: origin, peer name, role, and working directory. The resulting task is
-recorded in the local ledger before optional waiting begins.
+recorded in the local ledger before optional waiting begins. Treat the A2A task
+as an operator projection over durable agent/objective/run state rather than as
+the run itself: the task id is the protocol handle, `contextId` is the durable
+conversation/work envelope, and Maestro stores the peer-local transcript needed
+to resume, reply, audit, or wait later.
 
 `reply` continues an existing remote A2A task by sending `message.taskId` and
 the durable ledger `contextId` when available. It appends the operator's reply
@@ -37,6 +41,13 @@ across the Mac mini, dev desktop, and local Maestro instances.
 The Rust control-plane A2A server uses the same task ledger path as the CLI. On
 startup it restores known tasks from the ledger, and each task state transition
 is written back to disk before being published to local subscribers.
+
+The CLI ledger is a JSON object with a top-level `tasks` array. Each entry keeps
+the local ledger id, peer name, remote `taskId`, optional `contextId` and
+`messageId`, current A2A `state`, operator request text, optional role/cwd,
+latest response text, transcript entries, metadata, and created/updated/completed
+timestamps. The ledger deliberately stores peer/task correlation and transcript
+shape, not bearer token material.
 
 Supported A2A HTTP+JSON operations:
 
@@ -54,14 +65,22 @@ POST /tasks/{id}:cancel
 
 `GET /tasks` accepts the spec-shaped fleet filters `contextId`, `status`,
 `statusTimestampAfter`, `pageSize`, `pageToken`, `historyLength`, and
-`includeArtifacts`. List responses include `nextPageToken`, `pageSize`, and
-`totalSize`.
+`includeArtifacts`. The implementation also accepts snake_case aliases
+(`context_id`, `page_size`, `page_token`, `status_timestamp_after`,
+`history_length`, and `include_artifacts`) plus `state`, `limit`, `offset`,
+`lastUpdatedAfter`, and `last_updated_after` for local operator convenience.
+List responses are sorted by newest status timestamp first and include `tasks`,
+`nextPageToken`, `pageSize`, and `totalSize`. `includeArtifacts=false` is the
+default; `historyLength=0` suppresses history in list responses.
 
-`POST /message:stream` and `tasks/{id}:subscribe` use Server-Sent Events with A2A
-`StreamResponse` payloads (`task`, `statusUpdate`, and `artifactUpdate`). The
-public Agent Card advertises streaming plus authenticated extended-card support,
-and the extended card declares Maestro's EvalOps operating-plane extension for
-workspace/session/trace/retention correlation metadata.
+`POST /message:stream`, `GET /tasks/{id}:subscribe`, and
+`POST /tasks/{id}:subscribe` use Server-Sent Events with A2A `StreamResponse`
+payloads (`task`, `statusUpdate`, and `artifactUpdate`). Subscribe is for
+nonterminal work; terminal tasks should be read with `GET /tasks/{id}` and must
+not be treated as a replayable subscription stream. The public Agent Card
+advertises `capabilities.streaming=true` plus authenticated extended-card
+support, and the extended card declares Maestro's EvalOps operating-plane
+extension for workspace/session/trace/retention correlation metadata.
 
 ## Files
 
@@ -79,6 +98,33 @@ The task ledger defaults to:
 
 `MAESTRO_A2A_TASKS_FILE` overrides the ledger path. `CODEX_A2A_TASKS_FILE` is
 accepted as a migration alias.
+
+## Operator Verification
+
+Use bounded one-shot checks against a local control-plane peer:
+
+```sh
+BASE_URL=http://127.0.0.1:18787
+TASK_ID=<task-id-from-delegate-or-send>
+CONTEXT_ID=<context-id-from-task-detail>
+
+curl -fsS "$BASE_URL/.well-known/agent-card.json" \
+  | node -e 'let s="";process.stdin.on("data",d=>s+=d);process.stdin.on("end",()=>{const j=JSON.parse(s);if(j.capabilities?.streaming!==true)process.exit(1);})'
+
+curl -fsS "$BASE_URL/tasks?status=TASK_STATE_COMPLETED&pageSize=1&pageToken=0&historyLength=1&includeArtifacts=false"
+curl -fsS "$BASE_URL/tasks?contextId=$CONTEXT_ID&pageSize=1&includeArtifacts=false"
+curl -fsS --max-time 10 \
+  -H 'Content-Type: application/json' \
+  -d '{"message":{"messageId":"operator-smoke","contextId":"operator-smoke-context","role":"ROLE_USER","parts":[{"text":"stream smoke","mediaType":"text/plain"}]}}' \
+  "$BASE_URL/message:stream" \
+  | rg '"statusUpdate"|"artifactUpdate"'
+```
+
+For the full local harness, run:
+
+```sh
+bash scripts/smoke-maestro-a2a-tmux.sh
+```
 
 ## Acceptance Tests
 

--- a/docs/protocols/a2a-tmux-smoke.md
+++ b/docs/protocols/a2a-tmux-smoke.md
@@ -4,7 +4,9 @@
 Maestro A2A pairing and delegation. It launches two local Maestro control-plane
 peers in tmux, uses the TypeScript `maestro a2a` CLI to exchange pairing codes,
 stores each peer in an isolated registry, delegates work into a durable task
-ledger, then verifies fleet health, task listing, `send`, and explicit `wait`.
+ledger, then verifies fleet health, task listing, Agent Card streaming
+capability, filtered/paginated `GET /tasks`, bounded `message:stream` SSE,
+`send`, and explicit `wait`.
 
 Run it from the repo root:
 
@@ -12,8 +14,9 @@ Run it from the repo root:
 bash scripts/smoke-maestro-a2a-tmux.sh
 ```
 
-The harness deliberately avoids the legacy Python relay. The only A2A client
-entrypoint it drives is:
+The harness deliberately avoids the legacy Python relay. It drives the native
+TypeScript A2A CLI plus direct local HTTP probes against the Rust control-plane
+surface:
 
 ```sh
 bun run a2a -- offer ...
@@ -24,6 +27,9 @@ bun run a2a -- fleet ...
 bun run a2a -- tasks ...
 bun run a2a -- send ...
 bun run a2a -- wait ...
+curl /.well-known/agent-card.json
+curl /tasks?...filters...
+curl /message:stream
 ```
 
 ## What it proves
@@ -38,6 +44,13 @@ bun run a2a -- wait ...
   bearer token values.
 - Peer B can send to peer A, parse the returned task id, and complete a bounded
   explicit `wait`.
+- The native Rust control-plane Agent Card advertises
+  `capabilities.streaming=true`.
+- The native Rust control-plane task list honors bounded local filters and
+  pagination: `status`, `contextId`, `pageSize`, `pageToken`, `historyLength`,
+  and `includeArtifacts`.
+- `POST /message:stream` returns a bounded Server-Sent Events response
+  containing task status and artifact updates.
 
 The local peers use `MAESTRO_A2A_FAKE_RESPONSE` so the smoke validates A2A
 transport, task storage, registry lookup, and CLI orchestration without spending
@@ -55,6 +68,12 @@ By default the script kills the tmux session on exit. Set
 `MAESTRO_A2A_TMUX_KEEP_SESSION=1` to inspect the peer panes after a failure.
 Logs, temporary peer registries, and task ledgers are written under
 `tmp/a2a-tmux-smoke/`.
+
+The HTTP checks are intentionally local and bounded. The streaming probe uses
+`MAESTRO_A2A_FAKE_RESPONSE` through `POST /message:stream`, so it should emit
+task status/artifact events and close without requiring an active model call.
+Terminal task subscribe success is not part of this smoke because the A2A
+contract reserves subscribe for nonterminal work.
 
 ## Expected output
 

--- a/packages/control-plane-rs/src/auth.rs
+++ b/packages/control-plane-rs/src/auth.rs
@@ -193,7 +193,8 @@ pub(crate) fn csrf_applies(head: &RequestHead) -> bool {
 }
 
 fn csrf_applies_to_a2a_path(path: &str) -> bool {
-    path == "/message:send" || a2a_task_id_from_cancel_path(path).is_some()
+    matches!(path, "/message:send" | "/message:stream")
+        || a2a_task_id_from_cancel_path(path).is_some()
 }
 
 pub(crate) fn a2a_task_id_from_cancel_path(path: &str) -> Option<&str> {

--- a/packages/control-plane-rs/src/auth.rs
+++ b/packages/control-plane-rs/src/auth.rs
@@ -195,10 +195,19 @@ pub(crate) fn csrf_applies(head: &RequestHead) -> bool {
 fn csrf_applies_to_a2a_path(path: &str) -> bool {
     matches!(path, "/message:send" | "/message:stream")
         || a2a_task_id_from_cancel_path(path).is_some()
+        || a2a_task_id_from_subscribe_path(path).is_some()
 }
 
 pub(crate) fn a2a_task_id_from_cancel_path(path: &str) -> Option<&str> {
     let id = path.strip_prefix("/tasks/")?.strip_suffix(":cancel")?;
+    (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
+}
+
+pub(crate) fn a2a_task_id_from_subscribe_path(path: &str) -> Option<&str> {
+    let id = path
+        .strip_prefix("/tasks/")?
+        .strip_suffix(":subscribe")
+        .or_else(|| path.strip_prefix("/tasks/")?.strip_suffix("/subscribe"))?;
     (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
 }
 

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::process::Command;
-use tokio::sync::{mpsc, watch, Mutex};
+use tokio::sync::{broadcast, mpsc, watch, Mutex};
 
 mod auth;
 mod codex_compat;
@@ -54,6 +54,10 @@ const A2A_PROTOCOL_VERSION: &str = "1.0";
 const A2A_DEFAULT_TURN_TIMEOUT_MS: u64 = 180_000;
 const A2A_DEFAULT_RESPONSE_END_SETTLE_MS: u64 = 250;
 const A2A_TERMINAL_TASK_STORE_LIMIT: usize = 128;
+const A2A_DEFAULT_LIST_PAGE_SIZE: usize = 50;
+const A2A_MAX_LIST_PAGE_SIZE: usize = 100;
+const A2A_DEFAULT_SUBSCRIBE_TIMEOUT_MS: u64 = 60_000;
+const EVALOPS_A2A_EXTENSION_URI: &str = "https://evalops.com/a2a/extensions/operating-plane/v1";
 const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA: &str = "evalops.maestro.codex.subagent-workgraph.v1";
 static CODEX_BRIDGE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static CODEX_HEADLESS_RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -115,6 +119,7 @@ struct Config {
     session_store_path: PathBuf,
     command_prefs_path: PathBuf,
     usage_file_path: PathBuf,
+    a2a_tasks_file_path: PathBuf,
     static_root: PathBuf,
     static_cache_max_age: u64,
     llm_gateway_models_url: Option<String>,
@@ -154,6 +159,7 @@ impl Config {
                 .unwrap_or_else(|_| default_session_store_path(&cwd)),
             command_prefs_path: command_prefs_path(),
             usage_file_path: usage_file_path(),
+            a2a_tasks_file_path: a2a_tasks_file_path(),
             static_root: env::var("MAESTRO_WEB_STATIC_ROOT")
                 .map(PathBuf::from)
                 .unwrap_or_else(|_| PathBuf::from("packages/web/dist")),
@@ -203,6 +209,8 @@ struct AppState {
     approval_modes: Arc<Mutex<HashMap<String, String>>>,
     pending_tool_responses: Arc<Mutex<HashMap<String, PendingToolResponseSender>>>,
     a2a_tasks: Arc<Mutex<HashMap<String, Value>>>,
+    a2a_task_persist_lock: Arc<Mutex<()>>,
+    a2a_task_events: broadcast::Sender<Value>,
     a2a_cancel_senders: Arc<Mutex<HashMap<String, A2ACancelSender>>>,
 }
 
@@ -347,6 +355,8 @@ async fn main() -> anyhow::Result<()> {
         load_session_store(&config.session_store_path).await;
     let shared_sessions = sessions.shared_sessions.clone();
     let command_prefs = load_command_prefs(&config.command_prefs_path).await;
+    let a2a_tasks = load_a2a_tasks(&config.a2a_tasks_file_path).await;
+    let (a2a_task_events, _) = broadcast::channel(256);
 
     let state = AppState {
         config: config.clone(),
@@ -364,7 +374,9 @@ async fn main() -> anyhow::Result<()> {
         shared_sessions: Arc::new(Mutex::new(shared_sessions)),
         approval_modes: Arc::new(Mutex::new(HashMap::new())),
         pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
-        a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
+        a2a_tasks: Arc::new(Mutex::new(a2a_tasks)),
+        a2a_task_persist_lock: Arc::new(Mutex::new(())),
+        a2a_task_events,
         a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
     };
 
@@ -398,6 +410,10 @@ async fn handle_connection(mut stream: TcpStream, state: AppState) -> Result<(),
 
         if is_chat_endpoint(&head) {
             return handle_chat_endpoint(stream, initial, head, state).await;
+        }
+
+        if is_a2a_streaming_endpoint(&head) {
+            return handle_a2a_streaming_endpoint(stream, initial, head, state).await;
         }
 
         if is_a2a_endpoint(&head) {
@@ -664,18 +680,40 @@ fn is_a2a_endpoint(head: &RequestHead) -> bool {
     if head.method == "OPTIONS" {
         return head.path == "/.well-known/agent-card.json"
             || head.path == "/message:send"
+            || head.path == "/message:stream"
+            || head.path == "/extendedAgentCard"
             || head.path == "/tasks"
             || head.path.starts_with("/tasks/");
     }
     matches!(
         (head.method.as_str(), head.path.as_str()),
-        ("GET", "/.well-known/agent-card.json") | ("POST", "/message:send") | ("GET", "/tasks")
+        ("GET", "/.well-known/agent-card.json")
+            | ("GET", "/extendedAgentCard")
+            | ("POST", "/message:send")
+            | ("POST", "/message:stream")
+            | ("GET", "/tasks")
     ) || (head.method == "GET" && a2a_task_id_from_get_path(&head.path).is_some())
         || (head.method == "POST" && a2a_task_id_from_cancel_path(&head.path).is_some())
+        || (head.method == "GET" && a2a_task_id_from_subscribe_path(&head.path).is_some())
+        || (head.method == "POST" && a2a_task_id_from_subscribe_path(&head.path).is_some())
+}
+
+fn is_a2a_streaming_endpoint(head: &RequestHead) -> bool {
+    (head.method == "POST" && head.path == "/message:stream")
+        || ((head.method == "GET" || head.method == "POST")
+            && a2a_task_id_from_subscribe_path(&head.path).is_some())
 }
 
 fn a2a_task_id_from_get_path(path: &str) -> Option<&str> {
     let id = path.strip_prefix("/tasks/")?;
+    (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
+}
+
+fn a2a_task_id_from_subscribe_path(path: &str) -> Option<&str> {
+    let id = path
+        .strip_prefix("/tasks/")?
+        .strip_suffix(":subscribe")
+        .or_else(|| path.strip_prefix("/tasks/")?.strip_suffix("/subscribe"))?;
     (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
 }
 
@@ -733,16 +771,15 @@ async fn handle_a2a_endpoint(
         return json_response(401, &serde_json::json!({ "error": "Unauthorized" }));
     };
 
+    if head.method == "GET" && head.path == "/extendedAgentCard" {
+        return json_response(200, &a2a_extended_agent_card(&head, &state.config));
+    }
+
     if head.method == "GET" && head.path == "/tasks" {
-        let tasks = state
-            .a2a_tasks
-            .lock()
-            .await
-            .values()
-            .filter(|task| a2a_task_visible_to_auth(task, &auth))
-            .cloned()
-            .collect::<Vec<_>>();
-        return json_response(200, &serde_json::json!({ "tasks": tasks }));
+        return match a2a_list_tasks_response(&head, state, &auth).await {
+            Ok(value) => json_response(200, &value),
+            Err(response) => response,
+        };
     }
 
     if head.method == "GET" {
@@ -752,7 +789,7 @@ async fn handle_a2a_endpoint(
                 || a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found"),
                 |task| {
                     if a2a_task_visible_to_auth(task, &auth) {
-                        json_response(200, task)
+                        json_response(200, &a2a_task_for_query(task, &head, true))
                     } else {
                         a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found")
                     }
@@ -775,6 +812,264 @@ async fn handle_a2a_endpoint(
     }
 
     a2a_error_response(404, "NOT_FOUND", "A2A endpoint not found")
+}
+
+async fn handle_a2a_streaming_endpoint(
+    mut stream: TcpStream,
+    mut initial: Vec<u8>,
+    head: RequestHead,
+    state: AppState,
+) -> Result<(), String> {
+    if let Err(response) = validate_a2a_protocol_version(&head) {
+        return write_response_and_close(&mut stream, response).await;
+    }
+    if let Err(response) = validate_csrf(&head, &state.config) {
+        return write_response_and_close(&mut stream, response).await;
+    }
+    let Some(auth) = auth_context(&head, &state.config) else {
+        return write_response_and_close(
+            &mut stream,
+            json_response(401, &serde_json::json!({ "error": "Unauthorized" })),
+        )
+        .await;
+    };
+
+    if head.method == "POST" && head.path == "/message:stream" {
+        return handle_a2a_message_stream(&mut stream, &mut initial, &head, &state, &auth).await;
+    }
+    if (head.method == "GET" || head.method == "POST")
+        && a2a_task_id_from_subscribe_path(&head.path).is_some()
+    {
+        return handle_a2a_task_subscribe(&mut stream, &head, &state, &auth).await;
+    }
+    write_response_and_close(
+        &mut stream,
+        a2a_error_response(404, "NOT_FOUND", "A2A streaming endpoint not found"),
+    )
+    .await
+}
+
+async fn write_response_and_close(stream: &mut TcpStream, response: Vec<u8>) -> Result<(), String> {
+    stream
+        .write_all(&response)
+        .await
+        .map_err(|error| error.to_string())?;
+    let _ = stream.shutdown().await;
+    Ok(())
+}
+
+async fn handle_a2a_message_stream(
+    stream: &mut TcpStream,
+    initial: &mut Vec<u8>,
+    head: &RequestHead,
+    state: &AppState,
+    auth: &AuthContext,
+) -> Result<(), String> {
+    let body = match read_request_body(stream, initial, head).await {
+        Ok(body) => body,
+        Err(error) => {
+            return write_response_and_close(
+                stream,
+                a2a_error_response(400, "INVALID_REQUEST", &error),
+            )
+            .await;
+        }
+    };
+    let request: A2ASendMessageRequest = match serde_json::from_slice(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            return write_response_and_close(
+                stream,
+                a2a_error_response(
+                    400,
+                    "INVALID_REQUEST",
+                    &format!("invalid A2A message request: {error}"),
+                ),
+            )
+            .await;
+        }
+    };
+    let Some(prompt) = a2a_message_text(&request.message) else {
+        return write_response_and_close(
+            stream,
+            a2a_error_response(
+                400,
+                "INVALID_REQUEST",
+                "A2A message must contain at least one text part",
+            ),
+        )
+        .await;
+    };
+    if let Err(error) = a2a_return_immediately(&request) {
+        return write_response_and_close(stream, a2a_error_response(400, "INVALID_REQUEST", error))
+            .await;
+    }
+
+    let metadata = a2a_task_metadata(head, &request, auth);
+    let target = match claim_a2a_send_task(state, &request, head, auth, metadata).await {
+        Ok(target) => target,
+        Err(response) => return write_response_and_close(stream, response).await,
+    };
+    let task_id = target.task_id;
+    let context_id = target.context_id;
+    let history = target.history;
+    let previous_task = target.previous_task;
+    let metadata = target.metadata;
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+    if let Err(response) = register_a2a_cancel_sender(state, &task_id, cancel_tx).await {
+        rollback_a2a_send_claim(state, &task_id, previous_task).await;
+        return write_response_and_close(stream, response).await;
+    }
+
+    stream
+        .write_all(sse_headers().as_bytes())
+        .await
+        .map_err(|error| error.to_string())?;
+    if let Some(task) = state.a2a_tasks.lock().await.get(&task_id).cloned() {
+        send_a2a_stream_response(stream, &serde_json::json!({ "task": task })).await?;
+    }
+    let task = complete_a2a_task(
+        state, prompt, task_id, context_id, history, metadata, cancel_rx,
+    )
+    .await;
+    send_a2a_stream_response(
+        stream,
+        &serde_json::json!({ "statusUpdate": a2a_status_update_event(&task) }),
+    )
+    .await?;
+    for artifact in task
+        .get("artifacts")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        send_a2a_stream_response(
+            stream,
+            &serde_json::json!({
+                "artifactUpdate": a2a_artifact_update_event(&task, artifact)
+            }),
+        )
+        .await?;
+    }
+    send_a2a_stream_response(stream, &serde_json::json!({ "task": task })).await?;
+    let _ = stream.shutdown().await;
+    Ok(())
+}
+
+async fn handle_a2a_task_subscribe(
+    stream: &mut TcpStream,
+    head: &RequestHead,
+    state: &AppState,
+    auth: &AuthContext,
+) -> Result<(), String> {
+    let task_id = a2a_task_id_from_subscribe_path(&head.path)
+        .expect("subscribe path should have been recognized");
+    let mut receiver = state.a2a_task_events.subscribe();
+    let current = {
+        let tasks = state.a2a_tasks.lock().await;
+        let Some(task) = tasks.get(task_id) else {
+            return write_response_and_close(
+                stream,
+                a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found"),
+            )
+            .await;
+        };
+        if !a2a_task_visible_to_auth(task, auth) {
+            return write_response_and_close(
+                stream,
+                a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found"),
+            )
+            .await;
+        }
+        task.clone()
+    };
+
+    stream
+        .write_all(sse_headers().as_bytes())
+        .await
+        .map_err(|error| error.to_string())?;
+    send_a2a_stream_response(stream, &serde_json::json!({ "task": current.clone() })).await?;
+    send_a2a_stream_response(
+        stream,
+        &serde_json::json!({ "statusUpdate": a2a_status_update_event(&current) }),
+    )
+    .await?;
+    if a2a_task_is_terminal(&current) {
+        let _ = stream.shutdown().await;
+        return Ok(());
+    }
+
+    let timeout_ms = env_u64(
+        "MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS",
+        A2A_DEFAULT_SUBSCRIBE_TIMEOUT_MS,
+    );
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let event = match tokio::time::timeout(remaining, receiver.recv()).await {
+            Ok(Ok(task)) => task,
+            Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(broadcast::error::RecvError::Closed)) | Err(_) => break,
+        };
+        if event.get("id").and_then(Value::as_str) != Some(task_id) {
+            continue;
+        }
+        if !a2a_task_visible_to_auth(&event, auth) {
+            continue;
+        }
+        send_a2a_stream_response(
+            stream,
+            &serde_json::json!({ "statusUpdate": a2a_status_update_event(&event) }),
+        )
+        .await?;
+        if a2a_task_is_terminal(&event) {
+            for artifact in event
+                .get("artifacts")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                send_a2a_stream_response(
+                    stream,
+                    &serde_json::json!({
+                        "artifactUpdate": a2a_artifact_update_event(&event, artifact)
+                    }),
+                )
+                .await?;
+            }
+            send_a2a_stream_response(stream, &serde_json::json!({ "task": event })).await?;
+            break;
+        }
+    }
+    let _ = stream.shutdown().await;
+    Ok(())
+}
+
+async fn send_a2a_stream_response(stream: &mut TcpStream, value: &Value) -> Result<(), String> {
+    send_sse(stream, value).await
+}
+
+fn a2a_status_update_event(task: &Value) -> Value {
+    serde_json::json!({
+        "taskId": task.get("id").cloned().unwrap_or(Value::Null),
+        "contextId": task.get("contextId").cloned().unwrap_or(Value::Null),
+        "status": task.get("status").cloned().unwrap_or(Value::Null),
+        "metadata": task.get("metadata").cloned().unwrap_or_else(|| serde_json::json!({}))
+    })
+}
+
+fn a2a_artifact_update_event(task: &Value, artifact: &Value) -> Value {
+    serde_json::json!({
+        "taskId": task.get("id").cloned().unwrap_or(Value::Null),
+        "contextId": task.get("contextId").cloned().unwrap_or(Value::Null),
+        "artifact": artifact,
+        "append": false,
+        "lastChunk": true,
+        "metadata": task.get("metadata").cloned().unwrap_or_else(|| serde_json::json!({}))
+    })
 }
 
 async fn cancel_a2a_task(
@@ -822,6 +1117,8 @@ async fn cancel_a2a_task(
     if let Some(sender) = state.a2a_cancel_senders.lock().await.remove(task_id) {
         let _ = sender.send(true);
     }
+    publish_a2a_task_update(state, &task);
+    persist_a2a_tasks(state).await;
 
     Ok(task)
 }
@@ -867,6 +1164,239 @@ fn a2a_task_visible_to_auth(task: &Value, auth: &AuthContext) -> bool {
     auth.subject
         .as_deref()
         .is_some_and(|subject| a2a_task_owner_subject(task) == Some(subject))
+}
+
+async fn load_a2a_tasks(path: &Path) -> HashMap<String, Value> {
+    let raw = match tokio::fs::read_to_string(path).await {
+        Ok(raw) => raw,
+        Err(error) => {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                eprintln!("failed to read A2A task ledger {}: {error}", path.display());
+            }
+            return HashMap::new();
+        }
+    };
+    let parsed: Value = match serde_json::from_str(&raw) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            eprintln!(
+                "failed to parse A2A task ledger {}: {error}",
+                path.display()
+            );
+            return HashMap::new();
+        }
+    };
+    let tasks = parsed
+        .get("tasks")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    tasks
+        .into_iter()
+        .filter_map(|task| {
+            let task_id = task.get("id").and_then(Value::as_str)?.trim().to_string();
+            (!task_id.is_empty()).then_some((task_id, task))
+        })
+        .collect()
+}
+
+async fn persist_a2a_tasks(state: &AppState) {
+    let _guard = state.a2a_task_persist_lock.lock().await;
+    let mut tasks = state
+        .a2a_tasks
+        .lock()
+        .await
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
+    tasks.sort_by(|left, right| {
+        a2a_task_status_timestamp(left)
+            .unwrap_or_default()
+            .cmp(a2a_task_status_timestamp(right).unwrap_or_default())
+            .then_with(|| {
+                left.get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .cmp(right.get("id").and_then(Value::as_str).unwrap_or_default())
+            })
+    });
+    let body = serde_json::to_vec_pretty(&serde_json::json!({ "tasks": tasks }))
+        .unwrap_or_else(|_| br#"{"tasks":[]}"#.to_vec());
+    let path = &state.config.a2a_tasks_file_path;
+    if let Some(parent) = path.parent() {
+        if let Err(error) = tokio::fs::create_dir_all(parent).await {
+            eprintln!(
+                "failed to create A2A task ledger directory {}: {error}",
+                parent.display()
+            );
+            return;
+        }
+    }
+    let tmp_path = path.with_extension("json.tmp");
+    if let Err(error) = tokio::fs::write(&tmp_path, body).await {
+        eprintln!(
+            "failed to write A2A task ledger {}: {error}",
+            tmp_path.display()
+        );
+        return;
+    }
+    if let Err(error) = tokio::fs::rename(&tmp_path, path).await {
+        eprintln!(
+            "failed to replace A2A task ledger {}: {error}",
+            path.display()
+        );
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+    }
+}
+
+fn publish_a2a_task_update(state: &AppState, task: &Value) {
+    let _ = state.a2a_task_events.send(task.clone());
+}
+
+async fn a2a_list_tasks_response(
+    head: &RequestHead,
+    state: &AppState,
+    auth: &AuthContext,
+) -> Result<Value, Vec<u8>> {
+    let page_size = match a2a_usize_query(head, &["pageSize", "page_size", "limit"]) {
+        Ok(Some(value)) => value.clamp(1, A2A_MAX_LIST_PAGE_SIZE),
+        Ok(None) => A2A_DEFAULT_LIST_PAGE_SIZE,
+        Err(message) => return Err(a2a_error_response(400, "INVALID_REQUEST", &message)),
+    };
+    let page_token = match a2a_usize_query(head, &["pageToken", "page_token", "offset"]) {
+        Ok(Some(value)) => value,
+        Ok(None) => 0,
+        Err(message) => return Err(a2a_error_response(400, "INVALID_REQUEST", &message)),
+    };
+    let context_id = a2a_string_query(head, &["contextId", "context_id"]);
+    let status =
+        a2a_string_query(head, &["status", "state"]).map(|value| a2a_normalize_state(&value));
+    let status_timestamp_after = a2a_string_query(
+        head,
+        &[
+            "statusTimestampAfter",
+            "status_timestamp_after",
+            "lastUpdatedAfter",
+            "last_updated_after",
+        ],
+    );
+    let include_artifacts = match a2a_bool_query(head, &["includeArtifacts", "include_artifacts"]) {
+        Ok(Some(value)) => value,
+        Ok(None) => false,
+        Err(message) => return Err(a2a_error_response(400, "INVALID_REQUEST", &message)),
+    };
+
+    let mut tasks = state
+        .a2a_tasks
+        .lock()
+        .await
+        .values()
+        .filter(|task| a2a_task_visible_to_auth(task, auth))
+        .filter(|task| {
+            context_id.as_deref().is_none_or(|context_id| {
+                task.get("contextId")
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| value == context_id)
+            })
+        })
+        .filter(|task| {
+            status
+                .as_deref()
+                .is_none_or(|status| a2a_task_status_state(task) == Some(status))
+        })
+        .filter(|task| {
+            status_timestamp_after.as_deref().is_none_or(|after| {
+                a2a_task_status_timestamp(task).is_some_and(|timestamp| timestamp >= after)
+            })
+        })
+        .map(|task| a2a_task_for_query(task, head, include_artifacts))
+        .collect::<Vec<_>>();
+    tasks.sort_by(|left, right| {
+        a2a_task_status_timestamp(right)
+            .unwrap_or_default()
+            .cmp(a2a_task_status_timestamp(left).unwrap_or_default())
+            .then_with(|| {
+                left.get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .cmp(right.get("id").and_then(Value::as_str).unwrap_or_default())
+            })
+    });
+    let total_size = tasks.len();
+    let page = tasks
+        .into_iter()
+        .skip(page_token)
+        .take(page_size)
+        .collect::<Vec<_>>();
+    let next_offset = page_token.saturating_add(page.len());
+    let next_page_token = (next_offset < total_size).then(|| next_offset.to_string());
+    Ok(serde_json::json!({
+        "tasks": page,
+        "nextPageToken": next_page_token.unwrap_or_default(),
+        "pageSize": page_size,
+        "totalSize": total_size
+    }))
+}
+
+fn a2a_task_for_query(task: &Value, head: &RequestHead, include_artifacts: bool) -> Value {
+    let mut task = task.clone();
+    if !include_artifacts {
+        task["artifacts"] = Value::Array(Vec::new());
+    }
+    if let Ok(Some(history_length)) = a2a_usize_query(head, &["historyLength", "history_length"]) {
+        if let Some(history) = task.get_mut("history").and_then(Value::as_array_mut) {
+            if history_length == 0 {
+                history.clear();
+            } else if history.len() > history_length {
+                let start = history.len() - history_length;
+                history.drain(..start);
+            }
+        }
+    }
+    task
+}
+
+fn a2a_string_query(head: &RequestHead, names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| {
+        head.query
+            .get(*name)
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+}
+
+fn a2a_usize_query(head: &RequestHead, names: &[&str]) -> Result<Option<usize>, String> {
+    let Some(value) = a2a_string_query(head, names) else {
+        return Ok(None);
+    };
+    value
+        .parse::<usize>()
+        .map(Some)
+        .map_err(|_| format!("A2A query parameter {} must be an integer", names[0]))
+}
+
+fn a2a_bool_query(head: &RequestHead, names: &[&str]) -> Result<Option<bool>, String> {
+    let Some(value) = a2a_string_query(head, names) else {
+        return Ok(None);
+    };
+    match value.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(Some(true)),
+        "0" | "false" | "no" | "off" => Ok(Some(false)),
+        _ => Err(format!(
+            "A2A query parameter {} must be a boolean",
+            names[0]
+        )),
+    }
+}
+
+fn a2a_normalize_state(value: &str) -> String {
+    let upper = value.trim().to_ascii_uppercase();
+    if upper.starts_with("TASK_STATE_") {
+        upper
+    } else {
+        format!("TASK_STATE_{upper}")
+    }
 }
 
 async fn claim_a2a_send_task(
@@ -974,8 +1504,11 @@ async fn claim_a2a_send_task(
         Vec::new(),
         task_metadata.clone(),
     );
-    tasks.insert(task_id.clone(), task);
+    tasks.insert(task_id.clone(), task.clone());
     prune_a2a_terminal_tasks(&mut tasks);
+    drop(tasks);
+    publish_a2a_task_update(state, &task);
+    persist_a2a_tasks(state).await;
     Ok(A2ASendTarget {
         task_id,
         context_id,
@@ -1008,10 +1541,14 @@ async fn rollback_a2a_send_claim(state: &AppState, task_id: &str, previous_task:
         return;
     }
     if let Some(previous_task) = previous_task {
-        tasks.insert(task_id.to_string(), previous_task);
+        tasks.insert(task_id.to_string(), previous_task.clone());
+        drop(tasks);
+        publish_a2a_task_update(state, &previous_task);
     } else {
         tasks.remove(task_id);
+        drop(tasks);
     }
+    persist_a2a_tasks(state).await;
 }
 
 async fn a2a_canceled_task(state: &AppState, task_id: &str) -> Option<Value> {
@@ -1029,6 +1566,9 @@ async fn store_a2a_task_unless_canceled(state: &AppState, task_id: &str, task: V
     }
     tasks.insert(task_id.to_string(), task.clone());
     prune_a2a_terminal_tasks(&mut tasks);
+    drop(tasks);
+    publish_a2a_task_update(state, &task);
+    persist_a2a_tasks(state).await;
     task
 }
 
@@ -1256,11 +1796,12 @@ async fn complete_a2a_task(
 
 fn a2a_agent_card(head: &RequestHead, config: &Config) -> Value {
     let base_url = a2a_public_base_url(head, config);
-    serde_json::json!({
+    let mut card = serde_json::json!({
         "protocolVersion": A2A_PROTOCOL_VERSION,
         "name": trimmed_env("MAESTRO_A2A_AGENT_NAME")
             .unwrap_or_else(|| "Maestro Desktop Agent".to_string()),
-        "description": "Local Maestro Rust/TS TUI agent endpoint for A2A task delegation.",
+        "description": trimmed_env("MAESTRO_A2A_AGENT_DESCRIPTION")
+            .unwrap_or_else(|| "Local Maestro Rust/TS TUI agent endpoint for A2A task delegation.".to_string()),
         "url": base_url,
         "preferredTransport": "HTTP+JSON",
         "supportedInterfaces": [{
@@ -1274,24 +1815,137 @@ fn a2a_agent_card(head: &RequestHead, config: &Config) -> Value {
         },
         "version": env!("CARGO_PKG_VERSION"),
         "capabilities": {
-            "streaming": false,
+            "streaming": true,
             "pushNotifications": false,
-            "extendedAgentCard": false
+            "extendedAgentCard": true,
+            "extensions": [a2a_operating_plane_extension(false)]
         },
         "defaultInputModes": ["text/plain"],
         "defaultOutputModes": ["text/plain", "application/json"],
-        "skills": [{
-            "id": "maestro-tui-turn",
-            "name": "Maestro TUI turn",
-            "description": "Run a prompt through the local Maestro native TUI agent runner.",
-            "tags": ["maestro", "tui", "codex", "a2a"],
-            "examples": [
-                "Review the current workspace and summarize the next highest leverage action."
+        "skills": a2a_agent_skills()
+    });
+    if let Some(security) = a2a_agent_card_security(config) {
+        if let Value::Object(card) = &mut card {
+            card.insert("securitySchemes".to_string(), security.0);
+            card.insert("securityRequirements".to_string(), security.1);
+        }
+    }
+    card
+}
+
+fn a2a_extended_agent_card(head: &RequestHead, config: &Config) -> Value {
+    let mut card = a2a_agent_card(head, config);
+    if let Value::Object(card_object) = &mut card {
+        card_object.insert(
+            "documentationUrl".to_string(),
+            Value::String(
+                "https://github.com/evalops/maestro/tree/main/docs/protocols".to_string(),
+            ),
+        );
+        card_object.insert(
+            "metadata".to_string(),
+            serde_json::json!({
+                "runtime": "maestro-rust-control-plane",
+                "taskStore": "durable-file",
+                "taskStorePath": config.a2a_tasks_file_path.to_string_lossy(),
+                "streamingEndpoints": ["/message:stream", "/tasks/{id}:subscribe"],
+                "taskList": {
+                    "filters": ["contextId", "status", "statusTimestampAfter"],
+                    "pagination": { "defaultPageSize": A2A_DEFAULT_LIST_PAGE_SIZE, "maxPageSize": A2A_MAX_LIST_PAGE_SIZE },
+                    "historyLength": true,
+                    "includeArtifacts": true
+                },
+                "operatingPlane": {
+                    "extensionUri": EVALOPS_A2A_EXTENSION_URI,
+                    "correlationFields": [
+                        "workspaceId",
+                        "sessionId",
+                        "agentId",
+                        "actorId",
+                        "traceparent",
+                        "tracestate"
+                    ],
+                    "retentionFields": ["data_classification", "retention_class", "safe_summary"]
+                }
+            }),
+        );
+        card_object.insert(
+            "capabilities".to_string(),
+            serde_json::json!({
+                "streaming": true,
+                "pushNotifications": false,
+                "extendedAgentCard": true,
+                "extensions": [a2a_operating_plane_extension(true)]
+            }),
+        );
+    }
+    card
+}
+
+fn a2a_operating_plane_extension(extended: bool) -> Value {
+    serde_json::json!({
+        "uri": EVALOPS_A2A_EXTENSION_URI,
+        "description": "Carries EvalOps/Maestro workspace, session, trace, retention, and approval correlation metadata without changing core A2A task semantics.",
+        "required": false,
+        "params": {
+            "version": "1",
+            "metadataFields": [
+                "workspaceId",
+                "sessionId",
+                "agentId",
+                "actorId",
+                "traceparent",
+                "tracestate",
+                "data_classification",
+                "retention_class",
+                "safe_summary"
             ],
-            "inputModes": ["text/plain"],
-            "outputModes": ["text/plain", "application/json"]
-        }]
+            "extendedAgentCard": extended
+        }
     })
+}
+
+fn a2a_agent_card_security(config: &Config) -> Option<(Value, Value)> {
+    if !config.require_key {
+        return None;
+    }
+    Some((
+        serde_json::json!({
+            "maestroApiKey": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "x-maestro-api-key",
+                "description": "Maestro control-plane API key."
+            },
+            "bearer": {
+                "type": "http",
+                "scheme": "bearer",
+                "description": "Bearer token accepted by Maestro shared-secret auth."
+            }
+        }),
+        serde_json::json!([
+            { "maestroApiKey": [] },
+            { "bearer": [] }
+        ]),
+    ))
+}
+
+fn a2a_agent_skills() -> Value {
+    let mut skill = serde_json::json!({
+        "id": "maestro-tui-turn",
+        "name": "Maestro TUI turn",
+        "description": "Run a prompt through the local Maestro native TUI agent runner.",
+        "tags": ["maestro", "tui", "codex", "a2a", "fleet"],
+        "examples": [
+            "Review the current workspace and summarize the next highest leverage action."
+        ],
+        "inputModes": ["text/plain"],
+        "outputModes": ["text/plain", "application/json"]
+    });
+    if let Some(model) = trimmed_env("MAESTRO_A2A_MODEL") {
+        skill["metadata"] = serde_json::json!({ "defaultModel": model });
+    }
+    Value::Array(vec![skill])
 }
 
 fn a2a_public_base_url(_head: &RequestHead, config: &Config) -> String {
@@ -3969,6 +4623,13 @@ fn usage_file_path() -> PathBuf {
     env::var("MAESTRO_USAGE_FILE")
         .map(PathBuf::from)
         .unwrap_or_else(|_| maestro_home().join("usage.json"))
+}
+
+fn a2a_tasks_file_path() -> PathBuf {
+    env::var("MAESTRO_A2A_TASKS_FILE")
+        .or_else(|_| env::var("CODEX_A2A_TASKS_FILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| maestro_home().join("a2a/tasks.json"))
 }
 
 async fn read_json_value(path: &str) -> Option<Value> {
@@ -9660,6 +10321,7 @@ setTimeout(() => {
             session_store_path: PathBuf::from("sessions.json"),
             command_prefs_path: PathBuf::from("command-prefs.json"),
             usage_file_path: PathBuf::from("usage.jsonl"),
+            a2a_tasks_file_path: unique_test_dir("maestro-a2a-tasks").join("tasks.json"),
             static_root: PathBuf::from("dist"),
             static_cache_max_age: 0,
             llm_gateway_models_url: None,
@@ -9716,6 +10378,7 @@ setTimeout(() => {
 
     fn test_app_state_with_sessions(sessions: HashMap<String, SessionRecord>) -> AppState {
         let config = Arc::new(auth_test_config());
+        let (a2a_task_events, _) = broadcast::channel(256);
         AppState {
             config: config.clone(),
             started_at: Instant::now(),
@@ -9736,6 +10399,8 @@ setTimeout(() => {
             approval_modes: Arc::new(Mutex::new(HashMap::new())),
             pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
             a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
+            a2a_task_persist_lock: Arc::new(Mutex::new(())),
+            a2a_task_events,
             a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -10055,6 +10720,9 @@ setTimeout(() => {
             "POST /message:send HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "GET /tasks/maestro-task-1 HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "GET /tasks HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "POST /message:stream HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "GET /tasks/maestro-task-1:subscribe HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "GET /extendedAgentCard HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "POST /tasks/maestro-task-1:cancel HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "OPTIONS /message:send HTTP/1.1\r\nHost: localhost\r\n\r\n",
         ] {
@@ -10086,6 +10754,16 @@ setTimeout(() => {
         assert_eq!(
             card["supportedInterfaces"][0]["protocolBinding"],
             "HTTP+JSON"
+        );
+        assert_eq!(card["capabilities"]["streaming"], true);
+        assert_eq!(card["capabilities"]["extendedAgentCard"], true);
+        assert_eq!(
+            card["capabilities"]["extensions"][0]["uri"],
+            EVALOPS_A2A_EXTENSION_URI
+        );
+        assert_eq!(
+            card["securitySchemes"]["maestroApiKey"]["name"],
+            "x-maestro-api-key"
         );
         assert_eq!(card["skills"][0]["id"], "maestro-tui-turn");
         if let Some(previous_a2a_url) = previous_a2a_url {
@@ -10605,6 +11283,166 @@ setTimeout(() => {
         } else {
             env::remove_var("MAESTRO_AUTH_SHARED_SECRET");
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_tasks_list_supports_spec_filters_pagination_and_payload_trimming() {
+        let state = test_app_state_with_sessions(HashMap::new());
+        for (task_id, context_id, status, minute) in [
+            ("task-a", "ctx-1", "TASK_STATE_COMPLETED", 3),
+            ("task-b", "ctx-1", "TASK_STATE_COMPLETED", 2),
+            ("task-c", "ctx-2", "TASK_STATE_WORKING", 1),
+        ] {
+            let mut task = a2a_task_value(
+                task_id,
+                context_id,
+                status,
+                a2a_agent_message(context_id, "done"),
+                vec![
+                    a2a_agent_message(context_id, "first"),
+                    a2a_agent_message(context_id, "second"),
+                ],
+                vec![serde_json::json!({
+                    "artifactId": format!("{task_id}-artifact"),
+                    "parts": [{ "text": "artifact", "mediaType": "text/plain" }]
+                })],
+                serde_json::json!({}),
+            );
+            task["status"]["timestamp"] = Value::String(format!("2026-05-15T00:0{minute}:00Z"));
+            state
+                .a2a_tasks
+                .lock()
+                .await
+                .insert(task_id.to_string(), task);
+        }
+        let request = "GET /tasks?contextId=ctx-1&status=completed&pageSize=1&historyLength=1 HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n";
+        let mut initial = request.as_bytes().to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let tasks = response["tasks"]
+            .as_array()
+            .expect("tasks should be an array");
+
+        assert_eq!(response["totalSize"], 2);
+        assert_eq!(response["pageSize"], 1);
+        assert_eq!(response["nextPageToken"], "1");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0]["id"], "task-a");
+        assert_eq!(tasks[0]["history"].as_array().unwrap().len(), 1);
+        assert_eq!(tasks[0]["artifacts"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_task_store_persists_control_plane_tasks_to_ledger_file() {
+        let root = TestDir::new("a2a-task-ledger");
+        let base_state = test_app_state_with_sessions(HashMap::new());
+        let mut config = auth_test_config();
+        config.a2a_tasks_file_path = root.path().join("tasks.json");
+        let state = AppState {
+            config: Arc::new(config),
+            ..base_state
+        };
+        let task = a2a_task_value(
+            "maestro-task-durable",
+            "ctx-1",
+            "TASK_STATE_COMPLETED",
+            a2a_agent_message("ctx-1", "complete"),
+            Vec::new(),
+            Vec::new(),
+            serde_json::json!({ "workspaceId": "ws-1" }),
+        );
+
+        store_a2a_task_unless_canceled(&state, "maestro-task-durable", task).await;
+        let loaded = load_a2a_tasks(&state.config.a2a_tasks_file_path).await;
+
+        assert_eq!(
+            loaded["maestro-task-durable"]["metadata"]["workspaceId"],
+            "ws-1"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_stream_emits_task_status_and_artifact_events() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "streamed fake response");
+        let body = r#"{"message":{"messageId":"msg-1","contextId":"ctx-stream","role":"ROLE_USER","parts":[{"text":"hello","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:stream HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let state = test_app_state_with_sessions(HashMap::new());
+        let (mut client, server) = tcp_stream_pair().await;
+        let state_for_run = state.clone();
+        let run = tokio::spawn(async move {
+            handle_a2a_streaming_endpoint(server, initial, head, state_for_run).await
+        });
+        let mut bytes = Vec::new();
+        tokio::time::timeout(Duration::from_secs(2), client.read_to_end(&mut bytes))
+            .await
+            .expect("stream response should close")
+            .expect("stream response should be readable");
+        run.await
+            .expect("stream task should join")
+            .expect("stream endpoint should succeed");
+        let response = String::from_utf8(bytes).expect("response should be utf-8");
+
+        assert!(response.contains("Content-Type: text/event-stream"));
+        assert!(response.contains("\"statusUpdate\""));
+        assert!(response.contains("\"artifactUpdate\""));
+        assert!(response.contains("streamed fake response"));
+        assert_eq!(state.a2a_tasks.lock().await.len(), 1);
+
+        if let Some(previous_fake) = previous_fake {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_task_subscribe_streams_existing_terminal_snapshot() {
+        let state = test_app_state_with_sessions(HashMap::new());
+        let task = a2a_task_value(
+            "maestro-task-subscribe",
+            "ctx-1",
+            "TASK_STATE_COMPLETED",
+            a2a_agent_message("ctx-1", "complete"),
+            Vec::new(),
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-subscribe".to_string(), task);
+        let request = "GET /tasks/maestro-task-subscribe:subscribe HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n";
+        let initial = request.as_bytes().to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (mut client, server) = tcp_stream_pair().await;
+        let state_for_run = state.clone();
+        let run = tokio::spawn(async move {
+            handle_a2a_streaming_endpoint(server, initial, head, state_for_run).await
+        });
+        let mut bytes = Vec::new();
+        tokio::time::timeout(Duration::from_secs(2), client.read_to_end(&mut bytes))
+            .await
+            .expect("subscribe response should close")
+            .expect("subscribe response should be readable");
+        run.await
+            .expect("subscribe task should join")
+            .expect("subscribe endpoint should succeed");
+        let response = String::from_utf8(bytes).expect("response should be utf-8");
+
+        assert!(response.contains("Content-Type: text/event-stream"));
+        assert!(response.contains("\"statusUpdate\""));
+        assert!(response.contains("maestro-task-subscribe"));
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -13374,6 +14212,7 @@ setTimeout(() => {
             session_store_path: static_root.join("sessions.json"),
             command_prefs_path: static_root.join("command-prefs.json"),
             usage_file_path: static_root.join("usage.json"),
+            a2a_tasks_file_path: static_root.join("a2a-tasks.json"),
             static_root: static_root.clone(),
             static_cache_max_age: 60,
             llm_gateway_models_url: None,
@@ -13414,6 +14253,7 @@ setTimeout(() => {
             session_store_path: static_root.join("sessions.json"),
             command_prefs_path: static_root.join("command-prefs.json"),
             usage_file_path: static_root.join("usage.json"),
+            a2a_tasks_file_path: static_root.join("a2a-tasks.json"),
             static_root: static_root.clone(),
             static_cache_max_age: 60,
             llm_gateway_models_url: None,
@@ -13459,6 +14299,7 @@ setTimeout(() => {
                 session_store_path: root.path().join("sessions.json"),
                 command_prefs_path: root.path().join("command-prefs.json"),
                 usage_file_path: root.path().join("usage.json"),
+                a2a_tasks_file_path: root.path().join("a2a-tasks.json"),
                 static_root: root.path().to_path_buf(),
                 static_cache_max_age: 60,
                 llm_gateway_models_url: None,
@@ -13487,6 +14328,8 @@ setTimeout(() => {
             approval_modes: Arc::new(Mutex::new(HashMap::new())),
             pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
             a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
+            a2a_task_persist_lock: Arc::new(Mutex::new(())),
+            a2a_task_events: broadcast::channel(256).0,
             a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
         };
         let (_client, mut server) = tcp_stream_pair().await;
@@ -13533,6 +14376,7 @@ setTimeout(() => {
                 session_store_path: session_store_path.clone(),
                 command_prefs_path: root.path().join("command-prefs.json"),
                 usage_file_path: root.path().join("usage.json"),
+                a2a_tasks_file_path: root.path().join("a2a-tasks.json"),
                 static_root: root.path().to_path_buf(),
                 static_cache_max_age: 60,
                 llm_gateway_models_url: None,
@@ -13564,6 +14408,8 @@ setTimeout(() => {
             approval_modes: Arc::new(Mutex::new(HashMap::new())),
             pending_tool_responses: Arc::new(Mutex::new(HashMap::new())),
             a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
+            a2a_task_persist_lock: Arc::new(Mutex::new(())),
+            a2a_task_events: broadcast::channel(256).0,
             a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
         };
 

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -58,6 +58,7 @@ const A2A_DEFAULT_LIST_PAGE_SIZE: usize = 50;
 const A2A_MAX_LIST_PAGE_SIZE: usize = 100;
 const A2A_DEFAULT_SUBSCRIBE_TIMEOUT_MS: u64 = 60_000;
 const A2A_DEFAULT_SUBSCRIBE_HEARTBEAT_MS: u64 = 15_000;
+const A2A_TASK_EVENT_REPLAY_LIMIT: usize = 256;
 const A2A_LEDGER_LOCK_RETRY_MS: u64 = 25;
 const A2A_LEDGER_LOCK_STALE_MS: u64 = 30_000;
 const A2A_LEDGER_LOCK_TIMEOUT_MS: u64 = A2A_LEDGER_LOCK_STALE_MS + A2A_LEDGER_LOCK_RETRY_MS;
@@ -218,8 +219,22 @@ struct AppState {
     pending_tool_responses: Arc<Mutex<HashMap<String, PendingToolResponseSender>>>,
     a2a_tasks: Arc<Mutex<HashMap<String, Value>>>,
     a2a_task_persist_lock: Arc<Mutex<()>>,
-    a2a_task_events: broadcast::Sender<Value>,
+    a2a_task_events: broadcast::Sender<A2ATaskUpdateEvent>,
+    a2a_task_event_history: Arc<Mutex<HashMap<String, A2ATaskEventHistory>>>,
     a2a_cancel_senders: Arc<Mutex<HashMap<String, A2ACancelSender>>>,
+}
+
+#[derive(Clone, Debug)]
+struct A2ATaskUpdateEvent {
+    task_id: String,
+    sequence: u64,
+    task: Value,
+}
+
+#[derive(Debug, Default)]
+struct A2ATaskEventHistory {
+    next_sequence: u64,
+    events: Vec<A2ATaskUpdateEvent>,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -385,6 +400,7 @@ async fn main() -> anyhow::Result<()> {
         a2a_tasks: Arc::new(Mutex::new(a2a_tasks)),
         a2a_task_persist_lock: Arc::new(Mutex::new(())),
         a2a_task_events,
+        a2a_task_event_history: Arc::new(Mutex::new(HashMap::new())),
         a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
     };
 
@@ -1009,6 +1025,7 @@ async fn handle_a2a_task_subscribe(
         &serde_json::json!({ "statusUpdate": a2a_status_update_event(&current) }),
     )
     .await?;
+    let mut next_replay_sequence = a2a_task_event_next_sequence(state, task_id).await;
 
     let subscribe_timeout = Duration::from_millis(
         env_u64(
@@ -1032,9 +1049,30 @@ async fn handle_a2a_task_subscribe(
         }
         let wait_timeout = remaining.min(heartbeat_interval);
         let event = match tokio::time::timeout(wait_timeout, receiver.recv()).await {
-            Ok(Ok(task)) => Some(task),
+            Ok(Ok(event)) => {
+                if event.task_id == task_id {
+                    next_replay_sequence = event.sequence.saturating_add(1);
+                    Some(event.task)
+                } else {
+                    None
+                }
+            }
             Ok(Err(broadcast::error::RecvError::Lagged(_))) => {
-                current_a2a_subscribe_task(state, task_id, auth).await
+                let replay =
+                    a2a_task_events_since(state, task_id, next_replay_sequence, auth).await;
+                if replay.is_empty() {
+                    next_replay_sequence = a2a_task_event_next_sequence(state, task_id).await;
+                    current_a2a_subscribe_task(state, task_id, auth).await
+                } else {
+                    for event in replay {
+                        next_replay_sequence = event.sequence.saturating_add(1);
+                        if send_a2a_subscribe_task_update(stream, &event.task, auth).await? {
+                            let _ = stream.shutdown().await;
+                            return Ok(());
+                        }
+                    }
+                    continue;
+                }
             }
             Ok(Err(broadcast::error::RecvError::Closed)) => break,
             Err(_) => {
@@ -1070,6 +1108,40 @@ async fn current_a2a_subscribe_task(
     let tasks = state.a2a_tasks.lock().await;
     let task = tasks.get(task_id)?;
     a2a_task_visible_to_auth(task, auth).then(|| task.clone())
+}
+
+async fn a2a_task_event_next_sequence(state: &AppState, task_id: &str) -> u64 {
+    state
+        .a2a_task_event_history
+        .lock()
+        .await
+        .get(task_id)
+        .map(|history| history.next_sequence)
+        .unwrap_or(0)
+}
+
+async fn a2a_task_events_since(
+    state: &AppState,
+    task_id: &str,
+    sequence: u64,
+    auth: &AuthContext,
+) -> Vec<A2ATaskUpdateEvent> {
+    state
+        .a2a_task_event_history
+        .lock()
+        .await
+        .get(task_id)
+        .map(|history| {
+            history
+                .events
+                .iter()
+                .filter(|event| {
+                    event.sequence >= sequence && a2a_task_visible_to_auth(&event.task, auth)
+                })
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 async fn send_a2a_subscribe_task_update(
@@ -1194,7 +1266,7 @@ async fn cancel_a2a_task(
     if let Some(sender) = state.a2a_cancel_senders.lock().await.remove(task_id) {
         let _ = sender.send(true);
     }
-    publish_a2a_task_update(state, &task);
+    publish_a2a_task_update(state, &task).await;
     persist_a2a_tasks(state).await;
 
     Ok(task)
@@ -1645,8 +1717,34 @@ fn unix_millis_now() -> u128 {
         .unwrap_or(0)
 }
 
-fn publish_a2a_task_update(state: &AppState, task: &Value) {
-    let _ = state.a2a_task_events.send(task.clone());
+async fn publish_a2a_task_update(state: &AppState, task: &Value) {
+    let Some(task_id) = task
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|task_id| !task_id.is_empty())
+    else {
+        return;
+    };
+    let event = {
+        let mut histories = state.a2a_task_event_history.lock().await;
+        let history = histories.entry(task_id.to_string()).or_default();
+        let event = A2ATaskUpdateEvent {
+            task_id: task_id.to_string(),
+            sequence: history.next_sequence,
+            task: task.clone(),
+        };
+        history.next_sequence = history.next_sequence.saturating_add(1);
+        history.events.push(event.clone());
+        let overflow = history
+            .events
+            .len()
+            .saturating_sub(A2A_TASK_EVENT_REPLAY_LIMIT);
+        if overflow > 0 {
+            history.events.drain(..overflow);
+        }
+        event
+    };
+    let _ = state.a2a_task_events.send(event);
 }
 
 fn a2a_ledger_entry_is_control_plane(entry: &Value) -> bool {
@@ -1881,9 +1979,8 @@ async fn a2a_list_tasks_response(
         Ok(None) => A2A_DEFAULT_LIST_PAGE_SIZE,
         Err(message) => return Err(a2a_error_response(400, "INVALID_REQUEST", &message)),
     };
-    let page_token = match a2a_usize_query(head, &["pageToken", "page_token", "offset"]) {
-        Ok(Some(value)) => value,
-        Ok(None) => 0,
+    let page_start = match a2a_task_page_start(head) {
+        Ok(value) => value,
         Err(message) => return Err(a2a_error_response(400, "INVALID_REQUEST", &message)),
     };
     let context_id = a2a_string_query(head, &["contextId", "context_id"]);
@@ -1935,21 +2032,20 @@ async fn a2a_list_tasks_response(
         .map(|task| a2a_task_for_query(task, include_artifacts, history_length))
         .collect::<Vec<_>>();
     tasks.sort_by(|left, right| {
-        compare_a2a_task_status_timestamps_desc(left, right).then_with(|| {
-            left.get("id")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .cmp(right.get("id").and_then(Value::as_str).unwrap_or_default())
-        })
+        compare_a2a_task_status_timestamps_desc(left, right)
+            .then_with(|| a2a_task_id_for_sort(left).cmp(a2a_task_id_for_sort(right)))
     });
     let total_size = tasks.len();
+    let page_start_index = a2a_task_page_start_index(&tasks, &page_start);
     let page = tasks
         .into_iter()
-        .skip(page_token)
+        .skip(page_start_index)
         .take(page_size)
         .collect::<Vec<_>>();
-    let next_offset = page_token.saturating_add(page.len());
-    let next_page_token = (next_offset < total_size).then(|| next_offset.to_string());
+    let next_offset = page_start_index.saturating_add(page.len());
+    let next_page_token = (next_offset < total_size)
+        .then(|| page.last().and_then(a2a_task_page_token))
+        .flatten();
     Ok(serde_json::json!({
         "tasks": page,
         "nextPageToken": next_page_token.unwrap_or_default(),
@@ -1969,8 +2065,16 @@ fn a2a_timestamp_at_or_after(timestamp: &str, after: &str) -> bool {
 }
 
 fn compare_a2a_task_status_timestamps_desc(left: &Value, right: &Value) -> std::cmp::Ordering {
-    let left_timestamp = a2a_task_status_timestamp(left);
-    let right_timestamp = a2a_task_status_timestamp(right);
+    compare_a2a_status_timestamps_desc(
+        a2a_task_status_timestamp(left),
+        a2a_task_status_timestamp(right),
+    )
+}
+
+fn compare_a2a_status_timestamps_desc(
+    left_timestamp: Option<&str>,
+    right_timestamp: Option<&str>,
+) -> std::cmp::Ordering {
     match (
         left_timestamp.and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok()),
         right_timestamp.and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok()),
@@ -1982,6 +2086,110 @@ fn compare_a2a_task_status_timestamps_desc(left: &Value, right: &Value) -> std::
             .unwrap_or_default()
             .cmp(left_timestamp.unwrap_or_default()),
     }
+}
+
+#[derive(Debug)]
+enum A2ATaskPageStart {
+    Beginning,
+    Offset(usize),
+    Cursor(A2ATaskPageCursor),
+}
+
+#[derive(Debug)]
+struct A2ATaskPageCursor {
+    status_timestamp: String,
+    id: String,
+}
+
+fn a2a_task_page_start(head: &RequestHead) -> Result<A2ATaskPageStart, String> {
+    if let Some(token) = a2a_string_query(head, &["pageToken", "page_token"]) {
+        if let Ok(offset) = token.parse::<usize>() {
+            return Ok(A2ATaskPageStart::Offset(offset));
+        }
+        return parse_a2a_task_page_token(&token).map(A2ATaskPageStart::Cursor);
+    }
+    match a2a_usize_query(head, &["offset"])? {
+        Some(offset) => Ok(A2ATaskPageStart::Offset(offset)),
+        None => Ok(A2ATaskPageStart::Beginning),
+    }
+}
+
+fn parse_a2a_task_page_token(token: &str) -> Result<A2ATaskPageCursor, String> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(token.as_bytes())
+        .map_err(|_| "A2A query parameter pageToken must be a valid task page token".to_string())?;
+    let value: Value = serde_json::from_slice(&bytes)
+        .map_err(|_| "A2A query parameter pageToken must be a valid task page token".to_string())?;
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            "A2A query parameter pageToken must be a valid task page token".to_string()
+        })?;
+    Ok(A2ATaskPageCursor {
+        status_timestamp: value
+            .get("statusTimestamp")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        id: id.to_string(),
+    })
+}
+
+fn a2a_task_page_start_index(tasks: &[Value], page_start: &A2ATaskPageStart) -> usize {
+    match page_start {
+        A2ATaskPageStart::Beginning => 0,
+        A2ATaskPageStart::Offset(offset) => *offset,
+        A2ATaskPageStart::Cursor(cursor) => tasks
+            .iter()
+            .position(|task| a2a_task_matches_page_cursor(task, cursor))
+            .map(|index| index.saturating_add(1))
+            .unwrap_or_else(|| {
+                tasks
+                    .iter()
+                    .position(|task| a2a_task_sorts_after_page_cursor(task, cursor))
+                    .unwrap_or(tasks.len())
+            }),
+    }
+}
+
+fn a2a_task_matches_page_cursor(task: &Value, cursor: &A2ATaskPageCursor) -> bool {
+    a2a_task_id_for_sort(task) == cursor.id
+        && compare_a2a_status_timestamps_desc(
+            a2a_task_status_timestamp(task),
+            Some(cursor.status_timestamp.as_str()),
+        )
+        .is_eq()
+}
+
+fn a2a_task_sorts_after_page_cursor(task: &Value, cursor: &A2ATaskPageCursor) -> bool {
+    match compare_a2a_status_timestamps_desc(
+        a2a_task_status_timestamp(task),
+        Some(cursor.status_timestamp.as_str()),
+    ) {
+        std::cmp::Ordering::Less => false,
+        std::cmp::Ordering::Equal => a2a_task_id_for_sort(task) > cursor.id.as_str(),
+        std::cmp::Ordering::Greater => true,
+    }
+}
+
+fn a2a_task_page_token(task: &Value) -> Option<String> {
+    let id = a2a_task_id_for_sort(task);
+    if id.is_empty() {
+        return None;
+    }
+    let value = serde_json::json!({
+        "statusTimestamp": a2a_task_status_timestamp(task).unwrap_or_default(),
+        "id": id,
+    });
+    serde_json::to_vec(&value)
+        .ok()
+        .map(|bytes| URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn a2a_task_id_for_sort(task: &Value) -> &str {
+    task.get("id").and_then(Value::as_str).unwrap_or_default()
 }
 
 fn a2a_task_for_query(
@@ -2159,7 +2367,7 @@ async fn claim_a2a_send_task(
     tasks.insert(task_id.clone(), task.clone());
     prune_a2a_terminal_tasks(&mut tasks);
     drop(tasks);
-    publish_a2a_task_update(state, &task);
+    publish_a2a_task_update(state, &task).await;
     persist_a2a_tasks(state).await;
     Ok(A2ASendTarget {
         task_id,
@@ -2195,7 +2403,7 @@ async fn rollback_a2a_send_claim(state: &AppState, task_id: &str, previous_task:
     if let Some(previous_task) = previous_task {
         tasks.insert(task_id.to_string(), previous_task.clone());
         drop(tasks);
-        publish_a2a_task_update(state, &previous_task);
+        publish_a2a_task_update(state, &previous_task).await;
     } else {
         tasks.remove(task_id);
         drop(tasks);
@@ -2219,7 +2427,7 @@ async fn store_a2a_task_unless_canceled(state: &AppState, task_id: &str, task: V
     tasks.insert(task_id.to_string(), task.clone());
     prune_a2a_terminal_tasks(&mut tasks);
     drop(tasks);
-    publish_a2a_task_update(state, &task);
+    publish_a2a_task_update(state, &task).await;
     persist_a2a_tasks(state).await;
     task
 }
@@ -11053,6 +11261,7 @@ setTimeout(() => {
             a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
             a2a_task_persist_lock: Arc::new(Mutex::new(())),
             a2a_task_events,
+            a2a_task_event_history: Arc::new(Mutex::new(HashMap::new())),
             a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -11267,6 +11476,20 @@ setTimeout(() => {
         .is_ok());
         assert!(validate_csrf(
             &csrf_head_for_path("POST", "/message:stream", None),
+            &config
+        )
+        .is_err());
+        assert!(validate_csrf(
+            &csrf_head_for_path(
+                "POST",
+                "/tasks/maestro-task-1:subscribe",
+                Some("csrf-token")
+            ),
+            &config,
+        )
+        .is_ok());
+        assert!(validate_csrf(
+            &csrf_head_for_path("POST", "/tasks/maestro-task-1:subscribe", None),
             &config
         )
         .is_err());
@@ -12043,11 +12266,45 @@ setTimeout(() => {
 
         assert_eq!(response["totalSize"], 3);
         assert_eq!(response["pageSize"], 1);
-        assert_eq!(response["nextPageToken"], "1");
+        let next_page_token = response["nextPageToken"]
+            .as_str()
+            .expect("next page token should be a string");
+        assert!(!next_page_token.is_empty());
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0]["id"], "task-d");
         assert_eq!(tasks[0]["history"].as_array().unwrap().len(), 1);
         assert!(tasks[0].get("artifacts").is_none());
+
+        let mut newer_task = a2a_task_value(
+            "task-e",
+            "ctx-1",
+            "TASK_STATE_COMPLETED",
+            a2a_agent_message("ctx-1", "newer"),
+            Vec::new(),
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        newer_task["status"]["timestamp"] = Value::String("2026-05-15T00:05:00Z".to_string());
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("task-e".to_string(), newer_task);
+        let request = format!(
+            "GET /tasks?contextId=ctx-1&status=completed&pageSize=1&historyLength=1&pageToken={next_page_token} HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n"
+        );
+        let mut initial = request.as_bytes().to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let tasks = response["tasks"]
+            .as_array()
+            .expect("tasks should be an array");
+
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0]["id"], "task-a");
 
         let request = "GET /tasks?statusTimestampAfter=2026-05-15T00:03:00Z HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n";
         let mut initial = request.as_bytes().to_vec();
@@ -12060,9 +12317,10 @@ setTimeout(() => {
             .as_array()
             .expect("tasks should be an array");
 
-        assert_eq!(response["totalSize"], 2);
-        assert_eq!(tasks[0]["id"], "task-d");
-        assert_eq!(tasks[1]["id"], "task-a");
+        assert_eq!(response["totalSize"], 3);
+        assert_eq!(tasks[0]["id"], "task-e");
+        assert_eq!(tasks[1]["id"], "task-d");
+        assert_eq!(tasks[2]["id"], "task-a");
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -12601,7 +12859,7 @@ setTimeout(() => {
             "maestro-task-active-subscribe".to_string(),
             terminal_task.clone(),
         );
-        publish_a2a_task_update(&state, &terminal_task);
+        publish_a2a_task_update(&state, &terminal_task).await;
         tokio::time::timeout(
             Duration::from_secs(2),
             client.read_to_end(&mut response_bytes),
@@ -12730,6 +12988,23 @@ setTimeout(() => {
                 .expect("subscribe response should be readable");
         response_bytes.truncate(initial_len);
 
+        let intermediate_task = a2a_task_value(
+            "maestro-task-lagged-subscribe",
+            "ctx-1",
+            "TASK_STATE_WORKING",
+            a2a_agent_message("ctx-1", "halfway after lag"),
+            vec![
+                a2a_agent_message("ctx-1", "working"),
+                a2a_agent_message("ctx-1", "halfway after lag"),
+            ],
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state.a2a_tasks.lock().await.insert(
+            "maestro-task-lagged-subscribe".to_string(),
+            intermediate_task.clone(),
+        );
+        publish_a2a_task_update(&state, &intermediate_task).await;
         let terminal_task = a2a_task_value(
             "maestro-task-lagged-subscribe",
             "ctx-1",
@@ -12737,6 +13012,7 @@ setTimeout(() => {
             a2a_agent_message("ctx-1", "complete after lag"),
             vec![
                 a2a_agent_message("ctx-1", "working"),
+                a2a_agent_message("ctx-1", "halfway after lag"),
                 a2a_agent_message("ctx-1", "complete after lag"),
             ],
             Vec::new(),
@@ -12746,7 +13022,7 @@ setTimeout(() => {
             "maestro-task-lagged-subscribe".to_string(),
             terminal_task.clone(),
         );
-        publish_a2a_task_update(&state, &terminal_task);
+        publish_a2a_task_update(&state, &terminal_task).await;
         for index in 0..4 {
             let unrelated_task = a2a_task_value(
                 &format!("unrelated-task-{index}"),
@@ -12757,7 +13033,7 @@ setTimeout(() => {
                 Vec::new(),
                 serde_json::json!({}),
             );
-            publish_a2a_task_update(&state, &unrelated_task);
+            publish_a2a_task_update(&state, &unrelated_task).await;
         }
 
         tokio::time::timeout(
@@ -12773,6 +13049,7 @@ setTimeout(() => {
         let response = String::from_utf8(response_bytes).expect("response should be utf-8");
 
         assert!(response.contains("TASK_STATE_COMPLETED"));
+        assert!(response.contains("halfway after lag"));
         assert!(response.contains("complete after lag"));
     }
 
@@ -15661,6 +15938,7 @@ setTimeout(() => {
             a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
             a2a_task_persist_lock: Arc::new(Mutex::new(())),
             a2a_task_events: broadcast::channel(256).0,
+            a2a_task_event_history: Arc::new(Mutex::new(HashMap::new())),
             a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
         };
         let (_client, mut server) = tcp_stream_pair().await;
@@ -15741,6 +16019,7 @@ setTimeout(() => {
             a2a_tasks: Arc::new(Mutex::new(HashMap::new())),
             a2a_task_persist_lock: Arc::new(Mutex::new(())),
             a2a_task_events: broadcast::channel(256).0,
+            a2a_task_event_history: Arc::new(Mutex::new(HashMap::new())),
             a2a_cancel_senders: Arc::new(Mutex::new(HashMap::new())),
         };
 

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -58,6 +58,8 @@ const A2A_DEFAULT_LIST_PAGE_SIZE: usize = 50;
 const A2A_MAX_LIST_PAGE_SIZE: usize = 100;
 const A2A_DEFAULT_SUBSCRIBE_TIMEOUT_MS: u64 = 60_000;
 const EVALOPS_A2A_EXTENSION_URI: &str = "https://evalops.com/a2a/extensions/operating-plane/v1";
+const A2A_CONTROL_PLANE_LEDGER_PEER: &str = "maestro-control-plane";
+const A2A_CONTROL_PLANE_LEDGER_DISPLAY_NAME: &str = "Maestro Control Plane";
 const CODEX_SUBAGENT_WORK_GRAPH_SCHEMA: &str = "evalops.maestro.codex.subagent-workgraph.v1";
 static CODEX_BRIDGE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static CODEX_HEADLESS_RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -984,6 +986,17 @@ async fn handle_a2a_task_subscribe(
         task.clone()
     };
 
+    if a2a_task_is_terminal(&current) {
+        return write_response_and_close(
+            stream,
+            a2a_error_response(
+                400,
+                "UNSUPPORTED_OPERATION",
+                "A2A terminal tasks cannot be subscribed to",
+            ),
+        )
+        .await;
+    }
     stream
         .write_all(sse_headers().as_bytes())
         .await
@@ -994,10 +1007,6 @@ async fn handle_a2a_task_subscribe(
         &serde_json::json!({ "statusUpdate": a2a_status_update_event(&current) }),
     )
     .await?;
-    if a2a_task_is_terminal(&current) {
-        let _ = stream.shutdown().await;
-        return Ok(());
-    }
 
     let timeout_ms = env_u64(
         "MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS",
@@ -1049,7 +1058,26 @@ async fn handle_a2a_task_subscribe(
 }
 
 async fn send_a2a_stream_response(stream: &mut TcpStream, value: &Value) -> Result<(), String> {
-    send_sse(stream, value).await
+    let Some(event_name) = a2a_stream_event_name(value) else {
+        return send_sse(stream, value).await;
+    };
+    let body = serde_json::to_string(value).map_err(|error| error.to_string())?;
+    stream
+        .write_all(format!("event: {event_name}\ndata: {body}\n\n").as_bytes())
+        .await
+        .map_err(|error| error.to_string())
+}
+
+fn a2a_stream_event_name(value: &Value) -> Option<&'static str> {
+    if value.get("task").is_some() {
+        Some("task")
+    } else if value.get("statusUpdate").is_some() {
+        Some("statusUpdate")
+    } else if value.get("artifactUpdate").is_some() {
+        Some("artifactUpdate")
+    } else {
+        None
+    }
 }
 
 fn a2a_status_update_event(task: &Value) -> Value {
@@ -1167,32 +1195,12 @@ fn a2a_task_visible_to_auth(task: &Value, auth: &AuthContext) -> bool {
 }
 
 async fn load_a2a_tasks(path: &Path) -> HashMap<String, Value> {
-    let raw = match tokio::fs::read_to_string(path).await {
-        Ok(raw) => raw,
-        Err(error) => {
-            if error.kind() != std::io::ErrorKind::NotFound {
-                eprintln!("failed to read A2A task ledger {}: {error}", path.display());
-            }
-            return HashMap::new();
-        }
+    let Some(parsed) = read_a2a_task_ledger_value(path).await else {
+        return HashMap::new();
     };
-    let parsed: Value = match serde_json::from_str(&raw) {
-        Ok(parsed) => parsed,
-        Err(error) => {
-            eprintln!(
-                "failed to parse A2A task ledger {}: {error}",
-                path.display()
-            );
-            return HashMap::new();
-        }
-    };
-    let tasks = parsed
-        .get("tasks")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    tasks
+    a2a_task_ledger_entries(&parsed)
         .into_iter()
+        .filter_map(|entry| a2a_task_from_ledger_entry(&entry))
         .filter_map(|task| {
             let task_id = task.get("id").and_then(Value::as_str)?.trim().to_string();
             (!task_id.is_empty()).then_some((task_id, task))
@@ -1200,27 +1208,162 @@ async fn load_a2a_tasks(path: &Path) -> HashMap<String, Value> {
         .collect()
 }
 
+async fn read_a2a_task_ledger_value(path: &Path) -> Option<Value> {
+    let raw = match tokio::fs::read_to_string(path).await {
+        Ok(raw) => raw,
+        Err(error) => {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                eprintln!("failed to read A2A task ledger {}: {error}", path.display());
+            }
+            return None;
+        }
+    };
+    match serde_json::from_str(&raw) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            eprintln!(
+                "failed to parse A2A task ledger {}: {error}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+fn a2a_task_ledger_entries(ledger: &Value) -> Vec<Value> {
+    ledger
+        .get("tasks")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn a2a_task_from_ledger_entry(entry: &Value) -> Option<Value> {
+    let peer = entry.get("peer").and_then(Value::as_str);
+    if peer.is_some_and(|peer| peer != A2A_CONTROL_PLANE_LEDGER_PEER) {
+        return None;
+    }
+    if let Some(task) = entry.get("a2aTask").and_then(Value::as_object) {
+        let task = Value::Object(task.clone());
+        if task.get("id").and_then(Value::as_str).is_some() {
+            return Some(task);
+        }
+    }
+    if entry.get("id").and_then(Value::as_str).is_some()
+        && entry.get("status").and_then(Value::as_object).is_some()
+    {
+        return Some(entry.clone());
+    }
+    if peer != Some(A2A_CONTROL_PLANE_LEDGER_PEER) {
+        return None;
+    }
+    let task_id = entry.get("taskId").and_then(Value::as_str)?;
+    let context_id = entry
+        .get("contextId")
+        .and_then(Value::as_str)
+        .unwrap_or("maestro-control-plane");
+    let state = entry
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or("TASK_STATE_UNKNOWN");
+    let updated_at = entry
+        .get("updatedAt")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(now_rfc3339);
+    let status_message_text = entry
+        .get("responseText")
+        .and_then(Value::as_str)
+        .or_else(|| entry.get("text").and_then(Value::as_str))
+        .unwrap_or("Restored A2A task from Maestro ledger.");
+    let status_message = a2a_agent_message(context_id, status_message_text);
+    let history = entry
+        .get("transcript")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| a2a_message_from_ledger_transcript(context_id, item))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let metadata = entry
+        .get("metadata")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+    let mut task = a2a_task_value(
+        task_id,
+        context_id,
+        state,
+        status_message,
+        history,
+        Vec::new(),
+        metadata,
+    );
+    task["status"]["timestamp"] = Value::String(updated_at);
+    Some(task)
+}
+
+fn a2a_message_from_ledger_transcript(context_id: &str, item: &Value) -> Option<Value> {
+    let text = item.get("text").and_then(Value::as_str)?.trim();
+    if text.is_empty() {
+        return None;
+    }
+    let role = match item.get("role").and_then(Value::as_str) {
+        Some(role) if role.eq_ignore_ascii_case("agent") => "ROLE_AGENT",
+        _ => "ROLE_USER",
+    };
+    let message_id = item
+        .get("messageId")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| generate_a2a_id("maestro-message"));
+    Some(serde_json::json!({
+        "messageId": message_id,
+        "contextId": context_id,
+        "role": role,
+        "parts": [{ "text": text, "mediaType": "text/plain" }]
+    }))
+}
+
 async fn persist_a2a_tasks(state: &AppState) {
     let _guard = state.a2a_task_persist_lock.lock().await;
-    let mut tasks = state
+    let existing_entries = read_a2a_task_ledger_value(&state.config.a2a_tasks_file_path)
+        .await
+        .map(|ledger| a2a_task_ledger_entries(&ledger))
+        .unwrap_or_default();
+    let mut retained_entries = existing_entries
+        .iter()
+        .filter(|entry| !a2a_ledger_entry_is_control_plane(entry))
+        .cloned()
+        .collect::<Vec<_>>();
+    let existing_control_plane_entries = existing_entries
+        .into_iter()
+        .filter(|entry| a2a_ledger_entry_is_control_plane(entry))
+        .filter_map(|entry| {
+            let task_id = entry.get("taskId").and_then(Value::as_str)?.to_string();
+            Some((task_id, entry))
+        })
+        .collect::<HashMap<_, _>>();
+    let mut control_plane_entries = state
         .a2a_tasks
         .lock()
         .await
         .values()
         .cloned()
+        .filter_map(|task| {
+            let task_id = task.get("id").and_then(Value::as_str)?;
+            let existing = existing_control_plane_entries.get(task_id);
+            Some(a2a_ledger_entry_from_task(&task, existing))
+        })
         .collect::<Vec<_>>();
-    tasks.sort_by(|left, right| {
-        a2a_task_status_timestamp(left)
-            .unwrap_or_default()
-            .cmp(a2a_task_status_timestamp(right).unwrap_or_default())
-            .then_with(|| {
-                left.get("id")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .cmp(right.get("id").and_then(Value::as_str).unwrap_or_default())
-            })
+    retained_entries.append(&mut control_plane_entries);
+    retained_entries.sort_by(|left, right| {
+        ledger_entry_updated_at(left)
+            .cmp(ledger_entry_updated_at(right))
+            .then_with(|| ledger_entry_task_id(left).cmp(ledger_entry_task_id(right)))
     });
-    let body = serde_json::to_vec_pretty(&serde_json::json!({ "tasks": tasks }))
+    let body = serde_json::to_vec_pretty(&serde_json::json!({ "tasks": retained_entries }))
         .unwrap_or_else(|_| br#"{"tasks":[]}"#.to_vec());
     let path = &state.config.a2a_tasks_file_path;
     if let Some(parent) = path.parent() {
@@ -1251,6 +1394,218 @@ async fn persist_a2a_tasks(state: &AppState) {
 
 fn publish_a2a_task_update(state: &AppState, task: &Value) {
     let _ = state.a2a_task_events.send(task.clone());
+}
+
+fn a2a_ledger_entry_is_control_plane(entry: &Value) -> bool {
+    entry.get("peer").and_then(Value::as_str) == Some(A2A_CONTROL_PLANE_LEDGER_PEER)
+}
+
+fn a2a_ledger_entry_from_task(task: &Value, existing: Option<&Value>) -> Value {
+    let task_id = task
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown-task");
+    let context_id = task.get("contextId").and_then(Value::as_str);
+    let state = a2a_task_status_state(task).unwrap_or("TASK_STATE_UNKNOWN");
+    let updated_at = a2a_task_status_timestamp(task)
+        .map(str::to_string)
+        .unwrap_or_else(now_rfc3339);
+    let transcript = a2a_task_transcript(task, state, &updated_at);
+    let text = transcript
+        .iter()
+        .find(|entry| entry.get("role").and_then(Value::as_str) == Some("user"))
+        .and_then(|entry| entry.get("text").and_then(Value::as_str))
+        .map(str::to_string)
+        .or_else(|| {
+            existing
+                .and_then(|entry| entry.get("text").and_then(Value::as_str))
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| format!("A2A task {task_id}"));
+    let response_text = a2a_task_response_text(task);
+    let created_at = existing
+        .and_then(|entry| entry.get("createdAt").and_then(Value::as_str))
+        .map(str::to_string)
+        .or_else(|| {
+            transcript
+                .first()
+                .and_then(|entry| entry.get("at").and_then(Value::as_str))
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| updated_at.clone());
+    let metadata = a2a_clean_ledger_metadata(task.get("metadata"));
+    let mut entry = serde_json::json!({
+        "id": existing
+            .and_then(|entry| entry.get("id").and_then(Value::as_str))
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("maestro-control-plane-{task_id}")),
+        "kind": "message",
+        "peer": A2A_CONTROL_PLANE_LEDGER_PEER,
+        "peerDisplayName": A2A_CONTROL_PLANE_LEDGER_DISPLAY_NAME,
+        "taskId": task_id,
+        "text": text,
+        "state": state,
+        "transcript": transcript,
+        "createdAt": created_at,
+        "updatedAt": updated_at,
+        "metadata": metadata,
+        "a2aTask": task
+    });
+    if let Some(context_id) = context_id {
+        entry["contextId"] = Value::String(context_id.to_string());
+    }
+    if let Some(message_id) = a2a_task_first_user_message_id(task) {
+        entry["messageId"] = Value::String(message_id);
+    }
+    if let Some(response_text) = response_text {
+        entry["responseText"] = Value::String(response_text);
+    }
+    if a2a_task_is_terminal(task) {
+        entry["completedAt"] = entry["updatedAt"].clone();
+    }
+    entry
+}
+
+fn a2a_task_transcript(task: &Value, state: &str, updated_at: &str) -> Vec<Value> {
+    task.get("history")
+        .and_then(Value::as_array)
+        .map(|history| {
+            history
+                .iter()
+                .filter_map(|message| a2a_transcript_entry_from_message(message, state, updated_at))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn a2a_transcript_entry_from_message(
+    message: &Value,
+    state: &str,
+    updated_at: &str,
+) -> Option<Value> {
+    let text = a2a_message_value_text(message)?;
+    let role = match message.get("role").and_then(Value::as_str) {
+        Some(role)
+            if role.eq_ignore_ascii_case("ROLE_AGENT") || role.eq_ignore_ascii_case("agent") =>
+        {
+            "agent"
+        }
+        _ => "user",
+    };
+    let mut entry = serde_json::json!({
+        "at": updated_at,
+        "role": role,
+        "text": text
+    });
+    if role == "agent" {
+        entry["state"] = Value::String(state.to_string());
+    }
+    if let Some(message_id) = message.get("messageId").and_then(Value::as_str) {
+        entry["messageId"] = Value::String(message_id.to_string());
+    }
+    Some(entry)
+}
+
+fn a2a_task_response_text(task: &Value) -> Option<String> {
+    task.get("status")
+        .and_then(|status| status.get("message"))
+        .and_then(a2a_message_value_text)
+        .or_else(|| {
+            task.get("artifacts")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .flat_map(|artifact| {
+                    artifact
+                        .get("parts")
+                        .and_then(Value::as_array)
+                        .into_iter()
+                        .flatten()
+                })
+                .filter_map(|part| part.get("text").and_then(Value::as_str))
+                .map(str::trim)
+                .find(|text| !text.is_empty())
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            task.get("history")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .rev()
+                .find(|message| {
+                    message
+                        .get("role")
+                        .and_then(Value::as_str)
+                        .is_some_and(|role| {
+                            role.eq_ignore_ascii_case("ROLE_AGENT")
+                                || role.eq_ignore_ascii_case("agent")
+                        })
+                })
+                .and_then(a2a_message_value_text)
+        })
+}
+
+fn a2a_message_value_text(message: &Value) -> Option<String> {
+    let text = message
+        .get("parts")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(|part| part.get("text").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    (!text.is_empty()).then_some(text)
+}
+
+fn a2a_task_first_user_message_id(task: &Value) -> Option<String> {
+    task.get("history")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .find(|message| {
+            message
+                .get("role")
+                .and_then(Value::as_str)
+                .is_none_or(|role| {
+                    role.eq_ignore_ascii_case("ROLE_USER") || role.eq_ignore_ascii_case("user")
+                })
+        })
+        .and_then(|message| message.get("messageId").and_then(Value::as_str))
+        .map(str::to_string)
+}
+
+fn a2a_clean_ledger_metadata(metadata: Option<&Value>) -> Value {
+    let object = metadata
+        .and_then(Value::as_object)
+        .map(|metadata| {
+            metadata
+                .iter()
+                .filter_map(|(key, value)| match value {
+                    Value::String(_) | Value::Number(_) | Value::Bool(_) => {
+                        Some((key.clone(), value.clone()))
+                    }
+                    _ => None,
+                })
+                .collect::<Map<_, _>>()
+        })
+        .unwrap_or_default();
+    Value::Object(object)
+}
+
+fn ledger_entry_updated_at(entry: &Value) -> &str {
+    entry
+        .get("updatedAt")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+}
+
+fn ledger_entry_task_id(entry: &Value) -> &str {
+    entry
+        .get("taskId")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
 }
 
 async fn a2a_list_tasks_response(
@@ -11345,6 +11700,26 @@ setTimeout(() => {
             config: Arc::new(config),
             ..base_state
         };
+        tokio::fs::write(
+            &state.config.a2a_tasks_file_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "tasks": [
+                    {
+                        "id": "remote-ledger-row",
+                        "kind": "message",
+                        "peer": "peer-b",
+                        "taskId": "remote-task",
+                        "text": "remote peer task",
+                        "state": "TASK_STATE_COMPLETED",
+                        "createdAt": "2026-05-15T00:00:00Z",
+                        "updatedAt": "2026-05-15T00:01:00Z"
+                    }
+                ]
+            }))
+            .expect("ledger should serialize"),
+        )
+        .await
+        .expect("existing ledger should be written");
         let task = a2a_task_value(
             "maestro-task-durable",
             "ctx-1",
@@ -11357,11 +11732,108 @@ setTimeout(() => {
 
         store_a2a_task_unless_canceled(&state, "maestro-task-durable", task).await;
         let loaded = load_a2a_tasks(&state.config.a2a_tasks_file_path).await;
+        let ledger: Value = serde_json::from_slice(
+            &tokio::fs::read(&state.config.a2a_tasks_file_path)
+                .await
+                .expect("ledger should be readable"),
+        )
+        .expect("ledger should be json");
+        let entries = ledger["tasks"]
+            .as_array()
+            .expect("ledger tasks should be an array");
+        let remote_entry = entries
+            .iter()
+            .find(|entry| entry["peer"] == "peer-b")
+            .expect("remote peer ledger row should be retained");
+        let control_plane_entry = entries
+            .iter()
+            .find(|entry| entry["peer"] == A2A_CONTROL_PLANE_LEDGER_PEER)
+            .expect("control-plane ledger row should be written");
 
+        assert_eq!(remote_entry["taskId"], "remote-task");
+        assert_eq!(control_plane_entry["taskId"], "maestro-task-durable");
+        assert_eq!(control_plane_entry["state"], "TASK_STATE_COMPLETED");
+        assert_eq!(
+            control_plane_entry["peerDisplayName"],
+            A2A_CONTROL_PLANE_LEDGER_DISPLAY_NAME
+        );
+        assert_eq!(control_plane_entry["a2aTask"]["id"], "maestro-task-durable");
+        assert!(!loaded.contains_key("remote-task"));
         assert_eq!(
             loaded["maestro-task-durable"]["metadata"]["workspaceId"],
             "ws-1"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_task_load_skips_remote_cli_ledger_entries() {
+        let root = TestDir::new("a2a-task-ledger-remote-skip");
+        let tasks_path = root.path().join("tasks.json");
+        tokio::fs::write(
+            &tasks_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "tasks": [
+                    {
+                        "id": "remote-ledger-row",
+                        "kind": "message",
+                        "peer": "peer-b",
+                        "taskId": "remote-task",
+                        "text": "remote peer task",
+                        "state": "TASK_STATE_COMPLETED",
+                        "createdAt": "2026-05-15T00:00:00Z",
+                        "updatedAt": "2026-05-15T00:01:00Z"
+                    },
+                    {
+                        "id": "raw-legacy-task",
+                        "contextId": "ctx-legacy",
+                        "status": {
+                            "state": "TASK_STATE_COMPLETED",
+                            "message": {
+                                "messageId": "legacy-msg",
+                                "contextId": "ctx-legacy",
+                                "role": "ROLE_AGENT",
+                                "parts": [{ "text": "legacy complete" }]
+                            }
+                        },
+                        "metadata": { "workspaceId": "legacy-ws" }
+                    },
+                    {
+                        "id": "maestro-control-plane-local-task",
+                        "kind": "message",
+                        "peer": A2A_CONTROL_PLANE_LEDGER_PEER,
+                        "taskId": "local-task",
+                        "contextId": "ctx-local",
+                        "text": "local request",
+                        "responseText": "local response",
+                        "state": "TASK_STATE_COMPLETED",
+                        "transcript": [
+                            { "role": "user", "text": "local request", "messageId": "msg-local" },
+                            { "role": "agent", "text": "local response", "state": "TASK_STATE_COMPLETED" }
+                        ],
+                        "createdAt": "2026-05-15T00:00:00Z",
+                        "updatedAt": "2026-05-15T00:02:00Z",
+                        "metadata": { "workspaceId": "local-ws" }
+                    }
+                ]
+            }))
+            .expect("ledger should serialize"),
+        )
+        .await
+        .expect("ledger should be written");
+
+        let loaded = load_a2a_tasks(&tasks_path).await;
+
+        assert!(!loaded.contains_key("remote-task"));
+        assert_eq!(
+            loaded["raw-legacy-task"]["metadata"]["workspaceId"],
+            "legacy-ws"
+        );
+        assert_eq!(loaded["local-task"]["metadata"]["workspaceId"], "local-ws");
+        assert_eq!(
+            loaded["local-task"]["status"]["message"]["parts"][0]["text"],
+            "local response"
+        );
+        assert_eq!(loaded["local-task"]["history"].as_array().unwrap().len(), 2);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -11393,6 +11865,9 @@ setTimeout(() => {
         let response = String::from_utf8(bytes).expect("response should be utf-8");
 
         assert!(response.contains("Content-Type: text/event-stream"));
+        assert!(response.contains("event: task"));
+        assert!(response.contains("event: statusUpdate"));
+        assert!(response.contains("event: artifactUpdate"));
         assert!(response.contains("\"statusUpdate\""));
         assert!(response.contains("\"artifactUpdate\""));
         assert!(response.contains("streamed fake response"));
@@ -11406,7 +11881,7 @@ setTimeout(() => {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn a2a_task_subscribe_streams_existing_terminal_snapshot() {
+    async fn a2a_task_subscribe_rejects_existing_terminal_task() {
         let state = test_app_state_with_sessions(HashMap::new());
         let task = a2a_task_value(
             "maestro-task-subscribe",
@@ -11439,10 +11914,87 @@ setTimeout(() => {
             .expect("subscribe task should join")
             .expect("subscribe endpoint should succeed");
         let response = String::from_utf8(bytes).expect("response should be utf-8");
+        let body: Value =
+            serde_json::from_str(response_body_text(&response)).expect("body should be json");
+
+        assert!(response.contains("400 Bad Request"));
+        assert_eq!(body["error"]["code"], "UNSUPPORTED_OPERATION");
+        assert!(body["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("terminal tasks cannot be subscribed"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_task_subscribe_streams_active_task_until_terminal_update() {
+        let state = test_app_state_with_sessions(HashMap::new());
+        let initial_task = a2a_task_value(
+            "maestro-task-active-subscribe",
+            "ctx-1",
+            "TASK_STATE_WORKING",
+            a2a_agent_message("ctx-1", "working"),
+            vec![a2a_agent_message("ctx-1", "working")],
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-active-subscribe".to_string(), initial_task);
+        let request = "GET /tasks/maestro-task-active-subscribe:subscribe HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n";
+        let initial = request.as_bytes().to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (mut client, server) = tcp_stream_pair().await;
+        let state_for_run = state.clone();
+        let run = tokio::spawn(async move {
+            handle_a2a_streaming_endpoint(server, initial, head, state_for_run).await
+        });
+        let mut response_bytes = vec![0_u8; 4096];
+        let initial_len =
+            tokio::time::timeout(Duration::from_secs(2), client.read(&mut response_bytes))
+                .await
+                .expect("subscribe response should start")
+                .expect("subscribe response should be readable");
+        response_bytes.truncate(initial_len);
+        let terminal_task = a2a_task_value(
+            "maestro-task-active-subscribe",
+            "ctx-1",
+            "TASK_STATE_COMPLETED",
+            a2a_agent_message("ctx-1", "complete"),
+            vec![
+                a2a_agent_message("ctx-1", "working"),
+                a2a_agent_message("ctx-1", "complete"),
+            ],
+            vec![serde_json::json!({
+                "artifactId": "artifact-1",
+                "parts": [{ "text": "artifact body", "mediaType": "text/plain" }]
+            })],
+            serde_json::json!({}),
+        );
+        state.a2a_tasks.lock().await.insert(
+            "maestro-task-active-subscribe".to_string(),
+            terminal_task.clone(),
+        );
+        publish_a2a_task_update(&state, &terminal_task);
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            client.read_to_end(&mut response_bytes),
+        )
+        .await
+        .expect("subscribe response should close")
+        .expect("subscribe response should be readable");
+        run.await
+            .expect("subscribe task should join")
+            .expect("subscribe endpoint should succeed");
+        let response = String::from_utf8(response_bytes).expect("response should be utf-8");
 
         assert!(response.contains("Content-Type: text/event-stream"));
-        assert!(response.contains("\"statusUpdate\""));
-        assert!(response.contains("maestro-task-subscribe"));
+        assert!(response.contains("event: task"));
+        assert!(response.contains("event: statusUpdate"));
+        assert!(response.contains("event: artifactUpdate"));
+        assert!(response.contains("TASK_STATE_COMPLETED"));
+        assert!(response.contains("artifact body"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -794,7 +794,7 @@ async fn handle_a2a_endpoint(
                 || a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found"),
                 |task| {
                     if a2a_task_visible_to_auth(task, &auth) {
-                        json_response(200, &a2a_task_for_query(task, &head, true))
+                        json_response(200, &a2a_task_for_query(task, true, None))
                     } else {
                         a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found")
                     }
@@ -1911,6 +1911,10 @@ async fn a2a_list_tasks_response(
         Ok(None) => false,
         Err(message) => return Err(a2a_error_response(400, "INVALID_REQUEST", &message)),
     };
+    let history_length = match a2a_usize_query(head, &["historyLength", "history_length"]) {
+        Ok(value) => value,
+        Err(message) => return Err(a2a_error_response(400, "INVALID_REQUEST", &message)),
+    };
 
     let mut tasks = state
         .a2a_tasks
@@ -1936,18 +1940,15 @@ async fn a2a_list_tasks_response(
                     .is_some_and(|timestamp| a2a_timestamp_at_or_after(timestamp, after))
             })
         })
-        .map(|task| a2a_task_for_query(task, head, include_artifacts))
+        .map(|task| a2a_task_for_query(task, include_artifacts, history_length))
         .collect::<Vec<_>>();
     tasks.sort_by(|left, right| {
-        a2a_task_status_timestamp(right)
-            .unwrap_or_default()
-            .cmp(a2a_task_status_timestamp(left).unwrap_or_default())
-            .then_with(|| {
-                left.get("id")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .cmp(right.get("id").and_then(Value::as_str).unwrap_or_default())
-            })
+        compare_a2a_task_status_timestamps_desc(left, right).then_with(|| {
+            left.get("id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .cmp(right.get("id").and_then(Value::as_str).unwrap_or_default())
+        })
     });
     let total_size = tasks.len();
     let page = tasks
@@ -1975,14 +1976,34 @@ fn a2a_timestamp_at_or_after(timestamp: &str, after: &str) -> bool {
     }
 }
 
-fn a2a_task_for_query(task: &Value, head: &RequestHead, include_artifacts: bool) -> Value {
+fn compare_a2a_task_status_timestamps_desc(left: &Value, right: &Value) -> std::cmp::Ordering {
+    let left_timestamp = a2a_task_status_timestamp(left);
+    let right_timestamp = a2a_task_status_timestamp(right);
+    match (
+        left_timestamp.and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok()),
+        right_timestamp.and_then(|timestamp| chrono::DateTime::parse_from_rfc3339(timestamp).ok()),
+    ) {
+        (Some(left), Some(right)) => right.cmp(&left),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => right_timestamp
+            .unwrap_or_default()
+            .cmp(left_timestamp.unwrap_or_default()),
+    }
+}
+
+fn a2a_task_for_query(
+    task: &Value,
+    include_artifacts: bool,
+    history_length: Option<usize>,
+) -> Value {
     let mut task = task.clone();
     if !include_artifacts {
         if let Some(task) = task.as_object_mut() {
             task.remove("artifacts");
         }
     }
-    if let Ok(Some(history_length)) = a2a_usize_query(head, &["historyLength", "history_length"]) {
+    if let Some(history_length) = history_length {
         if let Some(history) = task.get_mut("history").and_then(Value::as_array_mut) {
             if history_length == 0 {
                 history.clear();
@@ -11955,10 +11976,31 @@ setTimeout(() => {
     #[tokio::test(flavor = "current_thread")]
     async fn a2a_tasks_list_supports_spec_filters_pagination_and_payload_trimming() {
         let state = test_app_state_with_sessions(HashMap::new());
-        for (task_id, context_id, status, minute) in [
-            ("task-a", "ctx-1", "TASK_STATE_COMPLETED", 3),
-            ("task-b", "ctx-1", "TASK_STATE_COMPLETED", 2),
-            ("task-c", "ctx-2", "TASK_STATE_WORKING", 1),
+        for (task_id, context_id, status, timestamp) in [
+            (
+                "task-a",
+                "ctx-1",
+                "TASK_STATE_COMPLETED",
+                "2026-05-15T00:03:00+00:00",
+            ),
+            (
+                "task-b",
+                "ctx-1",
+                "TASK_STATE_COMPLETED",
+                "2026-05-15T00:02:00Z",
+            ),
+            (
+                "task-c",
+                "ctx-2",
+                "TASK_STATE_WORKING",
+                "2026-05-15T00:01:00Z",
+            ),
+            (
+                "task-d",
+                "ctx-1",
+                "TASK_STATE_COMPLETED",
+                "2026-05-14T19:04:00-05:00",
+            ),
         ] {
             let mut task = a2a_task_value(
                 task_id,
@@ -11975,11 +12017,7 @@ setTimeout(() => {
                 })],
                 serde_json::json!({}),
             );
-            task["status"]["timestamp"] = Value::String(if task_id == "task-a" {
-                "2026-05-15T00:03:00+00:00".to_string()
-            } else {
-                format!("2026-05-15T00:0{minute}:00Z")
-            });
+            task["status"]["timestamp"] = Value::String(timestamp.to_string());
             state
                 .a2a_tasks
                 .lock()
@@ -11997,11 +12035,11 @@ setTimeout(() => {
             .as_array()
             .expect("tasks should be an array");
 
-        assert_eq!(response["totalSize"], 2);
+        assert_eq!(response["totalSize"], 3);
         assert_eq!(response["pageSize"], 1);
         assert_eq!(response["nextPageToken"], "1");
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0]["id"], "task-a");
+        assert_eq!(tasks[0]["id"], "task-d");
         assert_eq!(tasks[0]["history"].as_array().unwrap().len(), 1);
         assert!(tasks[0].get("artifacts").is_none());
 
@@ -12016,8 +12054,27 @@ setTimeout(() => {
             .as_array()
             .expect("tasks should be an array");
 
-        assert_eq!(response["totalSize"], 1);
-        assert_eq!(tasks[0]["id"], "task-a");
+        assert_eq!(response["totalSize"], 2);
+        assert_eq!(tasks[0]["id"], "task-d");
+        assert_eq!(tasks[1]["id"], "task-a");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_tasks_list_rejects_invalid_history_length() {
+        let state = test_app_state_with_sessions(HashMap::new());
+        let request = "GET /tasks?historyLength=abc HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n";
+        let mut initial = request.as_bytes().to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert_eq!(response["error"]["code"], "INVALID_REQUEST");
+        assert_eq!(
+            response["error"]["message"],
+            "A2A query parameter historyLength must be an integer"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -57,6 +57,11 @@ const A2A_TERMINAL_TASK_STORE_LIMIT: usize = 128;
 const A2A_DEFAULT_LIST_PAGE_SIZE: usize = 50;
 const A2A_MAX_LIST_PAGE_SIZE: usize = 100;
 const A2A_DEFAULT_SUBSCRIBE_TIMEOUT_MS: u64 = 60_000;
+const A2A_LEDGER_LOCK_RETRY_MS: u64 = 25;
+const A2A_LEDGER_LOCK_STALE_MS: u64 = 30_000;
+const A2A_LEDGER_LOCK_TIMEOUT_MS: u64 = A2A_LEDGER_LOCK_STALE_MS + A2A_LEDGER_LOCK_RETRY_MS;
+const A2A_LEDGER_LOCK_OWNER_FILE: &str = "owner";
+const A2A_LEDGER_LOCK_HEARTBEAT_FILE: &str = "heartbeat";
 const EVALOPS_A2A_EXTENSION_URI: &str = "https://evalops.com/a2a/extensions/operating-plane/v1";
 const A2A_CONTROL_PLANE_LEDGER_PEER: &str = "maestro-control-plane";
 const A2A_CONTROL_PLANE_LEDGER_DISPLAY_NAME: &str = "Maestro Control Plane";
@@ -915,20 +920,27 @@ async fn handle_a2a_message_stream(
     let task_id = target.task_id;
     let context_id = target.context_id;
     let history = target.history;
-    let previous_task = target.previous_task;
+    let mut previous_task = target.previous_task;
     let metadata = target.metadata;
     let (cancel_tx, cancel_rx) = watch::channel(false);
     if let Err(response) = register_a2a_cancel_sender(state, &task_id, cancel_tx).await {
-        rollback_a2a_send_claim(state, &task_id, previous_task).await;
+        rollback_a2a_send_claim(state, &task_id, previous_task.take()).await;
         return write_response_and_close(stream, response).await;
     }
 
-    stream
-        .write_all(sse_headers().as_bytes())
-        .await
-        .map_err(|error| error.to_string())?;
+    if let Err(error) = stream.write_all(sse_headers().as_bytes()).await {
+        state.a2a_cancel_senders.lock().await.remove(&task_id);
+        rollback_a2a_send_claim(state, &task_id, previous_task.take()).await;
+        return Err(error.to_string());
+    }
     if let Some(task) = state.a2a_tasks.lock().await.get(&task_id).cloned() {
-        send_a2a_stream_response(stream, &serde_json::json!({ "task": task })).await?;
+        if let Err(error) =
+            send_a2a_stream_response(stream, &serde_json::json!({ "task": task })).await
+        {
+            state.a2a_cancel_senders.lock().await.remove(&task_id);
+            rollback_a2a_send_claim(state, &task_id, previous_task.take()).await;
+            return Err(error);
+        }
     }
     let task = complete_a2a_task(
         state, prompt, task_id, context_id, history, metadata, cancel_rx,
@@ -1328,13 +1340,31 @@ fn a2a_message_from_ledger_transcript(context_id: &str, item: &Value) -> Option<
 
 async fn persist_a2a_tasks(state: &AppState) {
     let _guard = state.a2a_task_persist_lock.lock().await;
+    let file_lock = match acquire_a2a_task_ledger_file_lock(&state.config.a2a_tasks_file_path).await
+    {
+        Ok(file_lock) => file_lock,
+        Err(error) => {
+            eprintln!("{error}");
+            return;
+        }
+    };
+    let result = persist_a2a_tasks_locked(state).await;
+    release_a2a_task_ledger_file_lock(file_lock).await;
+    if let Err(error) = result {
+        eprintln!("{error}");
+    }
+}
+
+async fn persist_a2a_tasks_locked(state: &AppState) -> Result<(), String> {
     let existing_entries = read_a2a_task_ledger_value(&state.config.a2a_tasks_file_path)
         .await
         .map(|ledger| a2a_task_ledger_entries(&ledger))
         .unwrap_or_default();
     let mut retained_entries = existing_entries
         .iter()
-        .filter(|entry| !a2a_ledger_entry_is_control_plane(entry))
+        .filter(|entry| {
+            !a2a_ledger_entry_is_control_plane(entry) && !a2a_ledger_entry_is_raw_a2a_task(entry)
+        })
         .cloned()
         .collect::<Vec<_>>();
     let existing_control_plane_entries = existing_entries
@@ -1368,28 +1398,175 @@ async fn persist_a2a_tasks(state: &AppState) {
     let path = &state.config.a2a_tasks_file_path;
     if let Some(parent) = path.parent() {
         if let Err(error) = tokio::fs::create_dir_all(parent).await {
-            eprintln!(
+            return Err(format!(
                 "failed to create A2A task ledger directory {}: {error}",
                 parent.display()
-            );
-            return;
+            ));
         }
     }
-    let tmp_path = path.with_extension("json.tmp");
+    let tmp_path = a2a_task_ledger_temp_path(path);
     if let Err(error) = tokio::fs::write(&tmp_path, body).await {
-        eprintln!(
+        return Err(format!(
             "failed to write A2A task ledger {}: {error}",
             tmp_path.display()
-        );
-        return;
+        ));
     }
     if let Err(error) = tokio::fs::rename(&tmp_path, path).await {
-        eprintln!(
+        let message = format!(
             "failed to replace A2A task ledger {}: {error}",
             path.display()
         );
         let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(message);
     }
+    Ok(())
+}
+
+struct A2ATaskLedgerFileLock {
+    path: PathBuf,
+    token: String,
+}
+
+async fn acquire_a2a_task_ledger_file_lock(path: &Path) -> Result<A2ATaskLedgerFileLock, String> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|error| {
+            format!(
+                "failed to create A2A task ledger directory {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    let lock_path = a2a_task_ledger_lock_path(path);
+    let token = format!(
+        "{}:{}",
+        process::id(),
+        ATTACHMENT_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    );
+    let deadline = Instant::now() + Duration::from_millis(A2A_LEDGER_LOCK_TIMEOUT_MS);
+    loop {
+        match tokio::fs::create_dir(&lock_path).await {
+            Ok(()) => {
+                if let Err(error) = write_a2a_task_ledger_lock_metadata(&lock_path, &token).await {
+                    let _ = tokio::fs::remove_dir_all(&lock_path).await;
+                    return Err(error);
+                }
+                return Ok(A2ATaskLedgerFileLock {
+                    path: lock_path,
+                    token,
+                });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if a2a_task_ledger_lock_is_stale(&lock_path).await {
+                    let _ = tokio::fs::remove_dir_all(&lock_path).await;
+                    continue;
+                }
+                if Instant::now() >= deadline {
+                    return Err(format!(
+                        "timed out waiting for A2A task ledger lock {}",
+                        lock_path.display()
+                    ));
+                }
+                tokio::time::sleep(Duration::from_millis(A2A_LEDGER_LOCK_RETRY_MS)).await;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to acquire A2A task ledger lock {}: {error}",
+                    lock_path.display()
+                ));
+            }
+        }
+    }
+}
+
+async fn write_a2a_task_ledger_lock_metadata(lock_path: &Path, token: &str) -> Result<(), String> {
+    tokio::fs::write(
+        lock_path.join(A2A_LEDGER_LOCK_OWNER_FILE),
+        format!("{token}\n"),
+    )
+    .await
+    .map_err(|error| {
+        format!(
+            "failed to write A2A task ledger lock owner {}: {error}",
+            lock_path.display()
+        )
+    })?;
+    write_a2a_task_ledger_lock_heartbeat(lock_path).await
+}
+
+async fn write_a2a_task_ledger_lock_heartbeat(lock_path: &Path) -> Result<(), String> {
+    tokio::fs::write(
+        lock_path.join(A2A_LEDGER_LOCK_HEARTBEAT_FILE),
+        format!("{}\n", unix_millis_now()),
+    )
+    .await
+    .map_err(|error| {
+        format!(
+            "failed to write A2A task ledger lock heartbeat {}: {error}",
+            lock_path.display()
+        )
+    })
+}
+
+async fn release_a2a_task_ledger_file_lock(file_lock: A2ATaskLedgerFileLock) {
+    if a2a_task_ledger_lock_is_owned(&file_lock.path, &file_lock.token).await {
+        let _ = tokio::fs::remove_dir_all(&file_lock.path).await;
+    }
+}
+
+async fn a2a_task_ledger_lock_is_owned(lock_path: &Path, token: &str) -> bool {
+    tokio::fs::read_to_string(lock_path.join(A2A_LEDGER_LOCK_OWNER_FILE))
+        .await
+        .map(|owner| owner.trim() == token)
+        .unwrap_or(false)
+}
+
+async fn a2a_task_ledger_lock_is_stale(lock_path: &Path) -> bool {
+    let modified_at = match a2a_task_ledger_lock_modified_at(lock_path).await {
+        Some(modified_at) => modified_at,
+        None => return true,
+    };
+    SystemTime::now()
+        .duration_since(modified_at)
+        .map(|age| age > Duration::from_millis(A2A_LEDGER_LOCK_STALE_MS))
+        .unwrap_or(false)
+}
+
+async fn a2a_task_ledger_lock_modified_at(lock_path: &Path) -> Option<SystemTime> {
+    for path in [
+        lock_path.join(A2A_LEDGER_LOCK_HEARTBEAT_FILE),
+        lock_path.join(A2A_LEDGER_LOCK_OWNER_FILE),
+        lock_path.to_path_buf(),
+    ] {
+        match tokio::fs::metadata(&path).await {
+            Ok(metadata) => return metadata.modified().ok(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => return None,
+        }
+    }
+    None
+}
+
+fn a2a_task_ledger_lock_path(path: &Path) -> PathBuf {
+    let mut lock_path = path.as_os_str().to_os_string();
+    lock_path.push(".lock");
+    PathBuf::from(lock_path)
+}
+
+fn a2a_task_ledger_temp_path(path: &Path) -> PathBuf {
+    let mut tmp_path = path.as_os_str().to_os_string();
+    tmp_path.push(format!(
+        ".{}.{}.tmp",
+        process::id(),
+        ATTACHMENT_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    PathBuf::from(tmp_path)
+}
+
+fn unix_millis_now() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
 }
 
 fn publish_a2a_task_update(state: &AppState, task: &Value) {
@@ -1398,6 +1575,13 @@ fn publish_a2a_task_update(state: &AppState, task: &Value) {
 
 fn a2a_ledger_entry_is_control_plane(entry: &Value) -> bool {
     entry.get("peer").and_then(Value::as_str) == Some(A2A_CONTROL_PLANE_LEDGER_PEER)
+}
+
+fn a2a_ledger_entry_is_raw_a2a_task(entry: &Value) -> bool {
+    entry.get("peer").is_none()
+        && entry.get("taskId").is_none()
+        && entry.get("id").and_then(Value::as_str).is_some()
+        && entry.get("status").and_then(Value::as_object).is_some()
 }
 
 fn a2a_ledger_entry_from_task(task: &Value, existing: Option<&Value>) -> Value {
@@ -10964,6 +11148,16 @@ setTimeout(() => {
             validate_csrf(&csrf_head_for_path("POST", "/message:send", None), &config).is_err()
         );
         assert!(validate_csrf(
+            &csrf_head_for_path("POST", "/message:stream", Some("csrf-token")),
+            &config,
+        )
+        .is_ok());
+        assert!(validate_csrf(
+            &csrf_head_for_path("POST", "/message:stream", None),
+            &config
+        )
+        .is_err());
+        assert!(validate_csrf(
             &csrf_head_for_path("POST", "/tasks/maestro-task-1:cancel", Some("csrf-token")),
             &config,
         )
@@ -11713,6 +11907,29 @@ setTimeout(() => {
                         "state": "TASK_STATE_COMPLETED",
                         "createdAt": "2026-05-15T00:00:00Z",
                         "updatedAt": "2026-05-15T00:01:00Z"
+                    },
+                    {
+                        "id": "raw-legacy-task",
+                        "contextId": "ctx-legacy",
+                        "status": {
+                            "state": "TASK_STATE_COMPLETED",
+                            "message": {
+                                "messageId": "legacy-msg",
+                                "contextId": "ctx-legacy",
+                                "role": "ROLE_AGENT",
+                                "parts": [{ "text": "legacy complete" }]
+                            },
+                            "timestamp": "2026-05-15T00:02:00Z"
+                        },
+                        "history": [
+                            {
+                                "messageId": "legacy-user",
+                                "contextId": "ctx-legacy",
+                                "role": "ROLE_USER",
+                                "parts": [{ "text": "legacy request" }]
+                            }
+                        ],
+                        "metadata": { "workspaceId": "legacy-ws" }
                     }
                 ]
             }))
@@ -11729,6 +11946,15 @@ setTimeout(() => {
             Vec::new(),
             serde_json::json!({ "workspaceId": "ws-1" }),
         );
+        let raw_legacy_task = load_a2a_tasks(&state.config.a2a_tasks_file_path)
+            .await
+            .remove("raw-legacy-task")
+            .expect("raw legacy task should hydrate before migration");
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("raw-legacy-task".to_string(), raw_legacy_task);
 
         store_a2a_task_unless_canceled(&state, "maestro-task-durable", task).await;
         let loaded = load_a2a_tasks(&state.config.a2a_tasks_file_path).await;
@@ -11747,8 +11973,15 @@ setTimeout(() => {
             .expect("remote peer ledger row should be retained");
         let control_plane_entry = entries
             .iter()
-            .find(|entry| entry["peer"] == A2A_CONTROL_PLANE_LEDGER_PEER)
+            .find(|entry| {
+                entry["peer"] == A2A_CONTROL_PLANE_LEDGER_PEER
+                    && entry["taskId"] == "maestro-task-durable"
+            })
             .expect("control-plane ledger row should be written");
+        let raw_legacy_entries = entries
+            .iter()
+            .filter(|entry| entry["id"] == "raw-legacy-task")
+            .count();
 
         assert_eq!(remote_entry["taskId"], "remote-task");
         assert_eq!(control_plane_entry["taskId"], "maestro-task-durable");
@@ -11758,10 +11991,71 @@ setTimeout(() => {
             A2A_CONTROL_PLANE_LEDGER_DISPLAY_NAME
         );
         assert_eq!(control_plane_entry["a2aTask"]["id"], "maestro-task-durable");
+        assert_eq!(
+            raw_legacy_entries, 0,
+            "raw legacy A2A rows should be migrated away from the shared TS ledger shape"
+        );
+        assert!(entries.iter().any(|entry| {
+            entry["peer"] == A2A_CONTROL_PLANE_LEDGER_PEER
+                && entry["taskId"] == "raw-legacy-task"
+                && entry["a2aTask"]["id"] == "raw-legacy-task"
+        }));
         assert!(!loaded.contains_key("remote-task"));
         assert_eq!(
             loaded["maestro-task-durable"]["metadata"]["workspaceId"],
             "ws-1"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_task_store_waits_for_shared_ledger_file_lock() {
+        let root = TestDir::new("a2a-task-ledger-lock");
+        let base_state = test_app_state_with_sessions(HashMap::new());
+        let mut config = auth_test_config();
+        config.a2a_tasks_file_path = root.path().join("tasks.json");
+        let state = AppState {
+            config: Arc::new(config),
+            ..base_state
+        };
+        let lock_path = a2a_task_ledger_lock_path(&state.config.a2a_tasks_file_path);
+        tokio::fs::create_dir_all(&lock_path)
+            .await
+            .expect("test lock should be created");
+        let task = a2a_task_value(
+            "maestro-task-locked",
+            "ctx-1",
+            "TASK_STATE_COMPLETED",
+            a2a_agent_message("ctx-1", "complete"),
+            Vec::new(),
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        let state_for_store = state.clone();
+        let store = tokio::spawn(async move {
+            store_a2a_task_unless_canceled(&state_for_store, "maestro-task-locked", task).await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(A2A_LEDGER_LOCK_RETRY_MS * 3)).await;
+        assert!(
+            tokio::fs::try_exists(&state.config.a2a_tasks_file_path)
+                .await
+                .expect("ledger existence should be checkable")
+                == false,
+            "persist should wait for the shared TS ledger lock before writing"
+        );
+        tokio::fs::remove_dir_all(&lock_path)
+            .await
+            .expect("test lock should be released");
+        tokio::time::timeout(Duration::from_secs(2), store)
+            .await
+            .expect("store should finish after lock release")
+            .expect("store task should join");
+
+        assert!(
+            tokio::fs::try_exists(&state.config.a2a_tasks_file_path)
+                .await
+                .expect("ledger existence should be checkable"),
+            "ledger should be written after lock release"
         );
     }
 

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -714,14 +714,6 @@ fn a2a_task_id_from_get_path(path: &str) -> Option<&str> {
     (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
 }
 
-fn a2a_task_id_from_subscribe_path(path: &str) -> Option<&str> {
-    let id = path
-        .strip_prefix("/tasks/")?
-        .strip_suffix(":subscribe")
-        .or_else(|| path.strip_prefix("/tasks/")?.strip_suffix("/subscribe"))?;
-    (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
-}
-
 fn validate_a2a_protocol_version(head: &RequestHead) -> Result<(), Vec<u8>> {
     let Some(version) = a2a_requested_protocol_version(head) else {
         return Ok(());
@@ -11285,6 +11277,20 @@ setTimeout(() => {
         .is_ok());
         assert!(validate_csrf(
             &csrf_head_for_path("POST", "/tasks/maestro-task-1:cancel", None),
+            &config
+        )
+        .is_err());
+        assert!(validate_csrf(
+            &csrf_head_for_path(
+                "POST",
+                "/tasks/maestro-task-1:subscribe",
+                Some("csrf-token")
+            ),
+            &config,
+        )
+        .is_ok());
+        assert!(validate_csrf(
+            &csrf_head_for_path("POST", "/tasks/maestro-task-1:subscribe", None),
             &config
         )
         .is_err());

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1880,7 +1880,9 @@ async fn a2a_list_tasks_response(
 fn a2a_task_for_query(task: &Value, head: &RequestHead, include_artifacts: bool) -> Value {
     let mut task = task.clone();
     if !include_artifacts {
-        task["artifacts"] = Value::Array(Vec::new());
+        if let Some(task) = task.as_object_mut() {
+            task.remove("artifacts");
+        }
     }
     if let Ok(Some(history_length)) = a2a_usize_query(head, &["historyLength", "history_length"]) {
         if let Some(history) = task.get_mut("history").and_then(Value::as_array_mut) {
@@ -11881,7 +11883,7 @@ setTimeout(() => {
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0]["id"], "task-a");
         assert_eq!(tasks[0]["history"].as_array().unwrap().len(), 1);
-        assert_eq!(tasks[0]["artifacts"].as_array().unwrap().len(), 0);
+        assert!(tasks[0].get("artifacts").is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -57,6 +57,7 @@ const A2A_TERMINAL_TASK_STORE_LIMIT: usize = 128;
 const A2A_DEFAULT_LIST_PAGE_SIZE: usize = 50;
 const A2A_MAX_LIST_PAGE_SIZE: usize = 100;
 const A2A_DEFAULT_SUBSCRIBE_TIMEOUT_MS: u64 = 60_000;
+const A2A_DEFAULT_SUBSCRIBE_HEARTBEAT_MS: u64 = 15_000;
 const A2A_LEDGER_LOCK_RETRY_MS: u64 = 25;
 const A2A_LEDGER_LOCK_STALE_MS: u64 = 30_000;
 const A2A_LEDGER_LOCK_TIMEOUT_MS: u64 = A2A_LEDGER_LOCK_STALE_MS + A2A_LEDGER_LOCK_RETRY_MS;
@@ -697,12 +698,9 @@ fn is_a2a_endpoint(head: &RequestHead) -> bool {
         ("GET", "/.well-known/agent-card.json")
             | ("GET", "/extendedAgentCard")
             | ("POST", "/message:send")
-            | ("POST", "/message:stream")
             | ("GET", "/tasks")
     ) || (head.method == "GET" && a2a_task_id_from_get_path(&head.path).is_some())
         || (head.method == "POST" && a2a_task_id_from_cancel_path(&head.path).is_some())
-        || (head.method == "GET" && a2a_task_id_from_subscribe_path(&head.path).is_some())
-        || (head.method == "POST" && a2a_task_id_from_subscribe_path(&head.path).is_some())
 }
 
 fn is_a2a_streaming_endpoint(head: &RequestHead) -> bool {
@@ -1020,21 +1018,37 @@ async fn handle_a2a_task_subscribe(
     )
     .await?;
 
-    let heartbeat_interval = Duration::from_millis(
+    let subscribe_timeout = Duration::from_millis(
         env_u64(
             "MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS",
             A2A_DEFAULT_SUBSCRIBE_TIMEOUT_MS,
         )
         .max(1),
     );
+    let heartbeat_interval = Duration::from_millis(
+        env_u64(
+            "MAESTRO_A2A_SUBSCRIBE_HEARTBEAT_MS",
+            A2A_DEFAULT_SUBSCRIBE_HEARTBEAT_MS,
+        )
+        .max(1),
+    );
+    let deadline = Instant::now() + subscribe_timeout;
     loop {
-        let event = match tokio::time::timeout(heartbeat_interval, receiver.recv()).await {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let wait_timeout = remaining.min(heartbeat_interval);
+        let event = match tokio::time::timeout(wait_timeout, receiver.recv()).await {
             Ok(Ok(task)) => Some(task),
             Ok(Err(broadcast::error::RecvError::Lagged(_))) => {
                 current_a2a_subscribe_task(state, task_id, auth).await
             }
             Ok(Err(broadcast::error::RecvError::Closed)) => break,
             Err(_) => {
+                if Instant::now() >= deadline {
+                    break;
+                }
                 stream
                     .write_all(b": keep-alive\n\n")
                     .await
@@ -11355,14 +11369,32 @@ setTimeout(() => {
             "POST /message:send HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "GET /tasks/maestro-task-1 HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "GET /tasks HTTP/1.1\r\nHost: localhost\r\n\r\n",
-            "POST /message:stream HTTP/1.1\r\nHost: localhost\r\n\r\n",
-            "GET /tasks/maestro-task-1:subscribe HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "GET /extendedAgentCard HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "POST /tasks/maestro-task-1:cancel HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "OPTIONS /message:send HTTP/1.1\r\nHost: localhost\r\n\r\n",
         ] {
             let head = parse_request_head(request.as_bytes()).expect("request should parse");
             assert!(is_a2a_endpoint(&head), "{request} should be A2A");
+        }
+    }
+
+    #[test]
+    fn detects_a2a_streaming_routes_separately() {
+        for request in [
+            "POST /message:stream HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "GET /tasks/maestro-task-1:subscribe HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "POST /tasks/maestro-task-1:subscribe HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "GET /tasks/maestro-task-1/subscribe HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        ] {
+            let head = parse_request_head(request.as_bytes()).expect("request should parse");
+            assert!(
+                is_a2a_streaming_endpoint(&head),
+                "{request} should be streaming A2A"
+            );
+            assert!(
+                !is_a2a_endpoint(&head),
+                "{request} should not be handled by non-streaming A2A routing"
+            );
         }
     }
 
@@ -12453,7 +12485,9 @@ setTimeout(() => {
     async fn a2a_task_subscribe_streams_active_task_until_terminal_update() {
         let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
         let previous_timeout = env::var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS").ok();
-        env::set_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS", "10");
+        let previous_heartbeat = env::var("MAESTRO_A2A_SUBSCRIBE_HEARTBEAT_MS").ok();
+        env::set_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS", "250");
+        env::set_var("MAESTRO_A2A_SUBSCRIBE_HEARTBEAT_MS", "10");
         let state = test_app_state_with_sessions(HashMap::new());
         let initial_task = a2a_task_value(
             "maestro-task-active-subscribe",
@@ -12528,6 +12562,70 @@ setTimeout(() => {
             env::set_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS", previous_timeout);
         } else {
             env::remove_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS");
+        }
+        if let Some(previous_heartbeat) = previous_heartbeat {
+            env::set_var("MAESTRO_A2A_SUBSCRIBE_HEARTBEAT_MS", previous_heartbeat);
+        } else {
+            env::remove_var("MAESTRO_A2A_SUBSCRIBE_HEARTBEAT_MS");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_task_subscribe_times_out_active_stream() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_timeout = env::var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS").ok();
+        let previous_heartbeat = env::var("MAESTRO_A2A_SUBSCRIBE_HEARTBEAT_MS").ok();
+        env::set_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS", "40");
+        env::set_var("MAESTRO_A2A_SUBSCRIBE_HEARTBEAT_MS", "10");
+        let state = test_app_state_with_sessions(HashMap::new());
+        let initial_task = a2a_task_value(
+            "maestro-task-timeout-subscribe",
+            "ctx-1",
+            "TASK_STATE_WORKING",
+            a2a_agent_message("ctx-1", "working"),
+            vec![a2a_agent_message("ctx-1", "working")],
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-timeout-subscribe".to_string(), initial_task);
+        let request = "GET /tasks/maestro-task-timeout-subscribe:subscribe HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n";
+        let initial = request.as_bytes().to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (mut client, server) = tcp_stream_pair().await;
+        let state_for_run = state.clone();
+        let run = tokio::spawn(async move {
+            handle_a2a_streaming_endpoint(server, initial, head, state_for_run).await
+        });
+        let mut response_bytes = Vec::new();
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            client.read_to_end(&mut response_bytes),
+        )
+        .await
+        .expect("subscribe response should close after timeout")
+        .expect("subscribe response should be readable");
+        run.await
+            .expect("subscribe task should join")
+            .expect("subscribe endpoint should succeed");
+        let response = String::from_utf8(response_bytes).expect("response should be utf-8");
+
+        assert!(response.contains("Content-Type: text/event-stream"));
+        assert!(response.contains("TASK_STATE_WORKING"));
+        assert!(response.contains(": keep-alive"));
+
+        if let Some(previous_timeout) = previous_timeout {
+            env::set_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS", previous_timeout);
+        } else {
+            env::remove_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS");
+        }
+        if let Some(previous_heartbeat) = previous_heartbeat {
+            env::set_var("MAESTRO_A2A_SUBSCRIBE_HEARTBEAT_MS", previous_heartbeat);
+        } else {
+            env::remove_var("MAESTRO_A2A_SUBSCRIBE_HEARTBEAT_MS");
         }
     }
 

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1029,8 +1029,10 @@ async fn handle_a2a_task_subscribe(
     );
     loop {
         let event = match tokio::time::timeout(heartbeat_interval, receiver.recv()).await {
-            Ok(Ok(task)) => task,
-            Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Ok(task)) => Some(task),
+            Ok(Err(broadcast::error::RecvError::Lagged(_))) => {
+                current_a2a_subscribe_task(state, task_id, auth).await
+            }
             Ok(Err(broadcast::error::RecvError::Closed)) => break,
             Err(_) => {
                 stream
@@ -1040,38 +1042,62 @@ async fn handle_a2a_task_subscribe(
                 continue;
             }
         };
+        let Some(event) = event else {
+            continue;
+        };
         if event.get("id").and_then(Value::as_str) != Some(task_id) {
             continue;
         }
-        if !a2a_task_visible_to_auth(&event, auth) {
-            continue;
-        }
-        send_a2a_stream_response(
-            stream,
-            &serde_json::json!({ "statusUpdate": a2a_status_update_event(&event) }),
-        )
-        .await?;
-        if a2a_task_is_terminal(&event) {
-            for artifact in event
-                .get("artifacts")
-                .and_then(Value::as_array)
-                .into_iter()
-                .flatten()
-            {
-                send_a2a_stream_response(
-                    stream,
-                    &serde_json::json!({
-                        "artifactUpdate": a2a_artifact_update_event(&event, artifact)
-                    }),
-                )
-                .await?;
-            }
-            send_a2a_stream_response(stream, &serde_json::json!({ "task": event })).await?;
+        if send_a2a_subscribe_task_update(stream, &event, auth).await? {
             break;
         }
     }
     let _ = stream.shutdown().await;
     Ok(())
+}
+
+async fn current_a2a_subscribe_task(
+    state: &AppState,
+    task_id: &str,
+    auth: &AuthContext,
+) -> Option<Value> {
+    let tasks = state.a2a_tasks.lock().await;
+    let task = tasks.get(task_id)?;
+    a2a_task_visible_to_auth(task, auth).then(|| task.clone())
+}
+
+async fn send_a2a_subscribe_task_update(
+    stream: &mut TcpStream,
+    task: &Value,
+    auth: &AuthContext,
+) -> Result<bool, String> {
+    if !a2a_task_visible_to_auth(task, auth) {
+        return Ok(false);
+    }
+    send_a2a_stream_response(
+        stream,
+        &serde_json::json!({ "statusUpdate": a2a_status_update_event(task) }),
+    )
+    .await?;
+    if a2a_task_is_terminal(task) {
+        for artifact in task
+            .get("artifacts")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            send_a2a_stream_response(
+                stream,
+                &serde_json::json!({
+                    "artifactUpdate": a2a_artifact_update_event(task, artifact)
+                }),
+            )
+            .await?;
+        }
+        send_a2a_stream_response(stream, &serde_json::json!({ "task": task })).await?;
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 async fn send_a2a_stream_response(stream: &mut TcpStream, value: &Value) -> Result<(), String> {
@@ -1365,10 +1391,22 @@ async fn persist_a2a_tasks_locked(state: &AppState) -> Result<(), String> {
         .await
         .map(|ledger| a2a_task_ledger_entries(&ledger))
         .unwrap_or_default();
+    let tasks = state.a2a_tasks.lock().await;
+    let local_task_ids = tasks.keys().cloned().collect::<Vec<_>>();
     let mut retained_entries = existing_entries
         .iter()
         .filter(|entry| {
-            !a2a_ledger_entry_is_control_plane(entry) && !a2a_ledger_entry_is_raw_a2a_task(entry)
+            if a2a_ledger_entry_is_raw_a2a_task(entry) {
+                return false;
+            }
+            if a2a_ledger_entry_is_control_plane(entry) {
+                let task_id = ledger_entry_task_id(entry);
+                if task_id.is_empty() {
+                    return true;
+                }
+                return !local_task_ids.iter().any(|local_id| local_id == task_id);
+            }
+            true
         })
         .cloned()
         .collect::<Vec<_>>();
@@ -1380,10 +1418,7 @@ async fn persist_a2a_tasks_locked(state: &AppState) -> Result<(), String> {
             Some((task_id, entry))
         })
         .collect::<HashMap<_, _>>();
-    let mut control_plane_entries = state
-        .a2a_tasks
-        .lock()
-        .await
+    let mut control_plane_entries = tasks
         .values()
         .cloned()
         .filter_map(|task| {
@@ -1392,6 +1427,7 @@ async fn persist_a2a_tasks_locked(state: &AppState) -> Result<(), String> {
             Some(a2a_ledger_entry_from_task(&task, existing))
         })
         .collect::<Vec<_>>();
+    drop(tasks);
     retained_entries.append(&mut control_plane_entries);
     retained_entries.sort_by(|left, right| {
         ledger_entry_updated_at(left)
@@ -11919,6 +11955,19 @@ setTimeout(() => {
                         "updatedAt": "2026-05-15T00:01:00Z"
                     },
                     {
+                        "id": "maestro-control-plane-other-task",
+                        "kind": "message",
+                        "peer": A2A_CONTROL_PLANE_LEDGER_PEER,
+                        "taskId": "other-control-plane-task",
+                        "contextId": "ctx-other",
+                        "text": "other process request",
+                        "responseText": "other process response",
+                        "state": "TASK_STATE_COMPLETED",
+                        "createdAt": "2026-05-15T00:00:00Z",
+                        "updatedAt": "2026-05-15T00:03:00Z",
+                        "metadata": { "workspaceId": "other-ws" }
+                    },
+                    {
                         "id": "raw-legacy-task",
                         "contextId": "ctx-legacy",
                         "status": {
@@ -11981,6 +12030,13 @@ setTimeout(() => {
             .iter()
             .find(|entry| entry["peer"] == "peer-b")
             .expect("remote peer ledger row should be retained");
+        let other_control_plane_entry = entries
+            .iter()
+            .find(|entry| {
+                entry["peer"] == A2A_CONTROL_PLANE_LEDGER_PEER
+                    && entry["taskId"] == "other-control-plane-task"
+            })
+            .expect("other process control-plane row should be retained");
         let control_plane_entry = entries
             .iter()
             .find(|entry| {
@@ -11994,6 +12050,10 @@ setTimeout(() => {
             .count();
 
         assert_eq!(remote_entry["taskId"], "remote-task");
+        assert_eq!(
+            other_control_plane_entry["metadata"]["workspaceId"],
+            "other-ws"
+        );
         assert_eq!(control_plane_entry["taskId"], "maestro-task-durable");
         assert_eq!(control_plane_entry["state"], "TASK_STATE_COMPLETED");
         assert_eq!(
@@ -12385,6 +12445,90 @@ setTimeout(() => {
         } else {
             env::remove_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS");
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_task_subscribe_reconciles_current_task_after_broadcast_lag() {
+        let base_state = test_app_state_with_sessions(HashMap::new());
+        let (a2a_task_events, _) = broadcast::channel(1);
+        let state = AppState {
+            a2a_task_events,
+            ..base_state
+        };
+        let initial_task = a2a_task_value(
+            "maestro-task-lagged-subscribe",
+            "ctx-1",
+            "TASK_STATE_WORKING",
+            a2a_agent_message("ctx-1", "working"),
+            vec![a2a_agent_message("ctx-1", "working")],
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("maestro-task-lagged-subscribe".to_string(), initial_task);
+        let request = "GET /tasks/maestro-task-lagged-subscribe:subscribe HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n";
+        let initial = request.as_bytes().to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (mut client, server) = tcp_stream_pair().await;
+        let state_for_run = state.clone();
+        let run = tokio::spawn(async move {
+            handle_a2a_streaming_endpoint(server, initial, head, state_for_run).await
+        });
+        let mut response_bytes = vec![0_u8; 4096];
+        let initial_len =
+            tokio::time::timeout(Duration::from_secs(2), client.read(&mut response_bytes))
+                .await
+                .expect("subscribe response should start")
+                .expect("subscribe response should be readable");
+        response_bytes.truncate(initial_len);
+
+        let terminal_task = a2a_task_value(
+            "maestro-task-lagged-subscribe",
+            "ctx-1",
+            "TASK_STATE_COMPLETED",
+            a2a_agent_message("ctx-1", "complete after lag"),
+            vec![
+                a2a_agent_message("ctx-1", "working"),
+                a2a_agent_message("ctx-1", "complete after lag"),
+            ],
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state.a2a_tasks.lock().await.insert(
+            "maestro-task-lagged-subscribe".to_string(),
+            terminal_task.clone(),
+        );
+        publish_a2a_task_update(&state, &terminal_task);
+        for index in 0..4 {
+            let unrelated_task = a2a_task_value(
+                &format!("unrelated-task-{index}"),
+                "ctx-other",
+                "TASK_STATE_WORKING",
+                a2a_agent_message("ctx-other", "noise"),
+                Vec::new(),
+                Vec::new(),
+                serde_json::json!({}),
+            );
+            publish_a2a_task_update(&state, &unrelated_task);
+        }
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            client.read_to_end(&mut response_bytes),
+        )
+        .await
+        .expect("subscribe response should close after reconciling lag")
+        .expect("subscribe response should be readable");
+        run.await
+            .expect("subscribe task should join")
+            .expect("subscribe endpoint should succeed");
+        let response = String::from_utf8(response_bytes).expect("response should be utf-8");
+
+        assert!(response.contains("TASK_STATE_COMPLETED"));
+        assert!(response.contains("complete after lag"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1020,20 +1020,25 @@ async fn handle_a2a_task_subscribe(
     )
     .await?;
 
-    let timeout_ms = env_u64(
-        "MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS",
-        A2A_DEFAULT_SUBSCRIBE_TIMEOUT_MS,
+    let heartbeat_interval = Duration::from_millis(
+        env_u64(
+            "MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS",
+            A2A_DEFAULT_SUBSCRIBE_TIMEOUT_MS,
+        )
+        .max(1),
     );
-    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
     loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            break;
-        }
-        let event = match tokio::time::timeout(remaining, receiver.recv()).await {
+        let event = match tokio::time::timeout(heartbeat_interval, receiver.recv()).await {
             Ok(Ok(task)) => task,
             Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
-            Ok(Err(broadcast::error::RecvError::Closed)) | Err(_) => break,
+            Ok(Err(broadcast::error::RecvError::Closed)) => break,
+            Err(_) => {
+                stream
+                    .write_all(b": keep-alive\n\n")
+                    .await
+                    .map_err(|error| error.to_string())?;
+                continue;
+            }
         };
         if event.get("id").and_then(Value::as_str) != Some(task_id) {
             continue;
@@ -12302,6 +12307,9 @@ setTimeout(() => {
 
     #[tokio::test(flavor = "current_thread")]
     async fn a2a_task_subscribe_streams_active_task_until_terminal_update() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_timeout = env::var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS").ok();
+        env::set_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS", "10");
         let state = test_app_state_with_sessions(HashMap::new());
         let initial_task = a2a_task_value(
             "maestro-task-active-subscribe",
@@ -12332,6 +12340,7 @@ setTimeout(() => {
                 .expect("subscribe response should start")
                 .expect("subscribe response should be readable");
         response_bytes.truncate(initial_len);
+        tokio::time::sleep(Duration::from_millis(30)).await;
         let terminal_task = a2a_task_value(
             "maestro-task-active-subscribe",
             "ctx-1",
@@ -12370,6 +12379,12 @@ setTimeout(() => {
         assert!(response.contains("event: artifactUpdate"));
         assert!(response.contains("TASK_STATE_COMPLETED"));
         assert!(response.contains("artifact body"));
+
+        if let Some(previous_timeout) = previous_timeout {
+            env::set_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS", previous_timeout);
+        } else {
+            env::remove_var("MAESTRO_A2A_SUBSCRIBE_TIMEOUT_MS");
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1575,6 +1575,9 @@ fn publish_a2a_task_update(state: &AppState, task: &Value) {
 
 fn a2a_ledger_entry_is_control_plane(entry: &Value) -> bool {
     entry.get("peer").and_then(Value::as_str) == Some(A2A_CONTROL_PLANE_LEDGER_PEER)
+        || (entry.get("peer").is_none()
+            && entry.get("id").and_then(Value::as_str).is_some()
+            && entry.get("status").and_then(Value::as_object).is_some())
 }
 
 fn a2a_ledger_entry_is_raw_a2a_task(entry: &Value) -> bool {
@@ -12130,6 +12133,82 @@ setTimeout(() => {
             "local response"
         );
         assert_eq!(loaded["local-task"]["history"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_task_persist_rewrites_legacy_control_plane_ledger_entries() {
+        let root = TestDir::new("a2a-task-ledger-legacy-rewrite");
+        let base_state = test_app_state_with_sessions(HashMap::new());
+        let mut config = auth_test_config();
+        config.a2a_tasks_file_path = root.path().join("tasks.json");
+        let state = AppState {
+            config: Arc::new(config),
+            ..base_state
+        };
+        tokio::fs::write(
+            &state.config.a2a_tasks_file_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "tasks": [
+                    {
+                        "id": "remote-ledger-row",
+                        "kind": "message",
+                        "peer": "peer-b",
+                        "taskId": "remote-task",
+                        "text": "remote peer task",
+                        "state": "TASK_STATE_COMPLETED",
+                        "createdAt": "2026-05-15T00:00:00Z",
+                        "updatedAt": "2026-05-15T00:01:00Z"
+                    },
+                    {
+                        "id": "raw-legacy-task",
+                        "contextId": "ctx-legacy",
+                        "status": {
+                            "state": "TASK_STATE_COMPLETED",
+                            "message": {
+                                "messageId": "legacy-msg",
+                                "contextId": "ctx-legacy",
+                                "role": "ROLE_AGENT",
+                                "parts": [{ "text": "legacy complete" }]
+                            }
+                        },
+                        "metadata": { "workspaceId": "legacy-ws" }
+                    }
+                ]
+            }))
+            .expect("ledger should serialize"),
+        )
+        .await
+        .expect("ledger should be written");
+
+        let loaded = load_a2a_tasks(&state.config.a2a_tasks_file_path).await;
+        state.a2a_tasks.lock().await.extend(loaded);
+
+        persist_a2a_tasks(&state).await;
+
+        let ledger: Value = serde_json::from_slice(
+            &tokio::fs::read(&state.config.a2a_tasks_file_path)
+                .await
+                .expect("ledger should be readable"),
+        )
+        .expect("ledger should be json");
+        let entries = ledger["tasks"]
+            .as_array()
+            .expect("ledger tasks should be an array");
+        let control_plane_entry = entries
+            .iter()
+            .find(|entry| entry["taskId"] == "raw-legacy-task")
+            .expect("legacy task should be rewritten as a control-plane row");
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(control_plane_entry["peer"], A2A_CONTROL_PLANE_LEDGER_PEER);
+        assert_eq!(control_plane_entry["a2aTask"]["id"], "raw-legacy-task");
+        assert_eq!(
+            control_plane_entry["a2aTask"]["metadata"]["workspaceId"],
+            "legacy-ws"
+        );
+        assert!(!entries
+            .iter()
+            .any(|entry| entry.get("peer").is_none() && entry["id"] == "raw-legacy-task"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1379,7 +1379,11 @@ async fn persist_a2a_tasks(state: &AppState) {
             return;
         }
     };
+    let heartbeat_task =
+        spawn_a2a_task_ledger_lock_heartbeat(&file_lock, a2a_task_ledger_lock_heartbeat_interval());
     let result = persist_a2a_tasks_locked(state).await;
+    heartbeat_task.abort();
+    let _ = heartbeat_task.await;
     release_a2a_task_ledger_file_lock(file_lock).await;
     if let Err(error) = result {
         eprintln!("{error}");
@@ -1545,6 +1549,31 @@ async fn write_a2a_task_ledger_lock_heartbeat(lock_path: &Path) -> Result<(), St
             "failed to write A2A task ledger lock heartbeat {}: {error}",
             lock_path.display()
         )
+    })
+}
+
+fn a2a_task_ledger_lock_heartbeat_interval() -> Duration {
+    Duration::from_millis(
+        (A2A_LEDGER_LOCK_STALE_MS / 3)
+            .max(A2A_LEDGER_LOCK_RETRY_MS)
+            .max(1),
+    )
+}
+
+fn spawn_a2a_task_ledger_lock_heartbeat(
+    file_lock: &A2ATaskLedgerFileLock,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    let lock_path = file_lock.path.clone();
+    let token = file_lock.token.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(interval).await;
+            if !a2a_task_ledger_lock_is_owned(&lock_path, &token).await {
+                break;
+            }
+            let _ = write_a2a_task_ledger_lock_heartbeat(&lock_path).await;
+        }
     })
 }
 
@@ -1889,7 +1918,8 @@ async fn a2a_list_tasks_response(
         })
         .filter(|task| {
             status_timestamp_after.as_deref().is_none_or(|after| {
-                a2a_task_status_timestamp(task).is_some_and(|timestamp| timestamp >= after)
+                a2a_task_status_timestamp(task)
+                    .is_some_and(|timestamp| a2a_timestamp_at_or_after(timestamp, after))
             })
         })
         .map(|task| a2a_task_for_query(task, head, include_artifacts))
@@ -1919,6 +1949,16 @@ async fn a2a_list_tasks_response(
         "pageSize": page_size,
         "totalSize": total_size
     }))
+}
+
+fn a2a_timestamp_at_or_after(timestamp: &str, after: &str) -> bool {
+    match (
+        chrono::DateTime::parse_from_rfc3339(timestamp),
+        chrono::DateTime::parse_from_rfc3339(after),
+    ) {
+        (Ok(timestamp), Ok(after)) => timestamp >= after,
+        _ => timestamp >= after,
+    }
 }
 
 fn a2a_task_for_query(task: &Value, head: &RequestHead, include_artifacts: bool) -> Value {
@@ -11903,7 +11943,11 @@ setTimeout(() => {
                 })],
                 serde_json::json!({}),
             );
-            task["status"]["timestamp"] = Value::String(format!("2026-05-15T00:0{minute}:00Z"));
+            task["status"]["timestamp"] = Value::String(if task_id == "task-a" {
+                "2026-05-15T00:03:00+00:00".to_string()
+            } else {
+                format!("2026-05-15T00:0{minute}:00Z")
+            });
             state
                 .a2a_tasks
                 .lock()
@@ -11928,6 +11972,20 @@ setTimeout(() => {
         assert_eq!(tasks[0]["id"], "task-a");
         assert_eq!(tasks[0]["history"].as_array().unwrap().len(), 1);
         assert!(tasks[0].get("artifacts").is_none());
+
+        let request = "GET /tasks?statusTimestampAfter=2026-05-15T00:03:00Z HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n";
+        let mut initial = request.as_bytes().to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let tasks = response["tasks"]
+            .as_array()
+            .expect("tasks should be an array");
+
+        assert_eq!(response["totalSize"], 1);
+        assert_eq!(tasks[0]["id"], "task-a");
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -12127,6 +12185,32 @@ setTimeout(() => {
                 .expect("ledger existence should be checkable"),
             "ledger should be written after lock release"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_task_ledger_lock_heartbeat_refreshes_while_owned() {
+        let root = TestDir::new("a2a-task-ledger-lock-heartbeat");
+        let tasks_path = root.path().join("tasks.json");
+        let file_lock = acquire_a2a_task_ledger_file_lock(&tasks_path)
+            .await
+            .expect("lock should be acquired");
+        let heartbeat_path = file_lock.path.join(A2A_LEDGER_LOCK_HEARTBEAT_FILE);
+        let first_heartbeat = tokio::fs::read_to_string(&heartbeat_path)
+            .await
+            .expect("heartbeat should be readable");
+
+        let heartbeat_task =
+            spawn_a2a_task_ledger_lock_heartbeat(&file_lock, Duration::from_millis(10));
+        tokio::time::sleep(Duration::from_millis(35)).await;
+        heartbeat_task.abort();
+        let _ = heartbeat_task.await;
+
+        let refreshed_heartbeat = tokio::fs::read_to_string(&heartbeat_path)
+            .await
+            .expect("heartbeat should still be readable");
+        assert_ne!(refreshed_heartbeat, first_heartbeat);
+
+        release_a2a_task_ledger_file_lock(file_lock).await;
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/scripts/smoke-maestro-a2a-tmux.sh
+++ b/scripts/smoke-maestro-a2a-tmux.sh
@@ -68,6 +68,129 @@ a2a_cli() {
 	MAESTRO_A2A_PEERS_FILE="$registry" bun run a2a -- "$@"
 }
 
+url_encode() {
+	node -e 'process.stdout.write(encodeURIComponent(process.argv[1] || ""))' "$1"
+}
+
+assert_agent_card_streaming() {
+	local name="$1"
+	local base_url="$2"
+	local card
+	card="$(curl -fsS --max-time 5 "$base_url/.well-known/agent-card.json")"
+	JSON_INPUT="$card" node -e '
+const card = JSON.parse(process.env.JSON_INPUT || "{}");
+if (card.capabilities?.streaming !== true) {
+  console.error("Agent Card did not advertise capabilities.streaming=true");
+  process.exit(1);
+}
+if (card.capabilities?.extendedAgentCard !== true) {
+  console.error("Agent Card did not advertise capabilities.extendedAgentCard=true");
+  process.exit(1);
+}
+'
+	echo "$name Agent Card advertises streaming=true"
+}
+
+assert_task_list_filters() {
+	local name="$1"
+	local base_url="$2"
+	local task_id="$3"
+	local task_json
+	local context_id
+	local encoded_context_id
+	local list_by_status
+	local list_by_context
+
+	task_json="$(curl -fsS --max-time 5 "$base_url/tasks/$(url_encode "$task_id")")"
+	context_id="$(JSON_INPUT="$task_json" node -e '
+const task = JSON.parse(process.env.JSON_INPUT || "{}");
+if (!task.id || !task.status?.state) {
+  console.error("task detail did not include id and status.state");
+  process.exit(1);
+}
+process.stdout.write(String(task.contextId || ""));
+')"
+	if [[ -z "$context_id" ]]; then
+		echo "$name task detail did not include contextId" >&2
+		exit 1
+	fi
+	encoded_context_id="$(url_encode "$context_id")"
+
+	list_by_status="$(curl -fsS --max-time 5 "$base_url/tasks?status=TASK_STATE_COMPLETED&pageSize=1&pageToken=0&historyLength=1&includeArtifacts=false")"
+	TASK_ID="$task_id" JSON_INPUT="$list_by_status" node -e '
+const response = JSON.parse(process.env.JSON_INPUT || "{}");
+const tasks = Array.isArray(response.tasks) ? response.tasks : [];
+if (response.pageSize !== 1 || typeof response.totalSize !== "number") {
+  console.error("task list did not include expected pagination metadata");
+  process.exit(1);
+}
+if (!tasks.some((task) => task.id === process.env.TASK_ID && task.status?.state === "TASK_STATE_COMPLETED")) {
+  console.error("status-filtered task list did not include the completed smoke task");
+  process.exit(1);
+}
+if (tasks.some((task) => Array.isArray(task.artifacts) && task.artifacts.length > 0)) {
+  console.error("includeArtifacts=false did not suppress task artifacts");
+  process.exit(1);
+}
+if (tasks.some((task) => Array.isArray(task.history) && task.history.length > 1)) {
+  console.error("historyLength=1 did not bound task history");
+  process.exit(1);
+}
+'
+
+	list_by_context="$(curl -fsS --max-time 5 "$base_url/tasks?contextId=$encoded_context_id&pageSize=1&pageToken=0&includeArtifacts=false")"
+	TASK_ID="$task_id" JSON_INPUT="$list_by_context" node -e '
+const response = JSON.parse(process.env.JSON_INPUT || "{}");
+const tasks = Array.isArray(response.tasks) ? response.tasks : [];
+if (!tasks.some((task) => task.id === process.env.TASK_ID)) {
+  console.error("contextId-filtered task list did not include the smoke task");
+  process.exit(1);
+}
+'
+	echo "$name GET /tasks filters and pagination returned the completed smoke task"
+}
+
+assert_message_stream() {
+	local name="$1"
+	local base_url="$2"
+	local message_id="tmux-smoke-stream-$$-$RANDOM"
+	local body
+	local stream_output
+
+	body="$(MESSAGE_ID="$message_id" node -e '
+const messageId = process.env.MESSAGE_ID;
+process.stdout.write(JSON.stringify({
+  message: {
+    messageId,
+    contextId: `${messageId}-context`,
+    role: "ROLE_USER",
+    parts: [{ text: "run the tmux A2A message stream smoke", mediaType: "text/plain" }]
+  }
+}));
+')"
+	stream_output="$(curl -fsS --max-time 10 -H "Content-Type: application/json" -d "$body" "$base_url/message:stream")"
+	STREAM_OUTPUT="$stream_output" node -e '
+const output = process.env.STREAM_OUTPUT || "";
+if (!output.includes("data:")) {
+  console.error("message:stream response did not look like an SSE stream");
+  process.exit(1);
+}
+if (!output.includes("\"statusUpdate\"")) {
+  console.error("message:stream did not include a status update");
+  process.exit(1);
+}
+if (!output.includes("\"artifactUpdate\"")) {
+  console.error("message:stream did not include an artifact update");
+  process.exit(1);
+}
+if (!output.includes("tmux peer A received the A2A message")) {
+  console.error("message:stream did not include the peer fake response");
+  process.exit(1);
+}
+'
+	echo "$name message:stream SSE returned bounded status and artifact events"
+}
+
 require_cmd tmux
 require_cmd cargo
 require_cmd bun
@@ -99,6 +222,10 @@ tmux new-window -t "$SESSION_NAME" -n peer-b \
 
 wait_for_health peer-a "$BASE_A"
 wait_for_health peer-b "$BASE_B"
+
+echo "checking native Agent Card streaming capability"
+assert_agent_card_streaming peer-a "$BASE_A"
+assert_agent_card_streaming peer-b "$BASE_B"
 
 echo "creating native pairing offers"
 CODE_A="$(a2a_cli "$REGISTRY_A" offer --url "$BASE_A" --name peer-a --peer-id peer-a --ttl-minutes 5)"
@@ -150,6 +277,10 @@ if ! grep -q "tmux peer A received the A2A message" <<<"$WAIT_B_TO_A"; then
 	echo "peer-b -> peer-a wait output did not include expected peer A text" >&2
 	exit 1
 fi
+
+echo "checking native task list filters, pagination, and message stream"
+assert_task_list_filters peer-a "$BASE_A" "$TASK_ID"
+assert_message_stream peer-a "$BASE_A"
 
 cat <<EOF
 tmux A2A smoke passed

--- a/scripts/smoke-maestro-a2a-tmux.sh
+++ b/scripts/smoke-maestro-a2a-tmux.sh
@@ -157,6 +157,7 @@ assert_message_stream() {
 	local body
 	local stream_output
 
+	# shellcheck disable=SC2016 # The single-quoted string is JavaScript; ${messageId} is a JS template expression.
 	body="$(MESSAGE_ID="$message_id" node -e '
 const messageId = process.env.MESSAGE_ID;
 process.stdout.write(JSON.stringify({

--- a/src/cli-tui/commands/command-catalog.ts
+++ b/src/cli-tui/commands/command-catalog.ts
@@ -181,12 +181,14 @@ export const PRIMARY_COMMAND_CATALOG: readonly CommandCatalogEntry[] = [
 	withArgs("a2a", "a2a", {
 		description: "Pair, inspect, and delegate to A2A peer agents",
 		usage:
-			"/a2a [accept <code>|fleet|peers|tasks|delegate <peer> <text>|reply <peer> <task-id> <text>]",
+			"/a2a [accept <code>|fleet|peers|tasks [--work-graph]|coordinate [--work-graph]|delegate <peer> <text>|reply <peer> <task-id> <text>]",
 		tags: ["tools", "agents"],
 		examples: [
 			"/a2a fleet",
 			"/a2a peers",
-			"/a2a tasks",
+			"/a2a tasks --work-graph",
+			"/a2a coordinate",
+			"/a2a coordinate mac-mini --work-graph --reply use the short smoke",
 			"/a2a delegate mac-mini run workspace smoke",
 			"/a2a reply mac-mini task-123 use the short smoke",
 			"/a2a accept maestro-pair-v1.payload.checksum --name mac-mini",

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -488,10 +488,12 @@ async function* parseA2AStreamEvents(
 	const reader = response.body.getReader();
 	const decoder = new TextDecoder();
 	let buffer = "";
+	let completed = false;
 	try {
 		while (true) {
 			const { done, value } = await reader.read();
 			if (done) {
+				completed = true;
 				break;
 			}
 			buffer += decoder.decode(value, { stream: true });
@@ -513,6 +515,9 @@ async function* parseA2AStreamEvents(
 			}
 		}
 	} finally {
+		if (!completed) {
+			await reader.cancel().catch(() => undefined);
+		}
 		reader.releaseLock();
 	}
 }

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -171,6 +171,37 @@ export interface SendA2AMessageResult {
 	task: A2ATask;
 }
 
+export type A2AStreamEventType = "task" | "statusUpdate" | "artifactUpdate";
+
+export interface A2ATaskStreamEvent {
+	type: "task";
+	task: A2ATask;
+}
+
+export interface A2AStatusUpdateStreamEvent {
+	type: "statusUpdate";
+	taskId?: string;
+	contextId?: string;
+	status: A2ATaskStatus;
+	final?: boolean;
+	metadata?: Record<string, unknown>;
+}
+
+export interface A2AArtifactUpdateStreamEvent {
+	type: "artifactUpdate";
+	taskId?: string;
+	contextId?: string;
+	artifact: A2AArtifact;
+	append?: boolean;
+	lastChunk?: boolean;
+	metadata?: Record<string, unknown>;
+}
+
+export type A2AStreamEvent =
+	| A2ATaskStreamEvent
+	| A2AStatusUpdateStreamEvent
+	| A2AArtifactUpdateStreamEvent;
+
 export interface A2ATraceContext {
 	traceparent?: string;
 	tracestate?: string;
@@ -280,6 +311,91 @@ export async function sendA2AMessage(
 	input: SendA2AMessageInput,
 	options: { signal?: AbortSignal } = {},
 ): Promise<SendA2AMessageResult> {
+	const { body, traceContext } = buildA2AMessageRequestBody(config, input);
+	const response = await fetchDownstream(
+		`${config.baseUrl}/message:send`,
+		{
+			method: "POST",
+			headers: buildA2AHeaders(config, traceContext),
+			body: JSON.stringify(body),
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "send message");
+	return (await response.json()) as SendA2AMessageResult;
+}
+
+export async function* streamA2AMessage(
+	config: A2AServiceConfig,
+	input: SendA2AMessageInput,
+	options: { signal?: AbortSignal } = {},
+): AsyncIterable<A2AStreamEvent> {
+	const { body, traceContext } = buildA2AMessageRequestBody(config, input);
+	const response = await fetchDownstream(
+		`${config.baseUrl}/message:stream`,
+		{
+			method: "POST",
+			headers: {
+				...buildA2AHeaders(config, traceContext),
+				Accept: "text/event-stream",
+			},
+			body: JSON.stringify(body),
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "stream message");
+	yield* parseA2AStreamEvents(response);
+}
+
+export async function* subscribeA2ATask(
+	config: A2AServiceConfig,
+	taskId: string,
+	options: { signal?: AbortSignal; traceContext?: A2ATraceContext } = {},
+): AsyncIterable<A2AStreamEvent> {
+	const trimmedTaskId = trimString(taskId);
+	if (!trimmedTaskId) {
+		throw new Error("A2A task id is required");
+	}
+	const response = await fetchDownstream(
+		`${config.baseUrl}/tasks/${encodeURIComponent(trimmedTaskId)}:subscribe`,
+		{
+			method: "GET",
+			headers: {
+				...buildA2AHeaders(config, options.traceContext),
+				Accept: "text/event-stream",
+			},
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "subscribe task");
+	yield* parseA2AStreamEvents(response);
+}
+
+function buildA2AMessageRequestBody(
+	config: A2AServiceConfig,
+	input: SendA2AMessageInput,
+): {
+	body: Omit<SendA2AMessageInput, "traceContext">;
+	traceContext?: A2ATraceContext;
+} {
 	// `traceContext` is caller control data, not part of the A2A request body.
 	// Project it into headers and message metadata so Platform can join
 	// the task to traces without receiving a Maestro-private wrapper field.
@@ -306,23 +422,7 @@ export async function sendA2AMessage(
 			},
 		},
 	};
-	const response = await fetchDownstream(
-		`${config.baseUrl}/message:send`,
-		{
-			method: "POST",
-			headers: buildA2AHeaders(config, traceContext),
-			body: JSON.stringify(body),
-			signal: options.signal,
-		},
-		{
-			serviceName: "platform-a2a",
-			failureMode: "required",
-			timeoutMs: config.timeoutMs,
-			maxAttempts: config.maxAttempts,
-		},
-	);
-	await throwForA2AError(response, "send message");
-	return (await response.json()) as SendA2AMessageResult;
+	return { body, traceContext };
 }
 
 export function resolveA2ATraceContext(
@@ -376,6 +476,179 @@ export async function getA2ATask(
 	);
 	await throwForA2AError(response, "get task");
 	return (await response.json()) as A2ATask;
+}
+
+async function* parseA2AStreamEvents(
+	response: Response,
+): AsyncIterable<A2AStreamEvent> {
+	if (!response.body) {
+		return;
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) {
+				break;
+			}
+			buffer += decoder.decode(value, { stream: true });
+			const parsed = splitCompleteServerSentEvents(buffer);
+			buffer = parsed.remainder;
+			for (const frame of parsed.frames) {
+				const event = parseA2AStreamEventFrame(frame);
+				if (event) {
+					yield event;
+				}
+			}
+		}
+
+		buffer += decoder.decode();
+		if (buffer.trim()) {
+			const event = parseA2AStreamEventFrame(buffer);
+			if (event) {
+				yield event;
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+function splitCompleteServerSentEvents(input: string): {
+	frames: string[];
+	remainder: string;
+} {
+	const frames: string[] = [];
+	let cursor = 0;
+	while (cursor < input.length) {
+		const lineBreakIndex = findServerSentEventBoundary(input, cursor);
+		if (lineBreakIndex === -1) {
+			break;
+		}
+		frames.push(input.slice(cursor, lineBreakIndex.start));
+		cursor = lineBreakIndex.end;
+	}
+	return { frames, remainder: input.slice(cursor) };
+}
+
+function findServerSentEventBoundary(
+	input: string,
+	startIndex: number,
+): { start: number; end: number } | -1 {
+	const boundaries = ["\r\n\r\n", "\n\n", "\r\r"];
+	let earliest: { start: number; end: number } | undefined;
+	for (const boundary of boundaries) {
+		const index = input.indexOf(boundary, startIndex);
+		if (index === -1) {
+			continue;
+		}
+		if (!earliest || index < earliest.start) {
+			earliest = { start: index, end: index + boundary.length };
+		}
+	}
+	return earliest ?? -1;
+}
+
+function parseA2AStreamEventFrame(frame: string): A2AStreamEvent | undefined {
+	let eventType: A2AStreamEventType | undefined;
+	const dataLines: string[] = [];
+	for (const line of frame.split(/\r\n|\n|\r/u)) {
+		if (!line || line.startsWith(":")) {
+			continue;
+		}
+		const separatorIndex = line.indexOf(":");
+		const field = separatorIndex === -1 ? line : line.slice(0, separatorIndex);
+		const rawValue =
+			separatorIndex === -1 ? "" : line.slice(separatorIndex + 1);
+		const value = rawValue.startsWith(" ") ? rawValue.slice(1) : rawValue;
+		if (field === "event") {
+			eventType = parseA2AStreamEventType(value);
+		}
+		if (field === "data") {
+			dataLines.push(value);
+		}
+	}
+	if (dataLines.length === 0) {
+		return undefined;
+	}
+
+	const payload = JSON.parse(dataLines.join("\n")) as Record<string, unknown>;
+	eventType ??= inferA2AStreamEventType(payload);
+	if (!eventType) {
+		return undefined;
+	}
+	return normalizeA2AStreamEvent(eventType, payload);
+}
+
+function parseA2AStreamEventType(
+	value: string,
+): A2AStreamEventType | undefined {
+	if (
+		value === "task" ||
+		value === "statusUpdate" ||
+		value === "artifactUpdate"
+	) {
+		return value;
+	}
+	return undefined;
+}
+
+function inferA2AStreamEventType(
+	payload: Record<string, unknown>,
+): A2AStreamEventType | undefined {
+	if (isRecord(payload.task)) {
+		return "task";
+	}
+	if (isRecord(payload.statusUpdate)) {
+		return "statusUpdate";
+	}
+	if (isRecord(payload.artifactUpdate) || isRecord(payload.artifact)) {
+		return "artifactUpdate";
+	}
+	if (isRecord(payload.status) && typeof payload.id === "string") {
+		return "task";
+	}
+	if (isRecord(payload.status)) {
+		return "statusUpdate";
+	}
+	return undefined;
+}
+
+function normalizeA2AStreamEvent(
+	eventType: A2AStreamEventType,
+	payload: Record<string, unknown>,
+): A2AStreamEvent {
+	if (eventType === "task") {
+		return {
+			type: "task",
+			task: (payload.task ?? payload) as A2ATask,
+		};
+	}
+	if (eventType === "statusUpdate") {
+		const statusUpdatePayload = isRecord(payload.statusUpdate)
+			? payload.statusUpdate
+			: payload;
+		return {
+			type: "statusUpdate",
+			...statusUpdatePayload,
+			status: statusUpdatePayload.status as A2ATaskStatus,
+		};
+	}
+	const artifactUpdatePayload = isRecord(payload.artifactUpdate)
+		? payload.artifactUpdate
+		: payload;
+	return {
+		type: "artifactUpdate",
+		...artifactUpdatePayload,
+		artifact: artifactUpdatePayload.artifact as A2AArtifact,
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function buildA2AHeaders(

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -580,7 +580,16 @@ function parseA2AStreamEventFrame(frame: string): A2AStreamEvent | undefined {
 		return undefined;
 	}
 
-	const payload = JSON.parse(dataLines.join("\n")) as Record<string, unknown>;
+	let payload: Record<string, unknown>;
+	try {
+		const parsed = JSON.parse(dataLines.join("\n")) as unknown;
+		if (!isRecord(parsed)) {
+			return undefined;
+		}
+		payload = parsed;
+	} catch {
+		return undefined;
+	}
 	eventType ??= inferA2AStreamEventType(payload);
 	if (!eventType) {
 		return undefined;

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -171,11 +171,20 @@ export interface SendA2AMessageResult {
 	task: A2ATask;
 }
 
-export type A2AStreamEventType = "task" | "statusUpdate" | "artifactUpdate";
+export type A2AStreamEventType =
+	| "task"
+	| "message"
+	| "statusUpdate"
+	| "artifactUpdate";
 
 export interface A2ATaskStreamEvent {
 	type: "task";
 	task: A2ATask;
+}
+
+export interface A2AMessageStreamEvent {
+	type: "message";
+	message: A2AMessage;
 }
 
 export interface A2AStatusUpdateStreamEvent {
@@ -199,6 +208,7 @@ export interface A2AArtifactUpdateStreamEvent {
 
 export type A2AStreamEvent =
 	| A2ATaskStreamEvent
+	| A2AMessageStreamEvent
 	| A2AStatusUpdateStreamEvent
 	| A2AArtifactUpdateStreamEvent;
 
@@ -602,6 +612,7 @@ function parseA2AStreamEventType(
 ): A2AStreamEventType | undefined {
 	if (
 		value === "task" ||
+		value === "message" ||
 		value === "statusUpdate" ||
 		value === "artifactUpdate"
 	) {
@@ -616,6 +627,9 @@ function inferA2AStreamEventType(
 	if (isRecord(payload.task)) {
 		return "task";
 	}
+	if (isRecord(payload.message)) {
+		return "message";
+	}
 	if (isRecord(payload.statusUpdate)) {
 		return "statusUpdate";
 	}
@@ -628,6 +642,12 @@ function inferA2AStreamEventType(
 	if (isRecord(payload.status)) {
 		return "statusUpdate";
 	}
+	if (
+		typeof payload.messageId === "string" &&
+		typeof payload.role === "string"
+	) {
+		return "message";
+	}
 	return undefined;
 }
 
@@ -639,6 +659,12 @@ function normalizeA2AStreamEvent(
 		return {
 			type: "task",
 			task: (payload.task ?? payload) as A2ATask,
+		};
+	}
+	if (eventType === "message") {
+		return {
+			type: "message",
+			message: (payload.message ?? payload) as A2AMessage,
 		};
 	}
 	if (eventType === "statusUpdate") {

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -301,7 +301,7 @@ export async function discoverA2AAgentCard(
 	const response = await fetchDownstream(
 		`${config.baseUrl}/.well-known/agent-card.json`,
 		{
-			method: "POST",
+			method: "GET",
 			headers: buildA2AHeaders(config),
 			signal: options.signal,
 		},
@@ -381,7 +381,7 @@ export async function* subscribeA2ATask(
 	const response = await fetchDownstream(
 		`${config.baseUrl}/tasks/${encodeURIComponent(trimmedTaskId)}:subscribe`,
 		{
-			method: "GET",
+			method: "POST",
 			headers: {
 				...buildA2AHeaders(config, options.traceContext),
 				Accept: "text/event-stream",

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -646,8 +646,8 @@ function normalizeA2AStreamEvent(
 			? payload.statusUpdate
 			: payload;
 		return {
-			type: "statusUpdate",
 			...statusUpdatePayload,
+			type: "statusUpdate",
 			status: statusUpdatePayload.status as A2ATaskStatus,
 		};
 	}
@@ -655,8 +655,8 @@ function normalizeA2AStreamEvent(
 		? payload.artifactUpdate
 		: payload;
 	return {
-		type: "artifactUpdate",
 		...artifactUpdatePayload,
+		type: "artifactUpdate",
 		artifact: artifactUpdatePayload.artifact as A2AArtifact,
 	};
 }

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -301,7 +301,7 @@ export async function discoverA2AAgentCard(
 	const response = await fetchDownstream(
 		`${config.baseUrl}/.well-known/agent-card.json`,
 		{
-			method: "GET",
+			method: "POST",
 			headers: buildA2AHeaders(config),
 			signal: options.signal,
 		},

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -483,6 +483,50 @@ describe("platform A2A client", () => {
 		]);
 	});
 
+	it("skips malformed A2A SSE frames without aborting the stream", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+		vi.mocked(fetch).mockImplementationOnce(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+				return sseResponse([
+					"data: not-json\n\n",
+					"data: null\n\n",
+					'data: {"statusUpdate":{"taskId":"run_stream","status":{"state":"TASK_STATE_COMPLETED"},"final":true}}\n\n',
+				]);
+			},
+		);
+
+		const events = await collectAsyncIterable(
+			streamA2AMessage(config, {
+				message: buildA2AUserMessage({
+					messageId: "msg_stream_malformed",
+					contextId: "session_1",
+					text: "Stream through malformed frames",
+				}),
+			}),
+		);
+
+		expect(events).toEqual([
+			{
+				type: "statusUpdate",
+				taskId: "run_stream",
+				status: { state: "TASK_STATE_COMPLETED" },
+				final: true,
+			},
+		]);
+	});
+
 	it("gets an A2A task by run id", async () => {
 		const config = await resolveA2AServiceConfig();
 		if (!config) {

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -273,8 +273,8 @@ describe("platform A2A client", () => {
 		});
 
 		expect(requests[0]).toMatchObject({
-			method: "POST",
 			url: "https://platform.test/.well-known/agent-card.json",
+			method: "GET",
 			headers: expect.objectContaining({
 				authorization: "Bearer a2a-token",
 				"x-evalops-workspace-id": "ws_1",
@@ -567,8 +567,8 @@ describe("platform A2A client", () => {
 		);
 
 		expect(requests[0]).toMatchObject({
-			method: "GET",
 			url: "https://platform.test/tasks/run_1:subscribe",
+			method: "POST",
 			headers: expect.objectContaining({
 				accept: "text/event-stream",
 				traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -273,7 +273,7 @@ describe("platform A2A client", () => {
 		});
 
 		expect(requests[0]).toMatchObject({
-			method: "GET",
+			method: "POST",
 			url: "https://platform.test/.well-known/agent-card.json",
 			headers: expect.objectContaining({
 				authorization: "Bearer a2a-token",

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -6,6 +6,8 @@ import {
 	resolveA2AServiceConfig,
 	resolveA2ATraceContext,
 	sendA2AMessage,
+	streamA2AMessage,
+	subscribeA2ATask,
 } from "../../src/platform/a2a-client.js";
 
 type CapturedRequest = {
@@ -28,6 +30,33 @@ function parseRequestBody(
 	return typeof body === "string"
 		? (JSON.parse(body) as Record<string, unknown>)
 		: undefined;
+}
+
+function sseResponse(chunks: string[]): Response {
+	const encoder = new TextEncoder();
+	return new Response(
+		new ReadableStream({
+			start(controller) {
+				for (const chunk of chunks) {
+					controller.enqueue(encoder.encode(chunk));
+				}
+				controller.close();
+			},
+		}),
+		{
+			headers: { "content-type": "text/event-stream" },
+		},
+	);
+}
+
+async function collectAsyncIterable<T>(
+	iterable: AsyncIterable<T>,
+): Promise<T[]> {
+	const values: T[] = [];
+	for await (const value of iterable) {
+		values.push(value);
+	}
+	return values;
 }
 
 describe("platform A2A client", () => {
@@ -136,12 +165,28 @@ describe("platform A2A client", () => {
 					});
 				}
 
+				if (parsed.pathname === "/message:stream") {
+					return sseResponse([
+						'data: {"task":{"id":"run_stream","contextId":"session_1","status":{"state":"TASK_STATE_SUBMITTED"}}}\n\n',
+						'data: {"statusUpdate":{"taskId":"run_stream","contextId":"session_1","status":{"state":"TASK_STATE_WORKING","timestamp":"2026-05-16T12:00:00.000Z"},"metadata":{"step":"start"}}}\n\n',
+						'data: {"artifactUpdate":{"taskId":"run_stream","contextId":"session_1","artifact":{"artifactId":"artifact_1","name":"summary","parts":[{"text":"done","mediaType":"text/plain"}]},"append":false,"lastChunk":true}}\n\n',
+					]);
+				}
+
 				if (parsed.pathname === "/tasks/run_1") {
 					return Response.json({
 						id: "run_1",
 						contextId: "session_1",
 						status: { state: "TASK_STATE_COMPLETED" },
 					});
+				}
+
+				if (parsed.pathname === "/tasks/run_1:subscribe") {
+					return sseResponse([
+						'data: {"taskId":"run_1","status":{"state":"TASK_STATE_WORKING"}}\r\n\r\n',
+						'data: {"taskId":"run_1","artifact":{"artifactId":"artifact_2","parts":[{"text":"partial"}]},"append":true}\r\n\r\n',
+						'data: {"taskId":"run_1","status":{"state":"TASK_STATE_COMPLETED"},"final":true}\r\n\r\n',
+					]);
 				}
 
 				return Response.json(
@@ -357,6 +402,87 @@ describe("platform A2A client", () => {
 		).not.toHaveProperty("tracestate");
 	});
 
+	it("streams A2A message events with Platform correlation metadata", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+
+		const events = await collectAsyncIterable(
+			streamA2AMessage(config, {
+				message: buildA2AUserMessage({
+					messageId: "msg_stream",
+					contextId: "session_1",
+					text: "Stream the release smoke test",
+				}),
+				traceContext: {
+					traceparent:
+						"00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+					tracestate: "evalops=maestro",
+				},
+			}),
+		);
+
+		expect(requests[0]).toMatchObject({
+			method: "POST",
+			url: "https://platform.test/message:stream",
+			body: {
+				message: expect.objectContaining({
+					messageId: "msg_stream",
+					metadata: expect.objectContaining({
+						workspaceId: "ws_1",
+						agentId: "agent_maestro",
+						sessionId: "session_1",
+						actorId: "user_1",
+						traceparent:
+							"00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+						tracestate: "evalops=maestro",
+					}),
+				}),
+			},
+			headers: expect.objectContaining({
+				accept: "text/event-stream",
+				authorization: "Bearer a2a-token",
+				traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+				tracestate: "evalops=maestro",
+				"x-evalops-workspace-id": "ws_1",
+			}),
+		});
+		expect(requests[0]?.body).not.toHaveProperty("traceContext");
+		expect(events).toEqual([
+			{
+				type: "task",
+				task: {
+					id: "run_stream",
+					contextId: "session_1",
+					status: { state: "TASK_STATE_SUBMITTED" },
+				},
+			},
+			{
+				type: "statusUpdate",
+				taskId: "run_stream",
+				contextId: "session_1",
+				status: {
+					state: "TASK_STATE_WORKING",
+					timestamp: "2026-05-16T12:00:00.000Z",
+				},
+				metadata: { step: "start" },
+			},
+			{
+				type: "artifactUpdate",
+				taskId: "run_stream",
+				contextId: "session_1",
+				artifact: {
+					artifactId: "artifact_1",
+					name: "summary",
+					parts: [{ text: "done", mediaType: "text/plain" }],
+				},
+				append: false,
+				lastChunk: true,
+			},
+		]);
+	});
+
 	it("gets an A2A task by run id", async () => {
 		const config = await resolveA2AServiceConfig();
 		if (!config) {
@@ -368,6 +494,55 @@ describe("platform A2A client", () => {
 			status: { state: "TASK_STATE_COMPLETED" },
 		});
 		expect(requests[0]?.url).toBe("https://platform.test/tasks/run_1");
+	});
+
+	it("subscribes to A2A task SSE updates with explicit trace headers", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+
+		const events = await collectAsyncIterable(
+			subscribeA2ATask(config, "run_1", {
+				traceContext: {
+					traceparent:
+						"00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+					tracestate: "evalops=maestro",
+				},
+			}),
+		);
+
+		expect(requests[0]).toMatchObject({
+			method: "GET",
+			url: "https://platform.test/tasks/run_1:subscribe",
+			headers: expect.objectContaining({
+				accept: "text/event-stream",
+				traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+				tracestate: "evalops=maestro",
+			}),
+		});
+		expect(events).toEqual([
+			{
+				type: "statusUpdate",
+				taskId: "run_1",
+				status: { state: "TASK_STATE_WORKING" },
+			},
+			{
+				type: "artifactUpdate",
+				taskId: "run_1",
+				artifact: {
+					artifactId: "artifact_2",
+					parts: [{ text: "partial" }],
+				},
+				append: true,
+			},
+			{
+				type: "statusUpdate",
+				taskId: "run_1",
+				status: { state: "TASK_STATE_COMPLETED" },
+				final: true,
+			},
+		]);
 	});
 
 	it("gets an A2A task with explicit trace headers", async () => {

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -168,8 +168,9 @@ describe("platform A2A client", () => {
 				if (parsed.pathname === "/message:stream") {
 					return sseResponse([
 						'data: {"task":{"id":"run_stream","contextId":"session_1","status":{"state":"TASK_STATE_SUBMITTED"}}}\n\n',
-						'data: {"statusUpdate":{"taskId":"run_stream","contextId":"session_1","status":{"state":"TASK_STATE_WORKING","timestamp":"2026-05-16T12:00:00.000Z"},"metadata":{"step":"start"}}}\n\n',
-						'data: {"artifactUpdate":{"taskId":"run_stream","contextId":"session_1","artifact":{"artifactId":"artifact_1","name":"summary","parts":[{"text":"done","mediaType":"text/plain"}]},"append":false,"lastChunk":true}}\n\n',
+						'event: message\ndata: {"message":{"messageId":"msg_agent","contextId":"session_1","role":"ROLE_AGENT","parts":[{"text":"streaming","mediaType":"text/plain"}]}}\n\n',
+						'data: {"statusUpdate":{"type":"payload-status","taskId":"run_stream","contextId":"session_1","status":{"state":"TASK_STATE_WORKING","timestamp":"2026-05-16T12:00:00.000Z"},"metadata":{"step":"start"}}}\n\n',
+						'data: {"artifactUpdate":{"type":"payload-artifact","taskId":"run_stream","contextId":"session_1","artifact":{"artifactId":"artifact_1","name":"summary","parts":[{"text":"done","mediaType":"text/plain"}]},"append":false,"lastChunk":true}}\n\n',
 					]);
 				}
 
@@ -456,6 +457,15 @@ describe("platform A2A client", () => {
 					id: "run_stream",
 					contextId: "session_1",
 					status: { state: "TASK_STATE_SUBMITTED" },
+				},
+			},
+			{
+				type: "message",
+				message: {
+					messageId: "msg_agent",
+					contextId: "session_1",
+					role: "ROLE_AGENT",
+					parts: [{ text: "streaming", mediaType: "text/plain" }],
 				},
 			},
 			{

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -545,6 +545,56 @@ describe("platform A2A client", () => {
 		]);
 	});
 
+	it("cancels the A2A SSE body when the consumer stops early", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+		let canceled = false;
+		vi.mocked(fetch).mockImplementationOnce(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+				const encoder = new TextEncoder();
+				return new Response(
+					new ReadableStream({
+						start(controller) {
+							controller.enqueue(
+								encoder.encode(
+									'data: {"taskId":"run_cancel","status":{"state":"TASK_STATE_WORKING"}}\n\n',
+								),
+							);
+						},
+						cancel() {
+							canceled = true;
+						},
+					}),
+					{ headers: { "content-type": "text/event-stream" } },
+				);
+			},
+		);
+
+		for await (const event of subscribeA2ATask(config, "run_cancel")) {
+			expect(event).toMatchObject({
+				type: "statusUpdate",
+				taskId: "run_cancel",
+			});
+			break;
+		}
+
+		expect(canceled).toBe(true);
+		expect(requests.at(-1)?.url).toBe(
+			"https://platform.test/tasks/run_cancel:subscribe",
+		);
+	});
+
 	it("gets an A2A task with explicit trace headers", async () => {
 		const config = await resolveA2AServiceConfig();
 		if (!config) {


### PR DESCRIPTION
## Summary
- Adds native Maestro A2A streaming support across Rust control-plane and the TypeScript client, including named SSE events and data-only SSE compatibility.
- Makes the shared A2A task ledger fleet-safe by preserving remote peer rows while hydrating only Maestro control-plane or legacy raw A2A task rows.
- Documents and smoke-tests Agent Card streaming, filtered task listing, message streaming, and terminal-subscribe semantics.

## Source Of Truth
- Internal companion PR: evalops/maestro-internal#1989

## Staged Rollout
- Staging is unnecessary for `src/cli-tui/commands/command-catalog.ts`: this PR mirrors existing internal A2A command discovery metadata and does not enable a new public execution path. Runtime A2A changes remain covered by existing auth, CSRF, task ownership, and smoke/CI checks.

## Test Plan
- `cargo test a2a --bin maestro-control-plane`
- `cargo fmt --check && cargo check --bin maestro-control-plane`
- `npm run test:fast -- test/platform/a2a-task-ledger.test.ts test/platform/a2a-client.test.ts test/cli/commands/a2a-fleet-delegation.test.ts test/cli-tui/commands/a2a-handlers.test.ts`
- `npx biome check src/platform/a2a-client.ts test/platform/a2a-client.test.ts && npx tsc -p tsconfig.build.json --noEmit --pretty false`
- `bash scripts/smoke-maestro-a2a-tmux.sh`
- Commit hook: Guardian, lint/eval checks, generated contract checks, and build
