### PR TITLE
Fix A2A SSE mixed-newline parsing

### DIFF
--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -553,18 +553,12 @@ function findServerSentEventBoundary(
 	input: string,
 	startIndex: number,
 ): { start: number; end: number } | -1 {
-	const boundaries = ["\r\n\r\n", "\n\n", "\r\r"];
-	let earliest: { start: number; end: number } | undefined;
-	for (const boundary of boundaries) {
-		const index = input.indexOf(boundary, startIndex);
-		if (index === -1) {
-			continue;
-		}
-		if (!earliest || index < earliest.start) {
-			earliest = { start: index, end: index + boundary.length };
-		}
-	}
-	return earliest ?? -1;
+	const boundary = /(?:\r\n|\r|\n)(?:\r\n|\r|\n)/gu;
+	boundary.lastIndex = startIndex;
+	const match = boundary.exec(input);
+	return match
+		? { start: match.index, end: match.index + match[0].length }
+		: -1;
 }
 
 function parseA2AStreamEventFrame(frame: string): A2AStreamEvent | undefined {

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -537,6 +537,56 @@ describe("platform A2A client", () => {
 		]);
 	});
 
+	it("handles mixed-newline A2A SSE frame delimiters", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+		vi.mocked(fetch).mockImplementationOnce(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+				return sseResponse([
+					'data: {"task":{"id":"run_mixed","status":{"state":"TASK_STATE_SUBMITTED"}}}\r\n\n',
+					'event: statusUpdate\ndata: {"taskId":"run_mixed","status":{"state":"TASK_STATE_COMPLETED"},"final":true}\n\r\n',
+				]);
+			},
+		);
+
+		const events = await collectAsyncIterable(
+			streamA2AMessage(config, {
+				message: buildA2AUserMessage({
+					messageId: "msg_stream_mixed",
+					contextId: "session_1",
+					text: "Stream mixed newline frames",
+				}),
+			}),
+		);
+
+		expect(events).toEqual([
+			{
+				type: "task",
+				task: {
+					id: "run_mixed",
+					status: { state: "TASK_STATE_SUBMITTED" },
+				},
+			},
+			{
+				type: "statusUpdate",
+				taskId: "run_mixed",
+				status: { state: "TASK_STATE_COMPLETED" },
+				final: true,
+			},
+		]);
+	});
+
 	it("gets an A2A task by run id", async () => {
 		const config = await resolveA2AServiceConfig();
 		if (!config) {


### PR DESCRIPTION
## Summary
- Parse SSE frame boundaries with mixed CR/LF blank-line delimiters.
- Add A2A client coverage for mixed-newline task/status events.
- Source-of-truth internal PR: evalops/maestro-internal#1989

## Test Plan
- npm run test:fast -- test/platform/a2a-client.test.ts
- Pre-commit checks: Guardian, Biome, eval lint, contract/codegen checks, build