### PR TITLE
Fix mixed-newline A2A SSE parsing

### DIFF
--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -553,12 +553,36 @@ function findServerSentEventBoundary(
 	input: string,
 	startIndex: number,
 ): { start: number; end: number } | -1 {
-	const boundary = /(?:\r\n|\r|\n)(?:\r\n|\r|\n)/gu;
-	boundary.lastIndex = startIndex;
-	const match = boundary.exec(input);
-	return match
-		? { start: match.index, end: match.index + match[0].length }
-		: -1;
+	for (let index = startIndex; index < input.length; index += 1) {
+		const firstLineEndingLength = getServerSentEventLineEndingLength(
+			input,
+			index,
+		);
+		if (firstLineEndingLength === 0) {
+			continue;
+		}
+		const secondLineEndingLength = getServerSentEventLineEndingLength(
+			input,
+			index + firstLineEndingLength,
+		);
+		if (secondLineEndingLength > 0) {
+			return {
+				start: index,
+				end: index + firstLineEndingLength + secondLineEndingLength,
+			};
+		}
+	}
+	return -1;
+}
+
+function getServerSentEventLineEndingLength(
+	input: string,
+	index: number,
+): number {
+	if (input[index] === "\r") {
+		return input[index + 1] === "\n" ? 2 : 1;
+	}
+	return input[index] === "\n" ? 1 : 0;
 }
 
 function parseA2AStreamEventFrame(frame: string): A2AStreamEvent | undefined {

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -553,18 +553,12 @@ function findServerSentEventBoundary(
 	input: string,
 	startIndex: number,
 ): { start: number; end: number } | -1 {
-	const boundaries = ["\r\n\r\n", "\n\n", "\r\r"];
-	let earliest: { start: number; end: number } | undefined;
-	for (const boundary of boundaries) {
-		const index = input.indexOf(boundary, startIndex);
-		if (index === -1) {
-			continue;
-		}
-		if (!earliest || index < earliest.start) {
-			earliest = { start: index, end: index + boundary.length };
-		}
-	}
-	return earliest ?? -1;
+	const boundary = /(?:\r\n|\r|\n)(?:\r\n|\r|\n)/gu;
+	boundary.lastIndex = startIndex;
+	const match = boundary.exec(input);
+	return match
+		? { start: match.index, end: match.index + match[0].length }
+		: -1;
 }
 
 function parseA2AStreamEventFrame(frame: string): A2AStreamEvent | undefined {

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -537,6 +537,56 @@ describe("platform A2A client", () => {
 		]);
 	});
 
+	it("handles mixed-newline A2A SSE frame delimiters", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+		vi.mocked(fetch).mockImplementationOnce(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+				return sseResponse([
+					'data: {"task":{"id":"run_mixed","status":{"state":"TASK_STATE_SUBMITTED"}}}\r\n\n',
+					'event: statusUpdate\ndata: {"taskId":"run_mixed","status":{"state":"TASK_STATE_COMPLETED"},"final":true}\n\r\n',
+				]);
+			},
+		);
+
+		const events = await collectAsyncIterable(
+			streamA2AMessage(config, {
+				message: buildA2AUserMessage({
+					messageId: "msg_stream_mixed",
+					contextId: "session_1",
+					text: "Stream mixed newline frames",
+				}),
+			}),
+		);
+
+		expect(events).toEqual([
+			{
+				type: "task",
+				task: {
+					id: "run_mixed",
+					status: { state: "TASK_STATE_SUBMITTED" },
+				},
+			},
+			{
+				type: "statusUpdate",
+				taskId: "run_mixed",
+				status: { state: "TASK_STATE_COMPLETED" },
+				final: true,
+			},
+		]);
+	});
+
 	it("gets an A2A task by run id", async () => {
 		const config = await resolveA2AServiceConfig();
 		if (!config) {

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -555,7 +555,7 @@ describe("platform A2A client", () => {
 				});
 				return sseResponse([
 					'data: {"task":{"id":"run_mixed","status":{"state":"TASK_STATE_SUBMITTED"}}}\r\n\n',
-					'event: statusUpdate\ndata: {"taskId":"run_mixed","status":{"state":"TASK_STATE_COMPLETED"},"final":true}\n\r\n',
+					'event: statusUpdate\r\ndata: {"taskId":"run_mixed","status":{"state":"TASK_STATE_COMPLETED"},"final":true}\r\n\r\n',
 				]);
 			},
 		);


### PR DESCRIPTION
## Summary
- Handles mixed LF/CRLF/CR blank-line delimiters in A2A SSE stream parsing.
- Replaces the regex with a deterministic scanner so a single CRLF cannot be backtracked into a full event boundary.
- Adds regression coverage for mixed-newline task/status events and CRLF multi-line `event:` + `data:` frames.

## Source
- Private source-of-truth PR: evalops/maestro-internal#1992
- Original A2A fleet PR: evalops/maestro-internal#1989

## Test Plan
- `npm run test:fast -- test/platform/a2a-client.test.ts`
- `npx biome check src/platform/a2a-client.ts test/platform/a2a-client.test.ts`
- `npx tsc -p tsconfig.build.json --noEmit --pretty false`