### PR TITLE
Add A2A push notification configs

### DIFF
--- a/docs/protocols/a2a-fleet-delegation.md
+++ b/docs/protocols/a2a-fleet-delegation.md
@@ -79,6 +79,10 @@ GET  /tasks/{id}
 GET  /tasks/{id}:subscribe
 POST /tasks/{id}:subscribe
 POST /tasks/{id}:cancel
+POST /tasks/{id}/pushNotificationConfigs
+GET  /tasks/{id}/pushNotificationConfigs
+GET  /tasks/{id}/pushNotificationConfigs/{configId}
+DELETE /tasks/{id}/pushNotificationConfigs/{configId}
 ```
 
 `GET /tasks` accepts the spec-shaped fleet filters `contextId`, `status`,
@@ -96,9 +100,54 @@ default; `historyLength=0` suppresses history in list responses.
 payloads (`task`, `statusUpdate`, and `artifactUpdate`). Subscribe is for
 nonterminal work; terminal tasks should be read with `GET /tasks/{id}` and must
 not be treated as a replayable subscription stream. The public Agent Card
-advertises `capabilities.streaming=true` plus authenticated extended-card
-support, and the extended card declares Maestro's EvalOps operating-plane
-extension for workspace/session/trace/retention correlation metadata.
+advertises `capabilities.streaming=true`, `capabilities.pushNotifications=true`,
+and authenticated extended-card support. The extended card declares Maestro's
+EvalOps operating-plane extension for workspace/session/trace/retention
+correlation metadata.
+
+`A2A-Extensions` and `message.extensions` are accepted for the EvalOps
+operating-plane extension URI:
+
+```text
+https://evalops.com/a2a/extensions/operating-plane/v1
+```
+
+Requests that ask Maestro to use unknown extensions fail before a task is
+created. That keeps mixed fleets explicit: peers can detect when they are using
+only core A2A versus EvalOps-specific workspace, trace, approval, and retention
+correlation.
+
+Push notification configs are stored with the task metadata in the same durable
+ledger. Maestro POSTs A2A `StreamResponse` payloads to each configured callback
+whenever a task state is published: a `statusUpdate` for every state publish,
+plus terminal `artifactUpdate` and final `task` payloads when artifacts/final
+state are available. Production callbacks should use HTTPS and public addresses;
+local development can opt into insecure/private callback URLs with
+`MAESTRO_A2A_PUSH_ALLOW_INSECURE=1` and
+`MAESTRO_A2A_PUSH_ALLOW_PRIVATE=1`. `MAESTRO_A2A_PUSH_TIMEOUT_MS` bounds callback
+delivery, and `MAESTRO_A2A_PUSH_DISABLE_DELIVERY=1` leaves configs stored without
+dispatching callbacks.
+
+## EvalOps Suite Integration
+
+The current suite split is deliberate:
+
+- Maestro owns the operator-native A2A peer surface: pairing, delegation, task
+  transcript, streaming, push callback dispatch, and extension negotiation.
+- Platform owns hosted AgentRuntime, AgentRun/Objective identity, task
+  projection, workspace auth, and CloudEvents/trace joins.
+- Deploy owns release-smoke and observability gates for the hosted A2A path:
+  dashboards, alerts, smoke agents, and promotion checks.
+- Cerebro should consume the same low-cardinality Platform events for analytics
+  rather than reading Maestro's local ledger directly.
+- Conductor remains a browser-control capability behind Maestro/Platform
+  receipts; it should surface as task artifacts and tool evidence, not as a
+  separate A2A peer protocol.
+
+The next cross-repo integration should project Maestro peer tasks into Platform
+work graph records with the same `contextId`, `taskId`, trace, workspace, and
+artifact metadata. Push callbacks then become the async wakeup path for clients
+that cannot keep SSE subscriptions open.
 
 ## Files
 

--- a/packages/control-plane-rs/src/auth.rs
+++ b/packages/control-plane-rs/src/auth.rs
@@ -196,6 +196,7 @@ fn csrf_applies_to_a2a_path(path: &str) -> bool {
     matches!(path, "/message:send" | "/message:stream")
         || a2a_task_id_from_cancel_path(path).is_some()
         || a2a_task_id_from_subscribe_path(path).is_some()
+        || a2a_push_notification_config_path(path).is_some()
 }
 
 pub(crate) fn a2a_task_id_from_cancel_path(path: &str) -> Option<&str> {
@@ -209,6 +210,19 @@ pub(crate) fn a2a_task_id_from_subscribe_path(path: &str) -> Option<&str> {
         .strip_suffix(":subscribe")
         .or_else(|| path.strip_prefix("/tasks/")?.strip_suffix("/subscribe"))?;
     (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
+}
+
+fn a2a_push_notification_config_path(path: &str) -> Option<()> {
+    let rest = path.strip_prefix("/tasks/")?;
+    let (task_id, suffix) = rest.split_once("/pushNotificationConfigs")?;
+    if task_id.is_empty() || task_id.contains('/') || task_id.contains(':') {
+        return None;
+    }
+    if suffix.is_empty() {
+        return Some(());
+    }
+    let config_id = suffix.strip_prefix('/')?;
+    (!config_id.is_empty() && !config_id.contains('/') && !config_id.contains(':')).then_some(())
 }
 
 pub(crate) fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -9,6 +9,7 @@ use sha1::{Digest, Sha1};
 use std::collections::HashMap;
 use std::env;
 use std::io::{Cursor, Read};
+use std::net::{IpAddr, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process::{self, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -59,6 +60,9 @@ const A2A_MAX_LIST_PAGE_SIZE: usize = 100;
 const A2A_DEFAULT_SUBSCRIBE_TIMEOUT_MS: u64 = 60_000;
 const A2A_DEFAULT_SUBSCRIBE_HEARTBEAT_MS: u64 = 15_000;
 const A2A_TASK_EVENT_REPLAY_LIMIT: usize = 256;
+const A2A_PUSH_NOTIFICATION_CONFIG_LIMIT: usize = 16;
+const A2A_DEFAULT_PUSH_TIMEOUT_MS: u64 = 10_000;
+const A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY: &str = "pushNotificationConfigs";
 const A2A_LEDGER_LOCK_RETRY_MS: u64 = 25;
 const A2A_LEDGER_LOCK_STALE_MS: u64 = 30_000;
 const A2A_LEDGER_LOCK_TIMEOUT_MS: u64 = A2A_LEDGER_LOCK_STALE_MS + A2A_LEDGER_LOCK_RETRY_MS;
@@ -717,6 +721,8 @@ fn is_a2a_endpoint(head: &RequestHead) -> bool {
             | ("GET", "/tasks")
     ) || (head.method == "GET" && a2a_task_id_from_get_path(&head.path).is_some())
         || (head.method == "POST" && a2a_task_id_from_cancel_path(&head.path).is_some())
+        || ((head.method == "GET" || head.method == "POST" || head.method == "DELETE")
+            && a2a_push_notification_config_path(&head.path).is_some())
 }
 
 fn is_a2a_streaming_endpoint(head: &RequestHead) -> bool {
@@ -728,6 +734,25 @@ fn is_a2a_streaming_endpoint(head: &RequestHead) -> bool {
 fn a2a_task_id_from_get_path(path: &str) -> Option<&str> {
     let id = path.strip_prefix("/tasks/")?;
     (!id.is_empty() && !id.contains('/') && !id.contains(':')).then_some(id)
+}
+
+fn a2a_push_notification_config_path(path: &str) -> Option<(String, Option<String>)> {
+    let rest = path.strip_prefix("/tasks/")?;
+    let (task_id, suffix) = rest.split_once("/pushNotificationConfigs")?;
+    if task_id.trim().is_empty() || task_id.contains('/') || task_id.contains(':') {
+        return None;
+    }
+    if suffix.is_empty() {
+        return Some((percent_decode_component(task_id), None));
+    }
+    let config_id = suffix.strip_prefix('/')?;
+    if config_id.trim().is_empty() || config_id.contains('/') || config_id.contains(':') {
+        return None;
+    }
+    Some((
+        percent_decode_component(task_id),
+        Some(percent_decode_component(config_id)),
+    ))
 }
 
 fn validate_a2a_protocol_version(head: &RequestHead) -> Result<(), Vec<u8>> {
@@ -756,6 +781,64 @@ fn a2a_requested_protocol_version(head: &RequestHead) -> Option<&str> {
         .or_else(|| head.query.get("a2a-version").map(String::as_str))
         .or_else(|| head.query.get("A2A-Version").map(String::as_str))
         .or_else(|| head.query.get("a2aVersion").map(String::as_str))
+}
+
+fn validate_a2a_requested_extensions(
+    head: &RequestHead,
+    message_extensions: Option<&[String]>,
+) -> Result<Vec<String>, Vec<u8>> {
+    let requested = requested_a2a_extensions(head, message_extensions);
+    let unsupported = requested
+        .iter()
+        .find(|extension| !a2a_supported_extension(extension));
+    if let Some(extension) = unsupported {
+        return Err(a2a_error_response(
+            400,
+            "EXTENSION_NOT_SUPPORTED",
+            &format!("A2A extension is not supported by this Maestro agent: {extension}"),
+        ));
+    }
+    Ok(requested)
+}
+
+fn requested_a2a_extensions(
+    head: &RequestHead,
+    message_extensions: Option<&[String]>,
+) -> Vec<String> {
+    let mut requested = Vec::new();
+    if let Some(header) = head.headers.get("a2a-extensions") {
+        for extension in header.split(',') {
+            push_unique_a2a_extension(&mut requested, extension);
+        }
+    }
+    if let Some(query) = head.query.get("a2a-extensions") {
+        for extension in query.split(',') {
+            push_unique_a2a_extension(&mut requested, extension);
+        }
+    }
+    if let Some(query) = head.query.get("A2A-Extensions") {
+        for extension in query.split(',') {
+            push_unique_a2a_extension(&mut requested, extension);
+        }
+    }
+    if let Some(extensions) = message_extensions {
+        for extension in extensions {
+            push_unique_a2a_extension(&mut requested, extension);
+        }
+    }
+    requested
+}
+
+fn push_unique_a2a_extension(requested: &mut Vec<String>, extension: &str) {
+    let extension = extension.trim();
+    if extension.is_empty() || requested.iter().any(|existing| existing == extension) {
+        return;
+    }
+    requested.push(extension.to_string());
+}
+
+fn a2a_supported_extension(extension: &str) -> bool {
+    extension == EVALOPS_A2A_EXTENSION_URI
 }
 
 async fn handle_a2a_endpoint(
@@ -792,6 +875,25 @@ async fn handle_a2a_endpoint(
         return match a2a_list_tasks_response(&head, state, &auth).await {
             Ok(value) => json_response(200, &value),
             Err(response) => response,
+        };
+    }
+
+    if let Some((task_id, config_id)) = a2a_push_notification_config_path(&head.path) {
+        return match (head.method.as_str(), config_id.as_deref()) {
+            ("GET", None) => handle_a2a_push_notification_config_list(state, &task_id, &auth).await,
+            ("GET", Some(config_id)) => {
+                handle_a2a_push_notification_config_get(state, &task_id, config_id, &auth).await
+            }
+            ("POST", None) => {
+                handle_a2a_push_notification_config_create(
+                    stream, initial, &head, state, &task_id, &auth,
+                )
+                .await
+            }
+            ("DELETE", Some(config_id)) => {
+                handle_a2a_push_notification_config_delete(state, &task_id, config_id, &auth).await
+            }
+            _ => a2a_error_response(404, "NOT_FOUND", "A2A endpoint not found"),
         };
     }
 
@@ -902,6 +1004,11 @@ async fn handle_a2a_message_stream(
             .await;
         }
     };
+    let requested_extensions =
+        match validate_a2a_requested_extensions(head, request.message.extensions.as_deref()) {
+            Ok(extensions) => extensions,
+            Err(response) => return write_response_and_close(stream, response).await,
+        };
     let Some(prompt) = a2a_message_text(&request.message) else {
         return write_response_and_close(
             stream,
@@ -918,7 +1025,7 @@ async fn handle_a2a_message_stream(
             .await;
     }
 
-    let metadata = a2a_task_metadata(head, &request, auth);
+    let metadata = a2a_task_metadata(head, &request, auth, &requested_extensions);
     let target = match claim_a2a_send_task(state, &request, head, auth, metadata).await {
         Ok(target) => target,
         Err(response) => return write_response_and_close(stream, response).await,
@@ -1745,6 +1852,102 @@ async fn publish_a2a_task_update(state: &AppState, task: &Value) {
         event
     };
     let _ = state.a2a_task_events.send(event);
+    dispatch_a2a_push_notifications(task);
+}
+
+fn dispatch_a2a_push_notifications(task: &Value) {
+    if truthy_env("MAESTRO_A2A_PUSH_DISABLE_DELIVERY") {
+        return;
+    }
+    let configs = a2a_task_push_notification_configs(task);
+    if configs.is_empty() {
+        return;
+    }
+    let payloads = a2a_push_notification_payloads(task);
+    for config in configs {
+        for payload in payloads.clone() {
+            let config = config.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                send_a2a_push_notification(&payload, &config);
+            });
+        }
+    }
+}
+
+fn a2a_task_without_push_notification_configs(task: &Value) -> Value {
+    let mut task = task.clone();
+    if let Some(metadata) = task.get_mut("metadata").and_then(Value::as_object_mut) {
+        metadata.remove(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY);
+    }
+    task
+}
+
+fn a2a_push_notification_payloads(task: &Value) -> Vec<Value> {
+    let task = a2a_task_without_push_notification_configs(task);
+    let mut payloads = vec![serde_json::json!({ "statusUpdate": a2a_status_update_event(&task) })];
+    if a2a_task_is_terminal(&task) {
+        for artifact in task
+            .get("artifacts")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            payloads.push(serde_json::json!({
+                "artifactUpdate": a2a_artifact_update_event(&task, artifact)
+            }));
+        }
+        payloads.push(serde_json::json!({ "task": task }));
+    }
+    payloads
+}
+
+fn send_a2a_push_notification(payload: &Value, config: &Value) {
+    let Some(url) = config.get("url").and_then(Value::as_str) else {
+        return;
+    };
+    if validate_a2a_push_notification_url(url).is_err() {
+        return;
+    }
+    let timeout = Duration::from_millis(env_u64(
+        "MAESTRO_A2A_PUSH_TIMEOUT_MS",
+        A2A_DEFAULT_PUSH_TIMEOUT_MS,
+    ));
+    let Ok(client) = reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .build()
+    else {
+        return;
+    };
+    let Ok(body) = serde_json::to_vec(payload) else {
+        return;
+    };
+    let mut request = client
+        .post(url)
+        .header("Content-Type", "application/a2a+json")
+        .body(body);
+    if let Some(token) = config.get("token").and_then(Value::as_str) {
+        request = request.header("X-A2A-Notification-Token", token);
+    }
+    if let Some(authentication) = config.get("authentication").and_then(Value::as_object) {
+        if let Some(header_value) = a2a_push_authorization_header(authentication) {
+            request = request.header("Authorization", header_value);
+        }
+    }
+    let _ = request.send();
+}
+
+fn a2a_push_authorization_header(authentication: &Map<String, Value>) -> Option<String> {
+    let scheme = authentication
+        .get("scheme")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let credentials = authentication
+        .get("credentials")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    Some(format!("{scheme} {credentials}"))
 }
 
 fn a2a_ledger_entry_is_control_plane(entry: &Value) -> bool {
@@ -2281,7 +2484,7 @@ async fn claim_a2a_send_task(
         .map(str::to_string);
 
     let mut tasks = state.a2a_tasks.lock().await;
-    let (task_id, context_id, mut history, previous_task, task_metadata) =
+    let (task_id, context_id, mut history, previous_task, mut task_metadata) =
         if let Some(task_id) = requested_task_id {
             let Some(task) = tasks.get(task_id) else {
                 return Err(a2a_error_response(
@@ -2353,6 +2556,10 @@ async fn claim_a2a_send_task(
                 metadata,
             )
         };
+    if let Some(config) = a2a_push_notification_config_from_send_request(request, &task_id)? {
+        task_metadata = a2a_metadata_with_push_notification_config(task_metadata, config)
+            .map_err(|message| a2a_error_response(400, "INVALID_REQUEST", &message))?;
+    }
     history.push(a2a_user_message_value(&request.message, &context_id));
     let working_message = a2a_agent_message(&context_id, "Maestro is working on the A2A task.");
     let task = a2a_task_value(
@@ -2390,6 +2597,250 @@ fn a2a_merge_task_metadata(existing_task: &Value, metadata: Value) -> Value {
         }
     }
     Value::Object(merged)
+}
+
+fn a2a_push_notification_config_from_send_request(
+    request: &A2ASendMessageRequest,
+    task_id: &str,
+) -> Result<Option<Value>, Vec<u8>> {
+    let Some(configuration) = request.configuration.as_ref().and_then(Value::as_object) else {
+        return Ok(None);
+    };
+    let config = configuration
+        .get("taskPushNotificationConfig")
+        .or_else(|| configuration.get("task_push_notification_config"))
+        .or_else(|| configuration.get("pushNotificationConfig"));
+    let Some(config) = config else {
+        return Ok(None);
+    };
+    normalize_a2a_push_notification_config(task_id, config.clone(), false)
+        .map(Some)
+        .map_err(|message| a2a_error_response(400, "INVALID_REQUEST", &message))
+}
+
+fn a2a_metadata_key_is_reserved(key: &str) -> bool {
+    key == A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY
+}
+
+fn a2a_metadata_with_push_notification_config(
+    metadata: Value,
+    config: Value,
+) -> Result<Value, String> {
+    let task = serde_json::json!({
+        "metadata": metadata
+    });
+    let updated = a2a_task_with_push_notification_config(&task, config)?;
+    Ok(updated
+        .get("metadata")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({})))
+}
+
+fn a2a_task_push_notification_configs(task: &Value) -> Vec<Value> {
+    let Some(task_id) = task.get("id").and_then(Value::as_str) else {
+        return Vec::new();
+    };
+    let Some(configs) = task
+        .get("metadata")
+        .and_then(|metadata| metadata.get(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY))
+        .and_then(Value::as_array)
+    else {
+        return Vec::new();
+    };
+    if configs.len() > A2A_PUSH_NOTIFICATION_CONFIG_LIMIT {
+        return Vec::new();
+    }
+    configs
+        .iter()
+        .filter_map(|config| {
+            normalize_a2a_push_notification_config(task_id, config.clone(), true).ok()
+        })
+        .collect()
+}
+
+fn normalize_a2a_push_notification_config(
+    task_id: &str,
+    config: Value,
+    require_task_match: bool,
+) -> Result<Value, String> {
+    let mut object = config
+        .as_object()
+        .cloned()
+        .ok_or_else(|| "A2A push notification config must be an object".to_string())?;
+    let url = object
+        .get("url")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "A2A push notification config url is required".to_string())?;
+    validate_a2a_push_notification_url(url)?;
+    object.insert("url".to_string(), Value::String(url.to_string()));
+
+    let configured_task_id = object
+        .get("taskId")
+        .or_else(|| object.get("task_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if require_task_match && configured_task_id.is_some_and(|value| value != task_id) {
+        return Err("A2A push notification config taskId must match the request path".to_string());
+    }
+    object.remove("task_id");
+    object.insert("taskId".to_string(), Value::String(task_id.to_string()));
+
+    let id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| task_id.to_string());
+    if id.contains('/') || id.contains(':') {
+        return Err("A2A push notification config id must not contain '/' or ':'".to_string());
+    }
+    object.insert("id".to_string(), Value::String(id));
+
+    if let Some(token) = object.get("token").and_then(Value::as_str).map(str::trim) {
+        object.insert("token".to_string(), Value::String(token.to_string()));
+    }
+    Ok(Value::Object(object))
+}
+
+fn validate_a2a_push_notification_url(url: &str) -> Result<(), String> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|error| format!("A2A push notification config url is invalid: {error}"))?;
+    match parsed.scheme() {
+        "https" => {}
+        "http" if truthy_env("MAESTRO_A2A_PUSH_ALLOW_INSECURE") => {}
+        _ => {
+            return Err(
+                "A2A push notification config url must use HTTPS unless MAESTRO_A2A_PUSH_ALLOW_INSECURE=1"
+                    .to_string(),
+            );
+        }
+    }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "A2A push notification config url must include a host".to_string())?;
+    let port = parsed.port_or_known_default().unwrap_or(443);
+    if !truthy_env("MAESTRO_A2A_PUSH_ALLOW_PRIVATE")
+        && (a2a_push_host_is_private(host) || a2a_push_host_resolves_private(host, port))
+    {
+        return Err(
+            "A2A push notification config url host is private; set MAESTRO_A2A_PUSH_ALLOW_PRIVATE=1 for local development"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn a2a_push_host_is_private(host: &str) -> bool {
+    let host = host.trim_matches(['[', ']']).to_ascii_lowercase();
+    if matches!(host.as_str(), "localhost" | "localhost.localdomain") {
+        return true;
+    }
+    host.parse::<IpAddr>().is_ok_and(a2a_push_ip_is_private)
+}
+
+fn a2a_push_host_resolves_private(host: &str, port: u16) -> bool {
+    if host.parse::<IpAddr>().is_ok() {
+        return false;
+    }
+    (host, port).to_socket_addrs().is_ok_and(|addresses| {
+        addresses
+            .map(|address| address.ip())
+            .any(a2a_push_ip_is_private)
+    })
+}
+
+fn a2a_push_ip_is_private(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(addr) => {
+            addr.is_loopback()
+                || addr.is_private()
+                || addr.is_link_local()
+                || addr.is_unspecified()
+                || addr.octets()[0] == 169 && addr.octets()[1] == 254
+        }
+        IpAddr::V6(addr) => {
+            if let Some(mapped) = addr.to_ipv4_mapped() {
+                return a2a_push_ip_is_private(IpAddr::V4(mapped));
+            }
+            addr.is_loopback()
+                || addr.is_unspecified()
+                || addr.segments()[0] & 0xfe00 == 0xfc00
+                || addr.segments()[0] & 0xffc0 == 0xfe80
+        }
+    }
+}
+
+fn a2a_task_with_push_notification_config(task: &Value, config: Value) -> Result<Value, String> {
+    let mut task_object = task
+        .as_object()
+        .cloned()
+        .ok_or_else(|| "A2A task must be an object".to_string())?;
+    let mut metadata = task_object
+        .get("metadata")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let mut configs = metadata
+        .get(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let config_id = config
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "A2A push notification config id is required".to_string())?;
+    if let Some(index) = configs
+        .iter()
+        .position(|existing| existing.get("id").and_then(Value::as_str) == Some(config_id))
+    {
+        configs[index] = config;
+    } else {
+        if configs.len() >= A2A_PUSH_NOTIFICATION_CONFIG_LIMIT {
+            return Err(format!(
+                "A2A task may have at most {A2A_PUSH_NOTIFICATION_CONFIG_LIMIT} push notification configs"
+            ));
+        }
+        configs.push(config);
+    }
+    metadata.insert(
+        A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY.to_string(),
+        Value::Array(configs),
+    );
+    task_object.insert("metadata".to_string(), Value::Object(metadata));
+    Ok(Value::Object(task_object))
+}
+
+fn a2a_task_without_push_notification_config(task: &Value, config_id: &str) -> Option<Value> {
+    let mut task_object = task.as_object()?.clone();
+    let mut metadata = task_object
+        .get("metadata")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let mut configs = metadata
+        .get(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY)
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let original_len = configs.len();
+    configs.retain(|config| config.get("id").and_then(Value::as_str) != Some(config_id));
+    if configs.len() == original_len {
+        return None;
+    }
+    if configs.is_empty() {
+        metadata.remove(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY);
+    } else {
+        metadata.insert(
+            A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY.to_string(),
+            Value::Array(configs),
+        );
+    }
+    task_object.insert("metadata".to_string(), Value::Object(metadata));
+    Some(Value::Object(task_object))
 }
 
 async fn rollback_a2a_send_claim(state: &AppState, task_id: &str, previous_task: Option<Value>) {
@@ -2476,6 +2927,121 @@ async fn register_a2a_cancel_sender(
     Ok(())
 }
 
+async fn handle_a2a_push_notification_config_list(
+    state: &AppState,
+    task_id: &str,
+    auth: &AuthContext,
+) -> Vec<u8> {
+    let tasks = state.a2a_tasks.lock().await;
+    let Some(task) = tasks.get(task_id) else {
+        return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");
+    };
+    if !a2a_task_visible_to_auth(task, auth) {
+        return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");
+    }
+    json_response(
+        200,
+        &serde_json::json!({
+            "configs": a2a_task_push_notification_configs(task)
+        }),
+    )
+}
+
+async fn handle_a2a_push_notification_config_get(
+    state: &AppState,
+    task_id: &str,
+    config_id: &str,
+    auth: &AuthContext,
+) -> Vec<u8> {
+    let tasks = state.a2a_tasks.lock().await;
+    let Some(task) = tasks.get(task_id) else {
+        return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");
+    };
+    if !a2a_task_visible_to_auth(task, auth) {
+        return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");
+    }
+    a2a_task_push_notification_configs(task)
+        .into_iter()
+        .find(|config| config.get("id").and_then(Value::as_str) == Some(config_id))
+        .map_or_else(
+            || {
+                a2a_error_response(
+                    404,
+                    "PUSH_NOTIFICATION_CONFIG_NOT_FOUND",
+                    "A2A push notification config not found",
+                )
+            },
+            |config| json_response(200, &config),
+        )
+}
+
+async fn handle_a2a_push_notification_config_create(
+    stream: &mut TcpStream,
+    initial: &mut Vec<u8>,
+    head: &RequestHead,
+    state: &AppState,
+    task_id: &str,
+    auth: &AuthContext,
+) -> Vec<u8> {
+    let body = match read_request_body(stream, initial, head).await {
+        Ok(body) => body,
+        Err(error) => return a2a_error_response(400, "INVALID_REQUEST", &error),
+    };
+    let raw_config: Value = match serde_json::from_slice(&body) {
+        Ok(config) => config,
+        Err(error) => {
+            return a2a_error_response(
+                400,
+                "INVALID_REQUEST",
+                &format!("invalid A2A push notification config: {error}"),
+            );
+        }
+    };
+    let config = match normalize_a2a_push_notification_config(task_id, raw_config, true) {
+        Ok(config) => config,
+        Err(message) => return a2a_error_response(400, "INVALID_REQUEST", &message),
+    };
+    let mut tasks = state.a2a_tasks.lock().await;
+    let Some(existing_task) = tasks.get(task_id) else {
+        return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");
+    };
+    if !a2a_task_visible_to_auth(existing_task, auth) {
+        return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");
+    }
+    let task = match a2a_task_with_push_notification_config(existing_task, config.clone()) {
+        Ok(task) => task,
+        Err(message) => return a2a_error_response(400, "INVALID_REQUEST", &message),
+    };
+    tasks.insert(task_id.to_string(), task.clone());
+    drop(tasks);
+    publish_a2a_task_update(state, &task).await;
+    persist_a2a_tasks(state).await;
+    json_response(200, &config)
+}
+
+async fn handle_a2a_push_notification_config_delete(
+    state: &AppState,
+    task_id: &str,
+    config_id: &str,
+    auth: &AuthContext,
+) -> Vec<u8> {
+    let mut tasks = state.a2a_tasks.lock().await;
+    let Some(existing_task) = tasks.get(task_id) else {
+        return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");
+    };
+    if !a2a_task_visible_to_auth(existing_task, auth) {
+        return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");
+    }
+    let Some(task) = a2a_task_without_push_notification_config(existing_task, config_id) else {
+        return json_response(200, &serde_json::json!({}));
+    };
+    tasks.insert(task_id.to_string(), task.clone());
+    drop(tasks);
+    publish_a2a_task_update(state, &task).await;
+    persist_a2a_tasks(state).await;
+    json_response(200, &serde_json::json!({}))
+}
+
 async fn handle_a2a_message_send(
     stream: &mut TcpStream,
     initial: &mut Vec<u8>,
@@ -2497,6 +3063,11 @@ async fn handle_a2a_message_send(
             );
         }
     };
+    let requested_extensions =
+        match validate_a2a_requested_extensions(head, request.message.extensions.as_deref()) {
+            Ok(extensions) => extensions,
+            Err(response) => return response,
+        };
 
     let Some(prompt) = a2a_message_text(&request.message) else {
         return a2a_error_response(
@@ -2510,7 +3081,7 @@ async fn handle_a2a_message_send(
         Err(error) => return a2a_error_response(400, "INVALID_REQUEST", error),
     };
 
-    let metadata = a2a_task_metadata(head, &request, auth);
+    let metadata = a2a_task_metadata(head, &request, auth, &requested_extensions);
     let target = match claim_a2a_send_task(state, &request, head, auth, metadata).await {
         Ok(target) => target,
         Err(response) => return response,
@@ -2676,7 +3247,7 @@ fn a2a_agent_card(head: &RequestHead, config: &Config) -> Value {
         "version": env!("CARGO_PKG_VERSION"),
         "capabilities": {
             "streaming": true,
-            "pushNotifications": false,
+            "pushNotifications": true,
             "extendedAgentCard": true,
             "extensions": [a2a_operating_plane_extension(false)]
         },
@@ -2709,6 +3280,10 @@ fn a2a_extended_agent_card(head: &RequestHead, config: &Config) -> Value {
                 "taskStore": "durable-file",
                 "taskStorePath": config.a2a_tasks_file_path.to_string_lossy(),
                 "streamingEndpoints": ["/message:stream", "/tasks/{id}:subscribe"],
+                "pushNotificationEndpoints": [
+                    "/tasks/{taskId}/pushNotificationConfigs",
+                    "/tasks/{taskId}/pushNotificationConfigs/{id}"
+                ],
                 "taskList": {
                     "filters": ["contextId", "status", "statusTimestampAfter"],
                     "pagination": { "defaultPageSize": A2A_DEFAULT_LIST_PAGE_SIZE, "maxPageSize": A2A_MAX_LIST_PAGE_SIZE },
@@ -2733,7 +3308,7 @@ fn a2a_extended_agent_card(head: &RequestHead, config: &Config) -> Value {
             "capabilities".to_string(),
             serde_json::json!({
                 "streaming": true,
-                "pushNotifications": false,
+                "pushNotifications": true,
                 "extendedAgentCard": true,
                 "extensions": [a2a_operating_plane_extension(true)]
             }),
@@ -2969,6 +3544,7 @@ fn a2a_task_metadata(
     head: &RequestHead,
     request: &A2ASendMessageRequest,
     auth: &AuthContext,
+    requested_extensions: &[String],
 ) -> Value {
     let mut metadata = Map::new();
     metadata.insert(
@@ -3002,20 +3578,49 @@ fn a2a_task_metadata(
     }
     if let Some(Value::Object(request_metadata)) = request.metadata.as_ref() {
         for (key, value) in request_metadata {
+            if a2a_metadata_key_is_reserved(key) {
+                continue;
+            }
             metadata.entry(key.clone()).or_insert_with(|| value.clone());
         }
     }
-    if let Some(configuration) = request.configuration.as_ref() {
+    if let Some(configuration) = request
+        .configuration
+        .as_ref()
+        .and_then(a2a_configuration_metadata)
+    {
         metadata
             .entry("configuration".to_string())
-            .or_insert_with(|| configuration.clone());
+            .or_insert(configuration);
     }
     if let Some(Value::Object(message_metadata)) = request.message.metadata.as_ref() {
         for (key, value) in message_metadata {
+            if a2a_metadata_key_is_reserved(key) {
+                continue;
+            }
             metadata.entry(key.clone()).or_insert_with(|| value.clone());
         }
     }
+    if !requested_extensions.is_empty() {
+        metadata.insert(
+            "a2aExtensions".to_string(),
+            Value::Array(
+                requested_extensions
+                    .iter()
+                    .map(|extension| Value::String(extension.clone()))
+                    .collect(),
+            ),
+        );
+    }
     Value::Object(metadata)
+}
+
+fn a2a_configuration_metadata(configuration: &Value) -> Option<Value> {
+    let mut object = configuration.as_object()?.clone();
+    object.remove("taskPushNotificationConfig");
+    object.remove("task_push_notification_config");
+    object.remove("pushNotificationConfig");
+    (!object.is_empty()).then_some(Value::Object(object))
 }
 
 fn a2a_return_immediately(request: &A2ASendMessageRequest) -> Result<bool, &'static str> {
@@ -11606,6 +12211,9 @@ setTimeout(() => {
             "GET /tasks/maestro-task-1 HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "GET /tasks HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "GET /extendedAgentCard HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "GET /tasks/maestro-task-1/pushNotificationConfigs HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "POST /tasks/maestro-task-1/pushNotificationConfigs HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            "DELETE /tasks/maestro-task-1/pushNotificationConfigs/config-1 HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "POST /tasks/maestro-task-1:cancel HTTP/1.1\r\nHost: localhost\r\n\r\n",
             "OPTIONS /message:send HTTP/1.1\r\nHost: localhost\r\n\r\n",
         ] {
@@ -11659,6 +12267,7 @@ setTimeout(() => {
             "HTTP+JSON"
         );
         assert_eq!(card["capabilities"]["streaming"], true);
+        assert_eq!(card["capabilities"]["pushNotifications"], true);
         assert_eq!(card["capabilities"]["extendedAgentCard"], true);
         assert_eq!(
             card["capabilities"]["extensions"][0]["uri"],
@@ -12036,6 +12645,325 @@ setTimeout(() => {
             env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
         } else {
             env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_records_extensions_and_push_config() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
+        let previous_disable_delivery = env::var("MAESTRO_A2A_PUSH_DISABLE_DELIVERY").ok();
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "hello with push config");
+        env::set_var("MAESTRO_A2A_PUSH_DISABLE_DELIVERY", "1");
+
+        let body = format!(
+            r#"{{
+                "message": {{
+                    "messageId": "msg-push",
+                    "contextId": "ctx-push",
+                    "role": "ROLE_USER",
+                    "extensions": ["{EVALOPS_A2A_EXTENSION_URI}"],
+                    "parts": [{{"text": "hello", "mediaType": "text/plain"}}]
+                }},
+                "configuration": {{
+                    "taskPushNotificationConfig": {{
+                        "id": "notify-1",
+                        "url": "https://hooks.example/a2a",
+                        "token": "notify-token",
+                        "authentication": {{
+                            "scheme": "Bearer",
+                            "credentials": "auth-token"
+                        }}
+                    }}
+                }}
+            }}"#
+        );
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nA2A-Extensions: {EVALOPS_A2A_EXTENSION_URI}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        let task = &response["task"];
+
+        assert_eq!(task["status"]["state"], "TASK_STATE_COMPLETED");
+        assert_eq!(
+            task["metadata"]["a2aExtensions"][0],
+            EVALOPS_A2A_EXTENSION_URI
+        );
+        assert_eq!(
+            task["metadata"]["pushNotificationConfigs"][0]["taskId"],
+            task["id"]
+        );
+        assert_eq!(
+            task["metadata"]["pushNotificationConfigs"][0]["token"],
+            "notify-token"
+        );
+        assert!(task["metadata"].get("configuration").is_none());
+
+        if let Some(previous_fake) = previous_fake {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+        if let Some(previous_disable_delivery) = previous_disable_delivery {
+            env::set_var(
+                "MAESTRO_A2A_PUSH_DISABLE_DELIVERY",
+                previous_disable_delivery,
+            );
+        } else {
+            env::remove_var("MAESTRO_A2A_PUSH_DISABLE_DELIVERY");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_rejects_unsupported_extensions() {
+        let body = r#"{"message":{"messageId":"msg-extension","contextId":"ctx-extension","role":"ROLE_USER","extensions":["https://example.test/a2a/extensions/unsupported/v1"],"parts":[{"text":"hello","mediaType":"text/plain"}]}}"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert_eq!(response["error"]["code"], "EXTENSION_NOT_SUPPORTED");
+        assert!(state.a2a_tasks.lock().await.is_empty());
+    }
+
+    #[test]
+    fn a2a_push_notification_payloads_use_stream_response_shape() {
+        let terminal_task = a2a_task_value(
+            "task-push-payload",
+            "ctx-push-payload",
+            "TASK_STATE_COMPLETED",
+            a2a_agent_message("ctx-push-payload", "done"),
+            Vec::new(),
+            vec![serde_json::json!({
+                "artifactId": "artifact-1",
+                "parts": [{ "text": "artifact text", "mediaType": "text/plain" }]
+            })],
+            serde_json::json!({
+                "workspaceId": "ws-1",
+                "pushNotificationConfigs": [{
+                    "id": "notify-1",
+                    "taskId": "task-push-payload",
+                    "url": "https://hooks.example/a2a",
+                    "token": "notify-token",
+                    "authentication": {
+                        "scheme": "Bearer",
+                        "credentials": "secret"
+                    }
+                }]
+            }),
+        );
+
+        let payloads = a2a_push_notification_payloads(&terminal_task);
+
+        assert_eq!(payloads.len(), 3);
+        assert_eq!(
+            payloads[0]["statusUpdate"]["taskId"],
+            serde_json::json!("task-push-payload")
+        );
+        assert_eq!(
+            payloads[1]["artifactUpdate"]["artifact"]["artifactId"],
+            serde_json::json!("artifact-1")
+        );
+        assert_eq!(
+            payloads[2]["task"]["id"],
+            serde_json::json!("task-push-payload")
+        );
+        assert_eq!(
+            payloads[0]["statusUpdate"]["metadata"]["workspaceId"],
+            "ws-1"
+        );
+        assert!(payloads[0]["statusUpdate"]["metadata"]
+            .get(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY)
+            .is_none());
+        assert!(payloads[1]["artifactUpdate"]["metadata"]
+            .get(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY)
+            .is_none());
+        assert!(payloads[2]["task"]["metadata"]
+            .get(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY)
+            .is_none());
+
+        for payload in payloads {
+            let stream_response_fields = ["task", "message", "statusUpdate", "artifactUpdate"]
+                .into_iter()
+                .filter(|field| payload.get(field).is_some())
+                .count();
+            assert_eq!(stream_response_fields, 1);
+        }
+    }
+
+    #[test]
+    fn a2a_push_notification_config_rejects_unaddressable_ids() {
+        for id in ["bad/id", "bad:id"] {
+            let result = normalize_a2a_push_notification_config(
+                "task-push",
+                serde_json::json!({
+                    "id": id,
+                    "taskId": "task-push",
+                    "url": "https://hooks.example/a2a"
+                }),
+                true,
+            );
+
+            assert!(result.is_err(), "expected {id} to be rejected");
+        }
+    }
+
+    #[test]
+    fn a2a_push_private_ip_check_includes_ipv4_mapped_ipv6() {
+        let mapped_loopback = "::ffff:127.0.0.1"
+            .parse::<IpAddr>()
+            .expect("mapped IPv6 parses");
+
+        assert!(a2a_push_ip_is_private(mapped_loopback));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_message_send_ignores_push_config_metadata_smuggling() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_fake = env::var("MAESTRO_A2A_FAKE_RESPONSE").ok();
+        let previous_disable_delivery = env::var("MAESTRO_A2A_PUSH_DISABLE_DELIVERY").ok();
+        env::set_var("MAESTRO_A2A_FAKE_RESPONSE", "hello without smuggled push");
+        env::set_var("MAESTRO_A2A_PUSH_DISABLE_DELIVERY", "1");
+
+        let body = r#"{
+            "message": {
+                "messageId": "msg-smuggle",
+                "contextId": "ctx-smuggle",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello", "mediaType": "text/plain"}],
+                "metadata": {
+                    "pushNotificationConfigs": [
+                        {"id": "msg-smuggled", "url": "https://hooks.example/a2a"}
+                    ]
+                }
+            },
+            "metadata": {
+                "pushNotificationConfigs": [
+                    {"id": "request-smuggled", "url": "https://hooks.example/a2a"}
+                ]
+            }
+        }"#;
+        let request = format!(
+            "POST /message:send HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let state = test_app_state_with_sessions(HashMap::new());
+
+        let response =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+
+        assert!(response["task"]["metadata"]
+            .get(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY)
+            .is_none());
+
+        if let Some(previous_fake) = previous_fake {
+            env::set_var("MAESTRO_A2A_FAKE_RESPONSE", previous_fake);
+        } else {
+            env::remove_var("MAESTRO_A2A_FAKE_RESPONSE");
+        }
+        if let Some(previous_disable_delivery) = previous_disable_delivery {
+            env::set_var(
+                "MAESTRO_A2A_PUSH_DISABLE_DELIVERY",
+                previous_disable_delivery,
+            );
+        } else {
+            env::remove_var("MAESTRO_A2A_PUSH_DISABLE_DELIVERY");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn a2a_push_notification_config_crud_updates_task_metadata() {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        let previous_disable_delivery = env::var("MAESTRO_A2A_PUSH_DISABLE_DELIVERY").ok();
+        env::set_var("MAESTRO_A2A_PUSH_DISABLE_DELIVERY", "1");
+        let state = test_app_state_with_sessions(HashMap::new());
+        let task = a2a_task_value(
+            "task-push",
+            "ctx-push",
+            "TASK_STATE_WORKING",
+            a2a_agent_message("ctx-push", "working"),
+            Vec::new(),
+            Vec::new(),
+            serde_json::json!({}),
+        );
+        state
+            .a2a_tasks
+            .lock()
+            .await
+            .insert("task-push".to_string(), task);
+
+        let body = r#"{"id":"notify-1","taskId":"task-push","url":"https://hooks.example/a2a","token":"notify-token"}"#;
+        let request = format!(
+            "POST /tasks/task-push/pushNotificationConfigs HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut initial = request.into_bytes();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let created =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        assert_eq!(created["id"], "notify-1");
+        assert_eq!(created["taskId"], "task-push");
+
+        let mut initial =
+            b"GET /tasks/task-push/pushNotificationConfigs HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n".to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let listed =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        assert_eq!(listed["configs"][0]["id"], "notify-1");
+
+        let mut initial =
+            b"GET /tasks/task-push/pushNotificationConfigs/notify-1 HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n".to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let fetched =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        assert_eq!(fetched["token"], "notify-token");
+
+        let mut initial =
+            b"DELETE /tasks/task-push/pushNotificationConfigs/notify-1 HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n".to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let deleted =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        assert_eq!(deleted, serde_json::json!({}));
+        assert!(state.a2a_tasks.lock().await["task-push"]["metadata"]
+            .get("pushNotificationConfigs")
+            .is_none());
+
+        let mut initial =
+            b"DELETE /tasks/task-push/pushNotificationConfigs/notify-1 HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n".to_vec();
+        let head = parse_request_head(&initial).expect("request should parse");
+        let (_client, mut server) = tcp_stream_pair().await;
+        let deleted_again =
+            response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
+        assert_eq!(deleted_again, serde_json::json!({}));
+
+        if let Some(previous_disable_delivery) = previous_disable_delivery {
+            env::set_var(
+                "MAESTRO_A2A_PUSH_DISABLE_DELIVERY",
+                previous_disable_delivery,
+            );
+        } else {
+            env::remove_var("MAESTRO_A2A_PUSH_DISABLE_DELIVERY");
         }
     }
 

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -76,6 +76,7 @@ static CODEX_BRIDGE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static CODEX_HEADLESS_RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
 static ATTACHMENT_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
+static A2A_ID_FALLBACK_COUNTER: AtomicU64 = AtomicU64::new(0);
 type PendingToolResponseSender = mpsc::UnboundedSender<(String, bool, Option<ToolResult>)>;
 type A2ACancelSender = watch::Sender<bool>;
 type A2ACancelReceiver = watch::Receiver<bool>;
@@ -2771,7 +2772,13 @@ fn normalize_a2a_push_notification_config(
     config: Value,
     require_task_match: bool,
 ) -> Result<Value, String> {
-    normalize_a2a_push_notification_config_inner(task_id, config, require_task_match, true)
+    normalize_a2a_push_notification_config_inner(
+        task_id,
+        config,
+        require_task_match,
+        true,
+        A2APushConfigIdPolicy::Generate,
+    )
 }
 
 fn normalize_a2a_push_notification_config_without_dns(
@@ -2779,7 +2786,18 @@ fn normalize_a2a_push_notification_config_without_dns(
     config: Value,
     require_task_match: bool,
 ) -> Result<Value, String> {
-    normalize_a2a_push_notification_config_inner(task_id, config, require_task_match, false)
+    normalize_a2a_push_notification_config_inner(
+        task_id,
+        config,
+        require_task_match,
+        false,
+        A2APushConfigIdPolicy::LegacyTaskFallback,
+    )
+}
+
+enum A2APushConfigIdPolicy {
+    Generate,
+    LegacyTaskFallback,
 }
 
 fn normalize_a2a_push_notification_config_inner(
@@ -2787,6 +2805,7 @@ fn normalize_a2a_push_notification_config_inner(
     config: Value,
     require_task_match: bool,
     resolve_dns: bool,
+    id_policy: A2APushConfigIdPolicy,
 ) -> Result<Value, String> {
     let mut object = config
         .as_object()
@@ -2819,7 +2838,10 @@ fn normalize_a2a_push_notification_config_inner(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
-        .unwrap_or_else(|| task_id.to_string());
+        .unwrap_or_else(|| match id_policy {
+            A2APushConfigIdPolicy::Generate => generate_a2a_id("pushcfg"),
+            A2APushConfigIdPolicy::LegacyTaskFallback => task_id.to_string(),
+        });
     if id.contains('/') || id.contains(':') {
         return Err("A2A push notification config id must not contain '/' or ':'".to_string());
     }
@@ -3958,7 +3980,8 @@ fn generate_a2a_id(prefix: &str) -> String {
     if getrandom::fill(&mut bytes).is_ok() {
         return format!("{prefix}-{}", URL_SAFE_NO_PAD.encode(bytes));
     }
-    format!("{prefix}-{}-{}", now_millis(), process::id())
+    let counter = A2A_ID_FALLBACK_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{}-{}-{counter}", now_millis(), process::id())
 }
 
 fn a2a_error_response(status: u16, code: &str, message: &str) -> Vec<u8> {
@@ -12799,7 +12822,7 @@ setTimeout(() => {
                         "url": "https://hooks.example/a2a",
                         "token": "notify-token",
                         "authentication": {{
-                            "scheme": "Bearer",
+                            "schemes": ["Bearer"],
                             "credentials": "auth-token"
                         }}
                     }}
@@ -12896,7 +12919,7 @@ setTimeout(() => {
                     "url": "https://hooks.example/a2a",
                     "token": "notify-token",
                     "authentication": {
-                        "scheme": "Bearer",
+                        "schemes": ["Bearer"],
                         "credentials": "secret"
                     }
                 }]
@@ -12957,6 +12980,36 @@ setTimeout(() => {
 
             assert!(result.is_err(), "expected {id} to be rejected");
         }
+    }
+
+    #[test]
+    fn a2a_push_notification_config_generates_distinct_ids_when_missing() {
+        let first = normalize_a2a_push_notification_config(
+            "task-push",
+            serde_json::json!({
+                "taskId": "task-push",
+                "url": "https://hooks.example/a2a"
+            }),
+            true,
+        )
+        .expect("first config should normalize");
+        let second = normalize_a2a_push_notification_config(
+            "task-push",
+            serde_json::json!({
+                "taskId": "task-push",
+                "url": "https://hooks.example/a2a"
+            }),
+            true,
+        )
+        .expect("second config should normalize");
+
+        let first_id = first["id"].as_str().expect("first id should exist");
+        let second_id = second["id"].as_str().expect("second id should exist");
+        assert_ne!(first_id, "task-push");
+        assert_ne!(second_id, "task-push");
+        assert_ne!(first_id, second_id);
+        assert!(first_id.starts_with("pushcfg-"));
+        assert!(second_id.starts_with("pushcfg-"));
     }
 
     #[test]

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -1905,7 +1905,7 @@ fn send_a2a_push_notification(payload: &Value, config: &Value) {
     let Some(url) = config.get("url").and_then(Value::as_str) else {
         return;
     };
-    if validate_a2a_push_notification_url(url).is_err() {
+    if validate_a2a_push_notification_url(url, true).is_err() {
         return;
     }
     let timeout = Duration::from_millis(env_u64(
@@ -2474,7 +2474,11 @@ async fn claim_a2a_send_task(
         .task_id
         .as_deref()
         .map(str::trim)
-        .filter(|task_id| !task_id.is_empty());
+        .filter(|task_id| !task_id.is_empty())
+        .map(str::to_string);
+    let task_id = requested_task_id
+        .clone()
+        .unwrap_or_else(|| generate_a2a_id("maestro-task"));
     let explicit_context_id = request
         .message
         .context_id
@@ -2482,11 +2486,12 @@ async fn claim_a2a_send_task(
         .map(str::trim)
         .filter(|context_id| !context_id.is_empty())
         .map(str::to_string);
+    let push_config = a2a_push_notification_config_from_send_request(request, &task_id).await?;
 
     let mut tasks = state.a2a_tasks.lock().await;
     let (task_id, context_id, mut history, previous_task, mut task_metadata) =
-        if let Some(task_id) = requested_task_id {
-            let Some(task) = tasks.get(task_id) else {
+        if requested_task_id.is_some() {
+            let Some(task) = tasks.get(&task_id) else {
                 return Err(a2a_error_response(
                     404,
                     "TASK_NOT_FOUND",
@@ -2541,7 +2546,7 @@ async fn claim_a2a_send_task(
                 .cloned()
                 .unwrap_or_default();
             (
-                task_id.to_string(),
+                task_id,
                 context_id,
                 history,
                 Some(task.clone()),
@@ -2549,14 +2554,14 @@ async fn claim_a2a_send_task(
             )
         } else {
             (
-                generate_a2a_id("maestro-task"),
+                task_id,
                 explicit_context_id.unwrap_or_else(|| a2a_context_id(request, head)),
                 Vec::new(),
                 None,
                 metadata,
             )
         };
-    if let Some(config) = a2a_push_notification_config_from_send_request(request, &task_id)? {
+    if let Some(config) = push_config {
         task_metadata = a2a_metadata_with_push_notification_config(task_metadata, config)
             .map_err(|message| a2a_error_response(400, "INVALID_REQUEST", &message))?;
     }
@@ -2599,7 +2604,7 @@ fn a2a_merge_task_metadata(existing_task: &Value, metadata: Value) -> Value {
     Value::Object(merged)
 }
 
-fn a2a_push_notification_config_from_send_request(
+async fn a2a_push_notification_config_from_send_request(
     request: &A2ASendMessageRequest,
     task_id: &str,
 ) -> Result<Option<Value>, Vec<u8>> {
@@ -2613,9 +2618,25 @@ fn a2a_push_notification_config_from_send_request(
     let Some(config) = config else {
         return Ok(None);
     };
-    normalize_a2a_push_notification_config(task_id, config.clone(), false)
+    normalize_a2a_push_notification_config_blocking(task_id, config.clone(), false)
+        .await
         .map(Some)
         .map_err(|message| a2a_error_response(400, "INVALID_REQUEST", &message))
+}
+
+async fn normalize_a2a_push_notification_config_blocking(
+    task_id: &str,
+    config: Value,
+    require_task_match: bool,
+) -> Result<Value, String> {
+    let task_id = task_id.to_string();
+    // URL validation resolves DNS to reject private callback targets, so keep it
+    // off Tokio worker threads on request paths.
+    tokio::task::spawn_blocking(move || {
+        normalize_a2a_push_notification_config(&task_id, config, require_task_match)
+    })
+    .await
+    .map_err(|error| format!("A2A push notification config validation failed: {error}"))?
 }
 
 fn a2a_metadata_key_is_reserved(key: &str) -> bool {
@@ -2653,7 +2674,7 @@ fn a2a_task_push_notification_configs(task: &Value) -> Vec<Value> {
     configs
         .iter()
         .filter_map(|config| {
-            normalize_a2a_push_notification_config(task_id, config.clone(), true).ok()
+            normalize_a2a_push_notification_config_without_dns(task_id, config.clone(), true).ok()
         })
         .collect()
 }
@@ -2662,6 +2683,23 @@ fn normalize_a2a_push_notification_config(
     task_id: &str,
     config: Value,
     require_task_match: bool,
+) -> Result<Value, String> {
+    normalize_a2a_push_notification_config_inner(task_id, config, require_task_match, true)
+}
+
+fn normalize_a2a_push_notification_config_without_dns(
+    task_id: &str,
+    config: Value,
+    require_task_match: bool,
+) -> Result<Value, String> {
+    normalize_a2a_push_notification_config_inner(task_id, config, require_task_match, false)
+}
+
+fn normalize_a2a_push_notification_config_inner(
+    task_id: &str,
+    config: Value,
+    require_task_match: bool,
+    resolve_dns: bool,
 ) -> Result<Value, String> {
     let mut object = config
         .as_object()
@@ -2673,7 +2711,7 @@ fn normalize_a2a_push_notification_config(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| "A2A push notification config url is required".to_string())?;
-    validate_a2a_push_notification_url(url)?;
+    validate_a2a_push_notification_url(url, resolve_dns)?;
     object.insert("url".to_string(), Value::String(url.to_string()));
 
     let configured_task_id = object
@@ -2706,7 +2744,7 @@ fn normalize_a2a_push_notification_config(
     Ok(Value::Object(object))
 }
 
-fn validate_a2a_push_notification_url(url: &str) -> Result<(), String> {
+fn validate_a2a_push_notification_url(url: &str, resolve_dns: bool) -> Result<(), String> {
     let parsed = reqwest::Url::parse(url)
         .map_err(|error| format!("A2A push notification config url is invalid: {error}"))?;
     match parsed.scheme() {
@@ -2724,7 +2762,8 @@ fn validate_a2a_push_notification_url(url: &str) -> Result<(), String> {
         .ok_or_else(|| "A2A push notification config url must include a host".to_string())?;
     let port = parsed.port_or_known_default().unwrap_or(443);
     if !truthy_env("MAESTRO_A2A_PUSH_ALLOW_PRIVATE")
-        && (a2a_push_host_is_private(host) || a2a_push_host_resolves_private(host, port))
+        && (a2a_push_host_is_private(host)
+            || (resolve_dns && a2a_push_host_resolves_private(host, port)))
     {
         return Err(
             "A2A push notification config url host is private; set MAESTRO_A2A_PUSH_ALLOW_PRIVATE=1 for local development"
@@ -2997,10 +3036,11 @@ async fn handle_a2a_push_notification_config_create(
             );
         }
     };
-    let config = match normalize_a2a_push_notification_config(task_id, raw_config, true) {
-        Ok(config) => config,
-        Err(message) => return a2a_error_response(400, "INVALID_REQUEST", &message),
-    };
+    let config =
+        match normalize_a2a_push_notification_config_blocking(task_id, raw_config, true).await {
+            Ok(config) => config,
+            Err(message) => return a2a_error_response(400, "INVALID_REQUEST", &message),
+        };
     let mut tasks = state.a2a_tasks.lock().await;
     let Some(existing_task) = tasks.get(task_id) else {
         return a2a_error_response(404, "TASK_NOT_FOUND", "A2A task not found");

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -916,7 +916,7 @@ async fn handle_a2a_endpoint(
     if head.method == "POST" {
         if let Some(task_id) = a2a_task_id_from_cancel_path(&head.path) {
             return match cancel_a2a_task(state, task_id, &auth).await {
-                Ok(task) => json_response(200, &task),
+                Ok(task) => json_response(200, &a2a_public_task(&task)),
                 Err(response) => response,
             };
         }
@@ -1047,8 +1047,11 @@ async fn handle_a2a_message_stream(
         return Err(error.to_string());
     }
     if let Some(task) = state.a2a_tasks.lock().await.get(&task_id).cloned() {
-        if let Err(error) =
-            send_a2a_stream_response(stream, &serde_json::json!({ "task": task })).await
+        if let Err(error) = send_a2a_stream_response(
+            stream,
+            &serde_json::json!({ "task": a2a_public_task(&task) }),
+        )
+        .await
         {
             state.a2a_cancel_senders.lock().await.remove(&task_id);
             rollback_a2a_send_claim(state, &task_id, previous_task.take()).await;
@@ -1078,7 +1081,11 @@ async fn handle_a2a_message_stream(
         )
         .await?;
     }
-    send_a2a_stream_response(stream, &serde_json::json!({ "task": task })).await?;
+    send_a2a_stream_response(
+        stream,
+        &serde_json::json!({ "task": a2a_public_task(&task) }),
+    )
+    .await?;
     let _ = stream.shutdown().await;
     Ok(())
 }
@@ -1279,7 +1286,11 @@ async fn send_a2a_subscribe_task_update(
             )
             .await?;
         }
-        send_a2a_stream_response(stream, &serde_json::json!({ "task": task })).await?;
+        send_a2a_stream_response(
+            stream,
+            &serde_json::json!({ "task": a2a_public_task(task) }),
+        )
+        .await?;
         return Ok(true);
     }
     Ok(false)
@@ -1309,6 +1320,7 @@ fn a2a_stream_event_name(value: &Value) -> Option<&'static str> {
 }
 
 fn a2a_status_update_event(task: &Value) -> Value {
+    let task = a2a_public_task(task);
     serde_json::json!({
         "taskId": task.get("id").cloned().unwrap_or(Value::Null),
         "contextId": task.get("contextId").cloned().unwrap_or(Value::Null),
@@ -1318,6 +1330,7 @@ fn a2a_status_update_event(task: &Value) -> Value {
 }
 
 fn a2a_artifact_update_event(task: &Value, artifact: &Value) -> Value {
+    let task = a2a_public_task(task);
     serde_json::json!({
         "taskId": task.get("id").cloned().unwrap_or(Value::Null),
         "contextId": task.get("contextId").cloned().unwrap_or(Value::Null),
@@ -1326,6 +1339,69 @@ fn a2a_artifact_update_event(task: &Value, artifact: &Value) -> Value {
         "lastChunk": true,
         "metadata": task.get("metadata").cloned().unwrap_or_else(|| serde_json::json!({}))
     })
+}
+
+fn a2a_public_task(task: &Value) -> Value {
+    let mut task = task.clone();
+    a2a_redact_push_notification_metadata(&mut task);
+    task
+}
+
+fn a2a_redact_push_notification_metadata(task: &mut Value) {
+    let Some(metadata) = task.get_mut("metadata").and_then(Value::as_object_mut) else {
+        return;
+    };
+    let Some(configs) = metadata
+        .get_mut(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY)
+        .and_then(Value::as_array_mut)
+    else {
+        return;
+    };
+    for config in configs {
+        a2a_redact_push_notification_secret_fields(config);
+    }
+}
+
+fn a2a_redacted_push_notification_config(config: &Value) -> Value {
+    let mut config = config.clone();
+    a2a_redact_push_notification_secret_fields(&mut config);
+    config
+}
+
+fn a2a_redact_push_notification_secret_fields(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                if a2a_push_notification_secret_key(key) {
+                    *value = Value::String("<redacted>".to_string());
+                } else {
+                    a2a_redact_push_notification_secret_fields(value);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                a2a_redact_push_notification_secret_fields(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn a2a_push_notification_secret_key(key: &str) -> bool {
+    let normalized = key.replace(['_', '-', '.', ' '], "").to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "token"
+            | "authtoken"
+            | "bearertoken"
+            | "authorization"
+            | "authorizationheader"
+            | "credential"
+            | "credentials"
+            | "secret"
+            | "password"
+    )
 }
 
 async fn cancel_a2a_task(
@@ -1865,12 +1941,12 @@ fn dispatch_a2a_push_notifications(task: &Value) {
     }
     let payloads = a2a_push_notification_payloads(task);
     for config in configs {
-        for payload in payloads.clone() {
-            let config = config.clone();
-            let _ = tokio::task::spawn_blocking(move || {
+        let payloads = payloads.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            for payload in payloads {
                 send_a2a_push_notification(&payload, &config);
-            });
-        }
+            }
+        });
     }
 }
 
@@ -1914,6 +1990,7 @@ fn send_a2a_push_notification(payload: &Value, config: &Value) {
     ));
     let Ok(client) = reqwest::blocking::Client::builder()
         .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none())
         .build()
     else {
         return;
@@ -1941,6 +2018,16 @@ fn a2a_push_authorization_header(authentication: &Map<String, Value>) -> Option<
         .get("scheme")
         .and_then(Value::as_str)
         .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            authentication
+                .get("schemes")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .find_map(Value::as_str)
+                .map(str::trim)
+        })
         .filter(|value| !value.is_empty())?;
     let credentials = authentication
         .get("credentials")
@@ -2400,7 +2487,7 @@ fn a2a_task_for_query(
     include_artifacts: bool,
     history_length: Option<usize>,
 ) -> Value {
-    let mut task = task.clone();
+    let mut task = a2a_public_task(task);
     if !include_artifacts {
         if let Some(task) = task.as_object_mut() {
             task.remove("artifacts");
@@ -2982,6 +3069,9 @@ async fn handle_a2a_push_notification_config_list(
         200,
         &serde_json::json!({
             "configs": a2a_task_push_notification_configs(task)
+                .iter()
+                .map(a2a_redacted_push_notification_config)
+                .collect::<Vec<_>>()
         }),
     )
 }
@@ -3010,7 +3100,7 @@ async fn handle_a2a_push_notification_config_get(
                     "A2A push notification config not found",
                 )
             },
-            |config| json_response(200, &config),
+            |config| json_response(200, &a2a_redacted_push_notification_config(&config)),
         )
 }
 
@@ -3055,7 +3145,7 @@ async fn handle_a2a_push_notification_config_create(
     tasks.insert(task_id.to_string(), task.clone());
     drop(tasks);
     persist_a2a_tasks(state).await;
-    json_response(200, &config)
+    json_response(200, &a2a_redacted_push_notification_config(&config))
 }
 
 async fn handle_a2a_push_notification_config_delete(
@@ -3137,7 +3227,7 @@ async fn handle_a2a_message_send(
     }
     if let Some(task) = a2a_canceled_task(state, &task_id).await {
         state.a2a_cancel_senders.lock().await.remove(&task_id);
-        return json_response(200, &serde_json::json!({ "task": task }));
+        return json_response(200, &serde_json::json!({ "task": a2a_public_task(&task) }));
     }
     if return_immediately {
         let accepted_message = a2a_agent_message(&context_id, "Maestro accepted the A2A task.");
@@ -3166,14 +3256,14 @@ async fn handle_a2a_message_send(
             )
             .await;
         });
-        return json_response(200, &serde_json::json!({ "task": task }));
+        return json_response(200, &serde_json::json!({ "task": a2a_public_task(&task) }));
     }
 
     let task = complete_a2a_task(
         state, prompt, task_id, context_id, history, metadata, cancel_rx,
     )
     .await;
-    json_response(200, &serde_json::json!({ "task": task }))
+    json_response(200, &serde_json::json!({ "task": a2a_public_task(&task) }))
 }
 
 async fn complete_a2a_task(
@@ -12740,6 +12830,14 @@ setTimeout(() => {
         );
         assert_eq!(
             task["metadata"]["pushNotificationConfigs"][0]["token"],
+            "<redacted>"
+        );
+        let stored_tasks = state.a2a_tasks.lock().await;
+        let stored_task = stored_tasks
+            .get(task["id"].as_str().expect("task id should be a string"))
+            .expect("task should be stored");
+        assert_eq!(
+            stored_task["metadata"]["pushNotificationConfigs"][0]["token"],
             "notify-token"
         );
         assert!(task["metadata"].get("configuration").is_none());
@@ -12870,6 +12968,21 @@ setTimeout(() => {
         assert!(a2a_push_ip_is_private(mapped_loopback));
     }
 
+    #[test]
+    fn a2a_push_authorization_header_accepts_schemes_list() {
+        let authentication = serde_json::json!({
+            "schemes": ["Bearer"],
+            "credentials": "secret"
+        });
+        let header = a2a_push_authorization_header(
+            authentication
+                .as_object()
+                .expect("authentication should be an object"),
+        );
+
+        assert_eq!(header.as_deref(), Some("Bearer secret"));
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn a2a_message_send_ignores_push_config_metadata_smuggling() {
         let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
@@ -12960,6 +13073,12 @@ setTimeout(() => {
             response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
         assert_eq!(created["id"], "notify-1");
         assert_eq!(created["taskId"], "task-push");
+        assert_eq!(created["token"], "<redacted>");
+        assert_eq!(
+            state.a2a_tasks.lock().await["task-push"]["metadata"]["pushNotificationConfigs"][0]
+                ["token"],
+            "notify-token"
+        );
         assert!(state.a2a_task_event_history.lock().await.is_empty());
 
         let mut initial =
@@ -12969,6 +13088,7 @@ setTimeout(() => {
         let listed =
             response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
         assert_eq!(listed["configs"][0]["id"], "notify-1");
+        assert_eq!(listed["configs"][0]["token"], "<redacted>");
 
         let mut initial =
             b"GET /tasks/task-push/pushNotificationConfigs/notify-1 HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n".to_vec();
@@ -12976,7 +13096,7 @@ setTimeout(() => {
         let (_client, mut server) = tcp_stream_pair().await;
         let fetched =
             response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
-        assert_eq!(fetched["token"], "notify-token");
+        assert_eq!(fetched["token"], "<redacted>");
 
         let mut initial =
             b"DELETE /tasks/task-push/pushNotificationConfigs/notify-1 HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n".to_vec();

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -3014,7 +3014,6 @@ async fn handle_a2a_push_notification_config_create(
     };
     tasks.insert(task_id.to_string(), task.clone());
     drop(tasks);
-    publish_a2a_task_update(state, &task).await;
     persist_a2a_tasks(state).await;
     json_response(200, &config)
 }
@@ -3037,7 +3036,6 @@ async fn handle_a2a_push_notification_config_delete(
     };
     tasks.insert(task_id.to_string(), task.clone());
     drop(tasks);
-    publish_a2a_task_update(state, &task).await;
     persist_a2a_tasks(state).await;
     json_response(200, &serde_json::json!({}))
 }
@@ -12792,6 +12790,7 @@ setTimeout(() => {
         assert!(payloads[1]["artifactUpdate"]["metadata"]
             .get(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY)
             .is_none());
+        assert_eq!(payloads[2]["task"]["metadata"]["workspaceId"], "ws-1");
         assert!(payloads[2]["task"]["metadata"]
             .get(A2A_PUSH_NOTIFICATION_CONFIG_METADATA_KEY)
             .is_none());
@@ -12921,6 +12920,7 @@ setTimeout(() => {
             response_json(handle_a2a_endpoint(&mut server, &mut initial, head, &state).await);
         assert_eq!(created["id"], "notify-1");
         assert_eq!(created["taskId"], "task-push");
+        assert!(state.a2a_task_event_history.lock().await.is_empty());
 
         let mut initial =
             b"GET /tasks/task-push/pushNotificationConfigs HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n".to_vec();
@@ -12948,6 +12948,7 @@ setTimeout(() => {
         assert!(state.a2a_tasks.lock().await["task-push"]["metadata"]
             .get("pushNotificationConfigs")
             .is_none());
+        assert!(state.a2a_task_event_history.lock().await.is_empty());
 
         let mut initial =
             b"DELETE /tasks/task-push/pushNotificationConfigs/notify-1 HTTP/1.1\r\nHost: localhost\r\nx-maestro-api-key: api-key\r\n\r\n".to_vec();

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -62,6 +62,11 @@ const A2A_MAX_ATTEMPTS_ENV_VARS = [
 	"AGENT_RUNTIME_SERVICE_MAX_ATTEMPTS",
 ] as const;
 
+const A2A_EXTENSIONS_ENV_VARS = [
+	"MAESTRO_PLATFORM_A2A_EXTENSIONS",
+	"MAESTRO_A2A_EXTENSIONS",
+] as const;
+
 const A2A_BASE_URL_SUFFIXES = [
 	"/.well-known/agent-card.json",
 	"/message:send",
@@ -76,6 +81,7 @@ export interface A2AServiceConfig extends PlatformServiceConfig {
 	actorId?: string;
 	traceparent?: string;
 	tracestate?: string;
+	extensions?: string[];
 }
 
 export interface A2AAgentCard {
@@ -91,6 +97,7 @@ export interface A2AAgentCard {
 		streaming?: boolean;
 		pushNotifications?: boolean;
 		extendedAgentCard?: boolean;
+		extensions?: A2AAgentExtension[];
 	};
 	defaultInputModes: string[];
 	defaultOutputModes: string[];
@@ -114,8 +121,16 @@ export interface A2AAgentSkill {
 	outputModes?: string[];
 }
 
+export interface A2AAgentExtension {
+	uri: string;
+	description?: string;
+	required?: boolean;
+	params?: Record<string, unknown>;
+}
+
 export interface A2APart {
 	text?: string;
+	raw?: string;
 	url?: string;
 	data?: unknown;
 	metadata?: Record<string, unknown>;
@@ -161,7 +176,10 @@ export interface SendA2AMessageInput {
 	message: A2AMessage;
 	configuration?: {
 		acceptedOutputModes?: string[];
+		historyLength?: number;
 		returnImmediately?: boolean;
+		taskPushNotificationConfig?: A2ATaskPushNotificationConfig;
+		pushNotificationConfig?: A2ATaskPushNotificationConfig;
 	};
 	metadata?: Record<string, unknown>;
 	traceContext?: A2ATraceContext;
@@ -215,6 +233,24 @@ export type A2AStreamEvent =
 export interface A2ATraceContext {
 	traceparent?: string;
 	tracestate?: string;
+}
+
+export interface A2ATaskPushNotificationAuthentication {
+	scheme: string;
+	credentials?: string;
+}
+
+export interface A2ATaskPushNotificationConfig {
+	tenant?: string;
+	id?: string;
+	taskId?: string;
+	url: string;
+	token?: string;
+	authentication?: A2ATaskPushNotificationAuthentication;
+}
+
+export interface A2ATaskPushNotificationConfigList {
+	configs: A2ATaskPushNotificationConfig[];
 }
 
 export function normalizeA2ABaseUrl(baseUrl: string): string {
@@ -274,6 +310,7 @@ export async function resolveA2AServiceConfig(
 		actorId:
 			trimString(overrides.actorId) ??
 			getEnvValue(["MAESTRO_USER_ID", "MAESTRO_ACTOR_ID"]),
+		extensions: resolveConfiguredA2AExtensions(overrides.extensions),
 	};
 }
 
@@ -283,6 +320,7 @@ export function buildA2AUserMessage(input: {
 	contextId?: string;
 	taskId?: string;
 	metadata?: Record<string, unknown>;
+	extensions?: string[];
 }): A2AMessage {
 	return {
 		messageId: input.messageId,
@@ -291,6 +329,7 @@ export function buildA2AUserMessage(input: {
 		role: "ROLE_USER",
 		parts: [{ text: input.text, mediaType: "text/plain" }],
 		metadata: input.metadata,
+		extensions: input.extensions,
 	};
 }
 
@@ -322,11 +361,12 @@ export async function sendA2AMessage(
 	options: { signal?: AbortSignal } = {},
 ): Promise<SendA2AMessageResult> {
 	const { body, traceContext } = buildA2AMessageRequestBody(config, input);
+	const extensions = resolveA2AExtensions(config, input.message.extensions);
 	const response = await fetchDownstream(
 		`${config.baseUrl}/message:send`,
 		{
 			method: "POST",
-			headers: buildA2AHeaders(config, traceContext),
+			headers: buildA2AHeaders(config, traceContext, extensions),
 			body: JSON.stringify(body),
 			signal: options.signal,
 		},
@@ -347,12 +387,13 @@ export async function* streamA2AMessage(
 	options: { signal?: AbortSignal } = {},
 ): AsyncIterable<A2AStreamEvent> {
 	const { body, traceContext } = buildA2AMessageRequestBody(config, input);
+	const extensions = resolveA2AExtensions(config, input.message.extensions);
 	const response = await fetchDownstream(
 		`${config.baseUrl}/message:stream`,
 		{
 			method: "POST",
 			headers: {
-				...buildA2AHeaders(config, traceContext),
+				...buildA2AHeaders(config, traceContext, extensions),
 				Accept: "text/event-stream",
 			},
 			body: JSON.stringify(body),
@@ -372,7 +413,11 @@ export async function* streamA2AMessage(
 export async function* subscribeA2ATask(
 	config: A2AServiceConfig,
 	taskId: string,
-	options: { signal?: AbortSignal; traceContext?: A2ATraceContext } = {},
+	options: {
+		signal?: AbortSignal;
+		traceContext?: A2ATraceContext;
+		extensions?: string[];
+	} = {},
 ): AsyncIterable<A2AStreamEvent> {
 	const trimmedTaskId = trimString(taskId);
 	if (!trimmedTaskId) {
@@ -383,7 +428,11 @@ export async function* subscribeA2ATask(
 		{
 			method: "POST",
 			headers: {
-				...buildA2AHeaders(config, options.traceContext),
+				...buildA2AHeaders(
+					config,
+					options.traceContext,
+					resolveA2AExtensions(config, options.extensions),
+				),
 				Accept: "text/event-stream",
 			},
 			signal: options.signal,
@@ -397,6 +446,107 @@ export async function* subscribeA2ATask(
 	);
 	await throwForA2AError(response, "subscribe task");
 	yield* parseA2AStreamEvents(response);
+}
+
+export async function createA2ATaskPushNotificationConfig(
+	config: A2AServiceConfig,
+	taskId: string,
+	pushConfig: A2ATaskPushNotificationConfig,
+	options: { signal?: AbortSignal; traceContext?: A2ATraceContext } = {},
+): Promise<A2ATaskPushNotificationConfig> {
+	const trimmedTaskId = requireA2ATaskId(taskId);
+	const response = await fetchDownstream(
+		`${config.baseUrl}/tasks/${encodeURIComponent(trimmedTaskId)}/pushNotificationConfigs`,
+		{
+			method: "POST",
+			headers: buildA2AHeaders(config, options.traceContext),
+			body: JSON.stringify(pushConfig),
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "create task push notification config");
+	return (await response.json()) as A2ATaskPushNotificationConfig;
+}
+
+export async function listA2ATaskPushNotificationConfigs(
+	config: A2AServiceConfig,
+	taskId: string,
+	options: { signal?: AbortSignal; traceContext?: A2ATraceContext } = {},
+): Promise<A2ATaskPushNotificationConfigList> {
+	const trimmedTaskId = requireA2ATaskId(taskId);
+	const response = await fetchDownstream(
+		`${config.baseUrl}/tasks/${encodeURIComponent(trimmedTaskId)}/pushNotificationConfigs`,
+		{
+			method: "GET",
+			headers: buildA2AHeaders(config, options.traceContext),
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "list task push notification configs");
+	return (await response.json()) as A2ATaskPushNotificationConfigList;
+}
+
+export async function getA2ATaskPushNotificationConfig(
+	config: A2AServiceConfig,
+	taskId: string,
+	configId: string,
+	options: { signal?: AbortSignal; traceContext?: A2ATraceContext } = {},
+): Promise<A2ATaskPushNotificationConfig> {
+	const trimmedTaskId = requireA2ATaskId(taskId);
+	const trimmedConfigId = requireA2APushConfigId(configId);
+	const response = await fetchDownstream(
+		`${config.baseUrl}/tasks/${encodeURIComponent(trimmedTaskId)}/pushNotificationConfigs/${encodeURIComponent(trimmedConfigId)}`,
+		{
+			method: "GET",
+			headers: buildA2AHeaders(config, options.traceContext),
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "get task push notification config");
+	return (await response.json()) as A2ATaskPushNotificationConfig;
+}
+
+export async function deleteA2ATaskPushNotificationConfig(
+	config: A2AServiceConfig,
+	taskId: string,
+	configId: string,
+	options: { signal?: AbortSignal; traceContext?: A2ATraceContext } = {},
+): Promise<void> {
+	const trimmedTaskId = requireA2ATaskId(taskId);
+	const trimmedConfigId = requireA2APushConfigId(configId);
+	const response = await fetchDownstream(
+		`${config.baseUrl}/tasks/${encodeURIComponent(trimmedTaskId)}/pushNotificationConfigs/${encodeURIComponent(trimmedConfigId)}`,
+		{
+			method: "DELETE",
+			headers: buildA2AHeaders(config, options.traceContext),
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "delete task push notification config");
 }
 
 function buildA2AMessageRequestBody(
@@ -466,10 +616,7 @@ export async function getA2ATask(
 	taskId: string,
 	options: { signal?: AbortSignal; traceContext?: A2ATraceContext } = {},
 ): Promise<A2ATask> {
-	const trimmedTaskId = trimString(taskId);
-	if (!trimmedTaskId) {
-		throw new Error("A2A task id is required");
-	}
+	const trimmedTaskId = requireA2ATaskId(taskId);
 	const response = await fetchDownstream(
 		`${config.baseUrl}/tasks/${encodeURIComponent(trimmedTaskId)}`,
 		{
@@ -718,9 +865,55 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function requireA2ATaskId(taskId: string): string {
+	const trimmedTaskId = trimString(taskId);
+	if (!trimmedTaskId) {
+		throw new Error("A2A task id is required");
+	}
+	return trimmedTaskId;
+}
+
+function requireA2APushConfigId(configId: string): string {
+	const trimmedConfigId = trimString(configId);
+	if (!trimmedConfigId) {
+		throw new Error("A2A push notification config id is required");
+	}
+	return trimmedConfigId;
+}
+
+function resolveA2AExtensions(
+	config: A2AServiceConfig,
+	requestExtensions?: string[],
+): string[] {
+	const extensions = new Set<string>();
+	for (const extension of [
+		...(config.extensions ?? []),
+		...(requestExtensions ?? []),
+	]) {
+		const value = trimString(extension);
+		if (value) {
+			extensions.add(value);
+		}
+	}
+	return [...extensions];
+}
+
+function resolveConfiguredA2AExtensions(
+	overrides?: string[],
+): string[] | undefined {
+	const values =
+		overrides ??
+		getEnvValue([...A2A_EXTENSIONS_ENV_VARS])
+			?.split(",")
+			.map((value) => value.trim())
+			.filter(Boolean);
+	return values && values.length > 0 ? [...new Set(values)] : undefined;
+}
+
 function buildA2AHeaders(
 	config: A2AServiceConfig,
 	traceContext?: A2ATraceContext,
+	extensions: string[] = [],
 ): Record<string, string> {
 	// Header projection mirrors message metadata projection: intermediaries can
 	// route and trace the HTTP request, while the task itself keeps durable
@@ -735,6 +928,7 @@ function buildA2AHeaders(
 		"X-EvalOps-Actor-Id": config.actorId,
 		traceparent: resolvedTraceContext?.traceparent,
 		tracestate: resolvedTraceContext?.tracestate,
+		"A2A-Extensions": extensions.length > 0 ? extensions.join(",") : undefined,
 	});
 }
 

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -236,8 +236,10 @@ export interface A2ATraceContext {
 }
 
 export interface A2ATaskPushNotificationAuthentication {
-	scheme: string;
+	schemes: string[];
 	credentials?: string;
+	/** @deprecated Use schemes. Accepted only for older Maestro peers. */
+	scheme?: string;
 }
 
 export interface A2ATaskPushNotificationConfig {

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	buildA2AUserMessage,
+	createA2ATaskPushNotificationConfig,
+	deleteA2ATaskPushNotificationConfig,
 	discoverA2AAgentCard,
 	getA2ATask,
+	getA2ATaskPushNotificationConfig,
+	listA2ATaskPushNotificationConfigs,
 	resolveA2AServiceConfig,
 	resolveA2ATraceContext,
 	sendA2AMessage,
@@ -101,6 +105,8 @@ describe("platform A2A client", () => {
 			"TRACE_STATE",
 			"MAESTRO_TRACEPARENT",
 			"MAESTRO_TRACESTATE",
+			"MAESTRO_PLATFORM_A2A_EXTENSIONS",
+			"MAESTRO_A2A_EXTENSIONS",
 		]) {
 			vi.stubEnv(name, "");
 		}
@@ -179,6 +185,39 @@ describe("platform A2A client", () => {
 						id: "run_1",
 						contextId: "session_1",
 						status: { state: "TASK_STATE_COMPLETED" },
+					});
+				}
+
+				if (parsed.pathname === "/tasks/run_1/pushNotificationConfigs") {
+					if (init?.method === "POST") {
+						return Response.json({
+							id: "cfg_1",
+							taskId: "run_1",
+							url: "https://hooks.test/a2a",
+							token: "notify-token",
+						});
+					}
+					return Response.json({
+						configs: [
+							{
+								id: "cfg_1",
+								taskId: "run_1",
+								url: "https://hooks.test/a2a",
+								token: "notify-token",
+							},
+						],
+					});
+				}
+
+				if (parsed.pathname === "/tasks/run_1/pushNotificationConfigs/cfg_1") {
+					if (init?.method === "DELETE") {
+						return Response.json({});
+					}
+					return Response.json({
+						id: "cfg_1",
+						taskId: "run_1",
+						url: "https://hooks.test/a2a",
+						token: "notify-token",
 					});
 				}
 
@@ -343,6 +382,80 @@ describe("platform A2A client", () => {
 			}),
 		});
 		expect(requests[0]?.body).not.toHaveProperty("traceContext");
+	});
+
+	it("projects requested A2A extensions into headers and message body", async () => {
+		const config = await resolveA2AServiceConfig({
+			extensions: ["https://evalops.com/a2a/extensions/operating-plane/v1"],
+		});
+		if (!config) {
+			throw new Error("expected config");
+		}
+
+		await sendA2AMessage(config, {
+			message: buildA2AUserMessage({
+				messageId: "msg_extension",
+				contextId: "session_1",
+				text: "Run with negotiated extension",
+				extensions: ["https://example.test/a2a/extensions/custom/v1"],
+			}),
+		});
+
+		expect(requests[0]?.headers).toMatchObject({
+			"a2a-extensions":
+				"https://evalops.com/a2a/extensions/operating-plane/v1,https://example.test/a2a/extensions/custom/v1",
+		});
+		expect(requests[0]?.body).toMatchObject({
+			message: {
+				extensions: ["https://example.test/a2a/extensions/custom/v1"],
+			},
+		});
+	});
+
+	it("configures A2A task push notifications", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+
+		await expect(
+			createA2ATaskPushNotificationConfig(config, "run_1", {
+				id: "cfg_1",
+				url: "https://hooks.test/a2a",
+				token: "notify-token",
+			}),
+		).resolves.toMatchObject({
+			id: "cfg_1",
+			taskId: "run_1",
+		});
+		await expect(
+			listA2ATaskPushNotificationConfigs(config, "run_1"),
+		).resolves.toMatchObject({
+			configs: [{ id: "cfg_1", taskId: "run_1" }],
+		});
+		await expect(
+			getA2ATaskPushNotificationConfig(config, "run_1", "cfg_1"),
+		).resolves.toMatchObject({
+			id: "cfg_1",
+			taskId: "run_1",
+		});
+		await expect(
+			deleteA2ATaskPushNotificationConfig(config, "run_1", "cfg_1"),
+		).resolves.toBeUndefined();
+
+		expect(
+			requests.map((request) => `${request.method} ${request.pathname}`),
+		).toEqual([
+			"POST /tasks/run_1/pushNotificationConfigs",
+			"GET /tasks/run_1/pushNotificationConfigs",
+			"GET /tasks/run_1/pushNotificationConfigs/cfg_1",
+			"DELETE /tasks/run_1/pushNotificationConfigs/cfg_1",
+		]);
+		expect(requests[0]?.body).toMatchObject({
+			id: "cfg_1",
+			url: "https://hooks.test/a2a",
+			token: "notify-token",
+		});
 	});
 
 	it("keeps explicit partial trace context isolated from env tracestate", () => {


### PR DESCRIPTION
## Summary
- add A2A task push notification config CRUD endpoints and advertise `pushNotifications=true` from the Maestro Agent Card
- dispatch push callbacks as A2A `StreamResponse` payloads, with HTTPS/private-host guardrails and bounded timeout env controls
- add EvalOps A2A extension negotiation through `A2A-Extensions` / `message.extensions`, plus TypeScript client helpers for extensions and push config CRUD
- document the EvalOps suite split: Maestro owns peer-native A2A, Platform owns hosted AgentRuntime/work graph projection, and Deploy owns release-smoke/observability gates

Internal source PR: evalops/maestro-internal#1998

## Test Plan
- `cargo fmt --check`
- `cargo test a2a --bin maestro-control-plane`
- `CARGO_TARGET_DIR=/Users/jonathanhaas/.codex-worktrees/maestro-a2a-push-extensions-20260516/packages/control-plane-rs/target cargo test a2a --bin maestro-control-plane` from the public worktree
- `bunx biome check src/platform/a2a-client.ts test/platform/a2a-client.test.ts`
- `npm run test:fast -- test/platform/a2a-client.test.ts`
- `npx tsc -p tsconfig.build.json --noEmit --pretty false`
- commit hook: Guardian staged scan, `bunx biome check .`, `bun run lint:evals`, `npm run build`, `npm run bun:compile`
