### PR TITLE
Fix A2A push auth typing compatibility

### DIFF
--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -235,12 +235,19 @@ export interface A2ATraceContext {
 	tracestate?: string;
 }
 
-export interface A2ATaskPushNotificationAuthentication {
-	schemes: string[];
-	credentials?: string;
-	/** @deprecated Use schemes. Accepted only for older Maestro peers. */
-	scheme?: string;
-}
+export type A2ATaskPushNotificationAuthentication =
+	| {
+			schemes: string[];
+			credentials?: string;
+			/** @deprecated Use schemes. Accepted only for older Maestro peers. */
+			scheme?: string;
+	  }
+	| {
+			/** @deprecated Use schemes. Accepted only for older Maestro peers. */
+			scheme: string;
+			credentials?: string;
+			schemes?: string[];
+	  };
 
 export interface A2ATaskPushNotificationConfig {
 	tenant?: string;


### PR DESCRIPTION
## Summary
- Change the public A2A push-notification auth helper type into a union that prefers `authentication.schemes` while keeping legacy `authentication.scheme` payloads type-compatible
- Matches the server behavior added in the A2A push config work, where Maestro accepts both shapes but emits/teaches the standard list form

Source-of-truth: https://github.com/evalops/maestro-internal/pull/2001

## Test Plan
- `bunx biome check --write src/platform/a2a-client.ts`
- `npx tsc -p tsconfig.build.json --noEmit --pretty false`
- commit hook: guardian, lint/eval surface checks, proto generation, TS build, bun compile