### PR TITLE
evalops: forward managed gateway thread metadata

### DIFF
--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -318,6 +318,13 @@ function resolveEvalOpsRequestMetadata(
 		agentMcp?.trace_id,
 		readFirstEnv(["MAESTRO_TRACE_ID", "TRACE_ID"]),
 	);
+	const threadID = firstNonEmptyString(
+		metadata?.threadId,
+		metadata?.thread_id,
+		agentMcp?.threadId,
+		agentMcp?.thread_id,
+		readFirstEnv(["MAESTRO_THREAD_ID", "MAESTRO_EVALOPS_THREAD_ID"]),
+	);
 	const turnID = firstNonEmptyString(
 		metadata?.turnId,
 		metadata?.turn_id,
@@ -356,6 +363,7 @@ function resolveEvalOpsRequestMetadata(
 			maestro_session_id: maestroSessionID,
 			surface,
 			trace_id: traceID,
+			thread_id: threadID,
 			turn_id: turnID,
 			tool_call_id: toolCallID,
 			workload,

--- a/test/auth/auth-resolver.test.ts
+++ b/test/auth/auth-resolver.test.ts
@@ -39,6 +39,7 @@ describe("auth resolver", () => {
 		"MAESTRO_EVALOPS_RUN_ID",
 		"MAESTRO_EVALOPS_SESSION_ID",
 		"MAESTRO_EVALOPS_SURFACE",
+		"MAESTRO_EVALOPS_THREAD_ID",
 		"MAESTRO_EVALOPS_TOOL_CALL_ID",
 		"MAESTRO_EVALOPS_TURN_ID",
 		"MAESTRO_EVALOPS_WORKLOAD",
@@ -46,6 +47,7 @@ describe("auth resolver", () => {
 		"MAESTRO_OBJECTIVE_ID",
 		"MAESTRO_SESSION_ID",
 		"MAESTRO_SURFACE",
+		"MAESTRO_THREAD_ID",
 		"MAESTRO_TOOL_CALL_ID",
 		"MAESTRO_TRACE_ID",
 		"MAESTRO_TURN_ID",
@@ -459,6 +461,7 @@ describe("auth resolver", () => {
 		process.env.MAESTRO_SESSION_ID = "session_456";
 		process.env.MAESTRO_SURFACE = "cli";
 		process.env.MAESTRO_TRACE_ID = "trace_123";
+		process.env.MAESTRO_THREAD_ID = "maestro/message/msg_123";
 		process.env.MAESTRO_TURN_ID = "turn_123";
 		process.env.MAESTRO_TOOL_CALL_ID = "tool_call_123";
 		process.env.MAESTRO_WORKLOAD = "maestro-coding-session";
@@ -492,6 +495,7 @@ describe("auth resolver", () => {
 				maestro_session_id: "session_456",
 				surface: "cli",
 				trace_id: "trace_123",
+				thread_id: "maestro/message/msg_123",
 				turn_id: "turn_123",
 				tool_call_id: "tool_call_123",
 				workload: "maestro-coding-session",
@@ -524,6 +528,7 @@ describe("auth resolver", () => {
 				},
 				runId: "run_legacy",
 				sessionId: "session_platform",
+				threadId: "maestro/message/msg_platform",
 			},
 		});
 
@@ -536,6 +541,7 @@ describe("auth resolver", () => {
 				maestro_session_id: "session_maestro",
 				run_id: "run_legacy",
 				session_id: "session_platform",
+				thread_id: "maestro/message/msg_platform",
 			},
 		});
 		mockedGetToken.mockReset();


### PR DESCRIPTION
## Summary
- forward `thread_id` into EvalOps managed gateway request metadata
- resolve the thread from explicit metadata, nested `agentMcp`, or `MAESTRO_THREAD_ID` / `MAESTRO_EVALOPS_THREAD_ID`
- extend auth resolver coverage so Platform can join Maestro model calls by run, session, thread, turn, and tool call

## Internal provenance
- https://github.com/evalops/maestro-internal/pull/2012

## Tests
- `node ./scripts/run-vitest.js --run test/auth/auth-resolver.test.ts`
- `git diff --check`
- `bunx biome check src/providers/auth.ts test/auth/auth-resolver.test.ts`
- `bunx tsc -p tsconfig.build.json --noEmit`
- commit hook: guardian, `bunx biome check .`, `bun run lint:evals`, build, binary compile