### PR TITLE
ci: set retention on uploaded workflow artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         if: ${{ always() && hashFiles('nx-tests-attempt-*.log') != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          retention-days: 14
           name: nx-tests-logs-${{ github.run_id }}
           path: nx-tests-attempt-*.log
           if-no-files-found: ignore
@@ -142,6 +143,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          retention-days: 14
           name: coverage-report-${{ github.run_id }}
           path: coverage/
           if-no-files-found: ignore

--- a/.github/workflows/flaky-canary.yml
+++ b/.github/workflows/flaky-canary.yml
@@ -96,6 +96,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          retention-days: 14
           name: flaky-canary-logs-${{ github.run_id }}
           path: flaky-canary-run-*.log
           if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          retention-days: 14
           name: npm-tarball-${{ needs.prepare.outputs.release_tag }}
           path: ${{ steps.pack.outputs.tarball }}
 

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -102,6 +102,7 @@ jobs:
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          retention-days: 14
           name: vscode-extension-${{ steps.version.outputs.version }}
           path: packages/vscode-extension/*.vsix
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- set explicit retention on GitHub Actions upload-artifact steps
- keep CI/release diagnostic artifacts from falling back to repo defaults

## Test plan
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' <changed workflows>
- git diff --check
