### PR TITLE
fix: require governed hosted ToolExecution IDs

### DIFF
--- a/src/server/hosted-agent-runtime-progress.ts
+++ b/src/server/hosted-agent-runtime-progress.ts
@@ -479,6 +479,18 @@ function toolDisplayName(event: {
 	return event.displayName ?? event.summaryLabel ?? event.toolName;
 }
 
+function materializedToolExecutionId(event: {
+	toolCallId: string;
+	toolExecutionId?: string;
+}): string | undefined {
+	const toolExecutionId = nonEmptyString(event.toolExecutionId)?.trim();
+	const toolCallId = nonEmptyString(event.toolCallId)?.trim();
+	if (!toolExecutionId || toolExecutionId === toolCallId) {
+		return undefined;
+	}
+	return toolExecutionId;
+}
+
 function waitTypeForRequest(
 	kind: ServerRequestLifecycleEvent["request"]["kind"],
 ): PlatformAgentRunWaitTypeValue {
@@ -608,7 +620,7 @@ export class HostedAgentRuntimeProgressRecorder {
 					input: this.basePayload({
 						event_type: event.type,
 						tool_call_id: event.toolCallId,
-						tool_execution_id: event.toolExecutionId,
+						tool_execution_id: materializedToolExecutionId(event),
 						tool_name: event.toolName,
 						display_name: event.displayName,
 						summary_label: event.summaryLabel,
@@ -633,7 +645,7 @@ export class HostedAgentRuntimeProgressRecorder {
 					output: this.basePayload({
 						event_type: event.type,
 						tool_call_id: event.toolCallId,
-						tool_execution_id: event.toolExecutionId,
+						tool_execution_id: materializedToolExecutionId(event),
 						approval_request_id: event.approvalRequestId,
 						tool_name: event.toolName,
 						display_name: event.displayName,
@@ -975,6 +987,7 @@ export class HostedAgentRuntimeProgressRecorder {
 				this.codexSubagentThreadWorkItemIds.set(threadId, workItemId);
 			}
 		}
+		const toolExecutionId = materializedToolExecutionId(event);
 		const prompt = nonEmptyString(event.args.prompt);
 		const model = nonEmptyString(event.args.model);
 		const reasoningEffort = nonEmptyString(event.args.reasoningEffort);
@@ -995,9 +1008,7 @@ export class HostedAgentRuntimeProgressRecorder {
 			title: toolDisplayName(event),
 			...(prompt ? { goal: prompt } : {}),
 			nextAction: codexSubagentNextAction(codexTool),
-			...(event.toolExecutionId
-				? { toolExecutionId: event.toolExecutionId }
-				: {}),
+			...(toolExecutionId ? { toolExecutionId } : {}),
 			evidenceRefs: [
 				`codex-tool-call:${event.toolCallId}`,
 				...receiverThreadIds.map((id) => `codex-thread:${id}`),
@@ -1177,6 +1188,7 @@ export class HostedAgentRuntimeProgressRecorder {
 			const shouldResolveDelegation =
 				delegationIds.length > 0 &&
 				shouldResolveCodexSubagentDelegation(codexTool, event.isError);
+			const toolExecutionId = materializedToolExecutionId(event);
 			let updateError: unknown;
 			try {
 				await this.operations.updateWorkItem({
@@ -1185,9 +1197,7 @@ export class HostedAgentRuntimeProgressRecorder {
 					state: event.isError
 						? PlatformAgentWorkItemStateValue.Failed
 						: PlatformAgentWorkItemStateValue.Succeeded,
-					...(event.toolExecutionId
-						? { toolExecutionId: event.toolExecutionId }
-						: {}),
+					...(toolExecutionId ? { toolExecutionId } : {}),
 					evidenceRefs: [
 						`codex-tool-call:${event.toolCallId}`,
 						...receiverThreadIds.map((id) => `codex-thread:${id}`),

--- a/test/server/hosted-agent-runtime-progress.test.ts
+++ b/test/server/hosted-agent-runtime-progress.test.ts
@@ -171,6 +171,7 @@ describe("hosted AgentRuntime progress recorder", () => {
 			toolName: "codex.subagent.spawnAgent",
 			displayName: "Codex subagent: spawn agent",
 			summaryLabel: "spawn agent 1 agent",
+			toolExecutionId: "collab-call-1",
 			args: {
 				codexTool: "spawnAgent",
 				senderThreadId: "parent-thread",
@@ -204,6 +205,7 @@ describe("hosted AgentRuntime progress recorder", () => {
 			toolName: "codex.subagent.spawnAgent",
 			displayName: "Codex subagent: spawn agent",
 			summaryLabel: "spawn agent 1 agent",
+			toolExecutionId: "texec-collab-call-1",
 			result: {
 				role: "toolResult",
 				toolCallId: "collab-call-1",
@@ -221,6 +223,13 @@ describe("hosted AgentRuntime progress recorder", () => {
 		await recorder.flush();
 
 		expect(recordStep).toHaveBeenCalledTimes(2);
+		const startStepInput = recordStep.mock.calls[0]?.[0]?.step?.input;
+		expect(startStepInput).not.toHaveProperty("tool_execution_id");
+		const endStepOutput = recordStep.mock.calls[1]?.[0]?.step?.output;
+		expect(endStepOutput).toHaveProperty(
+			"tool_execution_id",
+			"texec-collab-call-1",
+		);
 		expect(recordWorkItem).toHaveBeenCalledWith({
 			runId: "run_1",
 			workItem: expect.objectContaining({
@@ -263,10 +272,13 @@ describe("hosted AgentRuntime progress recorder", () => {
 				}),
 			}),
 		});
+		const recordedWorkItem = recordWorkItem.mock.calls[0]?.[0]?.workItem;
+		expect(recordedWorkItem).not.toHaveProperty("toolExecutionId");
 		expect(updateWorkItem).toHaveBeenCalledWith({
 			runId: "run_1",
 			workItemId: "maestro:session_1:work:collab-call-1",
 			state: PlatformAgentWorkItemStateValue.Succeeded,
+			toolExecutionId: "texec-collab-call-1",
 			evidenceRefs: [
 				"codex-tool-call:collab-call-1",
 				"codex-thread:child-thread-1",


### PR DESCRIPTION
## Summary
- stop projecting raw provider tool-call ids as hosted AgentRuntime `toolExecutionId` values
- keep raw Codex tool-call ids in evidence refs while only forwarding materialized Platform ToolExecution ids
- extend the hosted Codex subagent progress test to cover raw-id suppression and governed-id preservation

Internal source: evalops/maestro-internal#2025

## Verification
- bun install
- node ./scripts/run-vitest.js --run test/server/hosted-agent-runtime-progress.test.ts
- bunx biome check src/server/hosted-agent-runtime-progress.ts test/server/hosted-agent-runtime-progress.test.ts
- bunx tsc -p tsconfig.build.json --noEmit
- npm run check:codex-operating-layer
