### PR TITLE
chore: sync release mirror from internal

### DIFF
--- a/src/telemetry/maestro-event-catalog.ts
+++ b/src/telemetry/maestro-event-catalog.ts
@@ -13,11 +13,13 @@ export enum MaestroBusEventType {
 	SkillInvoked = "maestro.events.skill.invoked",
 	SkillSucceeded = "maestro.events.skill.succeeded",
 	SkillFailed = "maestro.events.skill.failed",
+	SubagentDispatched = "maestro.events.subagent.dispatched",
 	EvalScored = "maestro.events.eval.scored",
 }
 
 export type MaestroBusEventCategory =
 	| "session"
+	| "agent"
 	| "approval"
 	| "safety"
 	| "tool"
@@ -149,6 +151,12 @@ export const MAESTRO_BUS_EVENT_CATALOG = {
 		"skill",
 		"SkillOutcome",
 		["skills.maestro-skill-events"],
+	),
+	[MaestroBusEventType.SubagentDispatched]: entry(
+		MaestroBusEventType.SubagentDispatched,
+		"agent",
+		"SubagentDispatch",
+		["agents.maestro-subagent-dispatches", "meter.maestro-subagent-dispatches"],
 	),
 	[MaestroBusEventType.EvalScored]: entry(
 		MaestroBusEventType.EvalScored,


### PR DESCRIPTION
## Summary
- sync the mirrored Maestro event catalog release file from maestro-internal
- unblocks internal public-release-mirror checks for public-surface Maestro changes

Source-of-truth internal PR: https://github.com/evalops/maestro-internal/pull/2032

## Test plan
- node /Users/jonathanhaas/.codex-worktrees/codex-mesh-workgraph-20260519/maestro-internal/scripts/sync-release-mirror.mjs --check --source /Users/jonathanhaas/.codex-worktrees/codex-mesh-workgraph-20260519/maestro-internal --target /Users/jonathanhaas/.codex-worktrees/codex-mesh-workgraph-20260519/maestro-public