### PR TITLE
agent: route swarm teammates over A2A

### DIFF
--- a/docs/protocols/a2a-fleet-delegation.md
+++ b/docs/protocols/a2a-fleet-delegation.md
@@ -66,6 +66,60 @@ the task moved forward or still needs operator input. If more than one actionabl
 task matches the requested scope, use `maestro a2a reply <peer> <task-id> <text>`
 to choose the task explicitly.
 
+## Remote Swarm Transport
+
+Maestro swarm execution can now use A2A as the teammate transport instead of
+spawning every teammate as a local subprocess. Set `transport: "a2a"` in the
+swarm config or export `MAESTRO_SWARM_TRANSPORT=a2a`. The coordinator formats
+the same delegation prompt used for local teammates, sends it through
+`message:send` with `returnImmediately=true`, records the remote task in the
+local A2A ledger, polls `GET /tasks/{id}` until the peer reaches a terminal A2A
+state, then maps the final artifact text back into the swarm task result.
+
+Static peer routing uses the local A2A peer registry:
+
+```sh
+MAESTRO_SWARM_TRANSPORT=a2a \
+MAESTRO_SWARM_A2A_PEERS=mac-mini,dev-desktop \
+MAESTRO_SWARM_A2A_TASKS=~/.maestro/a2a/tasks.json \
+maestro swarm run plan.md
+```
+
+Platform discovery uses Agent Registry candidates instead of a local peer list:
+
+```sh
+MAESTRO_SWARM_TRANSPORT=a2a \
+MAESTRO_SWARM_A2A_DISCOVER=1 \
+MAESTRO_SWARM_A2A_WORKSPACE_ID="$EVALOPS_WORKSPACE_ID" \
+MAESTRO_SWARM_A2A_SKILL_ID=maestro.subagent.code-review \
+MAESTRO_SWARM_A2A_PREFER_INTERNAL=1 \
+maestro swarm run plan.md
+```
+
+Task-level overrides let the planner pin a specific peer or A2A skill with
+`a2aPeer` and `a2aSkillId`. With Platform discovery, `a2aPeer` matches the
+candidate agent id, agent name, A2A endpoint, or Agent Card URL before the
+round-robin fallback. Otherwise Maestro round-robins across configured or
+discovered peers and maps Codex subagent lanes to advertised A2A skill ids such
+as `maestro.subagent.code-writer`, `maestro.subagent.code-review`,
+`maestro.subagent.test-runner`, `maestro.subagent.repo-explorer`, and
+`maestro.subagent.release-shepherd`.
+
+Every remote swarm task carries native A2A plus EvalOps operating-plane
+metadata: `requestKind=maestro-swarm-task`, `transport=a2a`, `swarmId`,
+`teammateId`, `taskId`, `relayPeer`, `a2aSkillId`, `evalops.swarm` lineage, and
+`evalops.subagentRequest`. This gives Platform enough correlation to show a
+root swarm, child delegations, remote task ids, and artifacts as one fleet-scale
+work graph rather than disconnected peer transcripts. Terminal states other
+than `TASK_STATE_COMPLETED`, including `INPUT_REQUIRED` or `AUTH_REQUIRED`, are
+kept as failed swarm tasks so the coordinator/operator can follow up instead of
+treating blocked remote work as successful.
+
+When a swarm is cancelled after a remote task has been accepted, Maestro keeps
+the non-secret peer/task/message correlation on the teammate state and sends the
+spec-native `POST /tasks/{id}:cancel` request to the remote peer before clearing
+local active-task bookkeeping.
+
 ## Native Control-Plane Surface
 
 The Rust control-plane A2A server uses the same task ledger path as the CLI. On

--- a/src/agent/swarm/executor.ts
+++ b/src/agent/swarm/executor.ts
@@ -12,10 +12,37 @@ import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { type DelegationPrompt, formatDelegation } from "@evalops/contracts";
+import { codexSubagentTypeA2ASkillID } from "../../codex/subagent-dispatch-table.js";
 import {
 	buildEvalOpsDelegationEnvironment,
 	issueEvalOpsDelegationToken,
 } from "../../oauth/index.js";
+import {
+	type A2AServiceConfig,
+	type A2ATask,
+	buildA2AUserMessage,
+	cancelA2ATask,
+	getA2ATask,
+	normalizeA2ABaseUrl,
+	sendA2AMessage,
+} from "../../platform/a2a-client.js";
+import {
+	type ResolvedA2APeer,
+	resolveA2APeer,
+} from "../../platform/a2a-peer-registry.js";
+import {
+	extractA2ATaskText,
+	isTerminalA2AState,
+	recordA2ATaskStart,
+	updateA2ATaskInLedger,
+} from "../../platform/a2a-task-ledger.js";
+import {
+	type PlatformAgentRegistryA2APeerCandidate,
+	PlatformAgentStatusValue,
+	listA2APeerCandidatesWithPlatform,
+	resolveAgentRegistryServiceConfig,
+} from "../../platform/agent-registry-client.js";
+import { getEnvValue, trimString } from "../../platform/client.js";
 import { recordSubagentDispatch } from "../../telemetry.js";
 import { createLogger } from "../../utils/logger.js";
 import {
@@ -27,6 +54,7 @@ import {
 } from "../modes.js";
 import { publishSwarmRuntimeEvent } from "./runtime-events.js";
 import type {
+	SwarmA2AConfig,
 	SwarmConfig,
 	SwarmEvent,
 	SwarmEventHandler,
@@ -44,6 +72,7 @@ const DEFAULT_TASK_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Maximum concurrent teammates */
 const MAX_TEAMMATES = 10;
+const DEFAULT_A2A_POLL_INTERVAL_MS = 2_000;
 
 /** Teammate name prefixes for friendly identification */
 const TEAMMATE_NAMES = [
@@ -88,12 +117,19 @@ function cloneTeammate(teammate: SwarmTeammate): SwarmTeammate {
 			? cloneTask(teammate.currentTask)
 			: undefined,
 		completedTasks: [...teammate.completedTasks],
+		a2a: teammate.a2a ? { ...teammate.a2a } : undefined,
 	};
 }
 
 function cloneConfig(config: SwarmConfig): SwarmConfig {
 	return {
 		...config,
+		a2a: config.a2a
+			? {
+					...config.a2a,
+					peers: config.a2a.peers ? [...config.a2a.peers] : undefined,
+				}
+			: undefined,
 		tasks: config.tasks.map(cloneTask),
 	};
 }
@@ -140,6 +176,54 @@ function providerFromPrefixedModel(
 	return parseModelProvider(model.slice(0, slashIndex));
 }
 
+function parseBooleanEnv(value: string | undefined): boolean | undefined {
+	const normalized = value?.trim().toLowerCase();
+	if (!normalized) {
+		return undefined;
+	}
+	if (["1", "true", "yes", "on"].includes(normalized)) {
+		return true;
+	}
+	if (["0", "false", "no", "off"].includes(normalized)) {
+		return false;
+	}
+	return undefined;
+}
+
+function parsePositiveIntEnv(value: string | undefined): number | undefined {
+	const parsed = Number.parseInt(value ?? "", 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseCSVEnv(value: string | undefined): string[] | undefined {
+	const parsed = value
+		?.split(",")
+		.map((item) => item.trim())
+		.filter(Boolean);
+	return parsed && parsed.length > 0 ? parsed : undefined;
+}
+
+function a2aStateCompleted(state: string | undefined): boolean {
+	return /COMPLETED/u.test(
+		(state ?? "").toUpperCase().replace(/[\s-]+/gu, "_"),
+	);
+}
+
+type A2ATeammateRoute = {
+	name: string;
+	displayName?: string;
+	config: A2AServiceConfig;
+	skillId?: string;
+	role?: string;
+	tasksPath?: string;
+	source: "registry" | "platform-agent-registry";
+};
+
+type RemoteA2ARunningTask = {
+	route: A2ATeammateRoute;
+	taskId: string;
+};
+
 function buildDispatchEnv(
 	dispatch: ResolvedSubagentDispatch | null,
 	reasoningEffortOverride?: string,
@@ -182,6 +266,8 @@ type TaskDispatchResolution = {
 export class SwarmExecutor {
 	private state: SwarmState;
 	private processes: Map<string, ChildProcess> = new Map();
+	private remoteA2ATasks: Map<string, RemoteA2ARunningTask> = new Map();
+	private a2aRouteCursor = 0;
 	private eventHandlers: Set<SwarmEventHandler> = new Set();
 	private abortController: AbortController;
 
@@ -266,6 +352,11 @@ export class SwarmExecutor {
 	 * Cancel the swarm execution.
 	 */
 	cancel(): void {
+		const remoteTasks = [...this.remoteA2ATasks.entries()];
+		for (const [teammateId, remoteTask] of remoteTasks) {
+			void this.cancelRemoteA2ATask(teammateId, remoteTask);
+		}
+
 		this.abortController.abort();
 		this.state.status = "cancelled";
 
@@ -296,6 +387,29 @@ export class SwarmExecutor {
 		logger.info("Swarm cancelled", { swarmId: this.state.id });
 	}
 
+	private async cancelRemoteA2ATask(
+		teammateId: string,
+		remoteTask: RemoteA2ARunningTask,
+	): Promise<void> {
+		try {
+			const cancelledTask = await cancelA2ATask(
+				remoteTask.route.config,
+				remoteTask.taskId,
+			);
+			await this.updateA2ASwarmTaskLedger(remoteTask.route, cancelledTask);
+		} catch (error) {
+			logger.warn("Failed to cancel remote A2A swarm task", {
+				error: error instanceof Error ? error.message : String(error),
+				swarmId: this.state.id,
+				teammateId,
+				remoteTaskId: remoteTask.taskId,
+				peer: remoteTask.route.name,
+			});
+		} finally {
+			this.remoteA2ATasks.delete(teammateId);
+		}
+	}
+
 	/**
 	 * Execute the swarm - runs all tasks with available teammates.
 	 */
@@ -318,6 +432,8 @@ export class SwarmExecutor {
 				this.state.status === "running" &&
 				(this.state.pendingTasks.length > 0 || this.state.activeTasks.size > 0)
 			) {
+				this.skipTasksBlockedByFailedDependencies();
+
 				// Assign tasks to idle teammates
 				await this.assignTasks();
 
@@ -418,16 +534,43 @@ export class SwarmExecutor {
 		for (const task of this.state.pendingTasks) {
 			// Check dependencies
 			if (task.dependsOn && task.dependsOn.length > 0) {
-				const allDepsCompleted = task.dependsOn.every(
-					(depId) =>
-						this.state.completedTasks.has(depId) ||
-						this.state.failedTasks.has(depId),
+				const allDepsCompleted = task.dependsOn.every((depId) =>
+					this.state.completedTasks.has(depId),
 				);
 				if (!allDepsCompleted) continue;
 			}
 			return task;
 		}
 		return null;
+	}
+
+	private skipTasksBlockedByFailedDependencies(): void {
+		const blockedTasks = this.state.pendingTasks.filter((task) =>
+			task.dependsOn?.some((depId) => this.state.failedTasks.has(depId)),
+		);
+		for (const task of blockedTasks) {
+			const pendingIndex = this.state.pendingTasks.findIndex(
+				(candidate) => candidate.id === task.id,
+			);
+			if (pendingIndex >= 0) {
+				this.state.pendingTasks.splice(pendingIndex, 1);
+			}
+			this.state.failedTasks.add(task.id);
+			const failedDependency = task.dependsOn?.find((depId) =>
+				this.state.failedTasks.has(depId),
+			);
+			const error = `Dependency ${failedDependency ?? "unknown"} failed`;
+			this.emit({
+				type: "task_fail",
+				swarmId: this.state.id,
+				teammateId: "dependency",
+				taskId: task.id,
+				error,
+			});
+			if (!this.state.config.continueOnFailure) {
+				this.state.status = "failed";
+			}
+		}
 	}
 
 	/**
@@ -596,6 +739,228 @@ export class SwarmExecutor {
 		);
 	}
 
+	private resolveA2AConfig(): SwarmA2AConfig | null {
+		const transport =
+			this.state.config.transport ??
+			trimString(process.env.MAESTRO_SWARM_TRANSPORT);
+		if (transport !== "a2a") {
+			return null;
+		}
+		const configured = this.state.config.a2a ?? {};
+		const peers =
+			configured.peers ?? parseCSVEnv(getEnvValue(["MAESTRO_SWARM_A2A_PEERS"]));
+		return {
+			...configured,
+			...(peers ? { peers } : {}),
+			registryPath:
+				configured.registryPath ??
+				trimString(process.env.MAESTRO_SWARM_A2A_REGISTRY),
+			tasksPath:
+				configured.tasksPath ?? trimString(process.env.MAESTRO_SWARM_A2A_TASKS),
+			skillId:
+				configured.skillId ??
+				trimString(process.env.MAESTRO_SWARM_A2A_SKILL_ID),
+			role: configured.role ?? trimString(process.env.MAESTRO_SWARM_A2A_ROLE),
+			discover:
+				configured.discover ??
+				parseBooleanEnv(process.env.MAESTRO_SWARM_A2A_DISCOVER),
+			workspaceId:
+				configured.workspaceId ??
+				trimString(process.env.MAESTRO_SWARM_A2A_WORKSPACE_ID),
+			capability:
+				configured.capability ??
+				trimString(process.env.MAESTRO_SWARM_A2A_CAPABILITY),
+			surface:
+				configured.surface ?? trimString(process.env.MAESTRO_SWARM_A2A_SURFACE),
+			preferInternalEndpoint:
+				configured.preferInternalEndpoint ??
+				parseBooleanEnv(process.env.MAESTRO_SWARM_A2A_PREFER_INTERNAL),
+			limit:
+				configured.limit ??
+				parsePositiveIntEnv(process.env.MAESTRO_SWARM_A2A_LIMIT),
+			timeoutMs:
+				configured.timeoutMs ??
+				parsePositiveIntEnv(process.env.MAESTRO_SWARM_A2A_TIMEOUT_MS),
+			maxAttempts:
+				configured.maxAttempts ??
+				parsePositiveIntEnv(process.env.MAESTRO_SWARM_A2A_MAX_ATTEMPTS),
+			maxWaitMs:
+				configured.maxWaitMs ??
+				parsePositiveIntEnv(process.env.MAESTRO_SWARM_A2A_MAX_WAIT_MS),
+			pollIntervalMs:
+				configured.pollIntervalMs ??
+				parsePositiveIntEnv(process.env.MAESTRO_SWARM_A2A_POLL_INTERVAL_MS),
+		};
+	}
+
+	private async resolveA2ATeammateRoute(
+		teammate: SwarmTeammate,
+		task: SwarmTask,
+		options: SwarmA2AConfig,
+	): Promise<A2ATeammateRoute> {
+		if (options.discover) {
+			return this.resolvePlatformDiscoveredA2ATeammateRoute(
+				teammate,
+				task,
+				options,
+			);
+		}
+		const peerName = this.selectA2APeerName(teammate, task, options);
+		const peer = await resolveA2APeer(peerName, {
+			path: options.registryPath,
+			timeoutMs: options.timeoutMs,
+			maxAttempts: options.maxAttempts,
+		});
+		return {
+			name: peer.name,
+			displayName: peer.entry.displayName,
+			config: peer.config,
+			skillId: this.resolveA2ASkillId(task, options, peer),
+			role: options.role ?? task.subagentType,
+			tasksPath: options.tasksPath,
+			source: "registry",
+		};
+	}
+
+	private async resolvePlatformDiscoveredA2ATeammateRoute(
+		teammate: SwarmTeammate,
+		task: SwarmTask,
+		options: SwarmA2AConfig,
+	): Promise<A2ATeammateRoute> {
+		const skillId = this.resolveA2ASkillId(task, options);
+		const pinnedPeer = trimString(task.a2aPeer);
+		const routeIndex = pinnedPeer ? 0 : this.nextA2ARouteIndex();
+		const candidates = await listA2APeerCandidatesWithPlatform({
+			workspaceId: options.workspaceId,
+			capability: options.capability,
+			surface: options.surface ?? "a2a",
+			status: PlatformAgentStatusValue.Idle,
+			limit:
+				options.limit ??
+				(pinnedPeer ? undefined : this.defaultA2ADiscoveryLimit()),
+			skillId,
+			preferInternalEndpoint: options.preferInternalEndpoint,
+		});
+		if (!candidates || candidates.length === 0) {
+			throw new Error(
+				`No Platform A2A peers available for swarm task ${task.id}${
+					skillId ? ` with skill ${skillId}` : ""
+				}`,
+			);
+		}
+		const candidatePool = pinnedPeer
+			? candidates.filter((candidate) =>
+					platformA2ACandidateMatchesPeer(candidate, pinnedPeer),
+				)
+			: candidates;
+		if (candidatePool.length === 0) {
+			throw new Error(
+				`No Platform A2A peer matched task ${task.id} a2aPeer ${pinnedPeer}`,
+			);
+		}
+		const candidateIndex = pinnedPeer ? 0 : routeIndex % candidatePool.length;
+		const candidate = candidatePool[candidateIndex];
+		if (!candidate) {
+			throw new Error(
+				"Platform A2A peer discovery returned an invalid candidate",
+			);
+		}
+		const config = await this.a2aConfigForPlatformCandidate(candidate, options);
+		return {
+			name: candidate.agent.name ?? candidate.agent.id ?? candidate.endpointUrl,
+			displayName: candidate.agent.name,
+			config,
+			skillId,
+			role: options.role ?? task.subagentType,
+			tasksPath: options.tasksPath,
+			source: "platform-agent-registry",
+		};
+	}
+
+	private async a2aConfigForPlatformCandidate(
+		candidate: PlatformAgentRegistryA2APeerCandidate,
+		options: SwarmA2AConfig,
+	): Promise<A2AServiceConfig> {
+		const platformConfig = await resolveAgentRegistryServiceConfig();
+		if (!platformConfig) {
+			throw new Error(
+				"Platform Agent Registry service is not configured for A2A swarm discovery",
+			);
+		}
+		return {
+			baseUrl: normalizeA2ABaseUrl(candidate.endpointUrl),
+			...(platformConfig.token ? { token: platformConfig.token } : {}),
+			...(platformConfig.organizationId
+				? { organizationId: platformConfig.organizationId }
+				: {}),
+			workspaceId:
+				candidate.agent.workspaceId ??
+				options.workspaceId ??
+				platformConfig.workspaceId,
+			...(candidate.agent.id ? { agentId: candidate.agent.id } : {}),
+			actorId: "maestro-swarm",
+			timeoutMs: options.timeoutMs ?? platformConfig.timeoutMs,
+			maxAttempts: options.maxAttempts ?? platformConfig.maxAttempts,
+		};
+	}
+
+	private selectA2APeerName(
+		teammate: SwarmTeammate,
+		task: SwarmTask,
+		options: SwarmA2AConfig,
+	): string {
+		const peerName = trimString(task.a2aPeer);
+		if (peerName) {
+			return peerName;
+		}
+		const peers = options.peers ?? [];
+		const selected = peers[this.nextA2ARouteIndex() % peers.length];
+		if (!selected) {
+			throw new Error(
+				"Remote A2A swarm transport requires a task a2aPeer, a2a.peers, MAESTRO_SWARM_A2A_PEERS, or a2a.discover=true",
+			);
+		}
+		return selected;
+	}
+
+	private resolveA2ASkillId(
+		task: SwarmTask,
+		options: SwarmA2AConfig,
+		peer?: ResolvedA2APeer,
+	): string | undefined {
+		const configured =
+			trimString(task.a2aSkillId) ??
+			trimString(options.skillId) ??
+			codexSubagentTypeA2ASkillID(
+				task.subagentType ?? this.state.config.subagentType,
+			);
+		if (configured) {
+			return configured;
+		}
+		return peer?.entry.skills?.[0]?.id;
+	}
+
+	private teammateIndex(teammate: SwarmTeammate): number {
+		const index = this.state.teammates.findIndex(
+			(item) => item.id === teammate.id,
+		);
+		return index >= 0 ? index : 0;
+	}
+
+	private nextA2ARouteIndex(): number {
+		const index = this.a2aRouteCursor;
+		this.a2aRouteCursor += 1;
+		return index;
+	}
+
+	private defaultA2ADiscoveryLimit(): number {
+		return Math.max(
+			1,
+			this.state.config.teammateCount,
+			this.state.config.tasks.length,
+		);
+	}
+
 	private async spawnTeammate(
 		teammate: SwarmTeammate,
 		task: SwarmTask,
@@ -620,6 +985,12 @@ export class SwarmExecutor {
 		const prompt = formatDelegation(delegationPrompt);
 
 		writeFileSync(tmpFile, prompt);
+
+		const a2aConfig = this.resolveA2AConfig();
+		if (a2aConfig) {
+			void this.spawnA2ATeammate(teammate, task, prompt, tmpFile, a2aConfig);
+			return;
+		}
 
 		const modelOverride =
 			task.model !== undefined
@@ -883,6 +1254,342 @@ export class SwarmExecutor {
 		});
 	}
 
+	private async spawnA2ATeammate(
+		teammate: SwarmTeammate,
+		task: SwarmTask,
+		prompt: string,
+		tmpFile: string,
+		options: SwarmA2AConfig,
+	): Promise<void> {
+		try {
+			const route = await this.resolveA2ATeammateRoute(teammate, task, options);
+			const messageId = `maestro-swarm-message-${randomUUID()}`;
+			const contextId = `maestro-swarm:${this.state.id}:${task.id}`;
+			const sent = await sendA2AMessage(route.config, {
+				message: buildA2AUserMessage({
+					messageId,
+					contextId,
+					text: prompt,
+					metadata: this.buildA2ASwarmMessageMetadata(teammate, task, route),
+				}),
+				configuration: {
+					returnImmediately: true,
+					acceptedOutputModes: ["text/plain", "application/json"],
+				},
+				metadata: {
+					route: "maestro_swarm",
+					transport: "a2a",
+					swarmId: this.state.id,
+					taskId: task.id,
+					teammateId: teammate.id,
+					peer: route.name,
+					source: route.source,
+				},
+			});
+			teammate.a2a = {
+				peer: route.name,
+				peerDisplayName: route.displayName,
+				source: route.source,
+				taskId: sent.task.id,
+				contextId: sent.task.contextId ?? contextId,
+				messageId,
+				skillId: route.skillId,
+				role: route.role,
+			};
+			this.remoteA2ATasks.set(teammate.id, {
+				route,
+				taskId: sent.task.id,
+			});
+			await this.recordA2ASwarmTaskStart(route, task, sent.task, {
+				messageId,
+				contextId,
+			});
+			if (
+				this.state.status === "cancelled" ||
+				this.abortController.signal.aborted
+			) {
+				await this.cancelRemoteA2ATask(teammate.id, {
+					route,
+					taskId: sent.task.id,
+				});
+				return;
+			}
+			const remoteTask = await this.waitForA2ASwarmTask(
+				route.config,
+				sent.task,
+				options,
+			);
+			await this.updateA2ASwarmTaskLedger(route, remoteTask);
+			this.completeA2ATeammate(teammate, task, remoteTask, route);
+		} catch (error) {
+			if (
+				this.state.status !== "cancelled" &&
+				!this.abortController.signal.aborted
+			) {
+				const remoteTask = this.remoteA2ATasks.get(teammate.id);
+				if (remoteTask) {
+					await this.cancelRemoteA2ATask(teammate.id, remoteTask);
+				}
+			}
+			this.failA2ATeammate(teammate, task, error);
+		} finally {
+			this.remoteA2ATasks.delete(teammate.id);
+			try {
+				unlinkSync(tmpFile);
+			} catch {
+				// Ignore cleanup errors
+			}
+		}
+	}
+
+	private buildA2ASwarmMessageMetadata(
+		teammate: SwarmTeammate,
+		task: SwarmTask,
+		route: A2ATeammateRoute,
+	): Record<string, unknown> {
+		const currentDelegationId = `${this.state.id}:${task.id}`;
+		const lineage = {
+			rootDelegationId: this.state.id,
+			...(this.state.config.parentSessionId
+				? { parentDelegationId: this.state.config.parentSessionId }
+				: {}),
+			currentDelegationId,
+			delegationChain: [this.state.id, currentDelegationId],
+			delegationChainDepth: 1,
+			maxDelegationChainDepth: 1,
+		};
+		const subagentRequest = route.skillId
+			? {
+					skillId: route.skillId,
+					role: route.role,
+					cwd: this.state.config.cwd,
+					taskId: task.id,
+					swarmId: this.state.id,
+				}
+			: undefined;
+		return {
+			requestKind: "maestro-swarm-task",
+			transport: "a2a",
+			relayPeer: route.name,
+			swarmId: this.state.id,
+			teammateId: teammate.id,
+			teammateName: teammate.name,
+			taskId: task.id,
+			...(route.skillId ? { a2aSkillId: route.skillId } : {}),
+			...(task.files?.length ? { files: task.files } : {}),
+			swarm: lineage,
+			evalops: {
+				swarm: lineage,
+				transport: "a2a",
+				peer: route.name,
+			},
+			...(subagentRequest
+				? { "evalops.subagentRequest": subagentRequest }
+				: {}),
+		};
+	}
+
+	private async waitForA2ASwarmTask(
+		config: A2AServiceConfig,
+		initialTask: A2ATask,
+		options: SwarmA2AConfig,
+	): Promise<A2ATask> {
+		const maxWaitMs =
+			options.maxWaitMs ??
+			this.state.config.taskTimeout ??
+			DEFAULT_TASK_TIMEOUT_MS;
+		const pollIntervalMs =
+			options.pollIntervalMs ?? DEFAULT_A2A_POLL_INTERVAL_MS;
+		const deadline = Date.now() + maxWaitMs;
+		let task = initialTask;
+		while (
+			!isTerminalA2AState(task.status.state) &&
+			Date.now() < deadline &&
+			!this.abortController.signal.aborted
+		) {
+			await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+			task = await getA2ATask(config, task.id, {
+				signal: this.abortController.signal,
+			});
+		}
+		if (!isTerminalA2AState(task.status.state)) {
+			throw new Error(
+				`Timed out waiting for remote A2A task ${task.id}; last state ${task.status.state}`,
+			);
+		}
+		return task;
+	}
+
+	private completeA2ATeammate(
+		teammate: SwarmTeammate,
+		task: SwarmTask,
+		remoteTask: A2ATask,
+		route: A2ATeammateRoute,
+	): void {
+		this.state.activeTasks.delete(task.id);
+		teammate.completedAt = Date.now();
+		teammate.currentTask = undefined;
+		teammate.output =
+			extractA2ATaskText(remoteTask) ??
+			`Remote A2A task ${remoteTask.id} finished with ${remoteTask.status.state}`;
+		if (this.state.status === "cancelled" || teammate.status === "cancelled") {
+			teammate.status = "cancelled";
+			this.emit({
+				type: "teammate_complete",
+				swarmId: this.state.id,
+				teammate,
+			});
+			return;
+		}
+		if (a2aStateCompleted(remoteTask.status.state)) {
+			teammate.status = "completed";
+			teammate.completedTasks.push(task.id);
+			this.state.completedTasks.add(task.id);
+			this.emit({
+				type: "task_complete",
+				swarmId: this.state.id,
+				teammateId: teammate.id,
+				taskId: task.id,
+				output: teammate.output,
+			});
+		} else {
+			teammate.status = "failed";
+			teammate.error = `Remote A2A task ${remoteTask.id} on ${route.name} ended in ${remoteTask.status.state}`;
+			this.state.failedTasks.add(task.id);
+			this.emit({
+				type: "task_fail",
+				swarmId: this.state.id,
+				teammateId: teammate.id,
+				taskId: task.id,
+				error: teammate.error,
+			});
+			if (!this.state.config.continueOnFailure) {
+				this.state.status = "failed";
+			}
+		}
+		this.emit({
+			type: "teammate_complete",
+			swarmId: this.state.id,
+			teammate,
+		});
+		if (
+			this.state.status === "running" &&
+			(this.state.pendingTasks.length > 0 || this.state.activeTasks.size > 0) &&
+			(teammate.status === "completed" || this.state.config.continueOnFailure)
+		) {
+			teammate.status = "pending";
+			teammate.error = undefined;
+		}
+	}
+
+	private failA2ATeammate(
+		teammate: SwarmTeammate,
+		task: SwarmTask,
+		error: unknown,
+	): void {
+		this.state.activeTasks.delete(task.id);
+		teammate.completedAt = Date.now();
+		teammate.currentTask = undefined;
+		if (this.state.status === "cancelled" || teammate.status === "cancelled") {
+			teammate.status = "cancelled";
+			this.emit({
+				type: "teammate_complete",
+				swarmId: this.state.id,
+				teammate,
+			});
+			return;
+		}
+		if (teammate.a2a && !this.remoteA2ATasks.has(teammate.id)) {
+			teammate.a2a = undefined;
+		}
+		teammate.status = "failed";
+		teammate.error = error instanceof Error ? error.message : String(error);
+		this.state.failedTasks.add(task.id);
+		this.emit({
+			type: "task_fail",
+			swarmId: this.state.id,
+			teammateId: teammate.id,
+			taskId: task.id,
+			error: teammate.error,
+		});
+		if (!this.state.config.continueOnFailure) {
+			this.state.status = "failed";
+		}
+		this.emit({
+			type: "teammate_complete",
+			swarmId: this.state.id,
+			teammate,
+		});
+
+		if (
+			this.state.status === "running" &&
+			(this.state.pendingTasks.length > 0 || this.state.activeTasks.size > 0) &&
+			this.state.config.continueOnFailure
+		) {
+			teammate.status = "pending";
+			teammate.error = undefined;
+			teammate.a2a = undefined;
+		}
+	}
+
+	private async recordA2ASwarmTaskStart(
+		route: A2ATeammateRoute,
+		task: SwarmTask,
+		remoteTask: A2ATask,
+		ids: { messageId: string; contextId: string },
+	): Promise<void> {
+		try {
+			await recordA2ATaskStart({
+				path: route.tasksPath,
+				peer: route.name,
+				peerDisplayName: route.displayName,
+				task: remoteTask,
+				text: task.prompt,
+				messageId: ids.messageId,
+				contextId: remoteTask.contextId ?? ids.contextId,
+				kind: "delegation",
+				role: route.role,
+				cwd: this.state.config.cwd,
+				metadata: {
+					requestKind: "maestro-swarm-task",
+					relayPeer: route.name,
+					swarmId: this.state.id,
+					taskId: task.id,
+					transport: "a2a",
+					source: route.source,
+					a2aSkillId: route.skillId,
+				},
+			});
+		} catch (error) {
+			logger.warn("Failed to record remote A2A swarm task in local ledger", {
+				error: error instanceof Error ? error.message : String(error),
+				swarmId: this.state.id,
+				taskId: task.id,
+				peer: route.name,
+			});
+		}
+	}
+
+	private async updateA2ASwarmTaskLedger(
+		route: A2ATeammateRoute,
+		remoteTask: A2ATask,
+	): Promise<void> {
+		try {
+			await updateA2ATaskInLedger({
+				path: route.tasksPath,
+				peer: route.name,
+				task: remoteTask,
+			});
+		} catch (error) {
+			logger.warn("Failed to update remote A2A swarm task in local ledger", {
+				error: error instanceof Error ? error.message : String(error),
+				swarmId: this.state.id,
+				remoteTaskId: remoteTask.id,
+				peer: route.name,
+			});
+		}
+	}
+
 	/**
 	 * Wait for any active task to complete.
 	 */
@@ -901,6 +1608,44 @@ export class SwarmExecutor {
 			}, 100);
 		});
 	}
+}
+
+function platformA2ACandidateMatchesPeer(
+	candidate: PlatformAgentRegistryA2APeerCandidate,
+	peer: string,
+): boolean {
+	const selector = normalizePeerSelector(peer);
+	const selectorBaseUrl = normalizePeerBaseUrl(peer);
+	if (!selector) {
+		return false;
+	}
+	const values = [
+		candidate.agent.id,
+		candidate.agent.name,
+		candidate.endpointUrl,
+		candidate.agentCardUrl,
+	];
+	return values.some((value) => {
+		const candidateSelector = normalizePeerSelector(value);
+		if (candidateSelector && candidateSelector === selector) {
+			return true;
+		}
+		const candidateBaseUrl = normalizePeerBaseUrl(value);
+		return Boolean(
+			selectorBaseUrl &&
+				candidateBaseUrl &&
+				candidateBaseUrl === selectorBaseUrl,
+		);
+	});
+}
+
+function normalizePeerSelector(value: string | undefined): string | undefined {
+	return trimString(value)?.toLowerCase();
+}
+
+function normalizePeerBaseUrl(value: string | undefined): string | undefined {
+	const trimmed = trimString(value);
+	return trimmed ? normalizeA2ABaseUrl(trimmed).toLowerCase() : undefined;
 }
 
 /**

--- a/src/agent/swarm/types.ts
+++ b/src/agent/swarm/types.ts
@@ -34,6 +34,10 @@ export interface SwarmTask {
 	model?: string;
 	/** Optional subagent type used for mode-level model dispatch */
 	subagentType?: SubagentType;
+	/** Optional A2A peer override when the swarm uses remote transport */
+	a2aPeer?: string;
+	/** Optional A2A skill override when the task maps to a remote Maestro lane */
+	a2aSkillId?: string;
 	/** Priority (higher = earlier execution when no dependencies) */
 	priority?: number;
 }
@@ -54,6 +58,8 @@ export interface SwarmTeammate {
 	completedTasks: string[];
 	/** Process ID if running as subprocess */
 	pid?: number;
+	/** Remote A2A task correlation when this teammate runs on a peer */
+	a2a?: SwarmA2ATeammateExecution;
 	/** Start timestamp */
 	startedAt?: number;
 	/** Completion timestamp */
@@ -88,12 +94,74 @@ export interface SwarmConfig {
 	subagentType?: SubagentType;
 	/** Default reasoning hint for teammate tasks */
 	reasoningEffort?: ReasoningEffort;
+	/** Execution transport for teammates; local preserves subprocess behavior. */
+	transport?: "local" | "a2a";
+	/** Remote A2A routing options for Platform-discovered or registry peers. */
+	a2a?: SwarmA2AConfig;
 	/** Maximum time per task in milliseconds */
 	taskTimeout?: number;
 	/** Whether to continue on individual task failures */
 	continueOnFailure?: boolean;
 	/** Git branch to work on (creates if doesn't exist) */
 	gitBranch?: string;
+}
+
+/**
+ * Configuration for remote A2A-backed swarm teammates.
+ */
+export interface SwarmA2AConfig {
+	/** Named peers from the local A2A registry, used round-robin. */
+	peers?: string[];
+	/** Override for the local A2A peer registry path. */
+	registryPath?: string;
+	/** Override for the local A2A task ledger path. */
+	tasksPath?: string;
+	/** Default remote A2A skill id. */
+	skillId?: string;
+	/** Optional delegation role shown in task ledger metadata. */
+	role?: string;
+	/** Discover remote peers from Platform Agent Registry instead of local peers. */
+	discover?: boolean;
+	/** Platform workspace id for discovery. */
+	workspaceId?: string;
+	/** Capability filter for Platform discovery. */
+	capability?: string;
+	/** Surface filter for Platform discovery. Defaults to a2a. */
+	surface?: string;
+	/** Prefer internal endpoints returned by Platform Agent Registry. */
+	preferInternalEndpoint?: boolean;
+	/** Maximum Platform candidates to consider. */
+	limit?: number;
+	/** Timeout for individual A2A HTTP calls. */
+	timeoutMs?: number;
+	/** Max attempts for individual A2A HTTP calls. */
+	maxAttempts?: number;
+	/** Max time to wait for a remote task to reach terminal state. */
+	maxWaitMs?: number;
+	/** Poll interval while waiting for remote task state. */
+	pollIntervalMs?: number;
+}
+
+/**
+ * Public, non-secret correlation metadata for a remote A2A swarm teammate.
+ */
+export interface SwarmA2ATeammateExecution {
+	/** Peer selected for this teammate task. */
+	peer: string;
+	/** Optional human-readable peer label. */
+	peerDisplayName?: string;
+	/** Peer source used by the router. */
+	source: "registry" | "platform-agent-registry";
+	/** A2A task id returned by the peer. */
+	taskId: string;
+	/** A2A context id used for resume/reply. */
+	contextId?: string;
+	/** A2A message id sent by the coordinator. */
+	messageId: string;
+	/** A2A skill id used for remote routing. */
+	skillId?: string;
+	/** Delegation role recorded for the remote task. */
+	role?: string;
 }
 
 /**

--- a/src/platform/a2a-client.ts
+++ b/src/platform/a2a-client.ts
@@ -653,6 +653,30 @@ export async function getA2ATask(
 	return (await response.json()) as A2ATask;
 }
 
+export async function cancelA2ATask(
+	config: A2AServiceConfig,
+	taskId: string,
+	options: { signal?: AbortSignal; traceContext?: A2ATraceContext } = {},
+): Promise<A2ATask> {
+	const trimmedTaskId = requireA2ATaskId(taskId);
+	const response = await fetchDownstream(
+		`${config.baseUrl}/tasks/${encodeURIComponent(trimmedTaskId)}:cancel`,
+		{
+			method: "POST",
+			headers: buildA2AHeaders(config, options.traceContext),
+			signal: options.signal,
+		},
+		{
+			serviceName: "platform-a2a",
+			failureMode: "required",
+			timeoutMs: config.timeoutMs,
+			maxAttempts: config.maxAttempts,
+		},
+	);
+	await throwForA2AError(response, "cancel task");
+	return (await response.json()) as A2ATask;
+}
+
 async function* parseA2AStreamEvents(
 	response: Response,
 ): AsyncIterable<A2AStreamEvent> {

--- a/test/agent/swarm-executor.test.ts
+++ b/test/agent/swarm-executor.test.ts
@@ -6,14 +6,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
 	buildEvalOpsDelegationEnvironmentMock,
+	cancelA2ATaskMock,
+	getA2ATaskMock,
 	issueEvalOpsDelegationTokenMock,
+	listA2APeerCandidatesWithPlatformMock,
 	recordSubagentDispatchMock,
+	recordA2ATaskStartMock,
+	resolveA2APeerMock,
+	resolveAgentRegistryServiceConfigMock,
 	spawnMock,
+	sendA2AMessageMock,
+	updateA2ATaskInLedgerMock,
 } = vi.hoisted(() => ({
 	buildEvalOpsDelegationEnvironmentMock: vi.fn(),
+	cancelA2ATaskMock: vi.fn(),
+	getA2ATaskMock: vi.fn(),
 	issueEvalOpsDelegationTokenMock: vi.fn(),
+	listA2APeerCandidatesWithPlatformMock: vi.fn(),
 	recordSubagentDispatchMock: vi.fn(),
+	recordA2ATaskStartMock: vi.fn(),
+	resolveA2APeerMock: vi.fn(),
+	resolveAgentRegistryServiceConfigMock: vi.fn(),
 	spawnMock: vi.fn(),
+	sendA2AMessageMock: vi.fn(),
+	updateA2ATaskInLedgerMock: vi.fn(),
 }));
 
 vi.mock("node:child_process", () => ({
@@ -24,6 +40,50 @@ vi.mock("../../src/oauth/index.js", () => ({
 	buildEvalOpsDelegationEnvironment: buildEvalOpsDelegationEnvironmentMock,
 	issueEvalOpsDelegationToken: issueEvalOpsDelegationTokenMock,
 }));
+
+vi.mock("../../src/platform/a2a-client.js", async () => {
+	const actual = await vi.importActual<
+		typeof import("../../src/platform/a2a-client.js")
+	>("../../src/platform/a2a-client.js");
+	return {
+		...actual,
+		cancelA2ATask: cancelA2ATaskMock,
+		getA2ATask: getA2ATaskMock,
+		sendA2AMessage: sendA2AMessageMock,
+	};
+});
+
+vi.mock("../../src/platform/a2a-peer-registry.js", async () => {
+	const actual = await vi.importActual<
+		typeof import("../../src/platform/a2a-peer-registry.js")
+	>("../../src/platform/a2a-peer-registry.js");
+	return {
+		...actual,
+		resolveA2APeer: resolveA2APeerMock,
+	};
+});
+
+vi.mock("../../src/platform/a2a-task-ledger.js", async () => {
+	const actual = await vi.importActual<
+		typeof import("../../src/platform/a2a-task-ledger.js")
+	>("../../src/platform/a2a-task-ledger.js");
+	return {
+		...actual,
+		recordA2ATaskStart: recordA2ATaskStartMock,
+		updateA2ATaskInLedger: updateA2ATaskInLedgerMock,
+	};
+});
+
+vi.mock("../../src/platform/agent-registry-client.js", async () => {
+	const actual = await vi.importActual<
+		typeof import("../../src/platform/agent-registry-client.js")
+	>("../../src/platform/agent-registry-client.js");
+	return {
+		...actual,
+		listA2APeerCandidatesWithPlatform: listA2APeerCandidatesWithPlatformMock,
+		resolveAgentRegistryServiceConfig: resolveAgentRegistryServiceConfigMock,
+	};
+});
 
 vi.mock("../../src/telemetry.js", () => ({
 	recordSubagentDispatch: recordSubagentDispatchMock,
@@ -133,6 +193,21 @@ function getSpawnedTempFile(): string {
 	return args.at(-1)!;
 }
 
+async function executeWithTimeout(
+	executor: SwarmExecutor,
+	timeoutMs = 500,
+): Promise<Awaited<ReturnType<SwarmExecutor["execute"]>>> {
+	return Promise.race([
+		executor.execute(),
+		new Promise<never>((_, reject) => {
+			setTimeout(
+				() => reject(new Error("swarm execution timed out")),
+				timeoutMs,
+			);
+		}),
+	]);
+}
+
 describe("SwarmExecutor", () => {
 	beforeEach(() => {
 		buildEvalOpsDelegationEnvironmentMock.mockReset();
@@ -149,6 +224,67 @@ describe("SwarmExecutor", () => {
 			),
 		);
 		recordSubagentDispatchMock.mockReset();
+		resolveA2APeerMock.mockReset();
+		resolveA2APeerMock.mockResolvedValue({
+			name: "remote-a",
+			entry: {
+				url: "https://remote-a.example/a2a",
+				displayName: "Remote A",
+				skills: [
+					{
+						id: "maestro.subagent.code-writer",
+						name: "Code Writer",
+					},
+				],
+			},
+			config: {
+				baseUrl: "https://remote-a.example/a2a",
+				agentId: "remote-a",
+				timeoutMs: 25,
+				maxAttempts: 1,
+			},
+		});
+		cancelA2ATaskMock.mockReset();
+		cancelA2ATaskMock.mockResolvedValue({
+			id: "remote-task-1",
+			contextId: "remote-context-1",
+			status: { state: "TASK_STATE_CANCELLED" },
+		});
+		sendA2AMessageMock.mockReset();
+		sendA2AMessageMock.mockResolvedValue({
+			task: {
+				id: "remote-task-1",
+				contextId: "remote-context-1",
+				status: { state: "TASK_STATE_WORKING" },
+			},
+		});
+		getA2ATaskMock.mockReset();
+		getA2ATaskMock.mockResolvedValue({
+			id: "remote-task-1",
+			contextId: "remote-context-1",
+			status: { state: "TASK_STATE_COMPLETED" },
+			artifacts: [
+				{
+					artifactId: "remote-result",
+					parts: [{ text: "remote done", mediaType: "text/plain" }],
+				},
+			],
+		});
+		recordA2ATaskStartMock.mockReset();
+		recordA2ATaskStartMock.mockResolvedValue(undefined);
+		updateA2ATaskInLedgerMock.mockReset();
+		updateA2ATaskInLedgerMock.mockResolvedValue(undefined);
+		listA2APeerCandidatesWithPlatformMock.mockReset();
+		listA2APeerCandidatesWithPlatformMock.mockResolvedValue([]);
+		resolveAgentRegistryServiceConfigMock.mockReset();
+		resolveAgentRegistryServiceConfigMock.mockResolvedValue({
+			baseUrl: "https://platform.example",
+			token: "platform-token",
+			organizationId: "org_evalops",
+			workspaceId: "workspace-default",
+			timeoutMs: 25,
+			maxAttempts: 1,
+		});
 		spawnMock.mockReset();
 	});
 
@@ -195,6 +331,638 @@ describe("SwarmExecutor", () => {
 			}),
 		);
 		expect(recordSubagentDispatchMock).not.toHaveBeenCalled();
+	});
+
+	it("dispatches swarm teammate tasks to configured A2A peers", async () => {
+		const executor = new SwarmExecutor({
+			...createConfig({
+				files: ["src/agent/swarm/executor.ts"],
+				subagentType: "coder",
+			}),
+			transport: "a2a",
+			a2a: {
+				peers: ["remote-a"],
+				role: "code-writer",
+				tasksPath: "/tmp/maestro-a2a-tasks.json",
+				maxWaitMs: 50,
+				pollIntervalMs: 1,
+			},
+			mode: "smart",
+			modelProvider: "anthropic",
+		});
+
+		const result = await executeWithTimeout(executor);
+
+		expect(result.status).toBe("completed");
+		expect(Array.from(result.completedTasks)).toContain("task-1");
+		expect(result.teammates[0]!.output).toBe("remote done");
+		expect(result.teammates[0]!.a2a).toEqual(
+			expect.objectContaining({
+				peer: "remote-a",
+				peerDisplayName: "Remote A",
+				source: "registry",
+				taskId: "remote-task-1",
+				contextId: "remote-context-1",
+				messageId: expect.stringContaining("maestro-swarm-message-"),
+				skillId: "maestro.subagent.code-writer",
+				role: "code-writer",
+			}),
+		);
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(resolveA2APeerMock).toHaveBeenCalledWith(
+			"remote-a",
+			expect.objectContaining({
+				path: undefined,
+				timeoutMs: undefined,
+				maxAttempts: undefined,
+			}),
+		);
+		const [serviceConfig, input] = sendA2AMessageMock.mock.calls[0] as [
+			{ baseUrl: string },
+			{
+				message: {
+					contextId?: string;
+					metadata?: Record<string, unknown>;
+					parts: Array<{ text?: string }>;
+				};
+				metadata?: Record<string, unknown>;
+			},
+		];
+		expect(serviceConfig).toEqual(
+			expect.objectContaining({
+				baseUrl: "https://remote-a.example/a2a",
+				agentId: "remote-a",
+			}),
+		);
+		expect(input.message.contextId).toBe(`maestro-swarm:${result.id}:task-1`);
+		expect(input.message.parts[0]!.text).toContain(
+			"## Task\nUpdate the implementation",
+		);
+		expect(input.message.metadata).toEqual(
+			expect.objectContaining({
+				requestKind: "maestro-swarm-task",
+				transport: "a2a",
+				relayPeer: "remote-a",
+				a2aSkillId: "maestro.subagent.code-writer",
+				files: ["src/agent/swarm/executor.ts"],
+				swarm: expect.objectContaining({
+					rootDelegationId: result.id,
+					currentDelegationId: `${result.id}:task-1`,
+				}),
+				evalops: expect.objectContaining({
+					transport: "a2a",
+					peer: "remote-a",
+				}),
+				"evalops.subagentRequest": expect.objectContaining({
+					skillId: "maestro.subagent.code-writer",
+					role: "code-writer",
+					taskId: "task-1",
+					swarmId: result.id,
+				}),
+			}),
+		);
+		expect(input.metadata).toEqual(
+			expect.objectContaining({
+				route: "maestro_swarm",
+				transport: "a2a",
+				swarmId: result.id,
+				taskId: "task-1",
+				peer: "remote-a",
+				source: "registry",
+			}),
+		);
+		expect(recordA2ATaskStartMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				path: "/tmp/maestro-a2a-tasks.json",
+				peer: "remote-a",
+				peerDisplayName: "Remote A",
+				kind: "delegation",
+				role: "code-writer",
+				contextId: "remote-context-1",
+				metadata: expect.objectContaining({
+					requestKind: "maestro-swarm-task",
+					a2aSkillId: "maestro.subagent.code-writer",
+				}),
+			}),
+		);
+		expect(updateA2ATaskInLedgerMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				path: "/tmp/maestro-a2a-tasks.json",
+				peer: "remote-a",
+				task: expect.objectContaining({
+					id: "remote-task-1",
+					status: { state: "TASK_STATE_COMPLETED" },
+				}),
+			}),
+		);
+	});
+
+	it("rotates configured A2A peers across successive tasks", async () => {
+		const executor = new SwarmExecutor(
+			createMultiTaskConfig(
+				[
+					{ id: "task-1", prompt: "First remote task" },
+					{ id: "task-2", prompt: "Second remote task" },
+					{ id: "task-3", prompt: "Third remote task" },
+				],
+				{
+					transport: "a2a",
+					a2a: {
+						peers: ["remote-a", "remote-b"],
+						maxWaitMs: 50,
+						pollIntervalMs: 1,
+					},
+				},
+			),
+		);
+
+		const result = await executeWithTimeout(executor);
+
+		expect(result.status).toBe("completed");
+		expect(resolveA2APeerMock.mock.calls.map((call) => call[0])).toEqual([
+			"remote-a",
+			"remote-b",
+			"remote-a",
+		]);
+	});
+
+	it("discovers A2A swarm peers through Platform Agent Registry", async () => {
+		listA2APeerCandidatesWithPlatformMock.mockResolvedValue([
+			{
+				agent: {
+					id: "agent-target",
+					name: "Target Maestro",
+					workspaceId: "workspace-1",
+					status: "AGENT_STATUS_IDLE",
+				},
+				endpointUrl: "https://target.internal/a2a",
+				endpointKind: "internal",
+				skills: [
+					{
+						id: "maestro.subagent.code-review",
+						name: "Code Review",
+					},
+				],
+			},
+		]);
+		const executor = new SwarmExecutor({
+			...createConfig({ subagentType: "review" }),
+			transport: "a2a",
+			a2a: {
+				discover: true,
+				skillId: "maestro.subagent.code-review",
+				workspaceId: "workspace-1",
+				capability: "code-review",
+				preferInternalEndpoint: true,
+				limit: 3,
+				maxWaitMs: 50,
+				pollIntervalMs: 1,
+			},
+			mode: "smart",
+			modelProvider: "anthropic",
+		});
+
+		const result = await executeWithTimeout(executor);
+
+		expect(result.status).toBe("completed");
+		expect(resolveA2APeerMock).not.toHaveBeenCalled();
+		expect(listA2APeerCandidatesWithPlatformMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				workspaceId: "workspace-1",
+				capability: "code-review",
+				surface: "a2a",
+				status: "AGENT_STATUS_IDLE",
+				limit: 3,
+				skillId: "maestro.subagent.code-review",
+				preferInternalEndpoint: true,
+			}),
+		);
+		const [serviceConfig, input] = sendA2AMessageMock.mock.calls[0] as [
+			{
+				baseUrl: string;
+				token?: string;
+				organizationId?: string;
+				agentId?: string;
+			},
+			{
+				message: { metadata?: Record<string, unknown> };
+				metadata?: Record<string, unknown>;
+			},
+		];
+		expect(serviceConfig).toEqual(
+			expect.objectContaining({
+				baseUrl: "https://target.internal/a2a",
+				token: "platform-token",
+				organizationId: "org_evalops",
+				workspaceId: "workspace-1",
+				agentId: "agent-target",
+				actorId: "maestro-swarm",
+			}),
+		);
+		expect(input.message.metadata).toEqual(
+			expect.objectContaining({
+				relayPeer: "Target Maestro",
+				a2aSkillId: "maestro.subagent.code-review",
+			}),
+		);
+		expect(input.metadata).toEqual(
+			expect.objectContaining({
+				source: "platform-agent-registry",
+				peer: "Target Maestro",
+			}),
+		);
+	});
+
+	it("honors task A2A peer pins during Platform discovery", async () => {
+		listA2APeerCandidatesWithPlatformMock.mockResolvedValue([
+			{
+				agent: {
+					id: "agent-round-robin-first",
+					name: "Wrong Maestro",
+					workspaceId: "workspace-1",
+					status: "AGENT_STATUS_IDLE",
+				},
+				endpointUrl: "https://wrong.internal/a2a",
+				endpointKind: "internal",
+				skills: [{ id: "maestro.subagent.code-review", name: "Code Review" }],
+			},
+			{
+				agent: {
+					id: "agent-pinned",
+					name: "Pinned Maestro",
+					workspaceId: "workspace-1",
+					status: "AGENT_STATUS_IDLE",
+				},
+				endpointUrl: "https://pinned.internal/a2a",
+				endpointKind: "internal",
+				skills: [{ id: "maestro.subagent.code-review", name: "Code Review" }],
+			},
+		]);
+		const executor = new SwarmExecutor({
+			...createConfig({
+				a2aPeer: "agent-pinned",
+				subagentType: "review",
+			}),
+			transport: "a2a",
+			a2a: {
+				discover: true,
+				skillId: "maestro.subagent.code-review",
+				workspaceId: "workspace-1",
+				capability: "code-review",
+				preferInternalEndpoint: true,
+				maxWaitMs: 50,
+				pollIntervalMs: 1,
+			},
+			mode: "smart",
+			modelProvider: "anthropic",
+		});
+
+		const result = await executeWithTimeout(executor);
+
+		expect(result.status).toBe("completed");
+		expect(listA2APeerCandidatesWithPlatformMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				limit: undefined,
+				skillId: "maestro.subagent.code-review",
+			}),
+		);
+		expect(sendA2AMessageMock.mock.calls[0]?.[0]).toEqual(
+			expect.objectContaining({
+				baseUrl: "https://pinned.internal/a2a",
+				agentId: "agent-pinned",
+			}),
+		);
+		expect(sendA2AMessageMock.mock.calls[0]?.[1].message.metadata).toEqual(
+			expect.objectContaining({
+				relayPeer: "Pinned Maestro",
+			}),
+		);
+	});
+
+	it("rotates discovered A2A candidates across successive tasks", async () => {
+		listA2APeerCandidatesWithPlatformMock.mockResolvedValue([
+			{
+				agent: {
+					id: "agent-a",
+					name: "Agent A",
+					workspaceId: "workspace-1",
+					status: "AGENT_STATUS_IDLE",
+				},
+				endpointUrl: "https://agent-a.internal/a2a",
+				endpointKind: "internal",
+				skills: [{ id: "maestro.subagent.code-review", name: "Code Review" }],
+			},
+			{
+				agent: {
+					id: "agent-b",
+					name: "Agent B",
+					workspaceId: "workspace-1",
+					status: "AGENT_STATUS_IDLE",
+				},
+				endpointUrl: "https://agent-b.internal/a2a",
+				endpointKind: "internal",
+				skills: [{ id: "maestro.subagent.code-review", name: "Code Review" }],
+			},
+		]);
+		const executor = new SwarmExecutor(
+			createMultiTaskConfig(
+				[
+					{
+						id: "task-1",
+						prompt: "First remote review",
+						subagentType: "review",
+					},
+					{
+						id: "task-2",
+						prompt: "Second remote review",
+						subagentType: "review",
+					},
+				],
+				{
+					transport: "a2a",
+					a2a: {
+						discover: true,
+						skillId: "maestro.subagent.code-review",
+						workspaceId: "workspace-1",
+						capability: "code-review",
+						preferInternalEndpoint: true,
+						maxWaitMs: 50,
+						pollIntervalMs: 1,
+					},
+					mode: "smart",
+					modelProvider: "anthropic",
+				},
+			),
+		);
+
+		const result = await executeWithTimeout(executor);
+
+		expect(result.status).toBe("completed");
+		expect(listA2APeerCandidatesWithPlatformMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				limit: 2,
+			}),
+		);
+		expect(
+			sendA2AMessageMock.mock.calls.map((call) => call[0].baseUrl),
+		).toEqual(["https://agent-a.internal/a2a", "https://agent-b.internal/a2a"]);
+	});
+
+	it("fails remote A2A tasks that finish in an action-required state", async () => {
+		getA2ATaskMock.mockResolvedValue({
+			id: "remote-task-1",
+			contextId: "remote-context-1",
+			status: {
+				state: "TASK_STATE_INPUT_REQUIRED",
+				message: {
+					messageId: "need-input",
+					role: "ROLE_AGENT",
+					parts: [{ text: "Need credentials", mediaType: "text/plain" }],
+				},
+			},
+		});
+		const executor = new SwarmExecutor({
+			...createConfig(),
+			transport: "a2a",
+			a2a: {
+				peers: ["remote-a"],
+				maxWaitMs: 50,
+				pollIntervalMs: 1,
+			},
+		});
+
+		const result = await executeWithTimeout(executor);
+
+		expect(result.status).toBe("failed");
+		expect(result.failedTasks.has("task-1")).toBe(true);
+		expect(result.teammates[0]!.status).toBe("failed");
+		expect(result.teammates[0]!.output).toBe("Need credentials");
+		expect(result.teammates[0]!.error).toContain("TASK_STATE_INPUT_REQUIRED");
+		expect(updateA2ATaskInLedgerMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				task: expect.objectContaining({
+					status: expect.objectContaining({
+						state: "TASK_STATE_INPUT_REQUIRED",
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("recycles a remote A2A teammate after a dispatch error when continueOnFailure is enabled", async () => {
+		resolveA2APeerMock.mockRejectedValueOnce(new Error("peer unavailable"));
+		const executor = new SwarmExecutor(
+			createMultiTaskConfig(
+				[
+					{ id: "task-1", prompt: "First remote task" },
+					{ id: "task-2", prompt: "Second remote task" },
+				],
+				{
+					continueOnFailure: true,
+					transport: "a2a",
+					a2a: {
+						peers: ["remote-a"],
+						maxWaitMs: 50,
+						pollIntervalMs: 1,
+					},
+				},
+			),
+		);
+
+		const result = await executeWithTimeout(executor);
+
+		expect(resolveA2APeerMock).toHaveBeenCalledTimes(2);
+		expect(sendA2AMessageMock).toHaveBeenCalledTimes(1);
+		expect(result.failedTasks.has("task-1")).toBe(true);
+		expect(result.completedTasks.has("task-2")).toBe(true);
+		expect(result.teammates[0]!.status).toBe("completed");
+		expect(result.teammates[0]!.completedTasks).toEqual(["task-2"]);
+	});
+
+	it("clears stale A2A metadata when a recycled teammate later fails before dispatch", async () => {
+		resolveA2APeerMock
+			.mockResolvedValueOnce({
+				name: "remote-a",
+				entry: {
+					url: "https://remote-a.example/a2a",
+					displayName: "Remote A",
+					skills: [{ id: "maestro.subagent.code-writer", name: "Code Writer" }],
+				},
+				config: {
+					baseUrl: "https://remote-a.example/a2a",
+					agentId: "remote-a",
+					timeoutMs: 25,
+					maxAttempts: 1,
+				},
+			})
+			.mockRejectedValueOnce(new Error("peer unavailable"));
+		const executor = new SwarmExecutor(
+			createMultiTaskConfig(
+				[
+					{ id: "task-1", prompt: "First remote task" },
+					{ id: "task-2", prompt: "Second remote task" },
+				],
+				{
+					continueOnFailure: true,
+					transport: "a2a",
+					a2a: {
+						peers: ["remote-a"],
+						maxWaitMs: 50,
+						pollIntervalMs: 1,
+					},
+				},
+			),
+		);
+
+		const result = await executeWithTimeout(executor);
+
+		expect(result.status).toBe("completed");
+		expect(result.completedTasks.has("task-1")).toBe(true);
+		expect(result.failedTasks.has("task-2")).toBe(true);
+		expect(result.teammates[0]!.status).toBe("failed");
+		expect(result.teammates[0]!.a2a).toBeUndefined();
+	});
+
+	it("cancels remote A2A tasks when the swarm is cancelled", async () => {
+		const remotePoll = createDeferredPromise<{
+			id: string;
+			contextId: string;
+			status: { state: string };
+		}>();
+		getA2ATaskMock.mockReturnValue(remotePoll.promise);
+		const executor = new SwarmExecutor({
+			...createConfig(),
+			transport: "a2a",
+			a2a: {
+				peers: ["remote-a"],
+				maxWaitMs: 5_000,
+				pollIntervalMs: 1,
+			},
+		});
+
+		const execution = executor.execute();
+		await vi.waitFor(() => {
+			expect(getA2ATaskMock).toHaveBeenCalled();
+		});
+
+		executor.cancel();
+		remotePoll.resolve({
+			id: "remote-task-1",
+			contextId: "remote-context-1",
+			status: { state: "TASK_STATE_CANCELLED" },
+		});
+		const result = await execution;
+
+		expect(result.status).toBe("cancelled");
+		expect(result.teammates[0]!.status).toBe("cancelled");
+		expect(result.teammates[0]!.a2a).toEqual(
+			expect.objectContaining({
+				peer: "remote-a",
+				taskId: "remote-task-1",
+				contextId: "remote-context-1",
+			}),
+		);
+		await vi.waitFor(() => {
+			expect(cancelA2ATaskMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					baseUrl: "https://remote-a.example/a2a",
+				}),
+				"remote-task-1",
+			);
+		});
+		expect(updateA2ATaskInLedgerMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				peer: "remote-a",
+				task: expect.objectContaining({
+					status: { state: "TASK_STATE_CANCELLED" },
+				}),
+			}),
+		);
+	});
+
+	it("cancels a remote A2A task accepted during a cancel-send race", async () => {
+		const remoteSend = createDeferredPromise<{
+			task: {
+				id: string;
+				contextId: string;
+				status: { state: string };
+			};
+		}>();
+		sendA2AMessageMock.mockReturnValueOnce(remoteSend.promise);
+		const executor = new SwarmExecutor({
+			...createConfig(),
+			transport: "a2a",
+			a2a: {
+				peers: ["remote-a"],
+				maxWaitMs: 5_000,
+				pollIntervalMs: 1,
+			},
+		});
+
+		const execution = executor.execute();
+		await vi.waitFor(() => {
+			expect(sendA2AMessageMock).toHaveBeenCalled();
+		});
+		expect(sendA2AMessageMock.mock.calls[0]?.[2]).toBeUndefined();
+
+		executor.cancel();
+		remoteSend.resolve({
+			task: {
+				id: "remote-task-1",
+				contextId: "remote-context-1",
+				status: { state: "TASK_STATE_WORKING" },
+			},
+		});
+		const result = await execution;
+
+		expect(result.status).toBe("cancelled");
+		await vi.waitFor(() => {
+			expect(cancelA2ATaskMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					baseUrl: "https://remote-a.example/a2a",
+				}),
+				"remote-task-1",
+			);
+		});
+	});
+
+	it("cancels remote A2A tasks when polling times out", async () => {
+		getA2ATaskMock.mockResolvedValue({
+			id: "remote-task-1",
+			contextId: "remote-context-1",
+			status: { state: "TASK_STATE_WORKING" },
+		});
+		const executor = new SwarmExecutor({
+			...createConfig(),
+			transport: "a2a",
+			a2a: {
+				peers: ["remote-a"],
+				maxWaitMs: 5,
+				pollIntervalMs: 1,
+			},
+		});
+
+		const result = await executeWithTimeout(executor);
+
+		expect(result.status).toBe("failed");
+		expect(result.failedTasks.has("task-1")).toBe(true);
+		expect(result.teammates[0]!.error).toContain(
+			"Timed out waiting for remote A2A task remote-task-1",
+		);
+		expect(cancelA2ATaskMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				baseUrl: "https://remote-a.example/a2a",
+			}),
+			"remote-task-1",
+		);
+		expect(updateA2ATaskInLedgerMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				peer: "remote-a",
+				task: expect.objectContaining({
+					status: { state: "TASK_STATE_CANCELLED" },
+				}),
+			}),
+		);
 	});
 
 	it("completes when a teammate finishes successfully", async () => {
@@ -835,6 +1603,44 @@ describe("SwarmExecutor", () => {
 		expect(result.teammates[0]!.status).toBe("failed");
 		expect(result.teammates[0]!.currentTask).toBeUndefined();
 		expect(existsSync(tempFile)).toBe(false);
+	});
+
+	it("does not run tasks whose dependencies failed", async () => {
+		const events: Array<{
+			type: string;
+			taskId?: string;
+			error?: string;
+		}> = [];
+		spawnMock.mockReturnValue(createMockChildProcess("", 1, "timer"));
+
+		const executor = new SwarmExecutor(
+			createMultiTaskConfig(
+				[
+					{ id: "task-1", prompt: "First task" },
+					{
+						id: "task-2",
+						prompt: "Second task",
+						dependsOn: ["task-1"],
+					},
+				],
+				{ continueOnFailure: true },
+			),
+		);
+		executor.onEvent((event) => events.push(event));
+
+		const result = await executeWithTimeout(executor);
+
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect(result.failedTasks.has("task-1")).toBe(true);
+		expect(result.failedTasks.has("task-2")).toBe(true);
+		expect(result.completedTasks.has("task-2")).toBe(false);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				type: "task_fail",
+				taskId: "task-2",
+				error: "Dependency task-1 failed",
+			}),
+		);
 	});
 
 	it("recycles a teammate after a subprocess error when continueOnFailure is enabled", async () => {

--- a/test/platform/a2a-client.test.ts
+++ b/test/platform/a2a-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	buildA2AUserMessage,
+	cancelA2ATask,
 	createA2ATaskPushNotificationConfig,
 	deleteA2ATaskPushNotificationConfig,
 	discoverA2AAgentCard,
@@ -185,6 +186,14 @@ describe("platform A2A client", () => {
 						id: "run_1",
 						contextId: "session_1",
 						status: { state: "TASK_STATE_COMPLETED" },
+					});
+				}
+
+				if (parsed.pathname === "/tasks/run_1:cancel") {
+					return Response.json({
+						id: "run_1",
+						contextId: "session_1",
+						status: { state: "TASK_STATE_CANCELLED" },
 					});
 				}
 
@@ -824,6 +833,28 @@ describe("platform A2A client", () => {
 			status: { state: "TASK_STATE_COMPLETED" },
 		});
 		expect(requests[0]?.url).toBe("https://platform.test/tasks/run_1");
+	});
+
+	it("cancels an A2A task by run id", async () => {
+		const config = await resolveA2AServiceConfig();
+		if (!config) {
+			throw new Error("expected config");
+		}
+
+		await expect(cancelA2ATask(config, "run_1")).resolves.toMatchObject({
+			id: "run_1",
+			status: { state: "TASK_STATE_CANCELLED" },
+		});
+		expect(requests[0]).toMatchObject({
+			url: "https://platform.test/tasks/run_1:cancel",
+			method: "POST",
+			headers: expect.objectContaining({
+				authorization: "Bearer a2a-token",
+				"x-evalops-actor-id": "user_1",
+				"x-evalops-agent-id": "agent_maestro",
+				"x-evalops-workspace-id": "ws_1",
+			}),
+		});
 	});
 
 	it("subscribes to A2A task SSE updates with explicit trace headers", async () => {


### PR DESCRIPTION
## Summary
- Add an A2A transport for Maestro swarm teammates, routing tasks to static A2A peers or Platform Agent Registry-discovered peers.
- Preserve swarm lineage, remote subagent skill metadata, local A2A ledger entries, non-secret teammate correlation, and spec-native remote cancellation.
- Add dependency-failure blocking so follow-on swarm tasks do not run after failed prerequisites.
- Document remote swarm transport env/config knobs and live fleet expectations.

## Source Of Truth
- Matching internal PR: https://github.com/evalops/maestro-internal/pull/2039

## Test Plan
- `npx biome check --write src/platform/a2a-client.ts src/agent/swarm/executor.ts src/agent/swarm/types.ts test/agent/swarm-executor.test.ts test/platform/a2a-client.test.ts docs/protocols/a2a-fleet-delegation.md`
- `VITEST_FAST=1 TMPDIR=/private/tmp bunx vitest --run --configLoader runner test/agent/swarm-executor.test.ts test/platform/a2a-client.test.ts`
- `npx tsc -p tsconfig.build.json --noEmit --pretty false 2>&1 | rg 'src/agent/swarm/(executor|types)|src/platform/a2a-client|test/agent/swarm-executor|test/platform/a2a-client'` produced no changed-file errors. Full extracted-tree typecheck still has unrelated local workspace-package resolution noise because this temp tree does not have built `@evalops/tui`/other workspace artifacts.
- `git diff --check origin/main -- src/agent/swarm/executor.ts src/agent/swarm/types.ts src/platform/a2a-client.ts test/agent/swarm-executor.test.ts test/platform/a2a-client.test.ts docs/protocols/a2a-fleet-delegation.md`
- Read-only gcloud/kubectl live check: `evalops-gke` is RUNNING on GKE `1.34.6-gke.1307000`; staging `a2a-swarm-agent-controller` is 1/1, `agent-runtime-a2a-peer` is 2/2, staging origin/target Agent Cards advertise the EvalOps operating-plane swarm extension and `platform-a2a-swarm-delegation`.
