### PR TITLE
[maestro] adopt org rails

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,4 @@ self-hosted-runner:
   labels:
     - blacksmith-*
     - evalops-maestro-internal-rbe
+    - evalops-maestro-rbe

--- a/.github/workflows/codex-rails-check.yml
+++ b/.github/workflows/codex-rails-check.yml
@@ -16,6 +16,6 @@ permissions:
 
 jobs:
   validate:
-    uses: evalops/.github/.github/workflows/codex-rails-check.yml@ff729846a97fd802242b9e24c738794b7c9b389c
+    uses: evalops/.github/.github/workflows/codex-rails-check.yml@7c84584083404b2f9da1b08c20d208db84b70040
     with:
       require_agents: true

--- a/.github/workflows/codex-rails-check.yml
+++ b/.github/workflows/codex-rails-check.yml
@@ -1,0 +1,21 @@
+name: Codex Rails
+
+on:
+  pull_request:
+    paths:
+      - "AGENTS.md"
+      - "**/AGENTS.md"
+      - ".agents/skills/**"
+      - ".github/CODEOWNERS"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
+      - ".github/workflows/codex-rails-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    uses: evalops/.github/.github/workflows/codex-rails-check.yml@ff729846a97fd802242b9e24c738794b7c9b389c
+    with:
+      require_agents: true

--- a/.github/workflows/codex-rails-check.yml
+++ b/.github/workflows/codex-rails-check.yml
@@ -5,11 +5,17 @@ on:
     paths:
       - "AGENTS.md"
       - "**/AGENTS.md"
+      - "labels.yml"
+      - "services.yaml"
       - ".agents/skills/**"
+      - ".github/actionlint.yaml"
       - ".github/CODEOWNERS"
+      - ".github/codex/**"
+      - ".github/contracts/**"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/pull_request_template.md"
-      - ".github/workflows/codex-rails-check.yml"
+      - ".github/workflows/**"
+      - ".github/workflow-templates/**"
 
 permissions:
   contents: read

--- a/.github/workflows/public-source-provenance.yml
+++ b/.github/workflows/public-source-provenance.yml
@@ -83,6 +83,7 @@ jobs:
           mirrored_files=()
           for file_path in "${changed_files[@]}"; do
             case "$file_path" in
+              .github/actionlint.yaml|\
               .github/workflows/*|\
               .github/release-mirror-manifest.json|\
               .github/public-release-mirror.exclude|\

--- a/.github/workflows/review-thread-guard.yml
+++ b/.github/workflows/review-thread-guard.yml
@@ -1,0 +1,22 @@
+name: Review thread guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  unresolved-review-threads:
+    if: ${{ github.event.pull_request.draft == false }}
+    uses: evalops/.github/.github/workflows/review-thread-guard.yml@ff729846a97fd802242b9e24c738794b7c9b389c
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      min_severity: high
+      guard_ref: ff729846a97fd802242b9e24c738794b7c9b389c

--- a/.github/workflows/review-thread-guard.yml
+++ b/.github/workflows/review-thread-guard.yml
@@ -15,8 +15,8 @@ permissions:
 jobs:
   unresolved-review-threads:
     if: ${{ github.event.pull_request.draft == false }}
-    uses: evalops/.github/.github/workflows/review-thread-guard.yml@ff729846a97fd802242b9e24c738794b7c9b389c
+    uses: evalops/.github/.github/workflows/review-thread-guard.yml@7c84584083404b2f9da1b08c20d208db84b70040
     with:
       pr_number: ${{ github.event.pull_request.number }}
       min_severity: high
-      guard_ref: ff729846a97fd802242b9e24c738794b7c9b389c
+      guard_ref: 7c84584083404b2f9da1b08c20d208db84b70040


### PR DESCRIPTION
## Summary
- add the org-level Codex Rails reusable workflow
- broaden the Codex Rails path filters to cover the full org-rail surface
- add the org review-thread guard workflow
- allow the evalops-maestro-rbe runner label in actionlint config
- classify .github/actionlint.yaml as public-only CI metadata for the existing provenance gate
- matching internal source-of-truth PR: evalops/maestro-internal#2043

## Test plan
- ruby YAML parse for .github/workflows/codex-rails-check.yml, .github/workflows/review-thread-guard.yml, .github/workflows/public-source-provenance.yml, and .github/actionlint.yaml
- actionlint -shellcheck= -pyflakes= .github/workflows/codex-rails-check.yml .github/workflows/review-thread-guard.yml .github/workflows/public-source-provenance.yml .github/workflows/bazel-rbe.yml
- git -c core.fsmonitor=false diff --check