### PR TITLE
Emit verifier-ready GitHub agent PR evidence

### DIFF
--- a/packages/github-agent/src/github/client.ts
+++ b/packages/github-agent/src/github/client.ts
@@ -861,6 +861,22 @@ export class GitHubApiClient {
 		return { number: data.number, url: data.html_url };
 	}
 
+	async updatePullRequest(input: {
+		pullNumber: number;
+		title?: string;
+		body?: string;
+		base?: string;
+	}): Promise<void> {
+		await this.request("PATCH /repos/{owner}/{repo}/pulls/{pull_number}", {
+			owner: this.owner,
+			repo: this.repo,
+			pull_number: input.pullNumber,
+			title: input.title,
+			body: input.body,
+			base: input.base,
+		});
+	}
+
 	async requestReviewers(input: {
 		pullNumber: number;
 		reviewers?: string[];

--- a/packages/github-agent/src/types.ts
+++ b/packages/github-agent/src/types.ts
@@ -127,10 +127,35 @@ export interface TaskResult {
 	success: boolean;
 	prNumber?: number;
 	prUrl?: string;
+	branch?: string;
+	headSha?: string;
+	checkRunId?: number;
+	evidence?: GitHubAgentEvidence;
 	error?: string;
 	duration: number;
 	tokensUsed?: number;
 	cost?: number;
+}
+
+export interface GitHubAgentEvidence {
+	schemaVersion: "evalops.github-agent.pr-evidence.v1";
+	taskId: string;
+	taskType: Task["type"];
+	repository: string;
+	baseBranch: string;
+	branch: string;
+	headSha: string;
+	prNumber: number;
+	prUrl: string;
+	checkRunId?: number;
+	durationMs: number;
+	tokensUsed?: number;
+	cost?: number;
+	verifier: {
+		name: "deploy/scripts/check-agent-action-pr-lane.py";
+		requiredOutput: "pull_request";
+		prOnly: true;
+	};
 }
 
 /**

--- a/packages/github-agent/src/worker/evalops.ts
+++ b/packages/github-agent/src/worker/evalops.ts
@@ -2,7 +2,7 @@ import {
 	type MaestroCloseReason,
 	recordMaestroSessionEvent,
 } from "@evalops/ai/telemetry";
-import type { AgentConfig, Task } from "../types.js";
+import type { AgentConfig, GitHubAgentEvidence, Task } from "../types.js";
 
 const DEFAULT_IDENTITY_URL = "http://127.0.0.1:8080";
 const DEFAULT_PROVIDER_REF_PROVIDER = "openai";
@@ -156,10 +156,14 @@ function buildGitHubTaskEventMetadata(
 export interface GitHubTaskSessionCloseInput {
 	status: "completed" | "failed";
 	branch?: string;
+	headSha?: string;
 	prUrl?: string;
+	prNumber?: number;
+	checkRunId?: number;
 	durationMs?: number;
 	tokensUsed?: number;
 	cost?: number;
+	evidence?: GitHubAgentEvidence;
 	error?: string;
 }
 
@@ -194,10 +198,14 @@ export function recordGitHubTaskSessionClosed(
 		metadata: buildGitHubTaskEventMetadata(task, {
 			status: input.status,
 			branch: input.branch,
+			head_sha: input.headSha,
 			pr_url: input.prUrl,
+			pr_number: input.prNumber,
+			check_run_id: input.checkRunId,
 			duration_ms: input.durationMs,
 			tokens_used: input.tokensUsed,
 			cost: input.cost,
+			evidence: input.evidence,
 		}),
 		env: buildGitHubTaskEventEnvironment(task, env),
 	});

--- a/packages/github-agent/src/worker/executor.test.ts
+++ b/packages/github-agent/src/worker/executor.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitHubApiClient } from "../github/client.js";
 import type { TaskProgress } from "../github/reporter.js";
 import type { MemoryStore } from "../memory/store.js";
 import type { AgentConfig, Task } from "../types.js";
@@ -57,6 +58,19 @@ class TestableExecutor extends TaskExecutor {
 			pr,
 			progress,
 		);
+	}
+
+	public async testRefreshExistingPrBody(
+		pr: { number: number; url: string },
+		body: string,
+	): Promise<void> {
+		type PrivateMethods = {
+			refreshExistingPrBody: (
+				p: { number: number; url: string },
+				b: string,
+			) => Promise<void>;
+		};
+		return (this as unknown as PrivateMethods).refreshExistingPrBody(pr, body);
 	}
 }
 
@@ -332,6 +346,27 @@ describe("TaskExecutor", () => {
 					requiredOutput: "pull_request",
 					prOnly: true,
 				},
+			});
+		});
+	});
+
+	describe("refreshExistingPrBody", () => {
+		it("updates reused PR bodies so verifier evidence is not stale", async () => {
+			const updatePullRequest = vi.fn().mockResolvedValue(undefined);
+			const executorWithClient = new TestableExecutor({
+				config: mockConfig,
+				memory: mockMemory as unknown as MemoryStore,
+				githubClient: { updatePullRequest } as unknown as GitHubApiClient,
+			});
+
+			await executorWithClient.testRefreshExistingPrBody(
+				{ number: 99, url: "https://github.com/testowner/testrepo/pull/99" },
+				"## EvalOps Agent Evidence",
+			);
+
+			expect(updatePullRequest).toHaveBeenCalledWith({
+				pullNumber: 99,
+				body: "## EvalOps Agent Evidence",
 			});
 		});
 	});

--- a/packages/github-agent/src/worker/executor.test.ts
+++ b/packages/github-agent/src/worker/executor.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TaskProgress } from "../github/reporter.js";
 import type { MemoryStore } from "../memory/store.js";
 import type { AgentConfig, Task } from "../types.js";
 import { TaskExecutor } from "./executor.js";
@@ -26,6 +27,36 @@ class TestableExecutor extends TaskExecutor {
 	public testBuildPRBody(task: Task): string {
 		type PrivateMethods = { buildPRBody: (t: Task) => string };
 		return (this as unknown as PrivateMethods).buildPRBody(task);
+	}
+
+	public testBuildPRBodyWithBranch(task: Task, branchName: string): string {
+		type PrivateMethods = { buildPRBody: (t: Task, b?: string) => string };
+		return (this as unknown as PrivateMethods).buildPRBody(task, branchName);
+	}
+
+	public testBuildGitHubAgentEvidence(
+		task: Task,
+		branchName: string,
+		headSha: string,
+		pr: { number: number; url: string },
+		progress: TaskProgress,
+	) {
+		type PrivateMethods = {
+			buildGitHubAgentEvidence: (
+				t: Task,
+				b: string,
+				h: string,
+				p: { number: number; url: string },
+				progress: TaskProgress,
+			) => unknown;
+		};
+		return (this as unknown as PrivateMethods).buildGitHubAgentEvidence(
+			task,
+			branchName,
+			headSha,
+			pr,
+			progress,
+		);
 	}
 }
 
@@ -247,6 +278,61 @@ describe("TaskExecutor", () => {
 
 			expect(body).toContain("generated autonomously");
 			expect(body).toContain("GitHub Agent");
+		});
+
+		it("should include EvalOps verifier evidence", () => {
+			const task = createTask({ id: "task-123" });
+			const body = executor.testBuildPRBodyWithBranch(
+				task,
+				"fix/refresh-receipt-42",
+			);
+
+			expect(body).toContain("## EvalOps Agent Evidence");
+			expect(body).toContain("Task ID: `task-123`");
+			expect(body).toContain("Action lane: `code_change_via_pr`");
+			expect(body).toContain("Branch: `fix/refresh-receipt-42`");
+			expect(body).toContain(
+				"Independent verifier: `deploy/scripts/check-agent-action-pr-lane.py`",
+			);
+		});
+	});
+
+	describe("buildGitHubAgentEvidence", () => {
+		it("should produce verifier-ready PR evidence", () => {
+			const task = createTask({ id: "task-123", type: "issue" });
+			const evidence = executor.testBuildGitHubAgentEvidence(
+				task,
+				"fix/refresh-receipt-42",
+				"abc123",
+				{ number: 99, url: "https://github.com/testowner/testrepo/pull/99" },
+				{
+					status: "completed",
+					steps: {},
+					durationMs: 12_000,
+					tokensUsed: 1234,
+					cost: 0.42,
+				},
+			);
+
+			expect(evidence).toMatchObject({
+				schemaVersion: "evalops.github-agent.pr-evidence.v1",
+				taskId: "task-123",
+				taskType: "issue",
+				repository: "testowner/testrepo",
+				baseBranch: "main",
+				branch: "fix/refresh-receipt-42",
+				headSha: "abc123",
+				prNumber: 99,
+				prUrl: "https://github.com/testowner/testrepo/pull/99",
+				durationMs: 12_000,
+				tokensUsed: 1234,
+				cost: 0.42,
+				verifier: {
+					name: "deploy/scripts/check-agent-action-pr-lane.py",
+					requiredOutput: "pull_request",
+					prOnly: true,
+				},
+			});
 		});
 	});
 });

--- a/packages/github-agent/src/worker/executor.ts
+++ b/packages/github-agent/src/worker/executor.ts
@@ -15,7 +15,12 @@ import { type DelegationPrompt, formatDelegation } from "@evalops/contracts";
 import type { GitHubApiClient } from "../github/client.js";
 import type { GitHubReporter, TaskProgress } from "../github/reporter.js";
 import type { MemoryStore } from "../memory/store.js";
-import type { AgentConfig, Task, TaskResult } from "../types.js";
+import type {
+	AgentConfig,
+	GitHubAgentEvidence,
+	Task,
+	TaskResult,
+} from "../types.js";
 import {
 	buildGitHubTaskEnvironment,
 	recordGitHubTaskSessionClosed,
@@ -123,26 +128,42 @@ export class TaskExecutor {
 			const pr: PrResult = prTemp;
 			progress.prUrl = pr.url;
 
+			const headSha = await this.resolveHeadSha(branchName);
 			await this.applyPrMetadata(pr.number);
 			await this.applyMergePolicy(pr.number, branchName);
 			await this.publishCheckRun(task, progress, branchName, pr);
 
 			progress.status = "completed";
 			progress.durationMs = Date.now() - startTime;
+			const evidence = this.buildGitHubAgentEvidence(
+				task,
+				branchName,
+				headSha,
+				pr,
+				progress,
+			);
 			await this.reportProgress(task, progress);
 			recordGitHubTaskSessionClosed(task, {
 				status: "completed",
 				branch: progress.branch,
+				headSha,
 				prUrl: progress.prUrl,
+				prNumber: pr.number,
+				checkRunId: task.checkRunId,
 				durationMs: progress.durationMs,
 				tokensUsed: progress.tokensUsed,
 				cost: progress.cost,
+				evidence,
 			});
 
 			return {
 				success: true,
 				prNumber: pr.number,
 				prUrl: pr.url,
+				branch: branchName,
+				headSha,
+				checkRunId: task.checkRunId,
+				evidence,
 				duration: Date.now() - startTime,
 				tokensUsed: composerResult.tokensUsed,
 				cost: composerResult.cost,
@@ -450,7 +471,7 @@ ${diff}
 			? `[composer] ${sanitizedTaskTitle} (fixes #${task.sourceIssue})`
 			: `[composer] ${sanitizedTaskTitle}`;
 
-		const body = this.buildPRBody(task);
+		const body = this.buildPRBody(task, branchName);
 
 		if (this.githubClient) {
 			const existing = await this.findExistingPr(branchName);
@@ -658,7 +679,7 @@ ${diff}
 		}
 	}
 
-	private buildPRBody(task: Task): string {
+	private buildPRBody(task: Task, branchName?: string): string {
 		const lines: string[] = [
 			"## Summary",
 			"",
@@ -679,12 +700,63 @@ ${diff}
 			"- [ ] Type check passes",
 			"- [ ] Manual verification (if applicable)",
 			"",
+			"## EvalOps Agent Evidence",
+			"",
+			`- Task ID: \`${task.id}\``,
+			"- Action lane: `code_change_via_pr`",
+			...(branchName ? [`- Branch: \`${branchName}\``] : []),
+			"- Independent verifier: `deploy/scripts/check-agent-action-pr-lane.py`",
+			"",
 			"---",
 			"",
 			"_This PR was generated autonomously by the GitHub Agent (Composer building Composer)._",
 		);
 
 		return lines.join("\n");
+	}
+
+	private async resolveHeadSha(branchName: string): Promise<string> {
+		if (this.githubClient) {
+			try {
+				return await this.githubClient.getBranchHeadSha(branchName);
+			} catch (err) {
+				this.log(
+					`[executor] Failed to resolve branch SHA through GitHub API: ${err instanceof Error ? err.message : err}`,
+				);
+			}
+		}
+		return (await this.runCommand("git", ["rev-parse", "HEAD"])).trim();
+	}
+
+	private buildGitHubAgentEvidence(
+		task: Task,
+		branchName: string,
+		headSha: string,
+		pr: { number: number; url: string },
+		progress: TaskProgress,
+	): GitHubAgentEvidence {
+		return {
+			schemaVersion: "evalops.github-agent.pr-evidence.v1",
+			taskId: task.id,
+			taskType: task.type,
+			repository: `${this.config.owner}/${this.config.repo}`,
+			baseBranch: this.config.baseBranch,
+			branch: branchName,
+			headSha,
+			prNumber: pr.number,
+			prUrl: pr.url,
+			...(task.checkRunId ? { checkRunId: task.checkRunId } : {}),
+			durationMs: progress.durationMs ?? 0,
+			...(typeof progress.tokensUsed === "number"
+				? { tokensUsed: progress.tokensUsed }
+				: {}),
+			...(typeof progress.cost === "number" ? { cost: progress.cost } : {}),
+			verifier: {
+				name: "deploy/scripts/check-agent-action-pr-lane.py",
+				requiredOutput: "pull_request",
+				prOnly: true,
+			},
+		};
 	}
 
 	private buildInitialProgress(task: Task, startTime: number): TaskProgress {

--- a/packages/github-agent/src/worker/executor.ts
+++ b/packages/github-agent/src/worker/executor.ts
@@ -479,6 +479,7 @@ ${diff}
 				this.log(
 					`[executor] Reusing existing PR #${existing.number} for ${branchName}`,
 				);
+				await this.refreshExistingPrBody(existing, body);
 				return existing;
 			}
 			try {
@@ -495,6 +496,7 @@ ${diff}
 					this.log(
 						`[executor] Found existing PR #${existingAfterError.number} after create failure`,
 					);
+					await this.refreshExistingPrBody(existingAfterError, body);
 					return existingAfterError;
 				}
 				this.log(
@@ -516,6 +518,7 @@ ${diff}
 			this.log(
 				`[executor] Reusing existing PR #${existing.number} for ${branchName}`,
 			);
+			await this.refreshExistingPrBodyViaGh(existing, body);
 			return existing;
 		}
 		const draftFlag = this.config.draftPullRequests ? ["--draft"] : [];
@@ -545,6 +548,42 @@ ${diff}
 		}
 
 		return { number: prNumber, url: prUrl };
+	}
+
+	private async refreshExistingPrBody(
+		pr: { number: number; url: string },
+		body: string,
+	): Promise<void> {
+		if (!this.githubClient) return;
+		try {
+			await this.githubClient.updatePullRequest({
+				pullNumber: pr.number,
+				body,
+			});
+		} catch (err) {
+			this.log(
+				`[executor] Failed to refresh existing PR body: ${err instanceof Error ? err.message : err}`,
+			);
+		}
+	}
+
+	private async refreshExistingPrBodyViaGh(
+		pr: { number: number; url: string },
+		body: string,
+	): Promise<void> {
+		try {
+			await this.runCommand("gh", [
+				"pr",
+				"edit",
+				String(pr.number),
+				"--body",
+				body,
+			]);
+		} catch (err) {
+			this.log(
+				`[executor] Failed to refresh existing PR body via gh: ${err instanceof Error ? err.message : err}`,
+			);
+		}
 	}
 
 	private async findExistingPr(


### PR DESCRIPTION
## Summary
- Add a typed GitHub Agent PR evidence object with branch, head SHA, PR, check-run, token, cost, and verifier metadata.
- Include EvalOps agent evidence in generated PR bodies so downstream verification can reject weak completion claims.
- Record the evidence in Maestro session close metadata.
- Refresh reused PR bodies so verifier evidence cannot go stale when a task retries on an existing branch.

## Source-of-truth
- evalops/maestro-internal#2055

## Test Plan
- `bun run check` and `bun run test src/worker/executor.test.ts` in `packages/github-agent`
- Commit hook: Guardian staged-file scan, Biome/eval checks, codegen checks, build, and compile completed.

## Notes
- This intentionally does not add CodeQL or heavyweight static-analysis jobs.