### PR TITLE
ci: move lint canaries to private runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
   labels:
     - blacksmith-*
+    - evalops-private-ci
     - evalops-maestro-internal-rbe
     - evalops-maestro-rbe

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   actionlint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: evalops-private-ci
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,19 +35,7 @@ jobs:
           go-version: "stable"
           cache: false
 
-      - name: Cache Go (Blacksmith)
-        if: ${{ startsWith(runner.name, 'blacksmith-') || env.BLACKSMITH_ACTIONS_RESULTS_URL != '' }}
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-actionlint-${{ hashFiles('.github/workflows/actionlint.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-go-actionlint-
-
-      - name: Cache Go (GitHub)
-        if: ${{ !(startsWith(runner.name, 'blacksmith-') || env.BLACKSMITH_ACTIONS_RESULTS_URL != '') }}
+      - name: Cache Go
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   shellcheck:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: evalops-private-ci
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Summary
- move actionlint and shellcheck from Blacksmith to the org private CI runner lane
- keep the actionlint self-hosted runner allowlist aware of evalops-private-ci
- collapse the actionlint Go cache to a runner-neutral cache step

## Validation
- actionlint .github/workflows/actionlint.yml .github/workflows/shellcheck.yml
- git diff --check

## Notes
This intentionally moves only the small lint canaries. The remaining 4-vCPU Blacksmith workflows should wait for the CPU quota-backed private CI lanes documented in evalops/deploy#3911.