### PR TITLE
ci: mirror owned runner workflow updates

### DIFF
--- a/.github/actions/setup-bun-nx/action.yml
+++ b/.github/actions/setup-bun-nx/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: Whether to install ripgrep if missing
     required: false
     default: "false"
+  ensure-rustfmt:
+    description: Whether to install rustfmt before bun install/codegen.
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
@@ -91,6 +95,13 @@ runs:
           sudo apt-get update
           sudo apt-get install -y ripgrep
         fi
+
+    - name: Ensure rustfmt
+      if: ${{ inputs.ensure-rustfmt == 'true' && inputs.install == 'true' }}
+      uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      with:
+        toolchain: stable
+        components: rustfmt
 
     - name: Install dependencies
       if: ${{ inputs.install == 'true' }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   tag-current-version:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.repository.id && 'ubuntu-latest' || (vars.INTERNAL_CONFIRMATION_RUNNER || 'evalops-internal') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   tag-current-version:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.repository.id && 'ubuntu-latest' || (vars.INTERNAL_CONFIRMATION_RUNNER || 'evalops-internal') }}
+    runs-on: ${{ github.repository == 'evalops/maestro-internal' && (vars.INTERNAL_CONFIRMATION_RUNNER || 'evalops-internal') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   version-bump:
     if: ${{ github.event_name != 'schedule' || github.repository == 'evalops/maestro-internal' }}
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.repository.id && 'ubuntu-latest' || (vars.INTERNAL_CONFIRMATION_RUNNER || 'evalops-internal') }}
+    runs-on: ${{ github.repository == 'evalops/maestro-internal' && (vars.INTERNAL_CONFIRMATION_RUNNER || 'evalops-internal') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   version-bump:
     if: ${{ github.event_name != 'schedule' || github.repository == 'evalops/maestro-internal' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.repository.id && 'ubuntu-latest' || (vars.INTERNAL_CONFIRMATION_RUNNER || 'evalops-internal') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Summary
- mirror internal owned-runner workflow changes for release-tag/version-bump lanes
- keep setup-bun-nx rustfmt behavior in sync with maestro-internal

Source
- evalops/maestro-internal#2058

Test plan
- node ../maestro-internal-owned-ci-blacksmith-20260520/scripts/sync-release-mirror.mjs --check --source ../maestro-internal-owned-ci-blacksmith-20260520 --target .
- actionlint -shellcheck= -pyflakes= .github/workflows/tag-release.yml .github/workflows/version-bump.yml
- git diff --check