### PR TITLE
ci: remove public Blacksmith runner paths

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,4 @@
 self-hosted-runner:
   labels:
-    - blacksmith-*
     - evalops-maestro-internal-rbe
     - evalops-maestro-rbe

--- a/.github/actions/setup-bun-nx/action.yml
+++ b/.github/actions/setup-bun-nx/action.yml
@@ -52,33 +52,16 @@ runs:
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version: ${{ inputs.bun-version }}
-        no-cache: ${{ startsWith(runner.name, 'blacksmith-') || env.BLACKSMITH_ACTIONS_RESULTS_URL != '' }}
 
-    - name: Cache Bun (Blacksmith)
-      if: ${{ inputs.cache-bun == 'true' && (startsWith(runner.name, 'blacksmith-') || env.BLACKSMITH_ACTIONS_RESULTS_URL != '') }}
+    - name: Cache Bun
+      if: ${{ inputs.cache-bun == 'true' }}
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.bun/install/cache
         key: ${{ runner.os }}-bun-v2-${{ inputs.bun-version }}-${{ hashFiles('bun.lockb') }}
 
-    - name: Cache Bun (GitHub)
-      if: ${{ inputs.cache-bun == 'true' && !(startsWith(runner.name, 'blacksmith-') || env.BLACKSMITH_ACTIONS_RESULTS_URL != '') }}
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: ~/.bun/install/cache
-        key: ${{ runner.os }}-bun-v2-${{ inputs.bun-version }}-${{ hashFiles('bun.lockb') }}
-
-    - name: Cache Nx (Blacksmith)
-      if: ${{ inputs.cache-nx == 'true' && (startsWith(runner.name, 'blacksmith-') || env.BLACKSMITH_ACTIONS_RESULTS_URL != '') }}
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: .nx/cache
-        key: ${{ runner.os }}-nx-${{ hashFiles('bun.lockb', 'nx.json', 'project.json', 'packages/**/project.json') }}
-        restore-keys: |
-          ${{ runner.os }}-nx-
-
-    - name: Cache Nx (GitHub)
-      if: ${{ inputs.cache-nx == 'true' && !(startsWith(runner.name, 'blacksmith-') || env.BLACKSMITH_ACTIONS_RESULTS_URL != '') }}
+    - name: Cache Nx
+      if: ${{ inputs.cache-nx == 'true' }}
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: .nx/cache

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   actionlint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,19 +35,7 @@ jobs:
           go-version: "stable"
           cache: false
 
-      - name: Cache Go (Blacksmith)
-        if: ${{ startsWith(runner.name, 'blacksmith-') || env.BLACKSMITH_ACTIONS_RESULTS_URL != '' }}
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-actionlint-${{ hashFiles('.github/workflows/actionlint.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-go-actionlint-
-
-      - name: Cache Go (GitHub)
-        if: ${{ !(startsWith(runner.name, 'blacksmith-') || env.BLACKSMITH_ACTIONS_RESULTS_URL != '') }}
+      - name: Cache Go
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   pr-checks:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,7 +49,7 @@ jobs:
           if-no-files-found: ignore
 
   rust-hosted-conformance:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -76,7 +76,7 @@ jobs:
         run: npm run test -- test/headless/runtime-conformance.test.ts
 
   coverage-scope:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
     outputs:
       should_run: ${{ steps.scope.outputs.should_run }}
@@ -122,7 +122,7 @@ jobs:
   coverage:
     needs: coverage-scope
     if: ${{ needs.coverage-scope.outputs.should_run == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -24,9 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: blacksmith-4vcpu-ubuntu-2404
+          - os: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
             chunkIndex: 1
-          - os: blacksmith-4vcpu-ubuntu-2404
+          - os: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
             chunkIndex: 2
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/flaky-canary.yml
+++ b/.github/workflows/flaky-canary.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   canary:
     if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/github-agent.yml
+++ b/.github/workflows/github-agent.yml
@@ -43,7 +43,7 @@ jobs:
          github.event.comment.author_association == 'COLLABORATOR')) ||
       github.event_name == 'workflow_dispatch'
 
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   typescript-hooks:
     name: TypeScript Hook Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
 
     steps:
@@ -71,7 +71,7 @@ jobs:
 
   rust-hooks:
     name: Rust Hook Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     defaults:
       run:
@@ -118,7 +118,7 @@ jobs:
 
   hooks-parity:
     name: TypeScript/Rust Parity Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     needs: [typescript-hooks, rust-hooks]
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   integration-tests:
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-integration') }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 45
     services:
       redis:

--- a/.github/workflows/jetbrains-plugin.yml
+++ b/.github/workflows/jetbrains-plugin.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 60
     defaults:
       run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   validate-trigger:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -51,7 +51,7 @@ jobs:
   skip-when-no-tag:
     if: ${{ needs.validate-trigger.outputs.should_run == 'false' }}
     needs: validate-trigger
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 2
     steps:
       - name: Skip release workflow
@@ -61,7 +61,7 @@ jobs:
   prepare:
     if: ${{ needs.validate-trigger.outputs.should_run == 'true' }}
     needs: validate-trigger
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 15
     outputs:
       release_tag: ${{ steps.release.outputs.release_tag }}
@@ -87,9 +87,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: blacksmith-4vcpu-ubuntu-2404
+          - os: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
             chunkIndex: 1
-          - os: blacksmith-4vcpu-ubuntu-2404
+          - os: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
             chunkIndex: 2
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 45
     defaults:
       run:
@@ -78,7 +78,7 @@ jobs:
           echo "- IPC bridge" >> $GITHUB_STEP_SUMMARY
 
   hooks-coverage:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   shellcheck:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/slack-agent.yml
+++ b/.github/workflows/slack-agent.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-nix-hash.yml
+++ b/.github/workflows/update-nix-hash.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   update-hash:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 45
     if: "!contains(github.event.head_commit.message, '[skip nix]')"
 

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 60
     permissions:
       contents: read
@@ -112,7 +112,7 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/vscode-v')) ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == true)
     needs: build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 45
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- replace hardcoded public Blacksmith runner labels with `PUBLIC_PR_VALIDATION_RUNNER || ubuntu-latest`
- remove stale Blacksmith actionlint/cache allowlist paths
- keep public CI safe until a separate owned public runner pool lands

Source: evalops/maestro-internal#2058

## Test plan
- `actionlint -shellcheck= -pyflakes= .github/workflows/*.yml`
- `git diff --check`
- `rg -n "blacksmith-4vcpu-ubuntu-2404|blacksmith-\*|Blacksmith|BLACKSMITH|blacksmith-" .github || true`