### PR TITLE
fix: support split-stream structured logs

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -33,6 +33,8 @@ interface LoggerConfig {
 	minLevel: LogLevel;
 	/** Whether to output JSON format (useful for log aggregation) */
 	jsonFormat: boolean;
+	/** Whether to route debug/info logs to stdout while preserving warnings/errors on stderr */
+	splitStreams: boolean;
 	/** Whether to include timestamps */
 	timestamps: boolean;
 	/** Custom output function (defaults to stderr) */
@@ -54,6 +56,13 @@ const LOG_LEVELS: Record<LogLevel, number> = {
 	error: 3,
 };
 
+const LOG_SEVERITIES: Record<LogLevel, string> = {
+	debug: "DEBUG",
+	info: "INFO",
+	warn: "WARNING",
+	error: "ERROR",
+};
+
 class Logger {
 	private config: LoggerConfig;
 
@@ -61,6 +70,7 @@ class Logger {
 		this.config = {
 			minLevel: (process.env.MAESTRO_LOG_LEVEL as LogLevel) ?? "info",
 			jsonFormat: process.env.MAESTRO_LOG_JSON === "1",
+			splitStreams: process.env.MAESTRO_LOG_SPLIT_STREAMS === "1",
 			timestamps: true,
 			...config,
 		};
@@ -114,7 +124,10 @@ class Logger {
 	 * Output as JSON (for log aggregation systems)
 	 */
 	private outputJson(entry: LogEntry): void {
-		console.error(JSON.stringify(entry));
+		this.writeLine(
+			entry,
+			JSON.stringify({ ...entry, severity: LOG_SEVERITIES[entry.level] }),
+		);
 	}
 
 	/**
@@ -134,11 +147,17 @@ class Logger {
 			parts.push(JSON.stringify(entry.context));
 		}
 
-		console.error(parts.join(" "));
+		this.writeLine(entry, parts.join(" "));
 
 		if (entry.error?.stack) {
-			console.error(entry.error.stack);
+			this.writeLine(entry, entry.error.stack);
 		}
+	}
+
+	private writeLine(entry: Pick<LogEntry, "level">, line: string): void {
+		const writeToStdout =
+			this.config.splitStreams && LOG_LEVELS[entry.level] < LOG_LEVELS.warn;
+		(writeToStdout ? console.log : console.error)(line);
 	}
 
 	/**

--- a/test/utils/logger.test.ts
+++ b/test/utils/logger.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("logger stream routing", () => {
+	afterEach(() => {
+		Reflect.deleteProperty(process.env, "MAESTRO_LOG_JSON");
+		Reflect.deleteProperty(process.env, "MAESTRO_LOG_LEVEL");
+		Reflect.deleteProperty(process.env, "MAESTRO_LOG_SPLIT_STREAMS");
+		vi.restoreAllMocks();
+		vi.resetModules();
+	});
+
+	it("routes debug and info logs to stdout when split streams are enabled", async () => {
+		process.env.MAESTRO_LOG_LEVEL = "debug";
+		process.env.MAESTRO_LOG_SPLIT_STREAMS = "1";
+		const stdout = vi.spyOn(console, "log").mockImplementation(() => {});
+		const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const { createLogger } = await import("../../src/utils/logger.js");
+		const logger = createLogger("logger-test");
+
+		logger.info("migration started");
+		logger.warn("migration slow");
+
+		expect(stdout).toHaveBeenCalledWith(
+			expect.stringContaining("[INFO] migration started"),
+		);
+		expect(stderr).toHaveBeenCalledWith(
+			expect.stringContaining("[WARN] migration slow"),
+		);
+	});
+
+	it("adds Cloud Logging severity to JSON log entries", async () => {
+		process.env.MAESTRO_LOG_JSON = "1";
+		process.env.MAESTRO_LOG_LEVEL = "info";
+		const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const { createLogger } = await import("../../src/utils/logger.js");
+		const logger = createLogger("logger-test");
+
+		logger.info("migration started");
+
+		expect(stderr).toHaveBeenCalledTimes(1);
+		const entry = JSON.parse(String(stderr.mock.calls[0]?.[0]));
+		expect(entry).toMatchObject({
+			level: "info",
+			severity: "INFO",
+			message: "migration started",
+			context: { module: "logger-test" },
+		});
+	});
+
+	it("keeps warning logs observable by late console spies", async () => {
+		const { createLogger } = await import("../../src/utils/logger.js");
+		const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logger = createLogger("logger-test");
+
+		logger.warn("configuration missing");
+
+		expect(stderr).toHaveBeenCalledWith(
+			expect.stringContaining("[WARN] configuration missing"),
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add Cloud Logging-compatible `severity` to JSON log entries
- add explicit `MAESTRO_LOG_SPLIT_STREAMS=1` support so debug/info can go to stdout while warnings/errors stay on stderr
- cover both behaviors with focused logger tests

## Why
The production log sweep showed Maestro migration INFO lines appearing as Cloud Logging `ERROR` entries because the logger writes every level to stderr. This keeps the CLI-safe default intact and gives production jobs an explicit opt-in for cleaner log severity.

## Validation
- `bunx biome check --write src/utils/logger.ts test/utils/logger.test.ts`
- `npm test -- test/utils/logger.test.ts`
- `npm run test:fast -- test/utils/logger.test.ts`
- `bunx tsc -p tsconfig.build.json --noEmit`
- pre-commit hook: Guardian, Biome, lint/eval guardrails, build, compiled bundle


## Source of Truth

- evalops/maestro-internal#2060
