### PR TITLE
ci: let eval test shard finish

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-bun-nx
         with:
@@ -60,7 +62,7 @@ jobs:
       - run: npx nx run maestro:build:all
       - run: npx nx run maestro:lint
       - name: Run tests
-        timeout-minutes: 3
+        timeout-minutes: 12
         run: bunx vitest --run --reporter=verbose --no-file-parallelism --shard=${{ matrix.chunkIndex }}/2
       - name: Run evals chunk
         timeout-minutes: 45


### PR DESCRIPTION
## Summary
- raise the eval workflow Vitest shard timeout from 3 to 12 minutes
- make the eval workflow checkout full history so `origin/main...HEAD` rollout checks work in GitHub Actions
- fixes the real `main` eval run failure where shard 1 was killed during `Run tests`, plus the PR-discovered lint blocker that prevented eval validation from reaching tests/evals
- keeps the workflow focused on existing build/lint/test/eval gates; no CodeQL or heavyweight scan path is added

## Production signal
- original failing run: https://github.com/evalops/maestro/actions/runs/26207946595
- original failed job: `run-evals (ubuntu-latest, 1)` / job `77111819097`
- original failed step: `Run tests`, started `2026-05-21T05:49:09Z`, failed `2026-05-21T05:52:22Z` under the 3 minute timeout
- PR-discovered blocker: https://github.com/evalops/maestro/actions/runs/26224488356, where `check-staged-rollout` could not resolve `origin/main...HEAD` because the eval workflow used shallow checkout

## Test Plan
- `bun install --frozen-lockfile`
- `bunx vitest --run --reporter=verbose --no-file-parallelism --shard=1/2` (4018 passed, 62 skipped; duration 109.45s)
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main bun run check:staged-rollout`
- `npx nx run maestro:lint`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/evals.yml"); puts "evals workflow yaml ok"'`\n- commit hook: `Guardian passed on 1 staged file(s) using semgrep + heuristic-scan`; `bunx biome check .`; `bun run lint:evals`; build/codegen checks\n\n## Rollback\n- revert this PR to restore the prior shallow checkout and 3 minute test timeout if the expanded budget masks a real hang.