### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,12 +51,29 @@ jobs:
       - name: Build
         timeout-minutes: 45
         run: |
-          cargo clean --release
-          cargo build --release
+          cargo_bin="${CARGO_HOME:-$HOME/.cargo}/bin/cargo"
+          build_log="$(mktemp)"
+          status=0
+          set +e
+          set -o pipefail
+          "$cargo_bin" build --release 2>&1 | tee "$build_log"
+          status="$?"
+          set +o pipefail
+          if [ "$status" -ne 0 ] && grep -q "could not parse/generate dep info" "$build_log"; then
+            echo "::warning title=Rust release cache repair::cargo reported stale dep-info; cleaning release target and retrying once"
+            "$cargo_bin" clean --release
+            "$cargo_bin" build --release
+            status="$?"
+          fi
+          set -e
+          rm -f "$build_log"
+          exit "$status"
 
       - name: Run all tests
         timeout-minutes: 30
-        run: cargo test --all-features -- --nocapture
+        run: |
+          cargo_bin="${CARGO_HOME:-$HOME/.cargo}/bin/cargo"
+          "$cargo_bin" test --all-features -- --nocapture
 
       - name: Run hook integration tests
         timeout-minutes: 15

--- a/packages/tui-rs/src/ai/anthropic.rs
+++ b/packages/tui-rs/src/ai/anthropic.rs
@@ -98,6 +98,11 @@ struct SseParserState {
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 
+fn anthropic_model_accepts_temperature(model: &str) -> bool {
+    let normalized = model.to_ascii_lowercase();
+    !(normalized == "claude-opus-4-7" || normalized.starts_with("claude-opus-4-7-"))
+}
+
 /// Anthropic API client for Claude models
 ///
 /// Maintains an HTTP client and API key for making requests to Anthropic's API.
@@ -310,7 +315,10 @@ impl AnthropicClient {
             }
         }
 
-        if let Some(temp) = config.temperature {
+        if let Some(temp) = config
+            .temperature
+            .filter(|_| anthropic_model_accepts_temperature(&model))
+        {
             body["temperature"] = serde_json::json!(temp);
         }
 
@@ -715,6 +723,49 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
         assert_eq!(body["stream"], true);
         // Without caching, system is a simple string
         assert_eq!(body["system"], "You are a helpful assistant.");
+    }
+
+    #[test]
+    fn test_build_request_body_keeps_temperature_for_models_that_accept_it() {
+        let client = AnthropicClient::new("test-key").unwrap();
+        let config = RequestConfig {
+            model: "claude-sonnet-4-5-20250514".to_string(),
+            temperature: Some(0.7),
+            ..Default::default()
+        };
+
+        let body = client.build_request_body(&[], &config).unwrap();
+
+        let temperature = body["temperature"].as_f64().unwrap();
+        assert!((temperature - 0.7).abs() < 0.000_001);
+    }
+
+    #[test]
+    fn test_build_request_body_omits_temperature_for_opus_47() {
+        let client = AnthropicClient::new("test-key").unwrap();
+        let config = RequestConfig {
+            model: "anthropic/claude-opus-4-7".to_string(),
+            temperature: Some(0.7),
+            ..Default::default()
+        };
+
+        let body = client.build_request_body(&[], &config).unwrap();
+
+        assert!(body.get("temperature").is_none());
+    }
+
+    #[test]
+    fn test_build_request_body_omits_temperature_for_opus_47_snapshot() {
+        let client = AnthropicClient::new("test-key").unwrap();
+        let config = RequestConfig {
+            model: "claude-opus-4-7-20260520".to_string(),
+            temperature: Some(0.7),
+            ..Default::default()
+        };
+
+        let body = client.build_request_body(&[], &config).unwrap();
+
+        assert!(body.get("temperature").is_none());
     }
 
     #[test]

--- a/src/models/builtin.ts
+++ b/src/models/builtin.ts
@@ -61,12 +61,30 @@ function cloneManagedGatewayModelsForApis(
 	);
 }
 
-// Manual overlay for Claude Opus 4.6 (not yet in models.dev registry)
-const ANTHROPIC_OPUS_46_OVERLAY = {
+// Manual overlay for current Claude Opus 4.x models not yet in models.dev.
+const ANTHROPIC_OPUS_4_OVERLAY = {
 	anthropic: {
 		"claude-opus-4-6": {
 			id: "claude-opus-4-6",
 			name: "Claude Opus 4.6",
+			api: "anthropic-messages",
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			reasoning: true,
+			toolUse: true,
+			input: ["text", "image"],
+			cost: {
+				input: 5,
+				output: 25,
+				cacheRead: 0.5,
+				cacheWrite: 6.25,
+			},
+			contextWindow: 1000000,
+			maxTokens: 128000,
+		} as Model<"anthropic-messages">,
+		"claude-opus-4-7": {
+			id: "claude-opus-4-7",
+			name: "Claude Opus 4.7",
 			api: "anthropic-messages",
 			provider: "anthropic",
 			baseUrl: "https://api.anthropic.com",
@@ -1840,7 +1858,7 @@ function convertGeneratedModels(): Record<string, Model<Api>[]> {
 
 	// Apply overlay additions
 	const overlays: Record<string, Record<string, Model<Api>>>[] = [
-		ANTHROPIC_OPUS_46_OVERLAY,
+		ANTHROPIC_OPUS_4_OVERLAY,
 		OPENROUTER_RESPONSES_OVERLAY,
 		GROQ_RESPONSES_OVERLAY,
 		OPENAI_CODEX_OVERLAY,

--- a/test/models/model-registry.test.ts
+++ b/test/models/model-registry.test.ts
@@ -68,6 +68,15 @@ describe("Built-in model registry", () => {
 		expect(model?.maxTokens).toBe(128000);
 	});
 
+	it("overlays Claude Opus 4.7 for direct Anthropic runtime use", () => {
+		const model = getModel("anthropic", "claude-opus-4-7");
+		expect(model).toBeTruthy();
+		expect(model?.api).toBe("anthropic-messages");
+		expect(model?.baseUrl).toContain("https://api.anthropic.com/v1/messages");
+		expect(model?.reasoning).toBe(true);
+		expect(model?.toolUse).toBe(true);
+	});
+
 	it("includes Groq responses overlay models normalized to /responses", () => {
 		const model = getModel("groq", "openai/gpt-oss-20b");
 		expect(model).toBeTruthy();

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -288,6 +288,25 @@ describe("ci workflow guardrails", () => {
 
 		expect(project.targets?.test?.dependsOn ?? []).not.toContain("build");
 	});
+
+	it("keeps the Rust release cache unless repairing dep-info corruption", () => {
+		const workflow = parse(
+			readFileSync(
+				new URL("../../.github/workflows/rust.yml", import.meta.url),
+				{ encoding: "utf8" },
+			),
+		) as Workflow;
+		const buildStep = workflow.jobs?.build?.steps?.find(
+			(step) => step.name === "Build",
+		);
+		const buildScript = buildStep?.run ?? "";
+
+		expect(buildScript).toContain("could not parse/generate dep info");
+		expect(buildScript).toContain('"$cargo_bin" build --release 2>&1 | tee');
+		expect(buildScript.indexOf('"$cargo_bin" clean --release')).toBeGreaterThan(
+			buildScript.indexOf('"$cargo_bin" build --release'),
+		);
+	});
 });
 
 describe("rust workflow guardrails", () => {
@@ -323,7 +342,10 @@ describe("rust workflow guardrails", () => {
 		expect(timeoutByStep.get("Run hook integration tests")).toBe(15);
 		expect(timeoutByStep.get("Test summary")).toBe(5);
 		expect(steps.find((step) => step.name === "Build")?.run).toContain(
-			"cargo clean --release",
+			'"$cargo_bin" clean --release',
+		);
+		expect(steps.find((step) => step.name === "Run all tests")?.run).toContain(
+			'cargo_bin="${CARGO_HOME:-$HOME/.cargo}/bin/cargo"',
 		);
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `b976a9640bf5b971dd1236b1e6aecfed6ae6b563`
- last generated public sync base: `9e4661fe8246461d3e1564d077f963fbf1d8ff15`
- previewed public-tree drift: `4` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (b976a9640bf5)`
- public projection: `https://github.com/evalops/maestro@main (9e4661fe8246)`
- files to copy or update: `4`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/tui-rs/src/ai/anthropic.rs
- copy/update src/models/builtin.ts
- copy/update test/models/model-registry.test.ts
- copy/update test/scripts/ci-guardrails.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/tui-rs/src/ai/anthropic.rs
- copy/update src/models/builtin.ts
- copy/update test/models/model-registry.test.ts
- copy/update test/scripts/ci-guardrails.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@b976a9640bf5b971dd1236b1e6aecfed6ae6b563`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.