### PR TITLE
fix: publish runtime workspaces before root package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,94 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      - name: Publish runtime workspace packages to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_PUBLISH_AUTH_MODE: ${{ vars.NPM_PUBLISH_AUTH_MODE || 'auto' }}
+        run: |
+          set -euo pipefail
+          NPM_TOKEN_FALLBACK="${NODE_AUTH_TOKEN:-}"
+
+          package_name() {
+            node -p "require('./$1/package.json').name"
+          }
+
+          package_version() {
+            node -p "require('./$1/package.json').version"
+          }
+
+          package_is_published() {
+            local package_dir="$1"
+            local name version
+            name="$(package_name "$package_dir")"
+            version="$(package_version "$package_dir")"
+            npm view "${name}@${version}" version --json >/dev/null 2>&1
+          }
+
+          publish_with_token() {
+            local package_dir="$1"
+            if [ -z "${NPM_TOKEN_FALLBACK:-}" ]; then
+              echo "::error::NPM_PUBLISH_AUTH_MODE=token requires the NPM_TOKEN secret."
+              exit 1
+            fi
+
+            echo "Publishing $(package_name "$package_dir") with NPM_TOKEN fallback."
+            printf "//registry.npmjs.org/:_authToken=%s\n" "$NPM_TOKEN_FALLBACK" > ~/.npmrc
+            NODE_AUTH_TOKEN="$NPM_TOKEN_FALLBACK" npm publish "./$package_dir" --access public --provenance
+          }
+
+          publish_with_trusted_publisher() {
+            local package_dir="$1"
+            echo "Publishing $(package_name "$package_dir") with npm trusted publishing."
+            unset NODE_AUTH_TOKEN
+            rm -f ~/.npmrc
+            npm publish "./$package_dir" --access public
+          }
+
+          publish_package_dir() {
+            local package_dir="$1"
+            local name version
+            name="$(package_name "$package_dir")"
+            version="$(package_version "$package_dir")"
+
+            if package_is_published "$package_dir"; then
+              echo "${name}@${version} is already published; skipping."
+              return
+            fi
+
+            case "${NPM_PUBLISH_AUTH_MODE}" in
+              auto|"")
+                echo "Attempting trusted publishing for ${name}@${version}; NPM_TOKEN is only a fallback."
+                trusted_status=0
+                publish_with_trusted_publisher "$package_dir" || trusted_status=$?
+                if [ "$trusted_status" -eq 0 ]; then
+                  return
+                fi
+
+                if [ -z "${NPM_TOKEN_FALLBACK:-}" ]; then
+                  echo "::error::Trusted publishing failed for ${name}@${version} and no NPM_TOKEN fallback is configured."
+                  exit "$trusted_status"
+                fi
+
+                echo "::warning::Trusted publishing failed for ${name}@${version}; falling back to NPM_TOKEN."
+                publish_with_token "$package_dir"
+                ;;
+              token)
+                publish_with_token "$package_dir"
+                ;;
+              trusted)
+                publish_with_trusted_publisher "$package_dir"
+                ;;
+              *)
+                echo "::error::Unsupported NPM_PUBLISH_AUTH_MODE '${NPM_PUBLISH_AUTH_MODE}'. Use auto, token, or trusted."
+                exit 1
+                ;;
+            esac
+          }
+
+          publish_package_dir packages/contracts
+          publish_package_dir packages/tui
+
       - id: pack
         run: |
           set -euo pipefail
@@ -290,6 +378,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare.outputs.release_tag }}
+
+      - uses: ./.github/actions/setup-bun-nx
+        with:
+          install: "false"
+          cache-nx: "false"
+          ensure-rustfmt: "false"
 
       - name: Setup Node for npm canary
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/scripts/smoke-registry-install.js
+++ b/scripts/smoke-registry-install.js
@@ -48,6 +48,7 @@ const version = overrides.version || defaults.version;
 const packageSpec = `${name}@${version}`;
 const npmCommand = getNpmCommand();
 const npxCommand = getNpxCommand();
+const bunCommand = process.platform === "win32" ? "bun.exe" : "bun";
 const maxAttempts = Number.parseInt(
 	process.env.MAESTRO_REGISTRY_POLL_ATTEMPTS ?? "120",
 	10,
@@ -129,6 +130,41 @@ async function main() {
 		console.log(`Smoke-tested ${packageSpec} from npm.`);
 	} finally {
 		rmSync(tempDir, { recursive: true, force: true });
+	}
+
+	if (process.env.MAESTRO_SKIP_BUN_INSTALL_SMOKE === "1") {
+		console.log(`Skipping Bun install smoke for ${packageSpec}.`);
+		return;
+	}
+
+	const bunTempDir = mkdtempSync(join(tmpdir(), "maestro-bun-registry-smoke-"));
+	try {
+		execFileSync(bunCommand, ["init", "-y"], {
+			cwd: bunTempDir,
+			stdio: "ignore",
+		});
+		execFileSync(bunCommand, ["add", packageSpec], {
+			cwd: bunTempDir,
+			stdio: "inherit",
+		});
+
+		const binPath =
+			process.platform === "win32"
+				? join(bunTempDir, "node_modules", ".bin", `${cliCommand}.cmd`)
+				: join(bunTempDir, "node_modules", ".bin", cliCommand);
+		const versionOutput = execFileSync(binPath, ["--version"], {
+			cwd: bunTempDir,
+			encoding: "utf8",
+		});
+		if (!versionOutput.includes(version)) {
+			throw new Error(
+				`Expected Bun-installed ${cliCommand} --version output to include ${version}, received: ${versionOutput.trim()}`,
+			);
+		}
+
+		console.log(`Smoke-tested ${packageSpec} from Bun.`);
+	} finally {
+		rmSync(bunTempDir, { recursive: true, force: true });
 	}
 }
 


### PR DESCRIPTION
## Summary
- publish @evalops/contracts and @evalops/tui before publishing @evalops/maestro
- skip workspace package publishes when the exact version is already on npm
- extend the post-publish canary to verify Bun can install the published package

## Verification
- actionlint .github/workflows/release.yml
- node --check scripts/smoke-registry-install.js

This must land before the next public release tag so Bun/npm resolvers can resolve the runtime workspaces.