### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -96,16 +96,17 @@ runs:
           rustup_bin="$(command -v rustup || true)"
         fi
         if [ -z "$rustup_bin" ] || [ ! -x "$rustup_bin" ]; then
-          echo "rustup is required to create Cargo tool proxies" >&2
+          echo "::error::rustup is required to create Cargo tool proxies"
           exit 1
         fi
 
         mkdir -p "$cargo_bin"
         for proxy in cargo rustc rustdoc rustfmt cargo-fmt cargo-clippy clippy-driver; do
-          if [ ! -e "$cargo_bin/$proxy" ] && [ ! -L "$cargo_bin/$proxy" ]; then
-            ln -s "$rustup_bin" "$cargo_bin/$proxy"
+          if [ ! -x "$cargo_bin/$proxy" ]; then
+            ln -sf "$rustup_bin" "$cargo_bin/$proxy"
           fi
         done
+        "$cargo_bin/cargo" --version
 
     - name: Cache Cargo
       uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ versioning when releases are cut.
   and keep scheduled public runs inert so public publishing stays downstream of
   the internal source-of-truth release.
 
+## [0.10.20] - 2026-05-22
+
+### Changed
+
+- Add Platform A2A control and evidence guardrails (#2065). <!-- maestro-release-note:a174de22308e -->
+- Skip TS checks for Rust-only PRs (#2078). <!-- maestro-release-note:de04550846b8 -->
+- Fix public mirror review blockers (#2074). <!-- maestro-release-note:5075220752bf -->
+- Expose tool scheduling diagnostics (#2072). <!-- maestro-release-note:3613ab6e7a64 -->
+- Report avoidable tool serialization (#2071). <!-- maestro-release-note:c1ffa9e1f331 -->
+- Recognize EvalOps platform base URL aliases (#2063). <!-- maestro-release-note:341c3e6ae5ed -->
+- Skip rust setup for workflow-only tui checks (#2069). <!-- maestro-release-note:6ae0842947a7 -->
+- Scope rust hook coverage (#2066). <!-- maestro-release-note:5e5d9cf3e02b -->
+- Add next wave tool scheduling gates (#2064). <!-- maestro-release-note:5b3b061e2b3d -->
+- Log control-plane startup on stdout (#2062). <!-- maestro-release-note:cd1f81614933 -->
+- Parallelize read-only tool waves (#2061). <!-- maestro-release-note:03f8a287b9c1 -->
+- Run authorship labeler on owned ci (#2059). <!-- maestro-release-note:3b71c588b1b8 -->
+
+### Fixed
+
+- Publish Maestro's runtime workspace packages before the public root package so
+  Bun and npm resolvers can install `@evalops/maestro` without registry 404s.
+- Run nix hash updater on hosted runner (#2082). <!-- maestro-release-note:2ae7fb184dfc -->
+- Support Anthropic Opus 4.7 runtime (#2076). <!-- maestro-release-note:d047c05f1a4d -->
+- Reject unsafe trusted runner roots (#2077). <!-- maestro-release-note:caa544bc2dae -->
+- Preserve tool concurrency cap (#2073). <!-- maestro-release-note:c5811f2dc910 -->
+- Support split-stream structured logs (#2060). <!-- maestro-release-note:4ab6fac8eb1d -->
+
 ## [0.10.19] - 2026-05-18
 
 ### Added

--- a/docs/protocols/a2a-fleet-delegation.md
+++ b/docs/protocols/a2a-fleet-delegation.md
@@ -11,6 +11,7 @@ back.
 maestro a2a fleet [--json] [--registry <path>] [--tasks <path>]
 maestro a2a register --url <base-url> [--agent-id <id>] [--workspace-id <id>] [--json]
 maestro a2a delegate <peer> <text> [--role <role>] [--cwd <path>] [--wait] [--work-graph]
+maestro a2a delegate --platform --from-agent-id <agent-id> [--to-agent-id <agent-id>|--capability <capability>] --skill <skill-id> <text> [--json]
 maestro a2a reply <peer> <task-id> <text> [--wait] [--work-graph]
 maestro a2a tasks [peer] [--json] [--refresh] [--work-graph]
 maestro a2a coordinate [peer] [--json] [--refresh] [--reply <text>] [--wait] [--work-graph]
@@ -54,6 +55,16 @@ as an operator projection over durable agent/objective/run state rather than as
 the run itself: the task id is the protocol handle, `contextId` is the durable
 conversation/work envelope, and Maestro stores the peer-local transcript needed
 to resume, reply, audit, or wait later.
+
+`delegate --platform` is the production-verifiable path for remote Maestro
+work. It submits `agents.v1.AgentService/Delegate` with the coordinator agent,
+target agent or capability, A2A skill id, workspace, prompt, role, cwd, and
+workflow/objective correlation. Platform returns the delegation record and, when
+dispatch is enabled, the remote A2A task id and resume-wait contract. Operators
+then use the Platform delegation id with `maestro a2a control` and
+`maestro a2a graph`, so the same durable handle joins registry discovery,
+remote task control, subagent lineage, trace spans, artifacts, and later signed
+evidence bundles.
 
 `reply` continues an existing remote A2A task by sending `message.taskId` and
 the durable ledger `contextId` when available. It appends the operator's reply

--- a/docs/protocols/a2a-peer-pairing.md
+++ b/docs/protocols/a2a-peer-pairing.md
@@ -94,6 +94,25 @@ maestro a2a delegate \
   "Review this branch and return the highest-risk finding"
 ```
 
+Create a Platform-owned A2A delegation when the delegation record itself must be
+the durable control/evidence handle:
+
+```sh
+maestro a2a delegate \
+  --platform \
+  --from-agent-id maestro-coordinator-a \
+  --to-agent-id maestro-worker-b \
+  --skill maestro.subagent.code-review \
+  --workspace-id "$EVALOPS_WORKSPACE_ID" \
+  "Review this branch and return the highest-risk finding"
+```
+
+`--platform` submits `agents.v1.AgentService/Delegate` and returns a Platform
+delegation id plus any remote A2A task id that Platform dispatches. Use that
+delegation id for `maestro a2a control` and `maestro a2a graph`; this is the
+production path when the proof needs to show work moved through Platform rather
+than only through a peer endpoint imported from Platform discovery.
+
 Control a remote Platform A2A delegation task or one of its child/subagent
 lanes:
 
@@ -112,6 +131,77 @@ id, trace/span ids, returned artifacts, and any downstream GitHub or
 deploy-verifier identifiers must resolve to live systems. Deterministic replay
 fixtures can prove the schema and message contract, but they must not be
 presented as proof of a production run.
+
+The full Platform-backed swarm goal is tracked as executable stage gates in
+[A2A swarm stage gates](./a2a-swarm-stage-gates.md). The JSON manifest behind
+that document is validated by `npm run check:evidence-integrity`, so each stage
+must retain concrete entry and exit evidence rather than drifting back into a
+checklist of claims.
+
+## Live Platform Proof Smoke
+
+Use the live smoke when the question is whether two remote Maestro instances can
+actually communicate through Platform. The command validates required
+environment before network calls, discovers both registered peers, checks fresh
+heartbeats and Agent Card observations, creates a Platform-owned delegation,
+observes the graph/task id, sends a control probe, fetches the remote A2A task,
+and writes redacted evidence plus a SHA-256 sidecar. Set
+`MAESTRO_A2A_LIVE_REQUIRE_INVALID_TOKEN_PROBE=true` to require a negative
+Agent Registry peer-discovery probe before the happy path; the smoke refuses to
+write evidence if Platform accepts the invalid token. When
+`MAESTRO_A2A_LIVE_EVIDENCE_SIGNING_PRIVATE_KEY` or
+`MAESTRO_A2A_LIVE_EVIDENCE_SIGNING_PRIVATE_KEY_FILE` is configured, the smoke
+also writes an Ed25519 detached signature sidecar bound to the evidence digest.
+
+```sh
+MAESTRO_AGENT_REGISTRY_SERVICE_URL="$EVALOPS_BASE_URL" \
+MAESTRO_AGENT_REGISTRY_SERVICE_TOKEN="$EVALOPS_TOKEN" \
+MAESTRO_AGENT_REGISTRY_ORG_ID="$EVALOPS_ORGANIZATION_ID" \
+MAESTRO_AGENT_REGISTRY_WORKSPACE_ID="$EVALOPS_WORKSPACE_ID" \
+MAESTRO_A2A_LIVE_FROM_AGENT_ID=maestro-coordinator-a \
+MAESTRO_A2A_LIVE_TO_AGENT_ID=maestro-worker-b \
+MAESTRO_A2A_LIVE_SKILL_ID=maestro.subagent.code-review \
+MAESTRO_A2A_LIVE_REQUIRE_INVALID_TOKEN_PROBE=true \
+npm run platform:a2a-delegation-live
+```
+
+Verify the emitted bundle before attaching it to a PR, release, or diligence
+packet:
+
+```sh
+npm run platform:a2a-evidence-verify -- tmp/platform-a2a-delegation-live/<run>/evidence.json
+```
+
+Require a trusted detached signature for diligence-grade packets:
+
+```sh
+MAESTRO_A2A_LIVE_EVIDENCE_VERIFY_PUBLIC_KEY_FILE=./platform-a2a-live.pub.pem \
+npm run platform:a2a-evidence-verify -- \
+  tmp/platform-a2a-delegation-live/<run>/evidence.json \
+  --require-signature
+```
+
+Require both trusted signatures and live GitHub API dereferencing for PR-ready
+evidence:
+
+```sh
+GITHUB_TOKEN="$GH_TOKEN" \
+MAESTRO_A2A_LIVE_EVIDENCE_VERIFY_PUBLIC_KEY_FILE=./platform-a2a-live.pub.pem \
+npm run platform:a2a-evidence-verify -- \
+  tmp/platform-a2a-delegation-live/<run>/evidence.json \
+  --require-signature \
+  --require-github-dereference \
+  --require-negative-auth-probe
+```
+
+The verifier checks the evidence digest sidecar, live marker, protocol version,
+40-hex Maestro git SHA, optional GitHub run/PR identifiers, optional Ed25519
+detached signature, optional GitHub API dereference, Platform delegation id,
+remote A2A task id, peer ids, graph nodes, control mode, task id, and optional
+invalid-token rejection evidence. It rejects digest mismatches,
+production-looking synthetic SHAs, slug-style PR refs, fake GHA run ids,
+unresolved required Actions/PR metadata, local proof ids, missing required
+signatures, key-fingerprint mismatches, and invalid detached signatures.
 
 ## TUI Surface
 

--- a/docs/protocols/a2a-swarm-stage-gates.json
+++ b/docs/protocols/a2a-swarm-stage-gates.json
@@ -1,0 +1,397 @@
+{
+	"protocolVersion": "evalops.maestro.a2a-swarm-stage-gates.v1",
+	"objective": "Deliver production-verifiable Platform-backed Maestro A2A swarm support with durable remote identity, discovery, delegation, task control, subagent routing, observability, signed evidence, and live external dereferencing.",
+	"globalInvariants": [
+		"Replay fixtures prove schema compatibility only and cannot satisfy exit evidence for production stages.",
+		"Every production claim must name the authoritative system of record and the command, query, or verifier that resolves it.",
+		"Live evidence must redact raw tokens and payloads while preserving enough stable identifiers for independent verification.",
+		"Stages advance in order; later stages may add evidence but cannot weaken prior-stage gates."
+	],
+	"stages": [
+		{
+			"id": "stage-0-integrity-foundation",
+			"title": "Integrity foundation",
+			"purpose": "Prevent local contract artifacts from being promoted as production proof and make live A2A evidence independently checkable.",
+			"dependsOn": [],
+			"entryEvidence": [
+				{
+					"id": "contract-fixture-gap-identified",
+					"proofClass": "gap-analysis",
+					"description": "Existing replay artifacts can emit the expected evidence shape but do not prove real GitHub, Platform, or deploy activity.",
+					"authoritativeSource": "Repository fixtures and PR review notes",
+					"verification": "Run npm run check:evidence-integrity and inspect flagged production-looking local identifiers before promotion."
+				},
+				{
+					"id": "live-proof-branch-open",
+					"proofClass": "pr-state",
+					"description": "The live-proof PR stack is open and scoped to evidence hardening rather than unrelated product changes.",
+					"authoritativeSource": "GitHub pull request state",
+					"verification": "gh pr view 2070 --repo evalops/maestro-internal --json headRefOid,baseRefName,statusCheckRollup"
+				}
+			],
+			"exitEvidence": [
+				{
+					"id": "guardian-blocks-synthetic-production-ids",
+					"proofClass": "precommit-guardrail",
+					"description": "Precommit and CI reject production-looking evidence that uses constructed SHAs, slug PR refs, local run ids, or replay-only proof ids.",
+					"authoritativeSource": "Maestro guardian hook and CI evidence-integrity check",
+					"verification": "npm run check:evidence-integrity && npm run test -- test/guardian/evidence-integrity.test.ts"
+				},
+				{
+					"id": "github-identifiers-dereference",
+					"proofClass": "live-identifier-dereference",
+					"description": "Live evidence verification can require GitHub Actions run ids and pull request numbers to resolve through the GitHub API.",
+					"authoritativeSource": "GitHub REST API",
+					"verification": "GITHUB_TOKEN=$GITHUB_TOKEN npm run platform:a2a-evidence-verify -- <evidence.json> --require-github-dereference"
+				},
+				{
+					"id": "evidence-bundle-signature",
+					"proofClass": "signed-evidence",
+					"description": "Live evidence bundles can be bound to an Ed25519 detached signature and trusted public-key fingerprint.",
+					"authoritativeSource": "Signed evidence sidecar and verifier output",
+					"verification": "MAESTRO_A2A_LIVE_EVIDENCE_VERIFY_PUBLIC_KEY_FILE=<public-key.pem> npm run platform:a2a-evidence-verify -- <evidence.json> --require-signature"
+				},
+				{
+					"id": "invalid-token-rejection",
+					"proofClass": "negative-auth",
+					"description": "The live smoke proves Platform Agent Registry peer discovery rejects an invalid token before happy-path delegation evidence is written.",
+					"authoritativeSource": "Platform Agent Registry authorization response",
+					"verification": "MAESTRO_A2A_LIVE_REQUIRE_INVALID_TOKEN_PROBE=true npm run platform:a2a-delegation-live"
+				}
+			]
+		},
+		{
+			"id": "stage-1-platform-identity-topology",
+			"title": "Platform identity and topology",
+			"purpose": "Make Platform the durable source of truth for two remote Maestro peers and their advertised A2A capabilities.",
+			"dependsOn": ["stage-0-integrity-foundation"],
+			"entryEvidence": [
+				{
+					"id": "integrity-gates-merged",
+					"proofClass": "prior-stage",
+					"description": "Stage 0 guardrails are merged, green, and active in CI before live topology evidence is trusted.",
+					"authoritativeSource": "GitHub PR merge state and CI checks",
+					"verification": "gh pr view 2070 --repo evalops/maestro-internal --json mergedAt,mergeCommit,statusCheckRollup"
+				},
+				{
+					"id": "two-remote-endpoints-ready",
+					"proofClass": "environment",
+					"description": "Two reachable Maestro A2A endpoints exist outside the local replay harness with distinct agent ids.",
+					"authoritativeSource": "Platform runner inventory and A2A Agent Card endpoints",
+					"verification": "maestro a2a discover --capability a2a:task --import && maestro a2a peers"
+				}
+			],
+			"exitEvidence": [
+				{
+					"id": "durable-agent-identities",
+					"proofClass": "identity",
+					"description": "Both remote Maestro instances register durable Platform agent ids with workspace, organization, endpoint, and capability metadata.",
+					"authoritativeSource": "Platform Agent Registry",
+					"verification": "maestro a2a discover --capability a2a:task --skill maestro.subagent.code-review --import"
+				},
+				{
+					"id": "eligible-peer-discovery",
+					"proofClass": "peer-discovery",
+					"description": "Platform discovery returns both peers only when capability, workspace, organization, and A2A dispatch filters match.",
+					"authoritativeSource": "Platform Agent Registry discovery API",
+					"verification": "npm run platform:a2a-delegation-live with MAESTRO_A2A_LIVE_FROM_AGENT_ID and MAESTRO_A2A_LIVE_TO_AGENT_ID set"
+				},
+				{
+					"id": "fresh-heartbeats",
+					"proofClass": "heartbeat",
+					"description": "Both peers expose fresh heartbeat timestamps and Agent Card observation timestamps within the configured freshness window.",
+					"authoritativeSource": "Platform Agent Registry heartbeat state",
+					"verification": "MAESTRO_A2A_LIVE_MAX_HEARTBEAT_AGE_MS=900000 npm run platform:a2a-delegation-live"
+				},
+				{
+					"id": "topology-audit-visible",
+					"proofClass": "audit",
+					"description": "Operator-visible topology shows peer identity, capabilities, endpoint kind, capacity, and last-seen state without exposing tokens.",
+					"authoritativeSource": "Platform audit or operator topology surface",
+					"verification": "Capture the Platform topology/audit record ids in the signed evidence bundle and verify the redaction fields."
+				}
+			]
+		},
+		{
+			"id": "stage-2-remote-delegation-task-control",
+			"title": "Remote delegation and task control",
+			"purpose": "Prove Maestro A can delegate work to Maestro B through Platform and control the resulting task lifecycle.",
+			"dependsOn": ["stage-1-platform-identity-topology"],
+			"entryEvidence": [
+				{
+					"id": "registered-peers-fresh",
+					"proofClass": "prior-stage",
+					"description": "Stage 1 identity, discovery, heartbeat, and audit evidence is current for the two participating peers.",
+					"authoritativeSource": "Signed Stage 1 evidence bundle",
+					"verification": "npm run platform:a2a-evidence-verify -- <stage-1-evidence.json> --require-signature --require-negative-auth-probe"
+				},
+				{
+					"id": "delegation-skill-declared",
+					"proofClass": "capability",
+					"description": "The target peer advertises the required skill or capability before Platform accepts a delegation.",
+					"authoritativeSource": "Platform Agent Registry capability metadata",
+					"verification": "maestro a2a discover --skill maestro.subagent.code-review --capability code:review"
+				}
+			],
+			"exitEvidence": [
+				{
+					"id": "platform-delegation-created",
+					"proofClass": "delegation",
+					"description": "Platform creates a durable delegation id that links from-agent id, to-agent id, workspace, skill, prompt hash, and remote task id.",
+					"authoritativeSource": "Platform Agent Registry Delegate response",
+					"verification": "npm run platform:a2a-delegation-live and inspect evidence.delegation.id plus evidence.delegation.a2aTaskId"
+				},
+				{
+					"id": "task-lifecycle-observed",
+					"proofClass": "task-lifecycle",
+					"description": "The remote A2A task is fetched from the target peer and reaches a terminal or explicitly configured nonterminal observation state.",
+					"authoritativeSource": "Target Maestro A2A task endpoint",
+					"verification": "npm run platform:a2a-delegation-live with MAESTRO_A2A_LIVE_REQUIRE_TERMINAL_TASK=true"
+				},
+				{
+					"id": "control-command-recorded",
+					"proofClass": "task-control",
+					"description": "A Platform-owned control probe records mode, task id, optional control id, queue state, and observed task state.",
+					"authoritativeSource": "Platform A2A delegation task-control API",
+					"verification": "Inspect evidence.control.mode, evidence.control.taskId, and evidence.control.observedAt in the signed bundle."
+				},
+				{
+					"id": "platform-only-routing",
+					"proofClass": "no-side-channel",
+					"description": "The proof path uses Platform discovery, delegate, graph, control, and task observations rather than a hand-edited peer registry or private relay.",
+					"authoritativeSource": "Smoke command environment and trace spans",
+					"verification": "Verify the evidence.platformEndpoint, graph nodes, trace spans, and absence of local peer-registry-only proof in the bundle."
+				}
+			]
+		},
+		{
+			"id": "stage-3-subagent-federation",
+			"title": "Subagent federation",
+			"purpose": "Let a remote Maestro expose governed subagent lanes that another Maestro can invoke through the Platform A2A boundary.",
+			"dependsOn": ["stage-2-remote-delegation-task-control"],
+			"entryEvidence": [
+				{
+					"id": "remote-delegation-green",
+					"proofClass": "prior-stage",
+					"description": "A signed Stage 2 bundle proves remote delegation and task control for the same workspace.",
+					"authoritativeSource": "Signed Stage 2 evidence bundle",
+					"verification": "npm run platform:a2a-evidence-verify -- <stage-2-evidence.json> --require-signature --require-github-dereference --require-negative-auth-probe"
+				},
+				{
+					"id": "subagent-lanes-declared",
+					"proofClass": "capability",
+					"description": "The target Maestro advertises subagent lanes with stable ids, skill ids, input schema, policy, and ownership semantics.",
+					"authoritativeSource": "Platform capability market or Agent Registry metadata",
+					"verification": "maestro a2a discover --skill maestro.subagent.code-review --capability subagent:invoke"
+				}
+			],
+			"exitEvidence": [
+				{
+					"id": "remote-subagent-invoked",
+					"proofClass": "subagent-routing",
+					"description": "The origin Maestro invokes a named subagent lane on the target Maestro through Platform and receives a child-run handle.",
+					"authoritativeSource": "Platform AgentRuntime child-run or delegation graph",
+					"verification": "Inspect graph child nodes for childRunId, subagentLaneId, parentDelegationId, and rootDelegationId."
+				},
+				{
+					"id": "capabilities-negotiated",
+					"proofClass": "capability-negotiation",
+					"description": "The subagent call records requested capability, granted capability, fallback decision, and rejected unsupported modes.",
+					"authoritativeSource": "Platform capability negotiation record",
+					"verification": "Verify capability negotiation fields in the signed evidence bundle and targeted negative test output."
+				},
+				{
+					"id": "subagent-authorization-enforced",
+					"proofClass": "authorization",
+					"description": "Cross-peer subagent invocation fails closed when the origin lacks the required workspace, capability, or policy grant.",
+					"authoritativeSource": "Platform authorization response and negative auth trace",
+					"verification": "Run the subagent federation negative-auth smoke and verify the denial trace id is present."
+				},
+				{
+					"id": "subagent-provenance-preserved",
+					"proofClass": "provenance",
+					"description": "Every child result includes parent task, remote peer, subagent lane, tool/evidence refs, and redaction-safe artifact ids.",
+					"authoritativeSource": "Platform AgentRuntime provenance chain",
+					"verification": "Verify the child-run provenance chain from root delegation to final artifact in Platform traces."
+				}
+			]
+		},
+		{
+			"id": "stage-4-swarm-coordination",
+			"title": "Swarm coordination",
+			"purpose": "Coordinate multiple Maestro instances so work can be split, owned, recovered, and reconciled into one coherent outcome.",
+			"dependsOn": ["stage-3-subagent-federation"],
+			"entryEvidence": [
+				{
+					"id": "subagent-federation-green",
+					"proofClass": "prior-stage",
+					"description": "Stage 3 proves remote subagent invocation, negotiation, authZ, and provenance for the swarm participants.",
+					"authoritativeSource": "Signed Stage 3 evidence bundle",
+					"verification": "Verify Stage 3 evidence signature, trace ids, child-run ids, and authorization denial ids."
+				},
+				{
+					"id": "shared-work-graph-enabled",
+					"proofClass": "environment",
+					"description": "Platform can store a shared work graph with root task, child tasks, ownership claims, dependencies, and outcome refs.",
+					"authoritativeSource": "Platform AgentRuntime work graph API",
+					"verification": "Create a dry-run work graph and verify the returned root work id and child lane ids resolve through Platform."
+				}
+			],
+			"exitEvidence": [
+				{
+					"id": "work-split-recorded",
+					"proofClass": "swarm-planning",
+					"description": "The root Maestro records a plan that splits a real task into remote child lanes with dependencies and acceptance gates.",
+					"authoritativeSource": "Platform AgentRuntime work graph",
+					"verification": "Inspect the root work graph for split decisions, child assignments, dependency edges, and acceptance gates."
+				},
+				{
+					"id": "exclusive-ownership-enforced",
+					"proofClass": "ownership",
+					"description": "Each file, task, external action, or PR lane has a single active owner or an explicit handoff record.",
+					"authoritativeSource": "Platform ownership ledger",
+					"verification": "Query ownership claims and verify no active overlapping claims exist for the same protected resource."
+				},
+				{
+					"id": "worker-failure-recovered",
+					"proofClass": "failure-recovery",
+					"description": "A remote worker failure, timeout, or drain produces reassignment or graceful degradation with preserved evidence.",
+					"authoritativeSource": "Platform AgentRuntime recovery events",
+					"verification": "Run the swarm failure smoke and verify reassignment, terminal state, and recovered artifact refs."
+				},
+				{
+					"id": "final-outcome-reconciled",
+					"proofClass": "outcome-reconciliation",
+					"description": "The root Maestro reconciles child outputs into one final answer, branch, PR, or deploy decision with traceable sources.",
+					"authoritativeSource": "Platform outcome ledger and GitHub PR state",
+					"verification": "Inspect final outcome refs, merged child artifact ids, root trace id, and linked GitHub PR or deploy verifier ids."
+				}
+			]
+		},
+		{
+			"id": "stage-5-production-proof-operations",
+			"title": "Production proof and operations",
+			"purpose": "Run the full Platform-backed swarm path against live repos and deploy lanes with independently resolvable operational evidence.",
+			"dependsOn": ["stage-4-swarm-coordination"],
+			"entryEvidence": [
+				{
+					"id": "swarm-coordination-green",
+					"proofClass": "prior-stage",
+					"description": "Stage 4 proves multi-peer work split, ownership, recovery, and reconciliation with signed Platform evidence.",
+					"authoritativeSource": "Signed Stage 4 evidence bundle",
+					"verification": "Verify Stage 4 evidence signature, Platform trace ids, ownership ledger ids, and final outcome refs."
+				},
+				{
+					"id": "production-lane-selected",
+					"proofClass": "environment",
+					"description": "A real repository or deploy lane is selected with safe blast radius, review path, rollback path, and operator approval.",
+					"authoritativeSource": "GitHub issue or PR and deployment plan",
+					"verification": "Inspect the linked GitHub issue or PR body for scope, test plan, rollback plan, and approval state."
+				}
+			],
+			"exitEvidence": [
+				{
+					"id": "real-commit-sha",
+					"proofClass": "git-sha",
+					"description": "The evidence names a 40-hex commit SHA returned by git rev-parse for the branch that produced the PR.",
+					"authoritativeSource": "Git repository",
+					"verification": "git rev-parse HEAD && gh pr view <number> --repo <owner/repo> --json headRefOid"
+				},
+				{
+					"id": "real-github-pr",
+					"proofClass": "github-pr",
+					"description": "The proof links to a real integer GitHub pull request with review state, base/head refs, and merge status.",
+					"authoritativeSource": "GitHub Pull Requests API",
+					"verification": "gh pr view <number> --repo <owner/repo> --json number,url,state,mergedAt,reviewDecision"
+				},
+				{
+					"id": "real-actions-run",
+					"proofClass": "github-actions",
+					"description": "The proof links to a real GitHub Actions run id with job logs for required checks.",
+					"authoritativeSource": "GitHub Actions API",
+					"verification": "gh run view <run-id> --repo <owner/repo> --json databaseId,status,conclusion,jobs,url"
+				},
+				{
+					"id": "signed-production-evidence",
+					"proofClass": "signed-evidence",
+					"description": "The complete production evidence bundle is hash-linked, signed, and verifies with the trusted public key.",
+					"authoritativeSource": "Signed evidence sidecar and verifier output",
+					"verification": "npm run platform:a2a-evidence-verify -- <evidence.json> --require-signature --require-github-dereference --require-negative-auth-probe"
+				},
+				{
+					"id": "deploy-verifier-outcome",
+					"proofClass": "deploy-verifier",
+					"description": "If the task touches deployment, the deploy verifier records the observed revision, rollout status, and rollback evidence.",
+					"authoritativeSource": "Deploy verifier and GitOps repository state",
+					"verification": "Run the deploy verifier for the target lane and attach its dereferenceable outcome id to the evidence bundle."
+				},
+				{
+					"id": "operator-visible-traces",
+					"proofClass": "traces",
+					"description": "Operators can inspect root trace, child traces, task lifecycle, control events, GitHub refs, and deploy refs from the Platform UI or API.",
+					"authoritativeSource": "Platform trace store and operator UI",
+					"verification": "Open the root trace id and verify every child run and external ref resolves from the operator surface."
+				}
+			]
+		},
+		{
+			"id": "stage-6-fleet-hardening",
+			"title": "Fleet hardening",
+			"purpose": "Turn the proven end-to-end path into a durable fleet service with load, chaos, SLO, quota, retention, and incident evidence.",
+			"dependsOn": ["stage-5-production-proof-operations"],
+			"entryEvidence": [
+				{
+					"id": "production-proof-green",
+					"proofClass": "prior-stage",
+					"description": "Stage 5 proves a complete live repo or deploy-lane workflow with signed, dereferenceable evidence.",
+					"authoritativeSource": "Signed Stage 5 evidence bundle",
+					"verification": "Verify Stage 5 evidence signature, GitHub dereference, deploy-verifier output, and root Platform trace id."
+				},
+				{
+					"id": "fleet-capacity-targets-declared",
+					"proofClass": "environment",
+					"description": "Target concurrency, latency, failure budgets, data retention, and operator ownership are declared before hardening starts.",
+					"authoritativeSource": "Platform SLO document or service config",
+					"verification": "Inspect the service config or SLO document for concrete fleet-scale thresholds and owners."
+				}
+			],
+			"exitEvidence": [
+				{
+					"id": "load-soak-passes",
+					"proofClass": "load-soak",
+					"description": "A bounded load and soak test exercises concurrent peer discovery, delegation, subagent routing, control, and evidence writes.",
+					"authoritativeSource": "Load test report and Platform metrics",
+					"verification": "Run the fleet soak harness and verify p95 latency, error rate, and evidence-write success rate against SLO."
+				},
+				{
+					"id": "chaos-cases-pass",
+					"proofClass": "chaos",
+					"description": "Peer loss, stale heartbeat, auth failure, Platform transient failure, GitHub failure, and deploy verifier failure have tested recovery behavior.",
+					"authoritativeSource": "Chaos test report and recovery traces",
+					"verification": "Run the A2A swarm chaos suite and verify each injected fault has a terminal recovery or degraded outcome."
+				},
+				{
+					"id": "slos-alerts-dashboards",
+					"proofClass": "slo",
+					"description": "Fleet dashboards and alerts cover registration freshness, delegation latency, task terminal rate, auth failures, evidence verification failures, and queue depth.",
+					"authoritativeSource": "Platform observability dashboard and alert config",
+					"verification": "Inspect dashboard panels and alert rules, then attach their stable ids to the release evidence."
+				},
+				{
+					"id": "operator-playbook-ready",
+					"proofClass": "operator-runbook",
+					"description": "Operators have a playbook for stuck delegations, poisoned peers, key rotation, bad evidence, failed deploy verification, and rollback.",
+					"authoritativeSource": "Operator runbook repository",
+					"verification": "Run the playbook checklist against a staging incident and link the checklist result to the hardening evidence."
+				},
+				{
+					"id": "quota-retention-enforced",
+					"proofClass": "quota-retention",
+					"description": "Workspace quotas, per-peer limits, evidence retention, signature key rotation, and redaction retention policies are enforced.",
+					"authoritativeSource": "Platform policy engine and retention jobs",
+					"verification": "Run policy probes for over-quota delegation, expired evidence lookup, and retired signature key verification."
+				}
+			]
+		}
+	]
+}

--- a/docs/protocols/a2a-swarm-stage-gates.md
+++ b/docs/protocols/a2a-swarm-stage-gates.md
@@ -1,0 +1,48 @@
+# A2A Swarm Stage Gates
+
+`a2a-swarm-stage-gates.json` is the executable goal contract for Platform-backed
+Maestro A2A swarm work. It turns "two remote Maestro instances can collaborate"
+into ordered evidence gates, with each stage naming the evidence that allows the
+next stage to start and the evidence that proves the stage is done.
+
+The manifest is checked by `npm run check:evidence-integrity`, which also runs
+from the guardian/precommit path. That keeps the goal honest: an exit gate must
+name a production-authoritative source and a concrete verification command,
+query, or operator inspection path. Replay fixtures can remain valuable schema
+evidence, but they cannot satisfy production exit gates.
+
+## Stages
+
+| Stage | Gate | What It Proves |
+| --- | --- | --- |
+| 0 | Integrity foundation | Synthetic or fixture-shaped identifiers cannot masquerade as production proof. |
+| 1 | Platform identity and topology | Two remote Maestro peers are durable Platform agents with fresh discovery and heartbeat state. |
+| 2 | Remote delegation and task control | Maestro A delegates to Maestro B through Platform and observes/controls the resulting A2A task. |
+| 3 | Subagent federation | Remote subagent lanes are negotiated, authorized, invoked, and traced through Platform. |
+| 4 | Swarm coordination | Multiple Maestro peers split work, hold ownership, recover from failures, and reconcile one outcome. |
+| 5 | Production proof and operations | A real repo or deploy workflow resolves to live GitHub, deploy, signature, and Platform trace evidence. |
+| 6 | Fleet hardening | Load, chaos, SLO, runbook, quota, and retention evidence make the system operable at fleet scale. |
+
+## Usage
+
+Before promoting a stage, collect the exit evidence named in the manifest and
+run:
+
+```sh
+npm run check:evidence-integrity
+```
+
+For live proof bundles, also run the strict verifier:
+
+```sh
+GITHUB_TOKEN="$GITHUB_TOKEN" \
+MAESTRO_A2A_LIVE_EVIDENCE_VERIFY_PUBLIC_KEY_FILE=./platform-a2a-live.pub.pem \
+npm run platform:a2a-evidence-verify -- \
+  tmp/platform-a2a-delegation-live/<run>/evidence.json \
+  --require-signature \
+  --require-github-dereference \
+  --require-negative-auth-probe
+```
+
+The stage is not complete until the evidence resolves in the named system of
+record. A pretty bundle with unresolvable identifiers is a failed gate.

--- a/evals/tools/batch-shaping-cases.json
+++ b/evals/tools/batch-shaping-cases.json
@@ -78,5 +78,82 @@
 				"promptOnlyFeedbackDelivered": true
 			}
 		}
+	},
+	{
+		"name": "repo triage singleton becomes schedulable inspection batch",
+		"userIntent": "Before editing, inspect the scheduler transport, telemetry tests, and eval scenario registry.",
+		"replays": {
+			"baseline": {
+				"promptMessages": [
+					"Before editing, inspect the scheduler transport, telemetry tests, and eval scenario registry."
+				],
+				"emittedToolCalls": [
+					{
+						"toolName": "search",
+						"args": {
+							"pattern": "tool_phase_summary",
+							"path": "src/agent"
+						}
+					}
+				]
+			},
+			"nudged": {
+				"promptMessages": [
+					"Before editing, inspect the scheduler transport, telemetry tests, and eval scenario registry.",
+					"When you need several independent reads or searches, emit them together in one assistant message so Maestro can batch them safely."
+				],
+				"emittedToolCalls": [
+					{
+						"toolName": "search",
+						"args": {
+							"pattern": "tool_phase_summary",
+							"path": "src/agent"
+						}
+					},
+					{
+						"toolName": "read",
+						"args": {
+							"file_path": "test/telemetry/telemetry-report.test.ts"
+						}
+					},
+					{
+						"toolName": "read",
+						"args": {
+							"file_path": "evals/scenarios.json"
+						}
+					}
+				]
+			}
+		},
+		"expected": {
+			"baseline": {
+				"modelToolCallCount": 1,
+				"multiCallTurns": 0,
+				"topSerializationReasons": [
+					{
+						"reason": "single_read_only_call",
+						"count": 1
+					}
+				]
+			},
+			"nudged": {
+				"modelToolCallCount": 3,
+				"multiCallTurns": 1,
+				"topSerializationReasons": []
+			},
+			"improvement": {
+				"modelToolCallCountDelta": 2,
+				"multiCallTurnDelta": 1,
+				"increasedMultiCallTurns": true
+			},
+			"privacy": {
+				"safe": true,
+				"disallowedSubstringCount": 0
+			},
+			"runtime": {
+				"exercisedAgentToolPhaseSummary": true,
+				"promptOnlyFeedbackDelivered": true
+			}
+		}
 	}
 ]

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Maestro Web API",
-    "version": "0.10.19",
+    "version": "0.10.20",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evalops/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "private": false,
   "type": "module",
   "workspaces": [
@@ -58,6 +58,8 @@
     "platform:sdk-smoke": "tsx scripts/check-platform-sdk-contract.ts",
     "platform:agentruntime-e2e": "tsx scripts/smoke-platform-agentruntime-lifecycle.ts",
     "platform:timeline-e2e": "tsx scripts/smoke-platform-timeline-e2e.ts",
+    "platform:a2a-delegation-live": "tsx scripts/smoke-platform-a2a-delegation-live.ts",
+    "platform:a2a-evidence-verify": "tsx scripts/verify-platform-a2a-live-evidence.ts",
     "developer-surface:check": "node scripts/check-developer-surface.mjs",
     "format": "biome format .",
     "check": "npm run lint && npm run check --workspaces --if-present && tsc -p tsconfig.build.json --noEmit",
@@ -159,8 +161,8 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1020.0",
     "@crosscopy/clipboard": "^0.2.8",
     "@daytonaio/sdk": "^0.155.0",
-    "@evalops/contracts": "^0.10.19",
-    "@evalops/tui": "^0.10.19",
+    "@evalops/contracts": "^0.10.20",
+    "@evalops/tui": "^0.10.20",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.75.0",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/ai",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Shared Maestro AI SDK (models, transport, and agent event stream facade).",
 	"type": "module",
 	"main": "./dist/packages/ai/src/index.js",
@@ -131,8 +131,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.19",
-		"@evalops/tui": "^0.10.19",
+		"@evalops/contracts": "^0.10.20",
+		"@evalops/tui": "^0.10.20",
 		"@google/genai": "^1.29.1",
 		"@sinclair/typebox": "^0.34.0",
 		"nats": "^2.29.3"

--- a/packages/consumer-sdk/package.json
+++ b/packages/consumer-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/consumer",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Unified EvalOps consumer SDK for Maestro service integrations",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -28,7 +28,7 @@
 		"directory": "packages/consumer-sdk"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.19"
+		"@evalops/contracts": "^0.10.20"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/contracts",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Shared Maestro contracts for frontend/backend integration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-core",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Maestro agent loop, transport, types, and sandbox primitives — the engine behind all Maestro interfaces",
 	"type": "module",
 	"main": "./dist/packages/core/src/index.js",
@@ -69,7 +69,7 @@
 		"vscode-jsonrpc": "^8.2.0"
 	},
 	"peerDependencies": {
-		"@evalops/tui": "^0.10.19"
+		"@evalops/tui": "^0.10.20"
 	},
 	"peerDependenciesMeta": {
 		"@evalops/tui": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-desktop",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Maestro Desktop - Beautiful Electron app for AI-assisted development",
 	"type": "module",
 	"main": "dist-electron/main/index.js",
@@ -37,7 +37,7 @@
 		"directory": "packages/desktop"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.19",
+		"@evalops/contracts": "^0.10.20",
 		"electron-store": "^10.0.1",
 		"electron-updater": "^6.3.9"
 	},

--- a/packages/github-agent/package.json
+++ b/packages/github-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/github-agent",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Autonomous GitHub agent - Maestro building Maestro",
 	"type": "module",
 	"bin": {
@@ -36,8 +36,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/ai": "^0.10.19",
-		"@evalops/contracts": "^0.10.19",
+		"@evalops/ai": "^0.10.20",
+		"@evalops/contracts": "^0.10.20",
 		"@octokit/rest": "^21.0.0",
 		"@octokit/webhooks": "^13.0.0",
 		"@sinclair/typebox": "^0.34.0",

--- a/packages/governance-mcp-server/package.json
+++ b/packages/governance-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance-mcp-server",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "MCP server exposing Platform governance proxy tools to any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -43,7 +43,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/governance": "^0.10.19",
+		"@evalops/governance": "^0.10.20",
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"zod": "^4.3.5"
 	},

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Thin Platform governance proxy for MCP-compatible agents.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/memory",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"private": true,
 	"type": "module",
 	"sideEffects": false,

--- a/packages/slack-agent-ui/package.json
+++ b/packages/slack-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent-ui",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Web UI for Slack Agent - Dashboard gallery, connector management, OAuth flows",
 	"type": "module",
 	"private": true,

--- a/packages/slack-agent/package.json
+++ b/packages/slack-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Slack bot agent with Docker sandbox support for Maestro",
 	"type": "module",
 	"bin": {
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@daytonaio/sdk": "^0.139.0",
-		"@evalops/ai": "^0.10.19",
+		"@evalops/ai": "^0.10.20",
 		"@sinclair/typebox": "^0.34.0",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/tui-rs/Cargo.toml
+++ b/packages/tui-rs/Cargo.toml
@@ -106,7 +106,7 @@ notify = { version = "7", optional = true }
 
 # Linux sandboxing (Landlock + seccomp)
 [target.'cfg(target_os = "linux")'.dependencies]
-landlock = "0.4"
+landlock = "0.4.5"
 seccompiler = "0.4"
 
 [features]

--- a/packages/tui-rs/src/agent/native.rs
+++ b/packages/tui-rs/src/agent/native.rs
@@ -272,6 +272,7 @@ async fn execute_native_read_only_tool_wave(
     cwd: &str,
     event_tx: &mpsc::UnboundedSender<FromAgent>,
     pending: &[QueuedReadOnlyToolExecution],
+    cancel_token: Option<CancellationToken>,
 ) -> HashMap<String, ToolResult> {
     let calls = pending
         .iter()
@@ -285,9 +286,15 @@ async fn execute_native_read_only_tool_wave(
         .collect();
     let batch_executor =
         BatchExecutor::with_config(cwd.to_string(), native_read_only_batch_config());
-    batch_executor
-        .execute(calls, Some(event_tx.clone()))
-        .await
+    let results = if let Some(cancel_token) = cancel_token {
+        batch_executor
+            .execute_with_cancel(calls, Some(event_tx.clone()), cancel_token)
+            .await
+    } else {
+        batch_executor.execute(calls, Some(event_tx.clone())).await
+    };
+
+    results
         .into_iter()
         .map(|result| (result.call_id, result.result))
         .collect()
@@ -2537,9 +2544,14 @@ impl NativeAgentRunner {
         }
 
         let pending_calls = std::mem::take(pending);
-        let mut results_by_call_id =
-            execute_native_read_only_tool_wave(&self.config.cwd, &self.event_tx, &pending_calls)
-                .await;
+        let cancel_token = self.cancel_token.clone();
+        let mut results_by_call_id = execute_native_read_only_tool_wave(
+            &self.config.cwd,
+            &self.event_tx,
+            &pending_calls,
+            cancel_token,
+        )
+        .await;
 
         for call in pending_calls {
             let result = results_by_call_id
@@ -2904,7 +2916,8 @@ mod tests {
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         let results =
-            execute_native_read_only_tool_wave(temp.path().to_str().unwrap(), &tx, &pending).await;
+            execute_native_read_only_tool_wave(temp.path().to_str().unwrap(), &tx, &pending, None)
+                .await;
 
         assert_eq!(results.len(), 4);
         assert!(results.values().all(|result| result.success));

--- a/packages/tui-rs/src/tools/batch.rs
+++ b/packages/tui-rs/src/tools/batch.rs
@@ -10,6 +10,8 @@ use std::time::Instant;
 
 use futures::future::join_all;
 use tokio::sync::{mpsc, Semaphore};
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
 
 use super::details::BatchDetails;
 use super::registry::ToolExecutor;
@@ -253,6 +255,207 @@ impl BatchExecutor {
             .collect();
 
         // Send batch end event
+        if let Some(ref tx) = event_tx {
+            if self.config.emit_events {
+                let successes = results.iter().filter(|r| r.result.success).count();
+                let failures = results.len() - successes;
+                let _ = tx.send(FromAgent::BatchEnd {
+                    total: results.len(),
+                    successes,
+                    failures,
+                });
+            }
+        }
+
+        results
+    }
+
+    /// Execute multiple tools in parallel and abort outstanding work when cancelled.
+    ///
+    /// Returns one result per requested call in input order. Calls that never
+    /// complete because cancellation wins are surfaced as failed tool results so
+    /// the caller can close out the batch cleanly.
+    pub async fn execute_with_cancel(
+        &self,
+        calls: Vec<BatchToolCall>,
+        event_tx: Option<mpsc::UnboundedSender<FromAgent>>,
+        cancel_token: CancellationToken,
+    ) -> Vec<BatchToolResult> {
+        let total = calls.len();
+        if calls.is_empty() {
+            return Vec::new();
+        }
+
+        if !self.config.continue_on_error {
+            if let Some(ref tx) = event_tx {
+                if self.config.emit_events {
+                    let _ = tx.send(FromAgent::BatchStart { total });
+                }
+            }
+
+            let mut results = Vec::with_capacity(total);
+            let mut failed = false;
+            let mut cancelled = false;
+
+            for call in calls {
+                if cancelled || cancel_token.is_cancelled() {
+                    cancelled = true;
+                    results.push(BatchToolResult {
+                        call_id: call.call_id,
+                        tool_name: call.tool_name,
+                        result: ToolResult::failure("Batch execution cancelled"),
+                    });
+                    continue;
+                }
+
+                if failed {
+                    results.push(BatchToolResult {
+                        call_id: call.call_id,
+                        tool_name: call.tool_name,
+                        result: ToolResult::failure("Skipped due to previous error in batch"),
+                    });
+                    continue;
+                }
+
+                let result = tokio::select! {
+                    result = self.executor.execute(
+                        &call.tool_name,
+                        &call.args,
+                        if self.config.emit_events { event_tx.as_ref() } else { None },
+                        &call.call_id,
+                    ) => result,
+                    () = cancel_token.cancelled() => {
+                        cancelled = true;
+                        ToolResult::failure("Batch execution cancelled")
+                    }
+                };
+
+                if !result.success {
+                    failed = true;
+                }
+
+                results.push(BatchToolResult {
+                    call_id: call.call_id,
+                    tool_name: call.tool_name,
+                    result,
+                });
+            }
+
+            if let Some(ref tx) = event_tx {
+                if self.config.emit_events {
+                    let successes = results.iter().filter(|r| r.result.success).count();
+                    let failures = results.len() - successes;
+                    let _ = tx.send(FromAgent::BatchEnd {
+                        total: results.len(),
+                        successes,
+                        failures,
+                    });
+                }
+            }
+
+            return results;
+        }
+
+        if let Some(ref tx) = event_tx {
+            if self.config.emit_events {
+                let _ = tx.send(FromAgent::BatchStart { total });
+            }
+        }
+
+        let call_metadata: Vec<(String, String)> = calls
+            .iter()
+            .map(|call| (call.call_id.clone(), call.tool_name.clone()))
+            .collect();
+        let semaphore = Arc::new(Semaphore::new(self.config.max_concurrency));
+        let mut task_set: JoinSet<(usize, BatchToolResult)> = JoinSet::new();
+        let mut result_slots: Vec<Option<BatchToolResult>> =
+            std::iter::repeat_with(|| None).take(total).collect();
+        let mut cancelled = cancel_token.is_cancelled();
+
+        if !cancelled {
+            for (index, call) in calls.into_iter().enumerate() {
+                let permit = tokio::select! {
+                    permit = semaphore.clone().acquire_owned() => permit,
+                    () = cancel_token.cancelled() => {
+                        cancelled = true;
+                        break;
+                    }
+                };
+
+                let Ok(permit) = permit else {
+                    cancelled = true;
+                    break;
+                };
+
+                let executor = Arc::clone(&self.executor);
+                let event_tx_clone = event_tx.clone();
+                let emit_events = self.config.emit_events;
+                let call_id = call.call_id;
+                let tool_name = call.tool_name;
+                let args = call.args;
+
+                task_set.spawn(async move {
+                    let result = executor
+                        .execute(
+                            &tool_name,
+                            &args,
+                            if emit_events {
+                                event_tx_clone.as_ref()
+                            } else {
+                                None
+                            },
+                            &call_id,
+                        )
+                        .await;
+
+                    drop(permit);
+
+                    (
+                        index,
+                        BatchToolResult {
+                            call_id,
+                            tool_name,
+                            result,
+                        },
+                    )
+                });
+            }
+        }
+
+        if cancelled {
+            task_set.abort_all();
+        }
+
+        while !task_set.is_empty() {
+            if cancelled {
+                record_joined_batch_result(task_set.join_next().await, &mut result_slots);
+                continue;
+            }
+
+            tokio::select! {
+                result = task_set.join_next() => {
+                    record_joined_batch_result(result, &mut result_slots);
+                }
+                () = cancel_token.cancelled() => {
+                    cancelled = true;
+                    task_set.abort_all();
+                }
+            }
+        }
+
+        for (index, slot) in result_slots.iter_mut().enumerate() {
+            if slot.is_none() {
+                let (call_id, tool_name) = &call_metadata[index];
+                *slot = Some(BatchToolResult {
+                    call_id: call_id.clone(),
+                    tool_name: tool_name.clone(),
+                    result: ToolResult::failure("Batch execution cancelled"),
+                });
+            }
+        }
+
+        let results: Vec<BatchToolResult> = result_slots.into_iter().flatten().collect();
+
         if let Some(ref tx) = event_tx {
             if self.config.emit_events {
                 let successes = results.iter().filter(|r| r.result.success).count();
@@ -543,6 +746,17 @@ impl BatchExecutor {
     }
 }
 
+fn record_joined_batch_result(
+    result: Option<Result<(usize, BatchToolResult), tokio::task::JoinError>>,
+    result_slots: &mut [Option<BatchToolResult>],
+) {
+    if let Some(Ok((index, result))) = result {
+        if let Some(slot) = result_slots.get_mut(index) {
+            *slot = Some(result);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -712,6 +926,82 @@ mod tests {
         assert_eq!(results.len(), 4);
         assert_eq!(details.max_concurrency, Some(2));
         assert_eq!(details.backpressure_count, Some(2));
+    }
+
+    #[tokio::test]
+    async fn test_batch_executor_cancel_closes_batch_with_failures() {
+        let config = BatchConfig::default().with_concurrency(2);
+        let batch = BatchExecutor::with_config("/tmp", config);
+        let calls = vec![
+            BatchToolCall::new("1", "glob", json!({"pattern": "*.rs"})),
+            BatchToolCall::new("2", "glob", json!({"pattern": "*.toml"})),
+            BatchToolCall::new("3", "glob", json!({"pattern": "*.json"})),
+        ];
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let results = batch
+            .execute_with_cancel(calls, Some(tx), cancel_token)
+            .await;
+
+        assert_eq!(results.len(), 3);
+        assert!(results.iter().all(|result| !result.result.success));
+        assert!(results.iter().all(|result| {
+            result
+                .result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("cancelled"))
+        }));
+
+        let mut saw_start = false;
+        let mut saw_end = false;
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                FromAgent::BatchStart { total } => {
+                    assert_eq!(total, 3);
+                    saw_start = true;
+                }
+                FromAgent::BatchEnd {
+                    total,
+                    successes,
+                    failures,
+                } => {
+                    assert_eq!(total, 3);
+                    assert_eq!(successes, 0);
+                    assert_eq!(failures, 3);
+                    saw_end = true;
+                }
+                _ => {}
+            }
+        }
+
+        assert!(saw_start);
+        assert!(saw_end);
+    }
+
+    #[tokio::test]
+    async fn test_cancelled_batch_drain_preserves_completed_results() {
+        let mut task_set = JoinSet::new();
+        task_set.spawn(async {
+            (
+                0,
+                BatchToolResult {
+                    call_id: "1".to_string(),
+                    tool_name: "glob".to_string(),
+                    result: ToolResult::success("completed before cancellation"),
+                },
+            )
+        });
+
+        let mut result_slots = vec![None];
+        record_joined_batch_result(task_set.join_next().await, &mut result_slots);
+
+        let result = result_slots.into_iter().next().flatten().unwrap();
+        assert_eq!(result.call_id, "1");
+        assert!(result.result.success);
+        assert_eq!(result.result.output, "completed before cancellation");
     }
 
     #[tokio::test]

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/tui",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Terminal UI library with differential rendering for Maestro",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Maestro",
 	"description": "Use Maestro's deterministic AI assistant inside VS Code.",
 	"publisher": "evalops",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"license": "MIT",
 	"type": "commonjs",
 	"main": "./dist/extension.js",
@@ -139,7 +139,7 @@
 		"test": "vitest --run"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.19"
+		"@evalops/contracts": "^0.10.20"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-web",
-	"version": "0.10.19",
+	"version": "0.10.20",
 	"description": "Web UI for Maestro - Browser-based AI coding assistant interface",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,7 +24,7 @@
 		"directory": "packages/web"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.19",
+		"@evalops/contracts": "^0.10.20",
 		"docx-preview": "^0.3.7",
 		"dompurify": "^3.3.0",
 		"exceljs": "^4.4.0",

--- a/scripts/check-evidence-integrity.ts
+++ b/scripts/check-evidence-integrity.ts
@@ -4,6 +4,77 @@ import { resolve } from "node:path";
 import { DEFAULT_EXCLUDES } from "../src/guardian/types.js";
 import { detectEvidenceIntegrityFindings } from "../src/guardian/runner.js";
 
+const A2A_SWARM_STAGE_GATE_MANIFEST =
+	"docs/protocols/a2a-swarm-stage-gates.json";
+
+const A2A_SWARM_STAGE_IDS = [
+	"stage-0-integrity-foundation",
+	"stage-1-platform-identity-topology",
+	"stage-2-remote-delegation-task-control",
+	"stage-3-subagent-federation",
+	"stage-4-swarm-coordination",
+	"stage-5-production-proof-operations",
+	"stage-6-fleet-hardening",
+] as const;
+
+const REQUIRED_A2A_SWARM_STAGE_PROOF_CLASSES: Record<
+	(typeof A2A_SWARM_STAGE_IDS)[number],
+	string[]
+> = {
+	"stage-0-integrity-foundation": [
+		"precommit-guardrail",
+		"live-identifier-dereference",
+		"signed-evidence",
+		"negative-auth",
+	],
+	"stage-1-platform-identity-topology": [
+		"identity",
+		"peer-discovery",
+		"heartbeat",
+		"audit",
+	],
+	"stage-2-remote-delegation-task-control": [
+		"delegation",
+		"task-lifecycle",
+		"task-control",
+		"no-side-channel",
+	],
+	"stage-3-subagent-federation": [
+		"subagent-routing",
+		"capability-negotiation",
+		"authorization",
+		"provenance",
+	],
+	"stage-4-swarm-coordination": [
+		"swarm-planning",
+		"ownership",
+		"failure-recovery",
+		"outcome-reconciliation",
+	],
+	"stage-5-production-proof-operations": [
+		"git-sha",
+		"github-pr",
+		"github-actions",
+		"signed-evidence",
+		"deploy-verifier",
+		"traces",
+	],
+	"stage-6-fleet-hardening": [
+		"load-soak",
+		"chaos",
+		"slo",
+		"operator-runbook",
+		"quota-retention",
+	],
+};
+
+const FIXTURE_SELF_TEST_PATHS = [
+	/test\/guardian\/evidence-integrity\.test\.ts$/,
+	/test\/platform\/a2a-platform-delegation-live\.test\.ts$/,
+	/test\/platform\/a2a-platform-live-evidence-verify\.test\.ts$/,
+	/src\/guardian\/runner\.ts$/,
+] as const;
+
 function listTrackedFiles(root: string): string[] {
 	const output = execFileSync("git", ["ls-files"], {
 		cwd: root,
@@ -26,10 +97,7 @@ function listTrackedFiles(root: string): string[] {
 }
 
 function shouldSkipFixtureSelfTest(relative: string): boolean {
-	return (
-		/test\/guardian\/evidence-integrity\.test\.ts$/.test(relative) ||
-		/src\/guardian\/runner\.ts$/.test(relative)
-	);
+	return FIXTURE_SELF_TEST_PATHS.some((fixture) => fixture.test(relative));
 }
 
 function readTextFile(path: string): string | null {
@@ -48,6 +116,179 @@ function readTextFile(path: string): string | null {
 	}
 }
 
+function validateA2ASwarmStageGateManifest(root: string): string[] {
+	const manifestPath = resolve(root, A2A_SWARM_STAGE_GATE_MANIFEST);
+	if (!existsSync(manifestPath)) {
+		return [
+			`Missing A2A swarm stage-gate manifest: ${A2A_SWARM_STAGE_GATE_MANIFEST}`,
+		];
+	}
+	const contents = readFileSync(manifestPath, "utf8");
+	const manifest = requireRecord(
+		JSON.parse(contents) as unknown,
+		A2A_SWARM_STAGE_GATE_MANIFEST,
+	);
+	const failures: string[] = [];
+	const protocolVersion = stringField(manifest, "protocolVersion");
+	if (protocolVersion !== "evalops.maestro.a2a-swarm-stage-gates.v1") {
+		failures.push(
+			`${A2A_SWARM_STAGE_GATE_MANIFEST} has unexpected protocolVersion ${protocolVersion}`,
+		);
+	}
+	const stages = arrayField(manifest, "stages");
+	if (stages.length !== A2A_SWARM_STAGE_IDS.length) {
+		failures.push(
+			`${A2A_SWARM_STAGE_GATE_MANIFEST} must define exactly ${A2A_SWARM_STAGE_IDS.length} stages`,
+		);
+	}
+	const seenStageIds = new Set<string>();
+	let previousStageId: string | undefined;
+	stages.forEach((stageValue, index) => {
+		const stage = requireRecord(stageValue, `stages[${index}]`);
+		const stageId = stringField(stage, "id");
+		const canonicalStageId = A2A_SWARM_STAGE_IDS[index];
+		if (!canonicalStageId) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} stage ${index} id ${stageId} is not canonical`,
+			);
+		} else if (stageId !== canonicalStageId) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} stage ${index} id must be ${canonicalStageId}`,
+			);
+		}
+		if (seenStageIds.has(stageId)) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} has duplicate stage id ${stageId}`,
+			);
+		}
+		seenStageIds.add(stageId);
+		stringField(stage, "title");
+		stringField(stage, "purpose");
+		const dependsOn = optionalStringArrayField(stage, "dependsOn");
+		if (index === 0 && dependsOn.length > 0) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} first stage must not depend on prior stages`,
+			);
+		}
+		if (index > 0 && previousStageId && !dependsOn.includes(previousStageId)) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} ${stageId} must depend on ${previousStageId}`,
+			);
+		}
+		const entryEvidence = arrayField(stage, "entryEvidence");
+		const exitEvidence = arrayField(stage, "exitEvidence");
+		if (entryEvidence.length < 2) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} ${stageId} must define at least two entry evidence gates`,
+			);
+		}
+		if (exitEvidence.length < 4) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} ${stageId} must define at least four exit evidence gates`,
+			);
+		}
+		validateEvidenceList(stageId, "entryEvidence", entryEvidence, failures);
+		const exitProofClasses = validateEvidenceList(
+			stageId,
+			"exitEvidence",
+			exitEvidence,
+			failures,
+		);
+		for (const proofClass of REQUIRED_A2A_SWARM_STAGE_PROOF_CLASSES[stageId] ??
+			[]) {
+			if (!exitProofClasses.has(proofClass)) {
+				failures.push(
+					`${A2A_SWARM_STAGE_GATE_MANIFEST} ${stageId} exitEvidence missing proofClass ${proofClass}`,
+				);
+			}
+		}
+		previousStageId = stageId;
+	});
+	return failures;
+}
+
+function validateEvidenceList(
+	stageId: string,
+	fieldName: "entryEvidence" | "exitEvidence",
+	evidence: unknown[],
+	failures: string[],
+): Set<string> {
+	const proofClasses = new Set<string>();
+	const evidenceIds = new Set<string>();
+	evidence.forEach((evidenceValue, index) => {
+		const item = requireRecord(
+			evidenceValue,
+			`${stageId}.${fieldName}[${index}]`,
+		);
+		const id = stringField(item, "id");
+		if (evidenceIds.has(id)) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} ${stageId}.${fieldName} has duplicate evidence id ${id}`,
+			);
+		}
+		evidenceIds.add(id);
+		stringField(item, "description");
+		const proofClass = stringField(item, "proofClass");
+		proofClasses.add(proofClass);
+		const source = stringField(item, "authoritativeSource");
+		const verification = stringField(item, "verification");
+		if (/tbd|todo|later|manual vibe/iu.test(verification)) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} ${stageId}.${fieldName}.${id} has non-actionable verification`,
+			);
+		}
+		if (
+			fieldName === "exitEvidence" &&
+			/(fixture|deterministic replay|local-only|synthetic)/iu.test(source)
+		) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} ${stageId}.${fieldName}.${id} exit source is not production-authoritative`,
+			);
+		}
+	});
+	return proofClasses;
+}
+
+function requireRecord(value: unknown, name: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`${name} must be an object`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string {
+	const value = record[key];
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new Error(`${key} must be a non-empty string`);
+	}
+	return value.trim();
+}
+
+function arrayField(record: Record<string, unknown>, key: string): unknown[] {
+	const value = record[key];
+	if (!Array.isArray(value)) {
+		throw new Error(`${key} must be an array`);
+	}
+	return value;
+}
+
+function optionalStringArrayField(
+	record: Record<string, unknown>,
+	key: string,
+): string[] {
+	const value = record[key];
+	if (value === undefined) {
+		return [];
+	}
+	if (
+		!Array.isArray(value) ||
+		!value.every((entry) => typeof entry === "string" && entry.trim())
+	) {
+		throw new Error(`${key} must be an array of non-empty strings`);
+	}
+	return value.map((entry) => entry.trim());
+}
+
 function main(): void {
 	const root = process.cwd();
 	const findings: string[] = [];
@@ -62,6 +303,9 @@ function main(): void {
 		for (const finding of detectEvidenceIntegrityFindings(contents)) {
 			findings.push(`${finding}: ${relative}`);
 		}
+	}
+	for (const finding of validateA2ASwarmStageGateManifest(root)) {
+		findings.push(finding);
 	}
 	if (findings.length > 0) {
 		console.error("Evidence integrity check failed:");

--- a/scripts/smoke-platform-a2a-delegation-live.ts
+++ b/scripts/smoke-platform-a2a-delegation-live.ts
@@ -1,0 +1,1111 @@
+import { execFileSync } from "node:child_process";
+import {
+	type KeyObject,
+	createHash,
+	createPrivateKey,
+	createPublicKey,
+	sign as signBytes,
+} from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+	PlatformA2ADelegationTaskControlModeValue,
+	type PlatformA2ADelegationGraphNode,
+	type PlatformAgentRegistryA2APeerCandidate,
+	type PlatformAgentRegistryControlA2ADelegationTaskResult,
+	type PlatformAgentRegistryDelegateResult,
+	type PlatformAgentRegistryGetA2ADelegationGraphResult,
+	controlA2ADelegationTaskWithPlatform,
+	delegateAgentWithPlatform,
+	getA2ADelegationGraphWithPlatform,
+	listA2APeerCandidatesWithPlatform,
+	resolveAgentRegistryServiceConfig,
+} from "../src/platform/agent-registry-client.js";
+import {
+	type A2AAgentCard,
+	type A2AServiceConfig,
+	type A2ATask,
+	discoverA2AAgentCard,
+	getA2ATask,
+} from "../src/platform/a2a-client.js";
+import {
+	DEFAULT_PLATFORM_MAX_ATTEMPTS,
+	DEFAULT_PLATFORM_TIMEOUT_MS,
+	type PlatformServiceConfig,
+	parsePositiveInt,
+	trimString,
+} from "../src/platform/client.js";
+import { getPackageName } from "../src/package-metadata.js";
+
+const SERVICE_URL_ENV_VARS = [
+	"MAESTRO_AGENT_REGISTRY_SERVICE_URL",
+	"AGENT_REGISTRY_SERVICE_URL",
+	"MAESTRO_AGENT_REGISTRY_URL",
+	"AGENT_REGISTRY_BASE_URL",
+	"PLATFORM_AGENT_REGISTRY_URL",
+	"MAESTRO_PLATFORM_BASE_URL",
+	"MAESTRO_EVALOPS_BASE_URL",
+	"EVALOPS_BASE_URL",
+] as const;
+
+const SERVICE_TOKEN_ENV_VARS = [
+	"MAESTRO_AGENT_REGISTRY_SERVICE_TOKEN",
+	"AGENT_REGISTRY_SERVICE_TOKEN",
+	"MAESTRO_AGENT_REGISTRY_TOKEN",
+	"AGENT_REGISTRY_TOKEN",
+	"MAESTRO_EVALOPS_ACCESS_TOKEN",
+	"EVALOPS_TOKEN",
+] as const;
+
+const ORGANIZATION_ENV_VARS = [
+	"MAESTRO_AGENT_REGISTRY_ORG_ID",
+	"AGENT_REGISTRY_ORGANIZATION_ID",
+	"AGENT_REGISTRY_ORG_ID",
+	"MAESTRO_EVALOPS_ORG_ID",
+	"EVALOPS_ORGANIZATION_ID",
+	"EVALOPS_ORG_ID",
+	"MAESTRO_ENTERPRISE_ORG_ID",
+] as const;
+
+const WORKSPACE_ENV_VARS = [
+	"MAESTRO_AGENT_REGISTRY_WORKSPACE_ID",
+	"AGENT_REGISTRY_WORKSPACE_ID",
+	"MAESTRO_REMOTE_RUNNER_WORKSPACE_ID",
+	"MAESTRO_EVALOPS_WORKSPACE_ID",
+	"EVALOPS_WORKSPACE_ID",
+	"MAESTRO_WORKSPACE_ID",
+] as const;
+
+const EVIDENCE_SIGNING_KEY_ENV_VARS = [
+	"MAESTRO_A2A_LIVE_EVIDENCE_SIGNING_PRIVATE_KEY",
+	"MAESTRO_A2A_LIVE_EVIDENCE_SIGNING_KEY",
+] as const;
+
+const EVIDENCE_SIGNING_KEY_FILE_ENV_VARS = [
+	"MAESTRO_A2A_LIVE_EVIDENCE_SIGNING_PRIVATE_KEY_FILE",
+	"MAESTRO_A2A_LIVE_EVIDENCE_SIGNING_KEY_FILE",
+] as const;
+
+const EVIDENCE_SIGNATURE_PROTOCOL_VERSION =
+	"evalops.maestro.platform-a2a-live-evidence-signature.v1";
+
+const TERMINAL_TASK_STATES = new Set([
+	"TASK_STATE_COMPLETED",
+	"TASK_STATE_FAILED",
+	"TASK_STATE_CANCELED",
+	"TASK_STATE_CANCELLED",
+	"TASK_STATE_REJECTED",
+]);
+
+type Env = Record<string, string | undefined>;
+
+export interface PlatformA2ALiveSmokeEnv {
+	serviceUrl: string;
+	serviceToken: string;
+	organizationId: string;
+	workspaceId: string;
+	fromAgentId: string;
+	toAgentId: string;
+	skillId?: string;
+	capability?: string;
+	prompt: string;
+	outputDir: string;
+	maxHeartbeatAgeMs: number;
+	observeAttempts: number;
+	observeIntervalMs: number;
+	taskAttempts: number;
+	taskIntervalMs: number;
+	fetchAgentCard: boolean;
+	requireInvalidTokenProbe: boolean;
+	requireTerminalTask: boolean;
+}
+
+export interface PlatformA2ALiveSmokeEvidence {
+	protocolVersion: "evalops.maestro.platform-a2a-live-smoke.v1";
+	eventType: "platform_a2a_delegation_live_smoke";
+	live: true;
+	createdAt: string;
+	workspaceId: string;
+	organizationId: string;
+	platformEndpoint: string;
+	maestro: {
+		gitSha: string;
+		cliPackage: string;
+	};
+	github?: PlatformA2ALiveSmokeGithubEvidence;
+	inputs: {
+		fromAgentId: string;
+		toAgentId: string;
+		skillId?: string;
+		capability?: string;
+		promptHash?: string;
+	};
+	peers: {
+		origin: PlatformA2APeerEvidence;
+		target: PlatformA2APeerEvidence;
+	};
+	delegation: {
+		id: string;
+		status?: string;
+		dispatchStatus?: string;
+		dispatchError?: string;
+		a2aTaskId: string;
+		a2aMessageId?: string;
+		a2aEndpointUrl?: string;
+		a2aSkillId?: string;
+		a2aDispatchedAt?: string;
+		a2aLeaseRenewedAt?: string;
+		rootDelegationId?: string;
+		parentDelegationId?: string;
+		chain?: string[];
+	};
+	graph: {
+		rootDelegationId?: string;
+		total?: number;
+		truncated?: boolean;
+		nodes: PlatformA2AGraphNodeEvidence[];
+		edges: { parentDelegationId?: string; childDelegationId?: string }[];
+	};
+	control?: {
+		mode: string;
+		taskId?: string;
+		state?: string;
+		controlId?: string;
+		queuedForWorker?: boolean;
+		observedAt?: string;
+	};
+	task?: {
+		id?: string;
+		state?: string;
+		terminal: boolean;
+		contextId?: string;
+	};
+	negativeAuthProbe?: {
+		surface: "platform-agent-registry-peer-discovery";
+		rejected: true;
+		errorClass: "unauthorized" | "forbidden";
+		observedAt: string;
+	};
+	redaction: {
+		rawTokensWithheld: true;
+		rawPayloadsWithheld: true;
+	};
+}
+
+export interface PlatformA2ALiveSmokeEvidenceWriteContext {
+	env: Env;
+	now: Date;
+}
+
+export interface PlatformA2ALiveSmokeGithubEvidence {
+	repository?: string;
+	serverUrl?: string;
+	runId?: string;
+	runUrl?: string;
+	sha?: string;
+	ref?: string;
+	headRef?: string;
+	baseRef?: string;
+	eventName?: string;
+	pullRequestNumber?: number;
+	pullRequestUrl?: string;
+}
+
+interface PlatformA2APeerEvidence {
+	agentId: string;
+	status?: string;
+	endpointUrl: string;
+	endpointKind?: string;
+	agentCardUrl?: string;
+	agentCardObservedAt?: string;
+	lastHeartbeatAt?: string;
+	lastHeartbeatAgeMs?: number;
+	activeConfigVersion?: number;
+	capacity?: {
+		current?: number;
+		max?: number;
+		remaining?: number;
+		reservedDelegationCount?: number;
+	};
+}
+
+interface PlatformA2AGraphNodeEvidence {
+	delegationId?: string;
+	depth?: number;
+	childCount?: number;
+	terminal?: boolean;
+	status?: string;
+	a2aTaskId?: string;
+	a2aDispatchStatus?: string;
+	parentDelegationId?: string;
+	rootDelegationId?: string;
+}
+
+export interface PlatformA2ALiveSmokeDependencies {
+	resolveConfig: () => Promise<PlatformServiceConfig | null>;
+	listPeers: typeof listA2APeerCandidatesWithPlatform;
+	delegate: typeof delegateAgentWithPlatform;
+	getGraph: typeof getA2ADelegationGraphWithPlatform;
+	control: typeof controlA2ADelegationTaskWithPlatform;
+	getTask: typeof getA2ATask;
+	discoverAgentCard: typeof discoverA2AAgentCard;
+	gitSha: () => string;
+	writeEvidence: (
+		outputDir: string,
+		evidence: PlatformA2ALiveSmokeEvidence,
+		context: PlatformA2ALiveSmokeEvidenceWriteContext,
+	) => Promise<string>;
+	sleep: (ms: number) => Promise<void>;
+	now: () => Date;
+	log: (message: string) => void;
+}
+
+export interface RunPlatformA2ALiveSmokeOptions {
+	env?: Env;
+	dependencies?: Partial<PlatformA2ALiveSmokeDependencies>;
+}
+
+const defaultDependencies: PlatformA2ALiveSmokeDependencies = {
+	resolveConfig: resolveAgentRegistryServiceConfig,
+	listPeers: listA2APeerCandidatesWithPlatform,
+	delegate: delegateAgentWithPlatform,
+	getGraph: getA2ADelegationGraphWithPlatform,
+	control: controlA2ADelegationTaskWithPlatform,
+	getTask: getA2ATask,
+	discoverAgentCard: discoverA2AAgentCard,
+	gitSha: readGitSha,
+	writeEvidence: writeEvidenceFile,
+	sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+	now: () => new Date(),
+	log: (message) => {
+		console.log(message);
+	},
+};
+
+export function resolvePlatformA2ALiveSmokeEnv(
+	env: Env = process.env,
+): PlatformA2ALiveSmokeEnv {
+	const serviceUrl = firstEnv(env, SERVICE_URL_ENV_VARS);
+	const serviceToken = firstEnv(env, SERVICE_TOKEN_ENV_VARS);
+	const organizationId = firstEnv(env, ORGANIZATION_ENV_VARS);
+	const workspaceId = firstEnv(env, WORKSPACE_ENV_VARS);
+	const fromAgentId = trimString(env.MAESTRO_A2A_LIVE_FROM_AGENT_ID);
+	const toAgentId = trimString(env.MAESTRO_A2A_LIVE_TO_AGENT_ID);
+	const skillId = trimString(env.MAESTRO_A2A_LIVE_SKILL_ID);
+	const capability = trimString(env.MAESTRO_A2A_LIVE_CAPABILITY);
+	const missing: string[] = [];
+	if (!serviceUrl) {
+		missing.push(`${SERVICE_URL_ENV_VARS[0]} or EVALOPS_BASE_URL`);
+	}
+	if (!serviceToken) {
+		missing.push(`${SERVICE_TOKEN_ENV_VARS[0]} or EVALOPS_TOKEN`);
+	}
+	if (!organizationId) {
+		missing.push(`${ORGANIZATION_ENV_VARS[0]} or EVALOPS_ORGANIZATION_ID`);
+	}
+	if (!workspaceId) {
+		missing.push(`${WORKSPACE_ENV_VARS[0]} or EVALOPS_WORKSPACE_ID`);
+	}
+	if (!fromAgentId) {
+		missing.push("MAESTRO_A2A_LIVE_FROM_AGENT_ID");
+	}
+	if (!toAgentId) {
+		missing.push("MAESTRO_A2A_LIVE_TO_AGENT_ID");
+	}
+	if (!skillId && !capability) {
+		missing.push("MAESTRO_A2A_LIVE_SKILL_ID or MAESTRO_A2A_LIVE_CAPABILITY");
+	}
+	if (missing.length > 0) {
+		throw new Error(
+			`Platform A2A live smoke is missing required environment: ${missing.join(", ")}`,
+		);
+	}
+	return {
+		serviceUrl,
+		serviceToken,
+		organizationId,
+		workspaceId,
+		fromAgentId,
+		toAgentId,
+		skillId,
+		capability,
+		prompt:
+			trimString(env.MAESTRO_A2A_LIVE_PROMPT) ??
+			"Platform live A2A smoke: acknowledge delegation, report the current workspace, and return one redaction-safe status artifact.",
+		outputDir:
+			trimString(env.MAESTRO_A2A_LIVE_EVIDENCE_DIR) ??
+			join(process.cwd(), "tmp", "platform-a2a-delegation-live"),
+		maxHeartbeatAgeMs: parsePositiveInt(
+			env.MAESTRO_A2A_LIVE_MAX_HEARTBEAT_AGE_MS,
+			15 * 60 * 1000,
+		),
+		observeAttempts: parsePositiveInt(
+			env.MAESTRO_A2A_LIVE_OBSERVE_ATTEMPTS,
+			6,
+		),
+		observeIntervalMs: parsePositiveInt(
+			env.MAESTRO_A2A_LIVE_OBSERVE_INTERVAL_MS,
+			1_000,
+		),
+		taskAttempts: parsePositiveInt(env.MAESTRO_A2A_LIVE_TASK_ATTEMPTS, 12),
+		taskIntervalMs: parsePositiveInt(
+			env.MAESTRO_A2A_LIVE_TASK_INTERVAL_MS,
+			5_000,
+		),
+		fetchAgentCard: env.MAESTRO_A2A_LIVE_FETCH_AGENT_CARD === "true",
+		requireInvalidTokenProbe:
+			env.MAESTRO_A2A_LIVE_REQUIRE_INVALID_TOKEN_PROBE === "true",
+		requireTerminalTask: env.MAESTRO_A2A_LIVE_REQUIRE_TERMINAL_TASK !== "false",
+	};
+}
+
+export async function runPlatformA2ADelegationLiveSmoke(
+	options: RunPlatformA2ALiveSmokeOptions = {},
+): Promise<{ evidence: PlatformA2ALiveSmokeEvidence; evidencePath: string }> {
+	const rawEnv = options.env ?? process.env;
+	const env = resolvePlatformA2ALiveSmokeEnv(rawEnv);
+	const deps = { ...defaultDependencies, ...options.dependencies };
+	const config = await deps.resolveConfig();
+	const effectiveConfig: PlatformServiceConfig = {
+		...(config ?? {
+			timeoutMs: DEFAULT_PLATFORM_TIMEOUT_MS,
+			maxAttempts: DEFAULT_PLATFORM_MAX_ATTEMPTS,
+		}),
+		baseUrl: env.serviceUrl,
+		token: env.serviceToken,
+		workspaceId: env.workspaceId,
+		organizationId: env.organizationId,
+	};
+	if (
+		!effectiveConfig.baseUrl ||
+		!effectiveConfig.workspaceId ||
+		!effectiveConfig.token
+	) {
+		throw new Error(
+			"Platform A2A live smoke could not resolve a usable Agent Registry service config after env validation",
+		);
+	}
+	const createdAt = deps.now().toISOString();
+	const negativeAuthProbe = env.requireInvalidTokenProbe
+		? await runInvalidTokenProbe(env, effectiveConfig, deps)
+		: undefined;
+	deps.log(
+		`Discovering Platform A2A target peers in workspace ${env.workspaceId} for ${env.skillId ?? env.capability}`,
+	);
+	const targetPeers = await deps.listPeers(
+		{
+			workspaceId: env.workspaceId,
+			skillId: env.skillId,
+			capability: env.capability,
+			limit: 100,
+			requireA2ADispatch: true,
+			eligibleForDelegation: true,
+		},
+		{ config: effectiveConfig },
+	);
+	if (!targetPeers) {
+		throw new Error("Platform A2A live smoke received no peer list from Platform");
+	}
+	const target = requirePeer(targetPeers, env.toAgentId, env, deps.now());
+	let origin = targetPeers.find(
+		(candidate) => candidate.agent.id === env.fromAgentId,
+	);
+	if (!origin) {
+		deps.log(
+			`Discovering Platform A2A origin peer ${env.fromAgentId} without target skill filters`,
+		);
+		const originPeers = await deps.listPeers(
+			{
+				workspaceId: env.workspaceId,
+				limit: 100,
+				requireA2ADispatch: true,
+			},
+			{ config: effectiveConfig },
+		);
+		if (!originPeers) {
+			throw new Error(
+				"Platform A2A live smoke received no origin peer list from Platform",
+			);
+		}
+		origin = requirePeer(originPeers, env.fromAgentId, env, deps.now());
+	} else {
+		origin = requirePeer(targetPeers, env.fromAgentId, env, deps.now());
+	}
+	if (env.fetchAgentCard) {
+		await assertAgentCardFetch(origin, effectiveConfig, deps);
+		await assertAgentCardFetch(target, effectiveConfig, deps);
+	}
+	const delegationResult = await deps.delegate(
+		{
+			workspaceId: env.workspaceId,
+			fromAgentId: env.fromAgentId,
+			toAgentId: env.toAgentId,
+			requiredCapability: env.capability,
+			a2aSkillId: env.skillId,
+			reason: "maestro-platform-a2a-live-smoke",
+			contextPayload: {
+				requestKind: "maestro-peer-delegation-live-smoke",
+				transport: "platform-a2a",
+				source: "scripts/smoke-platform-a2a-delegation-live.ts",
+				requestedAt: createdAt,
+				prompt: env.prompt,
+				fromAgentId: env.fromAgentId,
+				toAgentId: env.toAgentId,
+				workspaceId: env.workspaceId,
+				a2aSkillId: env.skillId,
+				requiredCapability: env.capability,
+				evidenceContract:
+					"delegation-id,a2a-task-id,graph,control,task-state,git-sha",
+			},
+		},
+		{ config: effectiveConfig },
+	);
+	const delegation = requireDelegation(delegationResult);
+	deps.log(`Platform delegation created: ${delegation.id}`);
+	const graph = await observeDelegationGraph(
+		delegation.id,
+		env,
+		effectiveConfig,
+		deps,
+	);
+	const observedDelegation =
+		findDelegationNode(graph, delegation.id)?.delegation ?? delegation;
+	const taskId = trimString(observedDelegation.a2aTaskId ?? delegation.a2aTaskId);
+	if (!taskId) {
+		throw new Error(
+			`Platform delegation ${delegation.id} did not expose a remote A2A task id after ${env.observeAttempts} graph observation attempts`,
+		);
+	}
+	const control = await runControlProbe(
+		delegation.id,
+		taskId,
+		env,
+		effectiveConfig,
+		deps,
+	);
+	const task = await observeRemoteTask(taskId, target, effectiveConfig, env, deps);
+	const taskState = trimString(task.status?.state);
+	const terminal = taskState ? TERMINAL_TASK_STATES.has(taskState) : false;
+	if (env.requireTerminalTask && !terminal) {
+		throw new Error(
+			`Remote A2A task ${taskId} did not reach a terminal state after ${env.taskAttempts} attempts; last state ${taskState ?? "unknown"}`,
+		);
+	}
+	const evidence = buildEvidence({
+		env,
+		config: effectiveConfig,
+		createdAt,
+		origin,
+		target,
+		delegation: observedDelegation,
+		graph,
+		control,
+		task,
+		terminal,
+		gitSha: deps.gitSha(),
+		github: buildGithubEvidence(rawEnv),
+		negativeAuthProbe,
+	});
+	const evidencePath = await deps.writeEvidence(env.outputDir, evidence, {
+		env: rawEnv,
+		now: deps.now(),
+	});
+	deps.log(`Platform A2A live smoke evidence written to ${evidencePath}`);
+	return { evidence, evidencePath };
+}
+
+function firstEnv(
+	env: Env,
+	names: readonly string[],
+): string | undefined {
+	for (const name of names) {
+		const value = trimString(env[name]);
+		if (value) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function requirePeer(
+	peers: PlatformAgentRegistryA2APeerCandidate[],
+	agentId: string,
+	env: PlatformA2ALiveSmokeEnv,
+	now: Date,
+): PlatformAgentRegistryA2APeerCandidate {
+	const peer = peers.find((candidate) => candidate.agent.id === agentId);
+	if (!peer) {
+		throw new Error(
+			`Platform A2A live smoke did not find registered A2A peer ${agentId}`,
+		);
+	}
+	const heartbeatAt = parseTimestamp(peer.agent.lastHeartbeatAt);
+	if (!heartbeatAt) {
+		throw new Error(
+			`Platform A2A peer ${agentId} has no parseable last heartbeat timestamp`,
+		);
+	}
+	const heartbeatAgeMs = Math.max(0, now.getTime() - heartbeatAt.getTime());
+	if (heartbeatAgeMs > env.maxHeartbeatAgeMs) {
+		throw new Error(
+			`Platform A2A peer ${agentId} heartbeat is stale: ${heartbeatAgeMs}ms old`,
+		);
+	}
+	if (!trimString(peer.agent.a2a?.agentCardObservedAt)) {
+		throw new Error(
+			`Platform A2A peer ${agentId} has no Agent Card observation timestamp`,
+		);
+	}
+	return peer;
+}
+
+async function runInvalidTokenProbe(
+	env: PlatformA2ALiveSmokeEnv,
+	config: PlatformServiceConfig,
+	deps: PlatformA2ALiveSmokeDependencies,
+): Promise<NonNullable<PlatformA2ALiveSmokeEvidence["negativeAuthProbe"]>> {
+	const probeConfig = {
+		...config,
+		token: ["maestro", "a2a", "live", "smoke", "rejected", "auth", "probe"].join(
+			"-",
+		),
+	};
+	try {
+		await deps.listPeers(
+			{
+				workspaceId: env.workspaceId,
+				skillId: env.skillId,
+				capability: env.capability,
+				limit: 1,
+				requireA2ADispatch: true,
+				eligibleForDelegation: true,
+			},
+			{ config: probeConfig },
+		);
+	} catch (error) {
+		const errorClass = classifyAuthRejection(error);
+		if (!errorClass) {
+			throw new Error(
+				`Platform A2A invalid-token probe failed, but not with an auth rejection: ${redactErrorMessage(error)}`,
+			);
+		}
+		return {
+			surface: "platform-agent-registry-peer-discovery",
+			rejected: true,
+			errorClass,
+			observedAt: deps.now().toISOString(),
+		};
+	}
+	throw new Error(
+		"Platform A2A invalid-token probe was accepted; refusing to write live proof evidence",
+	);
+}
+
+async function assertAgentCardFetch(
+	peer: PlatformAgentRegistryA2APeerCandidate,
+	config: PlatformServiceConfig,
+	deps: PlatformA2ALiveSmokeDependencies,
+): Promise<A2AAgentCard> {
+	const a2aConfig = buildA2AConfig(peer, config);
+	return await deps.discoverAgentCard(a2aConfig);
+}
+
+function requireDelegation(
+	result: PlatformAgentRegistryDelegateResult | null,
+): NonNullable<PlatformAgentRegistryDelegateResult["delegation"]> {
+	const delegation = result?.delegation;
+	if (!delegation?.id) {
+		throw new Error("Platform did not return a durable delegation id");
+	}
+	return delegation;
+}
+
+async function observeDelegationGraph(
+	delegationId: string,
+	env: PlatformA2ALiveSmokeEnv,
+	config: PlatformServiceConfig,
+	deps: PlatformA2ALiveSmokeDependencies,
+): Promise<PlatformAgentRegistryGetA2ADelegationGraphResult> {
+	let lastGraph: PlatformAgentRegistryGetA2ADelegationGraphResult | null = null;
+	for (let attempt = 1; attempt <= env.observeAttempts; attempt += 1) {
+		try {
+			const graph = await deps.getGraph(
+				{
+					workspaceId: env.workspaceId,
+					delegationId,
+					maxDepth: 8,
+					limit: 100,
+				},
+				{ config },
+			);
+			if (!graph) {
+				throw new Error("Platform returned no A2A delegation graph");
+			}
+			lastGraph = graph;
+			const node = findDelegationNode(graph, delegationId);
+			if (node?.delegation?.a2aTaskId) {
+				return graph;
+			}
+		} catch (error) {
+			throwIfUnsupportedContract(error, "A2A delegation graph");
+			if (attempt >= env.observeAttempts) {
+				throw error;
+			}
+		}
+		if (attempt < env.observeAttempts) {
+			await deps.sleep(env.observeIntervalMs);
+		}
+	}
+	if (lastGraph) {
+		return lastGraph;
+	}
+	throw new Error("Platform returned no A2A delegation graph");
+}
+
+async function runControlProbe(
+	delegationId: string,
+	taskId: string,
+	env: PlatformA2ALiveSmokeEnv,
+	config: PlatformServiceConfig,
+	deps: PlatformA2ALiveSmokeDependencies,
+): Promise<PlatformAgentRegistryControlA2ADelegationTaskResult> {
+	try {
+		const result = await deps.control(
+			{
+				workspaceId: env.workspaceId,
+				delegationId,
+				mode: PlatformA2ADelegationTaskControlModeValue.Collect,
+				message: "Collect current remote Maestro A2A task state for live proof.",
+				idempotencyKey: `maestro-a2a-live-smoke-${delegationId}-${taskId}`,
+				metadata: {
+					source: "scripts/smoke-platform-a2a-delegation-live.ts",
+					proof: "platform-a2a-live-smoke",
+				},
+			},
+			{ config },
+		);
+		if (!result) {
+			throw new Error("Platform returned no A2A task control result");
+		}
+		const controlTaskId = trimString(result.remoteTask?.taskId);
+		if (!controlTaskId) {
+			throw new Error(
+				`Platform A2A task control for delegation ${delegationId} did not return remoteTask.taskId`,
+			);
+		}
+		if (controlTaskId !== taskId) {
+			throw new Error(
+				`Platform A2A task control returned remoteTask.taskId ${controlTaskId} for expected task ${taskId}`,
+			);
+		}
+		return result;
+	} catch (error) {
+		throwIfUnsupportedContract(error, "A2A task control");
+		throw error;
+	}
+}
+
+async function observeRemoteTask(
+	taskId: string,
+	peer: PlatformAgentRegistryA2APeerCandidate,
+	config: PlatformServiceConfig,
+	env: PlatformA2ALiveSmokeEnv,
+	deps: PlatformA2ALiveSmokeDependencies,
+): Promise<A2ATask> {
+	const a2aConfig = buildA2AConfig(peer, config);
+	let lastTask: A2ATask | undefined;
+	let lastError: unknown;
+	for (let attempt = 1; attempt <= env.taskAttempts; attempt += 1) {
+		try {
+			lastTask = await deps.getTask(a2aConfig, taskId);
+			const state = trimString(lastTask.status?.state);
+			if (
+				!env.requireTerminalTask ||
+				(state && TERMINAL_TASK_STATES.has(state))
+			) {
+				return lastTask;
+			}
+		} catch (error) {
+			lastError = error;
+			if (attempt >= env.taskAttempts) {
+				throw error;
+			}
+		}
+		if (attempt < env.taskAttempts) {
+			await deps.sleep(env.taskIntervalMs);
+		}
+	}
+	if (!lastTask) {
+		if (lastError instanceof Error) {
+			throw lastError;
+		}
+		throw new Error(`Remote A2A task ${taskId} could not be fetched`);
+	}
+	return lastTask;
+}
+
+function buildA2AConfig(
+	peer: PlatformAgentRegistryA2APeerCandidate,
+	config: PlatformServiceConfig,
+): A2AServiceConfig {
+	return {
+		baseUrl: peer.endpointUrl,
+		token: config.token,
+		organizationId: config.organizationId,
+		workspaceId: config.workspaceId ?? "",
+		timeoutMs: config.timeoutMs,
+		maxAttempts: config.maxAttempts,
+		agentId: "maestro-platform-a2a-live-smoke",
+	};
+}
+
+function buildEvidence(input: {
+	env: PlatformA2ALiveSmokeEnv;
+	config: PlatformServiceConfig;
+	createdAt: string;
+	origin: PlatformAgentRegistryA2APeerCandidate;
+	target: PlatformAgentRegistryA2APeerCandidate;
+	delegation: NonNullable<PlatformAgentRegistryDelegateResult["delegation"]>;
+	graph: PlatformAgentRegistryGetA2ADelegationGraphResult;
+	control: PlatformAgentRegistryControlA2ADelegationTaskResult;
+	task: A2ATask;
+	terminal: boolean;
+	gitSha: string;
+	github?: PlatformA2ALiveSmokeGithubEvidence;
+	negativeAuthProbe?: PlatformA2ALiveSmokeEvidence["negativeAuthProbe"];
+}): PlatformA2ALiveSmokeEvidence {
+	const remoteTask = input.control.remoteTask;
+	return {
+		protocolVersion: "evalops.maestro.platform-a2a-live-smoke.v1",
+		eventType: "platform_a2a_delegation_live_smoke",
+		live: true,
+		createdAt: input.createdAt,
+		workspaceId: input.env.workspaceId,
+		organizationId: input.env.organizationId,
+		platformEndpoint: input.config.baseUrl,
+		maestro: {
+			gitSha: input.gitSha,
+			cliPackage: getPackageName(),
+		},
+		github: input.github,
+		inputs: {
+			fromAgentId: input.env.fromAgentId,
+			toAgentId: input.env.toAgentId,
+			skillId: input.env.skillId,
+			capability: input.env.capability,
+			promptHash: sha256Hex(input.env.prompt),
+		},
+		peers: {
+			origin: buildPeerEvidence(input.origin, input.createdAt),
+			target: buildPeerEvidence(input.target, input.createdAt),
+		},
+		delegation: {
+			id: input.delegation.id ?? "",
+			status: input.delegation.status,
+			dispatchStatus: input.delegation.a2aDispatchStatus,
+			dispatchError: input.delegation.a2aDispatchError,
+			a2aTaskId: input.delegation.a2aTaskId ?? input.task.id ?? "",
+			a2aMessageId: input.delegation.a2aMessageId,
+			a2aEndpointUrl: input.delegation.a2aEndpointUrl,
+			a2aSkillId: input.delegation.a2aSkillId,
+			a2aDispatchedAt: input.delegation.a2aDispatchedAt,
+			a2aLeaseRenewedAt: input.delegation.a2aLeaseRenewedAt,
+			rootDelegationId: input.delegation.a2aRootDelegationId,
+			parentDelegationId: input.delegation.a2aParentDelegationId,
+			chain: input.delegation.a2aDelegationChain,
+		},
+		graph: {
+			rootDelegationId: input.graph.rootDelegationId,
+			total: input.graph.total,
+			truncated: input.graph.truncated,
+			nodes: input.graph.nodes.map(buildGraphNodeEvidence),
+			edges: input.graph.edges.map((edge) => ({
+				parentDelegationId: edge.parentDelegationId,
+				childDelegationId: edge.childDelegationId,
+			})),
+		},
+		control: {
+			mode:
+				remoteTask?.controlMode ??
+				PlatformA2ADelegationTaskControlModeValue.Collect,
+			taskId: remoteTask?.taskId,
+			state: remoteTask?.state,
+			controlId: remoteTask?.controlId,
+			queuedForWorker: remoteTask?.queuedForWorker,
+			observedAt: remoteTask?.observedAt,
+		},
+		task: {
+			id: input.task.id,
+			state: input.task.status?.state,
+			terminal: input.terminal,
+			contextId: input.task.contextId,
+		},
+		negativeAuthProbe: input.negativeAuthProbe,
+		redaction: {
+			rawTokensWithheld: true,
+			rawPayloadsWithheld: true,
+		},
+	};
+}
+
+function buildGithubEvidence(env: Env): PlatformA2ALiveSmokeGithubEvidence | undefined {
+	const repository = trimString(env.GITHUB_REPOSITORY);
+	const serverUrl = trimString(env.GITHUB_SERVER_URL) ?? "https://github.com";
+	const runId = trimString(env.GITHUB_RUN_ID);
+	const sha = trimString(env.GITHUB_SHA);
+	const ref = trimString(env.GITHUB_REF);
+	const headRef = trimString(env.GITHUB_HEAD_REF);
+	const baseRef = trimString(env.GITHUB_BASE_REF);
+	const eventName = trimString(env.GITHUB_EVENT_NAME);
+	const pullRequestNumber = parsePullRequestNumber(env);
+	if (
+		!repository &&
+		!runId &&
+		!sha &&
+		!ref &&
+		!headRef &&
+		!baseRef &&
+		!eventName &&
+		pullRequestNumber === undefined
+	) {
+		return undefined;
+	}
+	return {
+		repository,
+		serverUrl: repository ? serverUrl : undefined,
+		runId,
+		runUrl: repository && runId ? `${serverUrl}/${repository}/actions/runs/${runId}` : undefined,
+		sha,
+		ref,
+		headRef,
+		baseRef,
+		eventName,
+		pullRequestNumber,
+		pullRequestUrl:
+			repository && pullRequestNumber
+				? `${serverUrl}/${repository}/pull/${pullRequestNumber}`
+				: undefined,
+	};
+}
+
+function parsePullRequestNumber(env: Env): number | undefined {
+	for (const key of [
+		"GITHUB_PR_NUMBER",
+		"PR_NUMBER",
+		"PULL_REQUEST_NUMBER",
+	] as const) {
+		const parsed = parsePositiveInteger(trimString(env[key]));
+		if (parsed !== undefined) {
+			return parsed;
+		}
+	}
+	for (const key of ["GITHUB_REF", "GITHUB_REF_NAME"] as const) {
+		const value = trimString(env[key]);
+		const match =
+			key === "GITHUB_REF"
+				? value?.match(/^refs\/pull\/([1-9]\d*)\/(?:head|merge)$/u)
+				: value?.match(/^([1-9]\d*)\/(?:head|merge)$/u);
+		const parsed = parsePositiveInteger(match?.[1]);
+		if (parsed !== undefined) {
+			return parsed;
+		}
+	}
+	return undefined;
+}
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+	if (!value || !/^[1-9]\d*$/u.test(value)) {
+		return undefined;
+	}
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function buildPeerEvidence(
+	peer: PlatformAgentRegistryA2APeerCandidate,
+	createdAt: string,
+): PlatformA2APeerEvidence {
+	const heartbeatAt = parseTimestamp(peer.agent.lastHeartbeatAt);
+	const observedAt = parseTimestamp(createdAt);
+	return {
+		agentId: peer.agent.id ?? "",
+		status: peer.agent.status,
+		endpointUrl: peer.endpointUrl,
+		endpointKind: peer.endpointKind,
+		agentCardUrl: peer.agentCardUrl,
+		agentCardObservedAt: peer.agent.a2a?.agentCardObservedAt,
+		lastHeartbeatAt: peer.agent.lastHeartbeatAt,
+		lastHeartbeatAgeMs:
+			heartbeatAt && observedAt
+				? Math.max(0, observedAt.getTime() - heartbeatAt.getTime())
+				: undefined,
+		activeConfigVersion: peer.agent.activeConfigVersion,
+		capacity: peer.agent.capacity,
+	};
+}
+
+function buildGraphNodeEvidence(
+	node: PlatformA2ADelegationGraphNode,
+): PlatformA2AGraphNodeEvidence {
+	return {
+		delegationId: node.delegation?.id,
+		depth: node.depth,
+		childCount: node.childCount,
+		terminal: node.terminal,
+		status: node.delegation?.status,
+		a2aTaskId: node.delegation?.a2aTaskId,
+		a2aDispatchStatus: node.delegation?.a2aDispatchStatus,
+		parentDelegationId: node.delegation?.a2aParentDelegationId,
+		rootDelegationId: node.delegation?.a2aRootDelegationId,
+	};
+}
+
+function findDelegationNode(
+	graph: PlatformAgentRegistryGetA2ADelegationGraphResult,
+	delegationId: string,
+): PlatformA2ADelegationGraphNode | undefined {
+	return graph.nodes.find((node) => node.delegation?.id === delegationId);
+}
+
+function parseTimestamp(value: string | undefined): Date | undefined {
+	const trimmed = trimString(value);
+	if (!trimmed) {
+		return undefined;
+	}
+	const date = new Date(trimmed);
+	return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function throwIfUnsupportedContract(error: unknown, surface: string): void {
+	const message = error instanceof Error ? error.message : String(error);
+	if (
+		/\b(404|501|unimplemented|unknown service|unknown method|not found)\b/iu.test(
+			message,
+		)
+	) {
+		throw new Error(
+			`Platform target does not support ${surface} yet; deploy a Platform build with agents.v1 AgentService graph/control support before claiming live A2A proof. Cause: ${message}`,
+		);
+	}
+}
+
+function classifyAuthRejection(
+	error: unknown,
+): "unauthorized" | "forbidden" | undefined {
+	const message = redactErrorMessage(error);
+	if (/\b(401|unauthori[sz]ed|unauthenticated|invalid token)\b/iu.test(message)) {
+		return "unauthorized";
+	}
+	if (/\b(403|forbidden|permission denied|access denied)\b/iu.test(message)) {
+		return "forbidden";
+	}
+	return undefined;
+}
+
+function redactErrorMessage(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.replace(/[A-Za-z0-9_.~+/=-]{20,}/gu, "[redacted]");
+}
+
+function readGitSha(): string {
+	return execFileSync("git", ["rev-parse", "HEAD"], {
+		cwd: process.cwd(),
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	}).trim();
+}
+
+async function writeEvidenceFile(
+	outputDir: string,
+	evidence: PlatformA2ALiveSmokeEvidence,
+	context: PlatformA2ALiveSmokeEvidenceWriteContext,
+): Promise<string> {
+	const runDir = join(outputDir, evidence.createdAt.replace(/[:.]/gu, "-"));
+	await mkdir(runDir, { recursive: true });
+	const evidencePath = join(runDir, "evidence.json");
+	const tempPath = `${evidencePath}.tmp`;
+	const evidenceBytes = `${JSON.stringify(evidence, null, 2)}\n`;
+	const evidenceDigest = sha256Hex(evidenceBytes);
+	await writeFile(tempPath, evidenceBytes);
+	await rename(tempPath, evidencePath);
+	await writeFile(`${evidencePath}.sha256`, `${evidenceDigest}  evidence.json\n`);
+	const signature = await buildEvidenceSignature(
+		evidenceBytes,
+		evidenceDigest,
+		context,
+	);
+	if (signature) {
+		await writeFile(
+			`${evidencePath}.sig.json`,
+			`${JSON.stringify(signature, null, 2)}\n`,
+		);
+	}
+	return evidencePath;
+}
+
+async function buildEvidenceSignature(
+	evidenceBytes: string,
+	evidenceDigest: string,
+	context: PlatformA2ALiveSmokeEvidenceWriteContext,
+): Promise<Record<string, unknown> | undefined> {
+	const signingKeyPem = await resolveSigningPrivateKey(context.env);
+	if (!signingKeyPem) {
+		return undefined;
+	}
+	const privateKey = createPrivateKey(signingKeyPem);
+	if (privateKey.asymmetricKeyType !== "ed25519") {
+		throw new Error(
+			`Platform A2A live evidence signing requires an Ed25519 private key, got ${privateKey.asymmetricKeyType ?? "unknown"}`,
+		);
+	}
+	const signature = signBytes(null, Buffer.from(evidenceBytes), privateKey);
+	return {
+		protocolVersion: EVIDENCE_SIGNATURE_PROTOCOL_VERSION,
+		algorithm: "ed25519",
+		evidenceSha256: evidenceDigest,
+		signature: signature.toString("base64"),
+		keyId: trimString(context.env.MAESTRO_A2A_LIVE_EVIDENCE_SIGNING_KEY_ID),
+		publicKeyFingerprintSha256: fingerprintPublicKey(privateKey),
+		signedAt: context.now.toISOString(),
+	};
+}
+
+async function resolveSigningPrivateKey(env: Env): Promise<string | undefined> {
+	const inlineKey = firstEnv(env, EVIDENCE_SIGNING_KEY_ENV_VARS);
+	if (inlineKey) {
+		return normalizePem(inlineKey);
+	}
+	const keyFile = firstEnv(env, EVIDENCE_SIGNING_KEY_FILE_ENV_VARS);
+	if (!keyFile) {
+		return undefined;
+	}
+	return normalizePem(await readFile(keyFile, "utf8"));
+}
+
+function fingerprintPublicKey(privateKey: KeyObject): string {
+	const publicKey = createPublicKey(privateKey);
+	const publicDer = publicKey.export({ format: "der", type: "spki" });
+	return createHash("sha256").update(publicDer).digest("hex");
+}
+
+function normalizePem(value: string): string {
+	return value.includes("\\n") ? value.replace(/\\n/gu, "\n") : value;
+}
+
+export function sha256Hex(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function isEntrypoint(): boolean {
+	const entrypoint = process.argv[1];
+	return Boolean(entrypoint && import.meta.url === pathToFileURL(entrypoint).href);
+}
+
+if (isEntrypoint()) {
+	runPlatformA2ADelegationLiveSmoke().catch((error: unknown) => {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(message);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/telemetry-report.js
+++ b/scripts/telemetry-report.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { readFile } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, dirname, isAbsolute } from "node:path";
+import { basename, dirname, extname, join, isAbsolute } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
@@ -10,34 +10,114 @@ const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "..");
 
 const jsonOutput = process.argv.includes("--json");
-const argsPath = process.argv.find((arg, index) => index > 1 && arg !== "--json");
+const argsPaths = process.argv
+	.slice(2)
+	.filter((arg) => arg !== "--json" && !arg.startsWith("--"));
 const envPath =
 	process.env.MAESTRO_TELEMETRY_FILE ?? process.env.PLAYWRIGHT_TELEMETRY_FILE;
 
-const logPath = argsPath
-	? isAbsolute(argsPath)
-		? argsPath
-		: join(projectRoot, argsPath)
-	: envPath
-		? envPath
-		: join(homedir(), ".composer", "telemetry.log");
+const defaultLogCandidates = [
+	envPath ? { path: envPath, preserveRelativePath: true } : undefined,
+	{ path: join(homedir(), ".maestro", "telemetry.log") },
+	{ path: join(homedir(), ".composer", "telemetry.log") },
+].filter(Boolean);
 
-if (!existsSync(logPath)) {
-	console.error(`Telemetry log not found at: ${logPath}`);
+function resolveLogPath(input, { preserveRelativePath = false } = {}) {
+	return isAbsolute(input) || preserveRelativePath
+		? input
+		: join(projectRoot, input);
+}
+
+async function expandTelemetrySource(input, options) {
+	const resolved = resolveLogPath(input, options);
+	if (!existsSync(resolved)) {
+		return [];
+	}
+	const info = await stat(resolved);
+	if (!info.isDirectory()) {
+		return [resolved];
+	}
+	const entries = await readdir(resolved, { withFileTypes: true });
+	return entries
+		.filter((entry) => entry.isFile())
+		.map((entry) => join(resolved, entry.name))
+		.filter((entryPath) => [".jsonl", ".log"].includes(extname(entryPath)))
+		.sort();
+}
+
+async function resolveTelemetrySources() {
+	const requestedPaths =
+		argsPaths.length > 0
+			? argsPaths.map((path) => ({ path }))
+			: defaultLogCandidates.slice(0, 1);
+	const sources = [];
+	for (const requestedPath of requestedPaths) {
+		sources.push(
+			...(await expandTelemetrySource(
+				requestedPath.path,
+				requestedPath.preserveRelativePath
+					? { preserveRelativePath: true }
+					: undefined,
+			)),
+		);
+	}
+	if (sources.length > 0 || argsPaths.length > 0 || envPath) {
+		return {
+			requestedPaths: requestedPaths.map((candidate) => candidate.path),
+			sources,
+		};
+	}
+	for (const candidate of defaultLogCandidates.slice(1)) {
+		const candidateSources = await expandTelemetrySource(
+			candidate.path,
+			candidate.preserveRelativePath ? { preserveRelativePath: true } : undefined,
+		);
+		if (candidateSources.length > 0) {
+			return {
+				requestedPaths: [candidate.path],
+				sources: candidateSources,
+			};
+		}
+	}
+	return {
+		requestedPaths: defaultLogCandidates.length
+			? [defaultLogCandidates[0].path]
+			: [join(homedir(), ".maestro", "telemetry.log")],
+		sources: [],
+	};
+}
+
+const { requestedPaths, sources } = await resolveTelemetrySources();
+
+if (sources.length === 0) {
+	console.error(`Telemetry log not found at: ${requestedPaths.join(", ")}`);
 	process.exit(1);
 }
 
-const raw = await readFile(logPath, "utf-8");
-const lines = raw
-	.split("\n")
-	.map((line) => line.trim())
-	.filter(Boolean);
+const sourceContents = await Promise.all(
+	sources.map(async (sourcePath) => ({
+		path: sourcePath,
+		raw: await readFile(sourcePath, "utf-8"),
+	})),
+);
+const lines = sourceContents.flatMap(({ path, raw }) =>
+	raw
+		.split("\n")
+		.map((line, index) => ({ path, lineNumber: index + 1, text: line.trim() }))
+		.filter((line) => line.text.length > 0),
+);
 
 let toolExecutions = 0;
 let toolSuccess = 0;
 let totalDuration = 0;
 let evaluations = 0;
 let evalSuccess = 0;
+let parsedEventCount = 0;
+let malformedLineCount = 0;
+let canonicalTurnCount = 0;
+let canonicalSchedulingSummaryCount = 0;
+let rawToolPhaseSummaryCount = 0;
+let dedupedRawToolPhaseSummaryCount = 0;
 const toolScheduling = {
 	modelToolCallCount: 0,
 	schedulableWaveCount: 0,
@@ -48,22 +128,83 @@ const toolScheduling = {
 	mcpOptInCallCount: 0,
 	cacheHitCount: 0,
 	totalToolWaitMs: 0,
+	modelSingletonTurnCount: 0,
+	modelMultiCallTurnCount: 0,
+	avoidableSingletonCount: 0,
 	topSerializationReasons: [],
+	serializationReasonTiming: [],
+	nextActions: [],
+	hasSchedulingData: false,
+	schedulingCoverageRatio: 0,
+	canonicalSchedulingSummaryCount: 0,
+	rawToolPhaseSummaryCount: 0,
+	dedupedRawToolPhaseSummaryCount: 0,
 };
 const serializationReasons = new Map();
+const serializationReasonTiming = new Map();
 const canonicalToolSchedulingSummaries = [];
 const canonicalTurnIds = new Set();
 const standaloneToolPhaseSummaries = [];
+
+function incrementReasonTiming(reason, waitMs = 0) {
+	if (!reason) return;
+	const current = serializationReasonTiming.get(reason) ?? {
+		reason,
+		count: 0,
+		totalWaitMs: 0,
+	};
+	current.count += 1;
+	current.totalWaitMs += Math.max(0, Number(waitMs) || 0);
+	serializationReasonTiming.set(reason, current);
+}
 
 function addSerializationReason(reason, count = 1) {
 	if (!reason || count <= 0) return;
 	serializationReasons.set(reason, (serializationReasons.get(reason) ?? 0) + count);
 }
 
-function recordToolSchedulingSummary(summary) {
+function decisionOutcome(decision) {
+	if (!decision || typeof decision !== "object") {
+		return undefined;
+	}
+	if (typeof decision.outcome === "string") {
+		return decision.outcome;
+	}
+	if (decision.cacheHit === true) {
+		return "cached";
+	}
+	if (decision.decision === "skipped") {
+		return "skipped";
+	}
+	if (decision.decision === "delayed" || decision.blockedByMutation === true) {
+		return "delayed";
+	}
+	if (decision.decision === "parallelized") {
+		return "parallelized";
+	}
+	if (decision.decision === "serialized" || decision.decision === "scheduled") {
+		return "serialized";
+	}
+	return undefined;
+}
+
+function decisionWaitMs(decision) {
+	return Number(decision?.waitMs ?? decision?.schedulerWaitMs) || 0;
+}
+
+function recordDecisionTiming(decision) {
+	const outcome = decisionOutcome(decision);
+	if (outcome !== "serialized" && outcome !== "delayed") {
+		return;
+	}
+	incrementReasonTiming(decision.reason, decisionWaitMs(decision));
+}
+
+function recordToolSchedulingSummary(summary, decisions = []) {
 	if (!summary || typeof summary !== "object") return;
-	toolScheduling.modelToolCallCount +=
+	const modelToolCallCount =
 		Number(summary.modelToolCallCount ?? summary.modelEmittedToolCallCount) || 0;
+	toolScheduling.modelToolCallCount += modelToolCallCount;
 	toolScheduling.schedulableWaveCount += Number(summary.schedulableWaveCount) || 0;
 	toolScheduling.parallelizedCallCount +=
 		Number(summary.parallelizedCallCount ?? summary.actuallyParallelizedCallCount) ||
@@ -77,6 +218,14 @@ function recordToolSchedulingSummary(summary) {
 	toolScheduling.cacheHitCount += Number(summary.cacheHitCount) || 0;
 	toolScheduling.totalToolWaitMs +=
 		Number(summary.totalToolWaitMs ?? summary.toolWaitTimeMs) || 0;
+	if (modelToolCallCount === 1) {
+		toolScheduling.modelSingletonTurnCount += 1;
+	} else if (modelToolCallCount > 1) {
+		toolScheduling.modelMultiCallTurnCount += 1;
+	}
+	if (summary.batchShapingFeedback?.avoidableSingleton === true) {
+		toolScheduling.avoidableSingletonCount += 1;
+	}
 
 	let usedExplicitReasons = false;
 	if (
@@ -87,6 +236,13 @@ function recordToolSchedulingSummary(summary) {
 		for (const [reason, count] of Object.entries(summary.serializationReasons)) {
 			addSerializationReason(reason, Number(count) || 0);
 		}
+	}
+	if (
+		!summary.batchShapingFeedback &&
+		typeof summary.serializationReasons?.single_read_only_call === "number"
+	) {
+		toolScheduling.avoidableSingletonCount +=
+			Number(summary.serializationReasons.single_read_only_call) || 0;
 	}
 	if (!usedExplicitReasons && Array.isArray(summary.decisions)) {
 		for (const decision of summary.decisions) {
@@ -99,6 +255,11 @@ function recordToolSchedulingSummary(summary) {
 			}
 		}
 	}
+	for (const decision of Array.isArray(summary.decisions)
+		? summary.decisions
+		: decisions) {
+		recordDecisionTiming(decision);
+	}
 }
 
 function eventTurnId(event) {
@@ -108,13 +269,14 @@ function eventTurnId(event) {
 }
 
 function recordCollectedToolSchedulingSummaries() {
-	for (const summary of canonicalToolSchedulingSummaries) {
-		recordToolSchedulingSummary(summary);
+	for (const { summary, decisions } of canonicalToolSchedulingSummaries) {
+		recordToolSchedulingSummary(summary, decisions);
 	}
 
 	for (const event of standaloneToolPhaseSummaries) {
 		const turnId = eventTurnId(event);
 		if (turnId && canonicalTurnIds.has(turnId)) {
+			dedupedRawToolPhaseSummaryCount += 1;
 			continue;
 		}
 		recordToolSchedulingSummary(event);
@@ -123,7 +285,8 @@ function recordCollectedToolSchedulingSummaries() {
 
 for (const line of lines) {
 	try {
-		const event = JSON.parse(line);
+		const event = JSON.parse(line.text);
+		parsedEventCount += 1;
 		if (event.type === "tool-execution") {
 			toolExecutions += 1;
 			if (event.success) {
@@ -136,18 +299,28 @@ for (const line of lines) {
 				evalSuccess += 1;
 			}
 		} else if (event.type === "canonical-turn") {
+			canonicalTurnCount += 1;
 			const turnId = eventTurnId(event);
 			if (event.toolScheduling) {
 				if (turnId) {
 					canonicalTurnIds.add(turnId);
 				}
-				canonicalToolSchedulingSummaries.push(event.toolScheduling);
+				canonicalSchedulingSummaryCount += 1;
+				canonicalToolSchedulingSummaries.push({
+					summary: event.toolScheduling,
+					decisions: Array.isArray(event.tools)
+						? event.tools
+								.map((tool) => tool?.scheduling)
+								.filter((scheduling) => scheduling && typeof scheduling === "object")
+						: [],
+				});
 			}
 		} else if (event.type === "tool_phase_summary") {
+			rawToolPhaseSummaryCount += 1;
 			standaloneToolPhaseSummaries.push(event);
 		}
 	} catch (_error) {
-		// ignore malformed lines
+		malformedLineCount += 1;
 	}
 }
 
@@ -157,12 +330,102 @@ const averageDuration = toolExecutions > 0 ? totalDuration / toolExecutions : 0;
 toolScheduling.topSerializationReasons = [...serializationReasons.entries()]
 	.map(([reason, count]) => ({ reason, count }))
 	.sort((left, right) => right.count - left.count);
+toolScheduling.serializationReasonTiming = [
+	...serializationReasonTiming.values(),
+]
+	.map((entry) => ({
+		reason: entry.reason,
+		count: entry.count,
+		totalWaitMs: Number(entry.totalWaitMs.toFixed(1)),
+		averageWaitMs:
+			entry.count > 0 ? Number((entry.totalWaitMs / entry.count).toFixed(1)) : 0,
+	}))
+	.sort((left, right) => right.totalWaitMs - left.totalWaitMs);
+toolScheduling.hasSchedulingData =
+	canonicalSchedulingSummaryCount + rawToolPhaseSummaryCount > 0;
+toolScheduling.canonicalSchedulingSummaryCount = canonicalSchedulingSummaryCount;
+toolScheduling.rawToolPhaseSummaryCount = rawToolPhaseSummaryCount;
+toolScheduling.dedupedRawToolPhaseSummaryCount = dedupedRawToolPhaseSummaryCount;
+toolScheduling.schedulingCoverageRatio =
+	canonicalTurnCount > 0
+		? Number((canonicalSchedulingSummaryCount / canonicalTurnCount).toFixed(3))
+		: toolScheduling.hasSchedulingData
+			? 1
+			: 0;
+
+function countReason(reason) {
+	return serializationReasons.get(reason) ?? 0;
+}
+
+function buildNextActions() {
+	if (!toolScheduling.hasSchedulingData) {
+		return [
+			{
+				id: "collect_real_tool_phase_telemetry",
+				reason:
+					"No canonical toolScheduling or raw tool_phase_summary events were found.",
+			},
+		];
+	}
+	const actions = [];
+	if (
+		toolScheduling.avoidableSingletonCount > 0 ||
+		countReason("single_read_only_call") > 0
+	) {
+		actions.push({
+			id: "batch_shaping_feedback",
+			reason: `${toolScheduling.avoidableSingletonCount} avoidable singleton read-only calls observed.`,
+		});
+	}
+	if (countReason("mutation_unknown_write_set") > 0) {
+		actions.push({
+			id: "path_scope_inference",
+			reason: `${countReason("mutation_unknown_write_set")} calls blocked by unknown mutation write set.`,
+		});
+	}
+	if (toolScheduling.cacheHitCount === 0 && toolScheduling.modelToolCallCount > 0) {
+		actions.push({
+			id: "adjacent_turn_read_cache",
+			reason:
+				"No tool-result cache hits were observed in turns with tool calls.",
+		});
+	}
+	if (toolScheduling.mcpOptInCallCount > 0) {
+		actions.push({
+			id: "mcp_capability_handshake",
+			reason: `${toolScheduling.mcpOptInCallCount} MCP opt-in calls depended on static parallel-safety config.`,
+		});
+	}
+	if (
+		toolScheduling.totalToolWaitMs > 0 &&
+		toolScheduling.delayedCallCount > 0
+	) {
+		actions.push({
+			id: "rust_cancellation_backpressure_parity",
+			reason: `${toolScheduling.delayedCallCount} delayed calls accumulated ${toolScheduling.totalToolWaitMs}ms of scheduler wait.`,
+		});
+	}
+	return actions;
+}
+
+toolScheduling.nextActions = buildNextActions();
+
+const logPath = sources.length === 1 ? sources[0] : `${sources.length} telemetry logs`;
 
 if (jsonOutput) {
 	console.log(
 		JSON.stringify(
 			{
 				logPath,
+				logPaths: sources,
+				sourceCount: sources.length,
+				lineCount: lines.length,
+				parsedEventCount,
+				malformedLineCount,
+				canonicalTurnCount,
+				canonicalSchedulingSummaryCount,
+				rawToolPhaseSummaryCount,
+				dedupedRawToolPhaseSummaryCount,
 				toolExecutions,
 				toolSuccess,
 				averageDuration,
@@ -179,6 +442,13 @@ if (jsonOutput) {
 
 console.log("Telemetry Summary\n=================");
 console.log(`Log file: ${logPath}`);
+if (sources.length > 1) {
+	console.log(`Source logs: ${sources.map((source) => basename(source)).join(", ")}`);
+}
+console.log(`Parsed events: ${parsedEventCount}`);
+if (malformedLineCount > 0) {
+	console.log(`Malformed lines ignored: ${malformedLineCount}`);
+}
 console.log(`Tool executions: ${toolExecutions}`);
 console.log(
 	`Tool success rate: ${toolExecutions === 0 ? "n/a" : `${((toolSuccess / toolExecutions) * 100).toFixed(1)}%`}`,
@@ -196,9 +466,30 @@ console.log(`Parallelized calls: ${toolScheduling.parallelizedCallCount}`);
 console.log(`Serialized calls: ${toolScheduling.serializedCallCount}`);
 console.log(`Delayed calls: ${toolScheduling.delayedCallCount}`);
 console.log(`Cache hits: ${toolScheduling.cacheHitCount}`);
+console.log(`Total tool wait: ${toolScheduling.totalToolWaitMs} ms`);
+console.log(
+	`Scheduling coverage: ${canonicalSchedulingSummaryCount}/${canonicalTurnCount} canonical turns`,
+);
+console.log(`Model singleton turns: ${toolScheduling.modelSingletonTurnCount}`);
+console.log(`Model multi-call turns: ${toolScheduling.modelMultiCallTurnCount}`);
+console.log(`Avoidable singleton calls: ${toolScheduling.avoidableSingletonCount}`);
 if (toolScheduling.topSerializationReasons.length > 0) {
 	console.log("Top serialization reasons:");
 	for (const entry of toolScheduling.topSerializationReasons.slice(0, 5)) {
 		console.log(`- ${entry.reason}: ${entry.count}`);
+	}
+}
+if (toolScheduling.serializationReasonTiming.length > 0) {
+	console.log("Top serialization wait reasons:");
+	for (const entry of toolScheduling.serializationReasonTiming.slice(0, 5)) {
+		console.log(
+			`- ${entry.reason}: ${entry.totalWaitMs} ms (${entry.count} calls)`,
+		);
+	}
+}
+if (toolScheduling.nextActions.length > 0) {
+	console.log("Suggested next actions:");
+	for (const action of toolScheduling.nextActions.slice(0, 5)) {
+		console.log(`- ${action.id}: ${action.reason}`);
 	}
 }

--- a/scripts/verify-platform-a2a-live-evidence.ts
+++ b/scripts/verify-platform-a2a-live-evidence.ts
@@ -1,0 +1,717 @@
+import { createHash, createPublicKey, verify as verifyBytes } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+type Env = Record<string, string | undefined>;
+type GithubApiClient = (
+	path: string,
+	env: Env,
+	serverUrl: string | undefined,
+) => Promise<unknown>;
+
+interface VerifiedGithubEvidence {
+	repository?: string;
+	serverUrl?: string;
+	runId?: string;
+	pullRequestNumber?: number;
+	sha?: string;
+}
+
+interface PlatformA2ALiveEvidenceVerification {
+	path: string;
+	evidenceSha256: string;
+	protocolVersion: string;
+	gitSha: string;
+	githubRunId?: string;
+	githubPullRequestNumber?: number;
+	githubDereferenced?: true;
+	negativeAuthProbe?: {
+		surface: "platform-agent-registry-peer-discovery";
+		errorClass: "unauthorized" | "forbidden";
+		rejected: true;
+	};
+	signature?: {
+		algorithm: "ed25519";
+		keyId?: string;
+		publicKeyFingerprintSha256: string;
+		signaturePath: string;
+		verified: true;
+	};
+	delegationId: string;
+	a2aTaskId: string;
+}
+
+export interface PlatformA2ALiveEvidenceVerificationOptions {
+	requireSignature?: boolean;
+	requireDereferenceableGithub?: boolean;
+	requireNegativeAuthProbe?: boolean;
+	publicKeyPem?: string;
+	publicKeyPath?: string;
+	env?: Env;
+	githubApiClient?: GithubApiClient;
+}
+
+const PROTOCOL_VERSION = "evalops.maestro.platform-a2a-live-smoke.v1";
+const SIGNATURE_PROTOCOL_VERSION =
+	"evalops.maestro.platform-a2a-live-evidence-signature.v1";
+
+const VERIFICATION_KEY_ENV_VARS = [
+	"MAESTRO_A2A_LIVE_EVIDENCE_VERIFY_PUBLIC_KEY",
+	"MAESTRO_A2A_LIVE_EVIDENCE_PUBLIC_KEY",
+] as const;
+
+const VERIFICATION_KEY_FILE_ENV_VARS = [
+	"MAESTRO_A2A_LIVE_EVIDENCE_VERIFY_PUBLIC_KEY_FILE",
+	"MAESTRO_A2A_LIVE_EVIDENCE_PUBLIC_KEY_FILE",
+] as const;
+
+export async function verifyPlatformA2ALiveEvidenceFile(
+	evidencePath: string,
+	options: PlatformA2ALiveEvidenceVerificationOptions = {},
+): Promise<PlatformA2ALiveEvidenceVerification> {
+	const evidenceBytes = await readFile(evidencePath, "utf8");
+	const sidecar = await readFile(`${evidencePath}.sha256`, "utf8");
+	const expectedDigest = parseSidecarDigest(sidecar);
+	const actualDigest = sha256Hex(evidenceBytes);
+	if (actualDigest !== expectedDigest) {
+		throw new Error(
+			`Platform A2A evidence digest mismatch for ${evidencePath}: expected ${expectedDigest}, got ${actualDigest}`,
+		);
+	}
+	const evidence = JSON.parse(evidenceBytes) as unknown;
+	const record = requireRecord(evidence, "evidence");
+	const signature = await verifyDetachedSignature(
+		evidencePath,
+		evidenceBytes,
+		actualDigest,
+		options,
+	);
+	const protocolVersion = requireString(record, "protocolVersion");
+	if (protocolVersion !== PROTOCOL_VERSION) {
+		throw new Error(
+			`unexpected Platform A2A evidence protocol ${protocolVersion}`,
+		);
+	}
+	if (record.live !== true) {
+		throw new Error("Platform A2A evidence is not marked live");
+	}
+	const maestro = requireRecord(record.maestro, "maestro");
+	const gitSha = requireString(maestro, "gitSha");
+	assertRealishGitSha(gitSha);
+	assertNoSyntheticProofId(record);
+	const github = verifyGithubEvidence(record.github);
+	const githubDereferenced = await verifyDereferenceableGithubEvidence(
+		github,
+		options,
+	);
+	const delegation = requireRecord(record.delegation, "delegation");
+	const delegationId = requireString(delegation, "id");
+	const a2aTaskId = requireString(delegation, "a2aTaskId");
+	const inputs = requireRecord(record.inputs, "inputs");
+	const fromAgentId = requireString(inputs, "fromAgentId");
+	const toAgentId = requireString(inputs, "toAgentId");
+	const peers = requireRecord(record.peers, "peers");
+	const origin = requireRecord(peers.origin, "peers.origin");
+	const target = requireRecord(peers.target, "peers.target");
+	const originAgentId = requireString(origin, "agentId");
+	const targetAgentId = requireString(target, "agentId");
+	if (fromAgentId !== originAgentId) {
+		throw new Error(
+			`Platform A2A evidence inputs.fromAgentId ${fromAgentId} does not match peers.origin.agentId ${originAgentId}`,
+		);
+	}
+	if (toAgentId !== targetAgentId) {
+		throw new Error(
+			`Platform A2A evidence inputs.toAgentId ${toAgentId} does not match peers.target.agentId ${targetAgentId}`,
+		);
+	}
+	const graph = requireRecord(record.graph, "graph");
+	const nodes = graph.nodes;
+	if (!Array.isArray(nodes) || nodes.length < 1) {
+		throw new Error("Platform A2A evidence graph has no nodes");
+	}
+	const graphIncludesDelegation = nodes.some((nodeValue, index) => {
+		const node = requireRecord(nodeValue, `graph.nodes[${index}]`);
+		return optionalString(node, "delegationId") === delegationId;
+	});
+	if (!graphIncludesDelegation) {
+		throw new Error(
+			`Platform A2A evidence graph does not include delegation.id ${delegationId}`,
+		);
+	}
+	const control = requireRecord(record.control, "control");
+	requireString(control, "mode");
+	const task = requireRecord(record.task, "task");
+	const taskId = requireString(task, "id");
+	if (taskId !== a2aTaskId) {
+		throw new Error(
+			`Platform A2A evidence delegation.a2aTaskId ${a2aTaskId} does not match task.id ${taskId}`,
+		);
+	}
+	const controlTaskId = requireString(control, "taskId");
+	if (controlTaskId !== taskId) {
+		throw new Error(
+			`Platform A2A evidence control.taskId ${controlTaskId} does not match task.id ${taskId}`,
+		);
+	}
+	const negativeAuthProbe = verifyNegativeAuthProbe(
+		record.negativeAuthProbe,
+		options,
+	);
+	return {
+		path: evidencePath,
+		evidenceSha256: actualDigest,
+		protocolVersion,
+		gitSha,
+		githubRunId: github?.runId,
+		githubPullRequestNumber: github?.pullRequestNumber,
+		githubDereferenced,
+		negativeAuthProbe,
+		signature,
+		delegationId,
+		a2aTaskId,
+	};
+}
+
+function verifyNegativeAuthProbe(
+	value: unknown,
+	options: PlatformA2ALiveEvidenceVerificationOptions,
+): PlatformA2ALiveEvidenceVerification["negativeAuthProbe"] | undefined {
+	if (value === undefined || value === null) {
+		if (options.requireNegativeAuthProbe) {
+			throw new Error(
+				"Platform A2A evidence requires invalid-token rejection evidence",
+			);
+		}
+		return undefined;
+	}
+	const probe = requireRecord(value, "negativeAuthProbe");
+	const surface = requireString(probe, "surface");
+	if (surface !== "platform-agent-registry-peer-discovery") {
+		throw new Error(
+			`Platform A2A evidence invalid-token probe has unsupported surface: ${surface}`,
+		);
+	}
+	if (probe.rejected !== true) {
+		throw new Error(
+			"Platform A2A evidence invalid-token probe is not marked rejected",
+		);
+	}
+	const errorClass = requireString(probe, "errorClass");
+	if (errorClass !== "unauthorized" && errorClass !== "forbidden") {
+		throw new Error(
+			`Platform A2A evidence invalid-token probe has unsupported error class: ${errorClass}`,
+		);
+	}
+	requireString(probe, "observedAt");
+	return {
+		surface,
+		errorClass,
+		rejected: true,
+	};
+}
+
+async function verifyDetachedSignature(
+	evidencePath: string,
+	evidenceBytes: string,
+	evidenceDigest: string,
+	options: PlatformA2ALiveEvidenceVerificationOptions,
+): Promise<PlatformA2ALiveEvidenceVerification["signature"] | undefined> {
+	const signaturePath = `${evidencePath}.sig.json`;
+	const signatureBytes = await readOptionalFile(signaturePath);
+	if (!signatureBytes) {
+		if (options.requireSignature) {
+			throw new Error(
+				`Platform A2A evidence requires a detached signature sidecar: ${signaturePath}`,
+			);
+		}
+		return undefined;
+	}
+	const publicKeyPem = await resolveVerificationPublicKey(options);
+	if (!publicKeyPem) {
+		if (options.requireSignature) {
+			throw new Error(
+				"Platform A2A evidence signature verification requires a trusted public key",
+			);
+		}
+		return undefined;
+	}
+	const signature = requireRecord(
+		JSON.parse(signatureBytes) as unknown,
+		"signature",
+	);
+	const protocolVersion = requireString(signature, "protocolVersion");
+	if (protocolVersion !== SIGNATURE_PROTOCOL_VERSION) {
+		throw new Error(
+			`unexpected Platform A2A evidence signature protocol ${protocolVersion}`,
+		);
+	}
+	const algorithm = requireString(signature, "algorithm");
+	if (algorithm !== "ed25519") {
+		throw new Error(
+			`Platform A2A evidence signature algorithm is not supported: ${algorithm}`,
+		);
+	}
+	const signedDigest = requireString(signature, "evidenceSha256");
+	if (signedDigest !== evidenceDigest) {
+		throw new Error(
+			`Platform A2A evidence signature digest mismatch: expected ${evidenceDigest}, got ${signedDigest}`,
+		);
+	}
+	const publicKey = createPublicKey(normalizePem(publicKeyPem));
+	if (publicKey.asymmetricKeyType !== "ed25519") {
+		throw new Error(
+			`Platform A2A evidence verification requires an Ed25519 public key, got ${publicKey.asymmetricKeyType ?? "unknown"}`,
+		);
+	}
+	const expectedFingerprint = fingerprintPublicKeyPem(publicKeyPem);
+	const signedFingerprint = requireString(
+		signature,
+		"publicKeyFingerprintSha256",
+	);
+	if (signedFingerprint !== expectedFingerprint) {
+		throw new Error(
+			`Platform A2A evidence signature key fingerprint mismatch: expected ${expectedFingerprint}, got ${signedFingerprint}`,
+		);
+	}
+	const signatureValue = requireString(signature, "signature");
+	const ok = verifyBytes(
+		null,
+		Buffer.from(evidenceBytes),
+		publicKey,
+		Buffer.from(signatureValue, "base64"),
+	);
+	if (!ok) {
+		throw new Error("Platform A2A evidence detached signature is invalid");
+	}
+	return {
+		algorithm: "ed25519",
+		keyId: optionalString(signature, "keyId"),
+		publicKeyFingerprintSha256: expectedFingerprint,
+		signaturePath,
+		verified: true,
+	};
+}
+
+async function readOptionalFile(path: string): Promise<string | undefined> {
+	try {
+		return await readFile(path, "utf8");
+	} catch (error) {
+		if (
+			error &&
+			typeof error === "object" &&
+			"code" in error &&
+			error.code === "ENOENT"
+		) {
+			return undefined;
+		}
+		throw error;
+	}
+}
+
+async function resolveVerificationPublicKey(
+	options: PlatformA2ALiveEvidenceVerificationOptions,
+): Promise<string | undefined> {
+	if (options.publicKeyPem) {
+		return normalizePem(options.publicKeyPem);
+	}
+	if (options.publicKeyPath) {
+		return normalizePem(await readFile(options.publicKeyPath, "utf8"));
+	}
+	const env = options.env ?? process.env;
+	const inlineKey = firstEnv(env, VERIFICATION_KEY_ENV_VARS);
+	if (inlineKey) {
+		return normalizePem(inlineKey);
+	}
+	const keyFile = firstEnv(env, VERIFICATION_KEY_FILE_ENV_VARS);
+	if (keyFile) {
+		return normalizePem(await readFile(keyFile, "utf8"));
+	}
+	return undefined;
+}
+
+function firstEnv(env: Env, names: readonly string[]): string | undefined {
+	for (const name of names) {
+		const value = env[name]?.trim();
+		if (value) {
+			return value;
+		}
+	}
+	return undefined;
+}
+
+function parseSidecarDigest(sidecar: string): string {
+	const digest = sidecar.trim().split(/\s+/u)[0];
+	if (!digest || !/^[a-f0-9]{64}$/u.test(digest)) {
+		throw new Error("Platform A2A evidence sidecar does not contain a SHA-256 digest");
+	}
+	return digest;
+}
+
+function requireRecord(value: unknown, name: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`Platform A2A evidence field ${name} is not an object`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function requireString(record: Record<string, unknown>, key: string): string {
+	const value = record[key];
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new Error(`Platform A2A evidence field ${key} is missing`);
+	}
+	return value.trim();
+}
+
+function optionalString(
+	record: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	const value = record[key];
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new Error(`Platform A2A evidence field ${key} must be a string`);
+	}
+	return value.trim();
+}
+
+function verifyGithubEvidence(
+	value: unknown,
+): VerifiedGithubEvidence | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	const github = requireRecord(value, "github");
+	const repository = optionalString(github, "repository");
+	if (repository && !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository)) {
+		throw new Error(
+			`Platform A2A evidence GitHub repository is not owner/repo: ${repository}`,
+		);
+	}
+	const sha = optionalString(github, "sha");
+	if (sha) {
+		assertRealishGitSha(sha);
+	}
+	const runId =
+		integerStringField(github, "runId") ??
+		integerStringField(github, "actionsRunId") ??
+		integerStringField(github, "ghaRunId");
+	const runUrl = optionalString(github, "runUrl");
+	if (runUrl && !/\/actions\/runs\/[1-9]\d*(?:$|[/?#])/u.test(runUrl)) {
+		throw new Error(
+			`Platform A2A evidence GitHub run URL is not dereferenceable: ${runUrl}`,
+		);
+	}
+	const pullRequestNumber =
+		positiveIntegerField(github, "pullRequestNumber") ??
+		positiveIntegerField(github, "prNumber") ??
+		pullRequestIdentifier(github, "pullRequest") ??
+		pullRequestIdentifier(github, "pullRequestRef") ??
+		pullRequestIdentifier(github, "pr");
+	const pullRequestUrl = optionalString(github, "pullRequestUrl");
+	if (pullRequestUrl && !/\/pull\/[1-9]\d*(?:$|[/?#])/u.test(pullRequestUrl)) {
+		throw new Error(
+			`Platform A2A evidence GitHub PR URL is not dereferenceable: ${pullRequestUrl}`,
+		);
+	}
+	const serverUrl = githubServerUrl(
+		optionalString(github, "serverUrl") ??
+			githubServerUrlFromWebUrl(runUrl) ??
+			githubServerUrlFromWebUrl(pullRequestUrl),
+	);
+	return { repository, serverUrl, runId, pullRequestNumber, sha };
+}
+
+async function verifyDereferenceableGithubEvidence(
+	github: VerifiedGithubEvidence | undefined,
+	options: PlatformA2ALiveEvidenceVerificationOptions,
+): Promise<true | undefined> {
+	if (!options.requireDereferenceableGithub) {
+		return undefined;
+	}
+	if (!github?.repository) {
+		throw new Error(
+			"Platform A2A evidence requires dereferenceable GitHub metadata but has no repository",
+		);
+	}
+	if (!github.runId) {
+		throw new Error(
+			"Platform A2A evidence requires dereferenceable GitHub metadata but has no Actions run id",
+		);
+	}
+	const env = options.env ?? process.env;
+	const apiClient = options.githubApiClient ?? defaultGithubApiClient;
+	const run = requireRecord(
+		await apiClient(
+			`/repos/${github.repository}/actions/runs/${github.runId}`,
+			env,
+			github.serverUrl,
+		),
+		"github.actionsRun",
+	);
+	const actualRunId = integerishRecordField(run, "id");
+	if (actualRunId !== github.runId) {
+		throw new Error(
+			`Platform A2A evidence GitHub run id mismatch: expected ${github.runId}, got ${actualRunId}`,
+		);
+	}
+	if (github.pullRequestNumber !== undefined) {
+		const pullRequest = requireRecord(
+			await apiClient(
+				`/repos/${github.repository}/pulls/${github.pullRequestNumber}`,
+				env,
+				github.serverUrl,
+			),
+			"github.pullRequest",
+		);
+		const actualPullRequestNumber = integerishRecordField(pullRequest, "number");
+		if (actualPullRequestNumber !== String(github.pullRequestNumber)) {
+			throw new Error(
+				`Platform A2A evidence GitHub PR number mismatch: expected ${github.pullRequestNumber}, got ${actualPullRequestNumber}`,
+			);
+		}
+	}
+	return true;
+}
+
+function githubServerUrl(value: string | undefined): string | undefined {
+	if (!value) {
+		return undefined;
+	}
+	try {
+		const url = new URL(value);
+		if (url.protocol !== "https:" && url.protocol !== "http:") {
+			throw new Error("unsupported protocol");
+		}
+		url.hash = "";
+		url.search = "";
+		url.pathname = url.pathname.replace(/\/+$/u, "");
+		return `${url.origin}${url.pathname}`;
+	} catch (error) {
+		throw new Error(
+			`Platform A2A evidence GitHub server URL is invalid: ${value}`,
+			{ cause: error },
+		);
+	}
+}
+
+function githubServerUrlFromWebUrl(value: string | undefined): string | undefined {
+	if (!value) {
+		return undefined;
+	}
+	try {
+		const url = new URL(value);
+		if (url.protocol !== "https:" && url.protocol !== "http:") {
+			return undefined;
+		}
+		return `${url.protocol}//${url.host}`;
+	} catch {
+		return undefined;
+	}
+}
+
+function githubRestApiBaseUrl(serverUrl: string | undefined): string {
+	const normalizedServerUrl = githubServerUrl(serverUrl) ?? "https://github.com";
+	if (normalizedServerUrl === "https://github.com") {
+		return "https://api.github.com";
+	}
+	return `${new URL(normalizedServerUrl).origin}/api/v3`;
+}
+
+async function defaultGithubApiClient(
+	path: string,
+	env: Env,
+	serverUrl: string | undefined,
+): Promise<unknown> {
+	const token = firstEnv(env, ["GITHUB_TOKEN", "GH_TOKEN"]);
+	const response = await fetch(`${githubRestApiBaseUrl(serverUrl)}${path}`, {
+		headers: {
+			Accept: "application/vnd.github+json",
+			"X-GitHub-Api-Version": "2022-11-28",
+			...(token ? { Authorization: `Bearer ${token}` } : {}),
+		},
+	});
+	if (!response.ok) {
+		const body = await response.text();
+		throw new Error(
+			`Platform A2A evidence GitHub dereference failed for ${path}: HTTP ${response.status} ${body.slice(0, 200)}`,
+		);
+	}
+	return await response.json();
+}
+
+function integerishRecordField(
+	record: Record<string, unknown>,
+	key: string,
+): string {
+	const value = record[key];
+	if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
+		return String(value);
+	}
+	if (typeof value === "string" && /^[1-9]\d*$/u.test(value.trim())) {
+		return value.trim();
+	}
+	throw new Error(`Platform A2A evidence GitHub API field ${key} is not an id`);
+}
+
+function integerStringField(
+	record: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	const value = record[key];
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
+		return String(value);
+	}
+	if (typeof value === "string" && /^[1-9]\d*$/u.test(value.trim())) {
+		return value.trim();
+	}
+	throw new Error(
+		`Platform A2A evidence GitHub ${key} must be a positive integer id`,
+	);
+}
+
+function positiveIntegerField(
+	record: Record<string, unknown>,
+	key: string,
+): number | undefined {
+	const value = record[key];
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
+		return value;
+	}
+	if (typeof value === "string" && /^[1-9]\d*$/u.test(value.trim())) {
+		return Number(value.trim());
+	}
+	throw new Error(
+		`Platform A2A evidence GitHub ${key} must be a positive integer`,
+	);
+}
+
+function pullRequestIdentifier(
+	record: Record<string, unknown>,
+	key: string,
+): number | undefined {
+	const value = record[key];
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
+		return value;
+	}
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		const numeric = trimmed.match(/^#?([1-9]\d*)$/u);
+		if (numeric?.[1]) {
+			return Number(numeric[1]);
+		}
+		const url = trimmed.match(/\/pull\/([1-9]\d*)(?:$|[/?#])/u);
+		if (url?.[1]) {
+			return Number(url[1]);
+		}
+	}
+	throw new Error(
+		`Platform A2A evidence GitHub ${key} must be an integer PR number or /pull/<number> URL`,
+	);
+}
+
+function assertRealishGitSha(gitSha: string): void {
+	if (!/^[a-f0-9]{40}$/u.test(gitSha)) {
+		throw new Error(`Platform A2A evidence git SHA is not a 40-hex SHA: ${gitSha}`);
+	}
+	if (/c0de5afe/u.test(gitSha) || /0{12,}$/u.test(gitSha)) {
+		throw new Error(`Platform A2A evidence git SHA looks synthetic: ${gitSha}`);
+	}
+}
+
+function assertNoSyntheticProofId(record: Record<string, unknown>): void {
+	for (const [key, value] of [
+		["proofId", record.proofId],
+		["evidenceId", record.evidenceId],
+	] as const) {
+		if (typeof value === "string" && looksLocalProofId(value)) {
+			throw new Error(
+				`Platform A2A evidence ${key} looks like a local synthetic proof id: ${value}`,
+			);
+		}
+	}
+	if (record.proof !== undefined) {
+		const proof = requireRecord(record.proof, "proof");
+		const id = optionalString(proof, "id");
+		if (id && looksLocalProofId(id)) {
+			throw new Error(
+				`Platform A2A evidence proof.id looks like a local synthetic proof id: ${id}`,
+			);
+		}
+	}
+}
+
+function looksLocalProofId(value: string): boolean {
+	return /(^|[-_])(local|fixture|replay)([-_]|$)/iu.test(value);
+}
+
+function sha256Hex(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function fingerprintPublicKeyPem(publicKeyPem: string): string {
+	const publicKey = createPublicKey(normalizePem(publicKeyPem));
+	const publicDer = publicKey.export({ format: "der", type: "spki" });
+	return createHash("sha256").update(publicDer).digest("hex");
+}
+
+function normalizePem(value: string): string {
+	return value.includes("\\n") ? value.replace(/\\n/gu, "\n") : value;
+}
+
+function booleanEnv(value: string | undefined): boolean {
+	return value === "1" || value === "true";
+}
+
+function isEntrypoint(): boolean {
+	const entrypoint = process.argv[1];
+	return Boolean(entrypoint && import.meta.url === pathToFileURL(entrypoint).href);
+}
+
+if (isEntrypoint()) {
+	const args = process.argv.slice(2);
+	const evidencePath =
+		args.find((arg) => !arg.startsWith("--"))?.trim() ||
+		process.env.MAESTRO_A2A_LIVE_EVIDENCE_PATH?.trim();
+	if (!evidencePath) {
+		console.error(
+			"Usage: tsx scripts/verify-platform-a2a-live-evidence.ts <evidence.json> [--require-signature] [--require-github-dereference] [--require-negative-auth-probe]",
+		);
+		process.exitCode = 2;
+	} else {
+		verifyPlatformA2ALiveEvidenceFile(evidencePath, {
+			requireDereferenceableGithub:
+				args.includes("--require-github-dereference") ||
+				booleanEnv(
+					process.env.MAESTRO_A2A_LIVE_EVIDENCE_REQUIRE_GITHUB_DEREFERENCE,
+				),
+			requireNegativeAuthProbe:
+				args.includes("--require-negative-auth-probe") ||
+				booleanEnv(
+					process.env.MAESTRO_A2A_LIVE_EVIDENCE_REQUIRE_NEGATIVE_AUTH_PROBE,
+				),
+			requireSignature:
+				args.includes("--require-signature") ||
+				booleanEnv(process.env.MAESTRO_A2A_LIVE_EVIDENCE_REQUIRE_SIGNATURE),
+		})
+			.then((result) => {
+				console.log(JSON.stringify(result, null, 2));
+			})
+			.catch((error: unknown) => {
+				const message = error instanceof Error ? error.message : String(error);
+				console.error(message);
+				process.exitCode = 1;
+			});
+	}
+}

--- a/src/agent/transport.ts
+++ b/src/agent/transport.ts
@@ -45,6 +45,10 @@
  * @module agent/transport
  */
 
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
 import { isContextFirewallBlockingEnabled } from "../config/env-vars.js";
 import { type ToolHookService, createToolHookService } from "../hooks/index.js";
 import { getProviderNetworkConfig } from "../providers/network-config.js";
@@ -141,18 +145,302 @@ type ReusableToolResultCacheGeneration = {
 	value: number;
 };
 
+function hashReusableToolResultSnapshot(value: string | Buffer): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function readGitSnapshotBuffer(cwd: string, args: string[]): Buffer {
+	return execFileSync("git", args, {
+		cwd,
+		stdio: ["ignore", "pipe", "ignore"],
+		timeout: 1_000,
+	});
+}
+
+function readGitSnapshotPart(cwd: string, args: string[]): string {
+	return readGitSnapshotBuffer(cwd, args).toString("utf8").trim();
+}
+
+function hashGitSnapshotPart(cwd: string, args: string[]): string {
+	return hashReusableToolResultSnapshot(readGitSnapshotBuffer(cwd, args));
+}
+
+function hashUntrackedGitFiles(root: string): string {
+	const files = readGitSnapshotBuffer(root, [
+		"ls-files",
+		"--others",
+		"--exclude-standard",
+		"-z",
+	])
+		.toString("utf8")
+		.split("\0")
+		.filter(Boolean)
+		.sort();
+	const hash = createHash("sha256");
+	for (const file of files) {
+		hash.update(file);
+		hash.update("\0");
+		hash.update(readFileSync(resolvePath(root, file)));
+		hash.update("\0");
+	}
+	return hash.digest("hex");
+}
+
+function hasDirtyGitSubmodules(root: string): boolean {
+	try {
+		return (
+			readGitSnapshotPart(root, [
+				"submodule",
+				"foreach",
+				"--recursive",
+				"--quiet",
+				"git status --porcelain=v1 --untracked-files=all",
+			]).length > 0
+		);
+	} catch {
+		return true;
+	}
+}
+
+function computeReusableToolResultSnapshot(cwd: string): string | undefined {
+	try {
+		const root = readGitSnapshotPart(cwd, ["rev-parse", "--show-toplevel"]);
+		const head = readGitSnapshotPart(cwd, ["rev-parse", "--verify", "HEAD"]);
+		const status = readGitSnapshotPart(root, [
+			"status",
+			"--porcelain=v1",
+			"--untracked-files=all",
+		]);
+		if (hasDirtyGitSubmodules(root)) {
+			return undefined;
+		}
+		const unstagedDiff = hashGitSnapshotPart(root, [
+			"diff",
+			"--no-ext-diff",
+			"--binary",
+		]);
+		const stagedDiff = hashGitSnapshotPart(root, [
+			"diff",
+			"--cached",
+			"--no-ext-diff",
+			"--binary",
+		]);
+		const untracked = hashUntrackedGitFiles(root);
+		return `git:${hashReusableToolResultSnapshot(
+			`${root}\n${head}\n${status}\n${unstagedDiff}\n${stagedDiff}\n${untracked}`,
+		)}`;
+	} catch {
+		return undefined;
+	}
+}
+
+const GIT_SNAPSHOT_REUSABLE_TOOL_NAMES = new Set([
+	"read",
+	"ls",
+	"list",
+	"glob",
+	"find",
+	"grep",
+	"search",
+	"parallel_ripgrep",
+	"diff",
+	"status",
+]);
+
+const REPO_PATH_ARGUMENTS_BY_TOOL = new Map<string, string[]>([
+	["read", ["path", "file_path"]],
+	["ls", ["path", "dir", "directory"]],
+	["list", ["path", "dir", "directory"]],
+	["glob", ["path", "cwd", "root", "glob"]],
+	["find", ["path", "cwd", "root", "glob"]],
+	["grep", ["path", "paths", "glob"]],
+	["search", ["path", "paths", "glob"]],
+	["parallel_ripgrep", ["path", "paths", "glob"]],
+	["diff", ["path", "paths", "cwd"]],
+	["status", ["path", "paths", "cwd"]],
+]);
+
+const REQUIRED_REPO_PATH_ARGUMENT_TOOLS = new Set(["read", "ls", "list"]);
+
+function collectStringValues(value: unknown): string[] {
+	if (typeof value === "string") {
+		return [value];
+	}
+	if (Array.isArray(value)) {
+		return value.flatMap((item) => collectStringValues(item));
+	}
+	return [];
+}
+
+function isRepoRelativePathArgument(value: string): boolean {
+	const trimmed = value.trim();
+	if (trimmed.length === 0) {
+		return false;
+	}
+	if (
+		trimmed.startsWith("/") ||
+		trimmed.startsWith("~") ||
+		trimmed.startsWith("\\\\") ||
+		/^[A-Za-z]:[\\/]/.test(trimmed)
+	) {
+		return false;
+	}
+	return !trimmed.split(/[\\/]+/).includes("..");
+}
+
+function isGitIgnoredRepoPath(cwd: string, repoPath: string): boolean {
+	try {
+		readGitSnapshotPart(cwd, ["check-ignore", "--quiet", "--", repoPath]);
+		return true;
+	} catch (error) {
+		if (
+			typeof error === "object" &&
+			error !== null &&
+			"status" in error &&
+			error.status === 1
+		) {
+			return false;
+		}
+		return true;
+	}
+}
+
+function isStatusCallIncludingIgnored(toolCall: ToolCall): boolean {
+	if (toolCall.name.toLowerCase() !== "status") {
+		return false;
+	}
+	const args = toolCall.arguments;
+	if (!args || typeof args !== "object" || Array.isArray(args)) {
+		return false;
+	}
+	const record = args as Record<string, unknown>;
+	return record.includeIgnored === true || record.include_ignored === true;
+}
+
+function hasRepoScopedReusableArguments(
+	toolCall: ToolCall,
+	cwd: string,
+): boolean {
+	const toolName = toolCall.name.toLowerCase();
+	if (isStatusCallIncludingIgnored(toolCall)) {
+		return false;
+	}
+	const argumentNames = REPO_PATH_ARGUMENTS_BY_TOOL.get(toolName) ?? [];
+	if (argumentNames.length === 0) {
+		return true;
+	}
+	const args = toolCall.arguments;
+	if (!args || typeof args !== "object" || Array.isArray(args)) {
+		return !REQUIRED_REPO_PATH_ARGUMENT_TOOLS.has(toolName);
+	}
+	const pathValues = argumentNames.flatMap((name) =>
+		collectStringValues((args as Record<string, unknown>)[name]),
+	);
+	if (
+		pathValues.length === 0 &&
+		REQUIRED_REPO_PATH_ARGUMENT_TOOLS.has(toolName)
+	) {
+		return false;
+	}
+	return pathValues.every(
+		(pathValue) =>
+			isRepoRelativePathArgument(pathValue) &&
+			!isGitIgnoredRepoPath(cwd, pathValue),
+	);
+}
+
+function isGitSnapshotReusableToolCall(
+	tool: AgentTool,
+	toolCall: ToolCall,
+	cwd: string,
+): boolean {
+	if (
+		tool.source !== undefined ||
+		tool.annotations?.openWorldHint === true ||
+		tool.executionLocation === "client"
+	) {
+		return false;
+	}
+	if (!GIT_SNAPSHOT_REUSABLE_TOOL_NAMES.has(tool.name.toLowerCase())) {
+		return false;
+	}
+	if (!isReadOnlyTool(tool.name, tool.annotations, tool.source)) {
+		return false;
+	}
+	return hasRepoScopedReusableArguments(toolCall, cwd);
+}
+
 type ToolDefinitionLookup = ReadonlyMap<string, AgentTool> | AgentTool[];
 
 type ToolMetadataCache = {
 	readonly definitions: ReadonlyMap<string, AgentTool>;
+	readonly reusableToolResultCwd: string;
 	lookupCount: number;
 	get(toolName: string): AgentTool | undefined;
 };
 
-function createToolMetadataCache(tools: AgentTool[]): ToolMetadataCache {
+const reusableToolDefinitionIdentities = new WeakMap<object, number>();
+let reusableToolDefinitionIdentityCounter = 0;
+
+function getReusableToolDefinitionIdentity(value: object): number {
+	const existing = reusableToolDefinitionIdentities.get(value);
+	if (existing !== undefined) {
+		return existing;
+	}
+	reusableToolDefinitionIdentityCounter += 1;
+	reusableToolDefinitionIdentities.set(
+		value,
+		reusableToolDefinitionIdentityCounter,
+	);
+	return reusableToolDefinitionIdentityCounter;
+}
+
+function getReusableToolFunctionIdentity(value: unknown): number | undefined {
+	return typeof value === "function"
+		? getReusableToolDefinitionIdentity(value)
+		: undefined;
+}
+
+function getReusableToolRegistrySignature(tools: readonly AgentTool[]): string {
+	return stableStringify(
+		tools.map((tool) => ({
+			allowedCallers: tool.allowedCallers,
+			annotations: tool.annotations,
+			deferApiDefinition: tool.deferApiDefinition,
+			description: tool.description,
+			executeIdentity: getReusableToolFunctionIdentity(tool.execute),
+			executionLocation: tool.executionLocation,
+			getActivityDescriptionIdentity: getReusableToolFunctionIdentity(
+				tool.getActivityDescription,
+			),
+			getDisplayNameIdentity: getReusableToolFunctionIdentity(
+				tool.getDisplayName,
+			),
+			getToolUseSummaryIdentity: getReusableToolFunctionIdentity(
+				tool.getToolUseSummary,
+			),
+			inputExamples: tool.inputExamples,
+			label: tool.label,
+			maxRetries: tool.maxRetries,
+			name: tool.name,
+			parameters: tool.parameters,
+			retryDelayMs: tool.retryDelayMs,
+			shouldRetryIdentity: getReusableToolFunctionIdentity(tool.shouldRetry),
+			source: tool.source,
+			toolIdentity: getReusableToolDefinitionIdentity(tool),
+			toolType: tool.toolType,
+		})),
+	);
+}
+
+function createToolMetadataCache(
+	tools: AgentTool[],
+	reusableToolResultCwd = process.cwd(),
+): ToolMetadataCache {
 	const definitions = new Map(tools.map((tool) => [tool.name, tool]));
 	return {
 		definitions,
+		reusableToolResultCwd,
 		lookupCount: 0,
 		get(toolName: string): AgentTool | undefined {
 			this.lookupCount += 1;
@@ -176,13 +464,24 @@ function getReusableToolResultCacheKey(
 	tools: ToolDefinitionLookup | ToolMetadataCache,
 ): string | undefined {
 	const tool = getToolDefinition(tools, toolCall.name);
-	if (!tool || tool.annotations?.destructiveHint === true) {
-		return undefined;
-	}
-	if (!isReadOnlyTool(tool.name, tool.annotations, tool.source)) {
+	const cwd =
+		"reusableToolResultCwd" in tools
+			? tools.reusableToolResultCwd
+			: process.cwd();
+	if (!tool || !isGitSnapshotReusableToolCall(tool, toolCall, cwd)) {
 		return undefined;
 	}
 	return `${toolCall.name}:${stableStringify(toolCall.arguments)}`;
+}
+
+function isReadOnlyToolCallForCacheInvalidation(
+	toolCall: ToolCall,
+	tools: ToolDefinitionLookup | ToolMetadataCache,
+): boolean {
+	const tool = getToolDefinition(tools, toolCall.name);
+	return tool
+		? isReadOnlyTool(tool.name, tool.annotations, tool.source)
+		: false;
 }
 
 function cloneToolResultForCache(
@@ -325,7 +624,7 @@ function invalidateReusableToolResultsAfterMutation(
 	pendingSafetyChecks: Map<string, number>,
 	cacheGeneration: ReusableToolResultCacheGeneration,
 ): void {
-	if (getReusableToolResultCacheKey(toolCall, tools) !== undefined) {
+	if (isReadOnlyToolCallForCacheInvalidation(toolCall, tools)) {
 		return;
 	}
 	clearReusableToolResultState(
@@ -343,7 +642,7 @@ function hasPendingMutatingToolExecution(
 ): boolean {
 	return pendingExecutions.some(
 		(execution) =>
-			getReusableToolResultCacheKey(execution.toolCall, tools) === undefined,
+			!isReadOnlyToolCallForCacheInvalidation(execution.toolCall, tools),
 	);
 }
 
@@ -564,6 +863,20 @@ export class ProviderTransport implements AgentTransport {
 	private readonly clock: Clock;
 	private readonly sessionTokenCounter?: SessionTokenCounter;
 	private readonly auditLogger?: ToolAuditLogger;
+	private readonly reusableToolResults = new Map<
+		string,
+		ReusableToolResultEntry
+	>();
+	private readonly pendingReusableToolResults = new Map<
+		string,
+		Promise<ToolExecutionOutcome>
+	>();
+	private readonly policyCheckedReusableToolResultKeys = new Set<string>();
+	private readonly pendingReusableToolSafetyChecks = new Map<string, number>();
+	private readonly reusableToolResultCacheGeneration: ReusableToolResultCacheGeneration =
+		{ value: 0 };
+	private reusableToolResultSnapshot?: string;
+	private reusableToolRegistrySignature?: string;
 
 	/**
 	 * Rate Limit Window - time window for counting tool invocations
@@ -612,6 +925,41 @@ export class ProviderTransport implements AgentTransport {
 				},
 			},
 		});
+	}
+
+	private refreshReusableToolResultState(
+		tools: readonly AgentTool[],
+		cwd: string,
+	): void {
+		const registrySignature = getReusableToolRegistrySignature(tools);
+		const snapshot = computeReusableToolResultSnapshot(cwd);
+		if (snapshot === undefined) {
+			clearReusableToolResultState(
+				this.reusableToolResults,
+				this.pendingReusableToolResults,
+				this.policyCheckedReusableToolResultKeys,
+				this.pendingReusableToolSafetyChecks,
+				this.reusableToolResultCacheGeneration,
+			);
+			this.reusableToolResultSnapshot = undefined;
+			this.reusableToolRegistrySignature = registrySignature;
+			return;
+		}
+		if (
+			this.reusableToolResultSnapshot !== snapshot ||
+			(this.reusableToolRegistrySignature !== undefined &&
+				this.reusableToolRegistrySignature !== registrySignature)
+		) {
+			clearReusableToolResultState(
+				this.reusableToolResults,
+				this.pendingReusableToolResults,
+				this.policyCheckedReusableToolResultKeys,
+				this.pendingReusableToolSafetyChecks,
+				this.reusableToolResultCacheGeneration,
+			);
+		}
+		this.reusableToolResultSnapshot = snapshot;
+		this.reusableToolRegistrySignature = registrySignature;
 	}
 
 	/**
@@ -758,18 +1106,20 @@ export class ProviderTransport implements AgentTransport {
 		}
 
 		const dynamicToolEventQueue = new AgentEventQueue();
-		const toolMetadataCache = createToolMetadataCache(tools);
-		const reusableToolResults = new Map<string, ReusableToolResultEntry>();
-		const pendingReusableToolResults = new Map<
-			string,
-			Promise<ToolExecutionOutcome>
-		>();
-		const policyCheckedReusableToolResultKeys = new Set<string>();
-		const pendingReusableToolSafetyChecks = new Map<string, number>();
-		const reusableToolResultCacheGeneration: ReusableToolResultCacheGeneration =
-			{
-				value: 0,
-			};
+		const reusableToolResultCwd = this.options.cwd ?? process.cwd();
+		const toolMetadataCache = createToolMetadataCache(
+			tools,
+			reusableToolResultCwd,
+		);
+		this.refreshReusableToolResultState(tools, reusableToolResultCwd);
+		const reusableToolResults = this.reusableToolResults;
+		const pendingReusableToolResults = this.pendingReusableToolResults;
+		const policyCheckedReusableToolResultKeys =
+			this.policyCheckedReusableToolResultKeys;
+		const pendingReusableToolSafetyChecks =
+			this.pendingReusableToolSafetyChecks;
+		const reusableToolResultCacheGeneration =
+			this.reusableToolResultCacheGeneration;
 		const pendingDynamicToolExecutions: PendingExecution[] = [];
 		const platformToolExecutionBridge = resolvePlatformToolExecutionBridge(
 			this.options.platformToolExecutionBridge,
@@ -1540,6 +1890,32 @@ export class ProviderTransport implements AgentTransport {
 					8,
 					configuredConcurrency,
 				);
+				const concurrencyLimitForTool = (
+					defaultLimit: number,
+					toolDef?: AgentTool,
+				): number => {
+					const sourceMaxConcurrency =
+						toolDef?.source?.type === "mcp"
+							? toolDef.source.parallelMaxConcurrency
+							: undefined;
+					return Math.min(
+						defaultLimit,
+						typeof sourceMaxConcurrency === "number" &&
+							Number.isFinite(sourceMaxConcurrency) &&
+							sourceMaxConcurrency > 0
+							? Math.floor(sourceMaxConcurrency)
+							: defaultLimit,
+					);
+				};
+				const readOnlyConcurrencyLimitForTool = (toolDef?: AgentTool): number =>
+					concurrencyLimitForTool(readOnlyConcurrencyLimit, toolDef);
+				const parallelSafeMutationConcurrencyLimitForTool = (
+					toolDef?: AgentTool,
+				): number =>
+					concurrencyLimitForTool(
+						parallelSafeMutationConcurrencyLimit,
+						toolDef,
+					);
 				let concurrencyLimit = configuredConcurrency;
 				const pendingMutationScopes = new Map<
 					PendingExecution,
@@ -1937,19 +2313,21 @@ export class ProviderTransport implements AgentTransport {
 					readOnly,
 					scope,
 					parallelSafe,
+					toolDef,
 				}: {
 					readOnly: boolean;
 					scope?: PathScopedMutation;
 					parallelSafe: boolean;
+					toolDef?: AgentTool;
 				}): number =>
 					requiresSerializedTurn
 						? 1
 						: readOnly
-							? readOnlyConcurrencyLimit
+							? readOnlyConcurrencyLimitForTool(toolDef)
 							: scope
 								? configuredConcurrency
 								: parallelSafe
-									? parallelSafeMutationConcurrencyLimit
+									? parallelSafeMutationConcurrencyLimitForTool(toolDef)
 									: 1;
 
 				// Override: workflow-tracked tools require serialization
@@ -2092,6 +2470,7 @@ export class ProviderTransport implements AgentTransport {
 									readOnly: skippedToolCallReadOnly,
 									parallelSafe: skippedToolCallParallelSafe,
 									scope: mutationScope,
+									toolDef,
 								}),
 							}),
 					);
@@ -2272,6 +2651,7 @@ export class ProviderTransport implements AgentTransport {
 								readOnly: originalToolCallReadOnly,
 								parallelSafe: originalToolCallParallelSafe,
 								scope: originalMutationScope,
+								toolDef: originalToolDef,
 							}),
 						});
 						if (
@@ -2357,6 +2737,7 @@ export class ProviderTransport implements AgentTransport {
 							readOnly: originalToolCallReadOnly,
 							parallelSafe: originalToolCallParallelSafe,
 							scope: originalMutationScope,
+							toolDef: originalToolDef,
 						}),
 					});
 					const initialSchedulingMetadata = mergeToolSchedulingMetadata(
@@ -2503,11 +2884,11 @@ export class ProviderTransport implements AgentTransport {
 					concurrencyLimit = requiresSerializedTurn
 						? 1
 						: effectiveToolCallReadOnly
-							? readOnlyConcurrencyLimit
+							? readOnlyConcurrencyLimitForTool(tool)
 							: effectiveMutationScope
 								? configuredConcurrency
 								: effectiveToolCallParallelSafe
-									? parallelSafeMutationConcurrencyLimit
+									? parallelSafeMutationConcurrencyLimitForTool(tool)
 									: 1;
 					const effectiveSchedulingMetadata = buildToolSchedulingMetadata({
 						toolDef: tool,
@@ -2521,6 +2902,12 @@ export class ProviderTransport implements AgentTransport {
 									? "candidate"
 									: "miss",
 						canJoinPathScope: joinsPathScopedMutationIsland,
+						laneConcurrencyLimit: laneConcurrencyLimit({
+							readOnly: effectiveToolCallReadOnly,
+							parallelSafe: effectiveToolCallParallelSafe,
+							scope: effectiveMutationScope,
+							toolDef: tool,
+						}),
 					});
 					const previousSchedulingMetadata = toolSchedulingMetadata.get(
 						toolCall.id,

--- a/src/agent/transport.ts
+++ b/src/agent/transport.ts
@@ -308,16 +308,20 @@ function isGitIgnoredRepoPath(cwd: string, repoPath: string): boolean {
 	}
 }
 
-function isStatusCallIncludingIgnored(toolCall: ToolCall): boolean {
-	if (toolCall.name.toLowerCase() !== "status") {
-		return false;
-	}
+function isToolCallIncludingIgnoredPaths(toolCall: ToolCall): boolean {
+	const toolName = toolCall.name.toLowerCase();
 	const args = toolCall.arguments;
 	if (!args || typeof args !== "object" || Array.isArray(args)) {
 		return false;
 	}
 	const record = args as Record<string, unknown>;
-	return record.includeIgnored === true || record.include_ignored === true;
+	if (toolName === "status") {
+		return record.includeIgnored === true || record.include_ignored === true;
+	}
+	if (toolName === "search" || toolName === "parallel_ripgrep") {
+		return record.useGitIgnore === false || record.use_git_ignore === false;
+	}
+	return false;
 }
 
 function hasRepoScopedReusableArguments(
@@ -325,7 +329,7 @@ function hasRepoScopedReusableArguments(
 	cwd: string,
 ): boolean {
 	const toolName = toolCall.name.toLowerCase();
-	if (isStatusCallIncludingIgnored(toolCall)) {
+	if (isToolCallIncludingIgnoredPaths(toolCall)) {
 		return false;
 	}
 	const argumentNames = REPO_PATH_ARGUMENTS_BY_TOOL.get(toolName) ?? [];
@@ -477,11 +481,14 @@ function getReusableToolResultCacheKey(
 	if (!isReadOnlyTool(tool.name, tool.annotations, tool.source)) {
 		return undefined;
 	}
+	const toolName = tool.name.toLowerCase();
 	const cacheKey = `${toolCall.name}:${stableStringify(toolCall.arguments)}`;
 	if (isGitSnapshotReusableToolCall(tool, toolCall, cwd)) {
 		return `${GIT_SCOPED_REUSABLE_TOOL_RESULT_KEY_PREFIX}${cacheKey}`;
 	}
 	if (
+		tool.source !== undefined ||
+		GIT_SNAPSHOT_REUSABLE_TOOL_NAMES.has(toolName) ||
 		tool.annotations?.openWorldHint === true ||
 		tool.executionLocation === "client"
 	) {

--- a/src/agent/transport.ts
+++ b/src/agent/transport.ts
@@ -260,6 +260,9 @@ const REPO_PATH_ARGUMENTS_BY_TOOL = new Map<string, string[]>([
 	["status", ["path", "paths", "cwd"]],
 ]);
 
+const GIT_SCOPED_REUSABLE_TOOL_RESULT_KEY_PREFIX = "git:";
+const RUN_SCOPED_REUSABLE_TOOL_RESULT_KEY_PREFIX = "run:";
+
 const REQUIRED_REPO_PATH_ARGUMENT_TOOLS = new Set(["read", "ls", "list"]);
 
 function collectStringValues(value: unknown): string[] {
@@ -468,10 +471,23 @@ function getReusableToolResultCacheKey(
 		"reusableToolResultCwd" in tools
 			? tools.reusableToolResultCwd
 			: process.cwd();
-	if (!tool || !isGitSnapshotReusableToolCall(tool, toolCall, cwd)) {
+	if (!tool || tool.annotations?.destructiveHint === true) {
 		return undefined;
 	}
-	return `${toolCall.name}:${stableStringify(toolCall.arguments)}`;
+	if (!isReadOnlyTool(tool.name, tool.annotations, tool.source)) {
+		return undefined;
+	}
+	const cacheKey = `${toolCall.name}:${stableStringify(toolCall.arguments)}`;
+	if (isGitSnapshotReusableToolCall(tool, toolCall, cwd)) {
+		return `${GIT_SCOPED_REUSABLE_TOOL_RESULT_KEY_PREFIX}${cacheKey}`;
+	}
+	if (
+		tool.annotations?.openWorldHint === true ||
+		tool.executionLocation === "client"
+	) {
+		return undefined;
+	}
+	return `${RUN_SCOPED_REUSABLE_TOOL_RESULT_KEY_PREFIX}${cacheKey}`;
 }
 
 function isReadOnlyToolCallForCacheInvalidation(
@@ -613,6 +629,43 @@ function clearReusableToolResultState(
 	policyCheckedKeys.clear();
 	pendingSafetyChecks.clear();
 	cacheGeneration.value += 1;
+}
+
+function clearRunScopedReusableToolResultState(
+	cache: Map<string, ReusableToolResultEntry>,
+	pending: Map<string, Promise<ToolExecutionOutcome>>,
+	policyCheckedKeys: Set<string>,
+	pendingSafetyChecks: Map<string, number>,
+	cacheGeneration: ReusableToolResultCacheGeneration,
+): void {
+	let cleared = false;
+	for (const key of cache.keys()) {
+		if (key.startsWith(RUN_SCOPED_REUSABLE_TOOL_RESULT_KEY_PREFIX)) {
+			cache.delete(key);
+			cleared = true;
+		}
+	}
+	for (const key of pending.keys()) {
+		if (key.startsWith(RUN_SCOPED_REUSABLE_TOOL_RESULT_KEY_PREFIX)) {
+			pending.delete(key);
+			cleared = true;
+		}
+	}
+	for (const key of policyCheckedKeys) {
+		if (key.startsWith(RUN_SCOPED_REUSABLE_TOOL_RESULT_KEY_PREFIX)) {
+			policyCheckedKeys.delete(key);
+			cleared = true;
+		}
+	}
+	for (const key of pendingSafetyChecks.keys()) {
+		if (key.startsWith(RUN_SCOPED_REUSABLE_TOOL_RESULT_KEY_PREFIX)) {
+			pendingSafetyChecks.delete(key);
+			cleared = true;
+		}
+	}
+	if (cleared) {
+		cacheGeneration.value += 1;
+	}
 }
 
 function invalidateReusableToolResultsAfterMutation(
@@ -1120,6 +1173,13 @@ export class ProviderTransport implements AgentTransport {
 			this.pendingReusableToolSafetyChecks;
 		const reusableToolResultCacheGeneration =
 			this.reusableToolResultCacheGeneration;
+		clearRunScopedReusableToolResultState(
+			reusableToolResults,
+			pendingReusableToolResults,
+			policyCheckedReusableToolResultKeys,
+			pendingReusableToolSafetyChecks,
+			reusableToolResultCacheGeneration,
+		);
 		const pendingDynamicToolExecutions: PendingExecution[] = [];
 		const platformToolExecutionBridge = resolvePlatformToolExecutionBridge(
 			this.options.platformToolExecutionBridge,

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -609,6 +609,8 @@ export interface McpToolSourceMetadata {
 	server: string;
 	tool: string;
 	supportsParallelToolCalls?: boolean;
+	parallelSafetyProvenance?: "static_config" | "server_capability" | "none";
+	parallelMaxConcurrency?: number;
 }
 
 export type ToolSourceMetadata = McpToolSourceMetadata;

--- a/src/cli/commands/a2a.ts
+++ b/src/cli/commands/a2a.ts
@@ -55,6 +55,7 @@ import {
 	type PlatformAgentRegistryAgent,
 	PlatformAgentStatusValue,
 	controlA2ADelegationTaskWithPlatform,
+	delegateAgentWithPlatform,
 	getA2ADelegationGraphWithPlatform,
 	heartbeatAgentWithPlatform,
 	isAgentAlreadyExistsError,
@@ -90,18 +91,24 @@ const A2A_VALUE_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> = {
 	delegate: [
 		"--capability",
 		"--cwd",
+		"--from-agent-id",
 		"--interval-ms",
 		"--limit",
 		"--max-wait-ms",
+		"--objective-id",
 		"--offset",
 		"--registry",
+		"--reason",
 		"--role",
 		"--skill",
 		"--status",
 		"--surface",
 		"--tasks",
 		"--timeout-ms",
+		"--to-agent-id",
 		"--workspace-id",
+		"--workflow-run-id",
+		"--workflow-step-id",
 	],
 	coordinate: [
 		"--interval-ms",
@@ -180,7 +187,13 @@ const A2A_VALUE_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> = {
 const A2A_BOOLEAN_FLAGS_BY_SUBCOMMAND: Record<string, readonly string[]> = {
 	accept: ["--default"],
 	coordinate: ["--json", "--refresh", "--wait", "--work-graph"],
-	delegate: ["--discover", "--prefer-internal", "--wait", "--work-graph"],
+	delegate: [
+		"--discover",
+		"--platform",
+		"--prefer-internal",
+		"--wait",
+		"--work-graph",
+	],
 	discover: ["--default", "--import", "--json", "--prefer-internal"],
 	fleet: ["--json"],
 	graph: ["--json"],
@@ -278,6 +291,9 @@ export function parseA2AArgs(args: string[]): ParsedA2AArgs {
 	const booleanFlags = new Set(
 		A2A_BOOLEAN_FLAGS_BY_SUBCOMMAND[subcommand] ?? [],
 	);
+	if (subcommand === "delegate" && args.includes("--platform")) {
+		booleanFlags.add("--json");
+	}
 	const collectValueFlags = new Set(
 		A2A_COLLECT_VALUE_FLAGS_BY_SUBCOMMAND[subcommand] ?? [],
 	);
@@ -980,6 +996,10 @@ async function handleA2ASend(parsed: ParsedA2AArgs): Promise<void> {
 }
 
 async function handleA2ADelegate(parsed: ParsedA2AArgs): Promise<void> {
+	if (booleanFlag(parsed, "--platform")) {
+		await handleA2APlatformDelegate(parsed);
+		return;
+	}
 	const discover = booleanFlag(parsed, "--discover");
 	const peerName = discover
 		? undefined
@@ -1061,6 +1081,102 @@ async function handleA2ADelegate(parsed: ParsedA2AArgs): Promise<void> {
 	printTask(task, {
 		includeWorkGraphDetails: booleanFlag(parsed, "--work-graph"),
 	});
+}
+
+async function handleA2APlatformDelegate(parsed: ParsedA2AArgs): Promise<void> {
+	const text = parsed.positionals.join(" ").trim();
+	if (!text) {
+		fail(
+			"Usage: maestro a2a delegate --platform --from-agent-id <agent-id> [--to-agent-id <agent-id>|--capability <capability>] --skill <skill-id> <text>",
+		);
+	}
+	const fromAgentId =
+		stringFlag(parsed, "--from-agent-id") ??
+		getEnvValue([
+			"MAESTRO_A2A_AGENT_ID",
+			"MAESTRO_AGENT_ID",
+			"MAESTRO_EVALOPS_AGENT_ID",
+			"EVALOPS_AGENT_ID",
+		]) ??
+		fail(
+			"Provide --from-agent-id or set MAESTRO_A2A_AGENT_ID/MAESTRO_AGENT_ID.",
+		);
+	const toAgentId = stringFlag(parsed, "--to-agent-id");
+	const requiredCapability = stringFlag(parsed, "--capability");
+	const skillId = stringFlag(parsed, "--skill");
+	if (!toAgentId && !requiredCapability && !skillId) {
+		fail(
+			"Provide --to-agent-id, --capability, or --skill for Platform routing.",
+		);
+	}
+	const role = stringFlag(parsed, "--role");
+	const cwd = stringFlag(parsed, "--cwd") ?? process.cwd();
+	const requestedAt = new Date().toISOString();
+	const result = await delegateAgentWithPlatform({
+		workspaceId: stringFlag(parsed, "--workspace-id"),
+		fromAgentId,
+		toAgentId,
+		requiredCapability,
+		a2aSkillId: skillId,
+		objectiveId: stringFlag(parsed, "--objective-id"),
+		workflowRunId: stringFlag(parsed, "--workflow-run-id"),
+		workflowStepId: stringFlag(parsed, "--workflow-step-id"),
+		contextPayload: {
+			requestKind: "maestro-peer-delegation",
+			transport: "platform-a2a",
+			prompt: text,
+			source: "maestro-cli",
+			requestedAt,
+			...(role ? { role } : {}),
+			...(cwd ? { cwd } : {}),
+			...(skillId ? { a2aSkillId: skillId } : {}),
+			...(requiredCapability ? { requiredCapability } : {}),
+		},
+		reason:
+			stringFlag(parsed, "--reason") ??
+			platformDelegationReason(text, skillId, requiredCapability),
+	});
+	if (!result) {
+		fail(agentRegistryNotConfiguredMessage());
+	}
+	if (booleanFlag(parsed, "--json")) {
+		console.log(JSON.stringify(result, null, 2));
+		return;
+	}
+	const delegation = result.delegation;
+	console.log(
+		`Platform A2A delegation ${chalk.bold(delegation?.id ?? "(submitted)")}: ${
+			delegation?.status ?? "submitted"
+		}`,
+	);
+	console.log(chalk.dim(`From: ${fromAgentId}`));
+	if (delegation?.toAgentId ?? toAgentId) {
+		console.log(chalk.dim(`To: ${delegation?.toAgentId ?? toAgentId}`));
+	}
+	if (delegation?.a2aTaskId) {
+		console.log(chalk.dim(`Remote task: ${delegation.a2aTaskId}`));
+	}
+	if (delegation?.a2aEndpointUrl) {
+		console.log(chalk.dim(`Endpoint: ${delegation.a2aEndpointUrl}`));
+	}
+	if (delegation?.a2aDispatchStatus) {
+		console.log(chalk.dim(`Dispatch: ${delegation.a2aDispatchStatus}`));
+	}
+	if (delegation?.a2aResumeWaitContracts?.length) {
+		console.log(
+			chalk.dim(`Resume waits: ${delegation.a2aResumeWaitContracts.length}`),
+		);
+	}
+}
+
+function platformDelegationReason(
+	text: string,
+	skillId: string | undefined,
+	requiredCapability: string | undefined,
+): string {
+	const target = skillId ?? requiredCapability ?? "a2a peer";
+	const compact = text.replace(/\s+/g, " ").trim();
+	return `maestro a2a delegate ${target}: ${compact.slice(0, 120)}`;
 }
 
 async function handleA2AControl(parsed: ParsedA2AArgs): Promise<void> {
@@ -2042,6 +2158,7 @@ function printA2AHelp(): void {
   maestro a2a coordinate [peer] [--reply <text>] [--wait] [--json] [--work-graph]
   maestro a2a delegate <peer> <text> [--role <role>] [--cwd <path>] [--wait] [--work-graph]
   maestro a2a delegate --discover --skill <skill-id> <text> [--capability <capability>] [--prefer-internal]
+  maestro a2a delegate --platform --from-agent-id <agent-id> [--to-agent-id <agent-id>|--capability <capability>] --skill <skill-id> <text> [--json]
   maestro a2a control <delegation-id> --mode steer|followup|collect|interrupt|cancel [--workspace-id <id>] [message]
   maestro a2a graph <delegation-id> [--workspace-id <id>] [--json]
   maestro a2a reply <peer> <task-id> <text> [--wait] [--work-graph]

--- a/src/guardian/runner.ts
+++ b/src/guardian/runner.ts
@@ -52,12 +52,14 @@ function runCommand(
 	args: string[],
 	cwd: string,
 	timeoutMs = DEFAULT_TIMEOUT_MS,
+	env?: NodeJS.ProcessEnv,
 ): CommandResult {
 	const started = Date.now();
 	try {
 		const result = spawnSync(command, args, {
 			cwd,
 			encoding: "utf-8",
+			env: env ? { ...process.env, ...env } : process.env,
 			maxBuffer: 8 * 1024 * 1024,
 			timeout: timeoutMs,
 		});
@@ -212,13 +214,17 @@ function runSemgrep(files: string[], root: string): GuardianToolResult {
 		"--error",
 		"--timeout",
 		"7",
+		"--jobs",
+		"1",
 		"--metrics=off",
 		"--disable-version-check",
 		...includeArgs,
 		".",
 	];
 	// Semgrep can take longer on larger workspaces; allow up to 2 minutes before timing out
-	const result = runCommand(cmd.command, args, root, 120_000);
+	const result = runCommand(cmd.command, args, root, 120_000, {
+		SEMGREP_SEND_METRICS: "off",
+	});
 	return {
 		tool: "semgrep",
 		exitCode: result.exitCode,

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -51,6 +51,7 @@ import {
 	ProgressNotificationSchema,
 	PromptListChangedNotificationSchema,
 	ResourceListChangedNotificationSchema,
+	type ServerCapabilities,
 	ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { getPackageVersion } from "../package-metadata.js";
@@ -81,6 +82,7 @@ import type {
 	McpPromptDefinition,
 	McpServerConfig,
 	McpServerStatus,
+	McpToolParallelSafety,
 } from "./types.js";
 import { ensureMcpWorkspaceTrusted } from "./workspace-trust.js";
 
@@ -110,6 +112,142 @@ const DEFAULT_RECONNECT_DELAY_MS = 5000;
 
 // Maximum number of automatic reconnection attempts
 const MAX_RECONNECT_ATTEMPTS = 3;
+const PARALLEL_SAFETY_EXPERIMENTAL_KEYS = [
+	"evalops.maestro.parallelSafety",
+	"evalops.maestro/parallelSafety",
+	"maestro.parallelSafety",
+];
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value > 0
+		? Math.floor(value)
+		: undefined;
+}
+
+function serverParallelSafetyAdvertisement(
+	capabilities: ServerCapabilities | undefined,
+): Record<string, unknown> | undefined {
+	const experimental = asRecord(capabilities?.experimental);
+	if (!experimental) {
+		return undefined;
+	}
+	for (const key of PARALLEL_SAFETY_EXPERIMENTAL_KEYS) {
+		const advertisement = asRecord(experimental[key]);
+		if (advertisement) {
+			return advertisement;
+		}
+	}
+	return undefined;
+}
+
+function resolveToolParallelSafety({
+	config,
+	serverCapabilities,
+	tool,
+}: {
+	config: McpServerConfig;
+	serverCapabilities?: ServerCapabilities;
+	tool: McpTool;
+}): McpToolParallelSafety {
+	const advertisement = serverParallelSafetyAdvertisement(serverCapabilities);
+	const advertisedTools = asRecord(advertisement?.tools);
+	const advertisedTool =
+		asRecord(advertisedTools?.[tool.name]) ?? asRecord(advertisedTools?.["*"]);
+	const toolSupportsParallel = advertisedTool?.supportsParallelToolCalls;
+	const advertisedSupports =
+		toolSupportsParallel === true ||
+		(toolSupportsParallel !== false &&
+			advertisement?.supportsParallelToolCalls === true);
+	const maxConcurrency =
+		positiveInteger(advertisedTool?.maxConcurrency) ??
+		positiveInteger(advertisement?.maxConcurrency);
+
+	if (config.supportsParallelToolCalls === true) {
+		return {
+			supportsParallelToolCalls: true,
+			provenance: "static_config",
+			...(maxConcurrency ? { maxConcurrency } : {}),
+			...(advertisedTool?.readOnlyHint === true ? { readOnlyHint: true } : {}),
+		};
+	}
+	if (advertisedSupports) {
+		return {
+			supportsParallelToolCalls: true,
+			provenance: "server_capability",
+			...(maxConcurrency ? { maxConcurrency } : {}),
+			...(advertisedTool?.readOnlyHint === true ? { readOnlyHint: true } : {}),
+		};
+	}
+	return {
+		supportsParallelToolCalls: false,
+		provenance: "none",
+		...(advertisedTool?.readOnlyHint === true ? { readOnlyHint: true } : {}),
+	};
+}
+
+function resolveParallelSafetyByTool({
+	config,
+	serverCapabilities,
+	tools,
+}: {
+	config: McpServerConfig;
+	serverCapabilities?: ServerCapabilities;
+	tools: McpTool[];
+}): Map<string, McpToolParallelSafety> {
+	return new Map(
+		tools.map((tool) => [
+			tool.name,
+			resolveToolParallelSafety({
+				config,
+				serverCapabilities,
+				tool,
+			}),
+		]),
+	);
+}
+
+function summarizeServerParallelSafety(
+	config: McpServerConfig,
+	connected: ConnectedServer | undefined,
+): McpServerStatus["parallelSafety"] {
+	if (!connected) {
+		return {
+			supportsParallelToolCalls: config.supportsParallelToolCalls === true,
+			provenance:
+				config.supportsParallelToolCalls === true ? "static_config" : "none",
+		};
+	}
+	const values = [...connected.parallelSafetyByTool.values()];
+	const supportsParallelToolCalls = values.some(
+		(value) => value.supportsParallelToolCalls === true,
+	);
+	const staticConfig = values.some(
+		(value) => value.provenance === "static_config",
+	);
+	const serverCapability = values.some(
+		(value) => value.provenance === "server_capability",
+	);
+	const maxConcurrencyValues = values
+		.map((value) => value.maxConcurrency)
+		.filter((value): value is number => typeof value === "number");
+	return {
+		supportsParallelToolCalls,
+		provenance: staticConfig
+			? "static_config"
+			: serverCapability
+				? "server_capability"
+				: "none",
+		...(maxConcurrencyValues.length > 0
+			? { maxConcurrency: Math.min(...maxConcurrencyValues) }
+			: {}),
+	};
+}
 
 function arraysEqual(
 	left: readonly string[] | undefined,
@@ -381,6 +519,8 @@ interface ConnectedServer {
 	prompts: string[];
 	/** Cached prompt metadata for structured prompt UIs */
 	promptDetails: McpPromptDefinition[];
+	/** Per-tool parallel safety resolved from static config or server handshake. */
+	parallelSafetyByTool: ReadonlyMap<string, McpToolParallelSafety>;
 	/** Counter for reconnection attempts */
 	reconnectAttempts: number;
 }
@@ -689,6 +829,12 @@ export class McpClientManager extends EventEmitter {
 			const resources = await this.fetchResources(client);
 			const promptDetails = await this.fetchPrompts(client);
 			const prompts = getPromptNames(promptDetails);
+			const serverCapabilities = client.getServerCapabilities();
+			const parallelSafetyByTool = resolveParallelSafetyByTool({
+				config,
+				serverCapabilities,
+				tools,
+			});
 
 			this.servers.set(name, {
 				config,
@@ -698,6 +844,7 @@ export class McpClientManager extends EventEmitter {
 				resources,
 				prompts,
 				promptDetails,
+				parallelSafetyByTool,
 				reconnectAttempts: 0,
 			});
 			this.lastErrors.delete(name);
@@ -843,6 +990,11 @@ export class McpClientManager extends EventEmitter {
 					const server = this.servers.get(serverName);
 					if (server) {
 						server.tools = await this.fetchTools(client);
+						server.parallelSafetyByTool = resolveParallelSafetyByTool({
+							config: server.config,
+							serverCapabilities: client.getServerCapabilities(),
+							tools: server.tools,
+						});
 						this.emit("tools_changed", {
 							name: serverName,
 							tools: server.tools,
@@ -1025,19 +1177,29 @@ export class McpClientManager extends EventEmitter {
 		server: string;
 		tool: McpTool;
 		supportsParallelToolCalls: boolean;
+		parallelSafety: McpToolParallelSafety;
 	}> {
 		const tools: Array<{
 			server: string;
 			tool: McpTool;
 			supportsParallelToolCalls: boolean;
+			parallelSafety: McpToolParallelSafety;
 		}> = [];
 		for (const [serverName, server] of this.servers) {
 			for (const tool of server.tools) {
+				const parallelSafety =
+					server.parallelSafetyByTool.get(tool.name) ??
+					resolveToolParallelSafety({
+						config: server.config,
+						serverCapabilities: server.client.getServerCapabilities(),
+						tool,
+					});
 				tools.push({
 					server: serverName,
 					tool,
 					supportsParallelToolCalls:
-						server.config.supportsParallelToolCalls === true,
+						parallelSafety.supportsParallelToolCalls === true,
+					parallelSafety,
 				});
 			}
 		}
@@ -1101,6 +1263,7 @@ export class McpClientManager extends EventEmitter {
 				authPreset: config.authPreset,
 				timeout: config.timeout,
 				supportsParallelToolCalls: config.supportsParallelToolCalls === true,
+				parallelSafety: summarizeServerParallelSafety(config, connected),
 				remoteTrust: remoteRegistryMatch?.trust,
 				officialRegistry: remoteRegistryMatch?.info,
 				projectApproval,

--- a/src/mcp/tool-bridge.ts
+++ b/src/mcp/tool-bridge.ts
@@ -1,6 +1,10 @@
 import type { Tool as McpTool } from "@modelcontextprotocol/sdk/types.js";
 import { type TSchema, Type } from "@sinclair/typebox";
-import type { AgentTool } from "../agent/types.js";
+import type {
+	AgentTool,
+	ToolAnnotations,
+	ToolSourceMetadata,
+} from "../agent/types.js";
 import {
 	trackToolApprovalRequired,
 	trackToolBlocked,
@@ -10,6 +14,7 @@ import { promptSafeText } from "../utils/prompt-safe-text.js";
 import { mcpManager } from "./manager.js";
 import type { McpToolCallResult } from "./manager.js";
 import { buildMcpToolName } from "./names.js";
+import type { McpToolParallelSafety } from "./types.js";
 
 interface McpToolDetails {
 	server: string;
@@ -412,7 +417,10 @@ function convertJsonSchemaToTypebox(schema: unknown): TSchema {
 export function createMcpToolWrapper(
 	serverName: string,
 	mcpTool: McpTool,
-	options?: { supportsParallelToolCalls?: boolean },
+	options?: {
+		supportsParallelToolCalls?: boolean;
+		parallelSafety?: McpToolParallelSafety;
+	},
 ) {
 	const toolName = buildMcpToolName(serverName, mcpTool.name);
 	const schema = mcpTool.inputSchema
@@ -428,7 +436,34 @@ export function createMcpToolWrapper(
 				openWorldHint?: boolean;
 		  }
 		| undefined;
-	const supportsParallelToolCalls = options?.supportsParallelToolCalls === true;
+	const supportsParallelToolCalls =
+		options?.parallelSafety?.supportsParallelToolCalls === true ||
+		options?.supportsParallelToolCalls === true;
+	const parallelSafetyProvenance =
+		options?.parallelSafety?.provenance ??
+		(options?.supportsParallelToolCalls === true ? "static_config" : "none");
+	const parallelMaxConcurrency = options?.parallelSafety?.maxConcurrency;
+	const advertisedParallelReadOnly =
+		supportsParallelToolCalls && options?.parallelSafety?.readOnlyHint === true;
+	const annotations: ToolAnnotations | undefined =
+		mcpAnnotations || advertisedParallelReadOnly
+			? {
+					readOnlyHint:
+						mcpAnnotations?.readOnlyHint ??
+						(advertisedParallelReadOnly ? true : undefined),
+					destructiveHint: mcpAnnotations?.destructiveHint,
+					idempotentHint: mcpAnnotations?.idempotentHint,
+					openWorldHint: mcpAnnotations?.openWorldHint,
+				}
+			: undefined;
+	const source: ToolSourceMetadata = {
+		type: "mcp",
+		server: serverName,
+		tool: mcpTool.name,
+		supportsParallelToolCalls,
+		parallelSafetyProvenance,
+		...(parallelMaxConcurrency ? { parallelMaxConcurrency } : {}),
+	};
 
 	return createTool<typeof schema, McpToolDetails>({
 		name: toolName,
@@ -437,20 +472,8 @@ export function createMcpToolWrapper(
 			promptSafeText(mcpTool.description) ??
 			`MCP tool from ${serverName}: ${mcpTool.name}`,
 		schema,
-		annotations: mcpAnnotations
-			? {
-					readOnlyHint: mcpAnnotations.readOnlyHint,
-					destructiveHint: mcpAnnotations.destructiveHint,
-					idempotentHint: mcpAnnotations.idempotentHint,
-					openWorldHint: mcpAnnotations.openWorldHint,
-				}
-			: undefined,
-		source: {
-			type: "mcp",
-			server: serverName,
-			tool: mcpTool.name,
-			supportsParallelToolCalls,
-		},
+		annotations,
+		source,
 		async run(params, { respond }) {
 			const result = await mcpManager.callTool(
 				serverName,
@@ -488,8 +511,12 @@ export function createMcpToolWrapper(
 export function getAllMcpTools(): AgentTool[] {
 	const mcpTools = mcpManager.getAllTools();
 	return [
-		...mcpTools.map(({ server, tool, supportsParallelToolCalls }) =>
-			createMcpToolWrapper(server, tool, { supportsParallelToolCalls }),
+		...mcpTools.map(
+			({ server, tool, supportsParallelToolCalls, parallelSafety }) =>
+				createMcpToolWrapper(server, tool, {
+					supportsParallelToolCalls,
+					parallelSafety,
+				}),
 		),
 		...getMcpHelperTools(),
 	];
@@ -503,9 +530,15 @@ export function getMcpToolMap(): Map<string, AgentTool> {
 		map.set(tool.name, tool);
 	}
 
-	for (const { server, tool, supportsParallelToolCalls } of mcpTools) {
+	for (const {
+		server,
+		tool,
+		supportsParallelToolCalls,
+		parallelSafety,
+	} of mcpTools) {
 		const wrapper = createMcpToolWrapper(server, tool, {
 			supportsParallelToolCalls,
+			parallelSafety,
 		});
 		map.set(wrapper.name, wrapper);
 	}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -120,6 +120,18 @@ export interface McpServerConfig {
 	scope?: McpScope;
 }
 
+export type McpParallelSafetyProvenance =
+	| "static_config"
+	| "server_capability"
+	| "none";
+
+export interface McpToolParallelSafety {
+	supportsParallelToolCalls: boolean;
+	provenance: McpParallelSafetyProvenance;
+	maxConcurrency?: number;
+	readOnlyHint?: boolean;
+}
+
 export interface McpConfig {
 	servers: McpServerConfig[];
 	authPresets: McpAuthPresetConfig[];
@@ -153,6 +165,11 @@ export interface McpServerStatus {
 	authPreset?: string;
 	timeout?: number;
 	supportsParallelToolCalls?: boolean;
+	parallelSafety?: {
+		supportsParallelToolCalls: boolean;
+		provenance: McpParallelSafetyProvenance;
+		maxConcurrency?: number;
+	};
 	remoteTrust?: McpRemoteTrust;
 	officialRegistry?: McpOfficialRegistryInfo;
 	projectApproval?: McpProjectApprovalStatus;

--- a/src/platform/agent-registry-client.ts
+++ b/src/platform/agent-registry-client.ts
@@ -152,6 +152,7 @@ export interface PlatformDelegationRecord {
 }
 
 export interface PlatformAgentRegistryDelegateInput {
+	workspaceId?: string;
 	fromAgentId: string;
 	toAgentId?: string;
 	requiredCapability?: string;
@@ -1347,9 +1348,18 @@ export async function delegateAgentWithPlatform(
 		signal?: AbortSignal;
 	},
 ): Promise<PlatformAgentRegistryDelegateResult | null> {
+	const explicitWorkspaceId = trimString(input.workspaceId);
+	const resolvedConfig = options?.config
+		? explicitWorkspaceId && explicitWorkspaceId !== options.config.workspaceId
+			? { ...options.config, workspaceId: explicitWorkspaceId }
+			: options.config
+		: explicitWorkspaceId
+			? await resolveAgentRegistryListServiceConfig(explicitWorkspaceId)
+			: undefined;
 	const payload = await postAgentRegistryOperation(
 		DELEGATE_PATH,
 		stripUndefinedValues({
+			workspaceId: explicitWorkspaceId,
 			fromAgentId: input.fromAgentId,
 			toAgentId: input.toAgentId,
 			requiredCapability: input.requiredCapability,
@@ -1360,7 +1370,7 @@ export async function delegateAgentWithPlatform(
 			contextPayload: encodeJsonBytes(input.contextPayload),
 			reason: input.reason,
 		}),
-		options,
+		resolvedConfig ? { ...options, config: resolvedConfig } : options,
 	);
 	if (!payload) {
 		return null;

--- a/test/agent/mcp-manager-transports.test.ts
+++ b/test/agent/mcp-manager-transports.test.ts
@@ -18,7 +18,13 @@ const mockClientClose = vi.fn();
 const mockCallTool = vi.fn();
 const mockSetNotificationHandler = vi.fn();
 const mockSetRequestHandler = vi.fn();
+const mockListTools = vi.fn().mockResolvedValue({ tools: [] });
 const mockListPrompts = vi.fn().mockResolvedValue({ prompts: [] });
+let mockServerCapabilities: Record<string, unknown> = {
+	tools: {},
+	resources: {},
+	prompts: {},
+};
 const sseTransportCtor = vi.fn();
 const httpTransportCtor = vi.fn();
 const clientCtorOptions: unknown[] = [];
@@ -30,12 +36,8 @@ vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
 		}
 
 		connect = mockClientConnect.mockResolvedValue(undefined);
-		getServerCapabilities = vi.fn(() => ({
-			tools: {},
-			resources: {},
-			prompts: {},
-		}));
-		listTools = vi.fn().mockResolvedValue({ tools: [] });
+		getServerCapabilities = vi.fn(() => mockServerCapabilities);
+		listTools = mockListTools;
 		listResources = vi.fn().mockResolvedValue({ resources: [] });
 		listPrompts = mockListPrompts;
 		callTool = mockCallTool.mockResolvedValue({
@@ -87,7 +89,13 @@ describe("MCP manager remote transports", () => {
 		mockCallTool.mockClear();
 		mockSetNotificationHandler.mockClear();
 		mockSetRequestHandler.mockClear();
+		mockListTools.mockReset().mockResolvedValue({ tools: [] });
 		mockListPrompts.mockReset().mockResolvedValue({ prompts: [] });
+		mockServerCapabilities = {
+			tools: {},
+			resources: {},
+			prompts: {},
+		};
 		sseTransportCtor.mockClear();
 		httpTransportCtor.mockClear();
 		clientCtorOptions.length = 0;
@@ -116,6 +124,74 @@ describe("MCP manager remote transports", () => {
 			"https://example.com/mcp",
 		);
 		expect(manager.isConnected("remote-http")).toBe(true);
+	});
+
+	it("refreshes parallel safety metadata when tool lists change", async () => {
+		const tool = {
+			name: "repo_status",
+			description: "Inspect repo status.",
+			inputSchema: { type: "object", properties: {} },
+		};
+		mockListTools
+			.mockResolvedValueOnce({ tools: [tool] })
+			.mockResolvedValueOnce({ tools: [tool] });
+		mockServerCapabilities = {
+			tools: {},
+			resources: {},
+			prompts: {},
+			experimental: {
+				"evalops.maestro.parallelSafety": {
+					tools: {
+						repo_status: {
+							supportsParallelToolCalls: true,
+							maxConcurrency: 4,
+						},
+					},
+				},
+			},
+		};
+
+		await manager.configure({
+			servers: [
+				{
+					name: "remote-http",
+					transport: "http",
+					url: "https://example.com/mcp",
+				},
+			],
+		});
+
+		expect(manager.getAllTools()[0]?.parallelSafety).toMatchObject({
+			supportsParallelToolCalls: true,
+			maxConcurrency: 4,
+			provenance: "server_capability",
+		});
+
+		mockServerCapabilities = {
+			tools: {},
+			resources: {},
+			prompts: {},
+			experimental: {
+				"evalops.maestro.parallelSafety": {
+					tools: {
+						repo_status: {
+							supportsParallelToolCalls: true,
+							maxConcurrency: 1,
+						},
+					},
+				},
+			},
+		};
+		const handleToolListChanged = mockSetNotificationHandler.mock
+			.calls[0]?.[1] as (() => Promise<void>) | undefined;
+		expect(handleToolListChanged).toBeDefined();
+		await handleToolListChanged?.();
+
+		expect(manager.getAllTools()[0]?.parallelSafety).toMatchObject({
+			supportsParallelToolCalls: true,
+			maxConcurrency: 1,
+			provenance: "server_capability",
+		});
 	});
 
 	it("reconnects unchanged configured servers after disconnectAll", async () => {

--- a/test/agent/mcp-tool-bridge.test.ts
+++ b/test/agent/mcp-tool-bridge.test.ts
@@ -64,7 +64,7 @@ describe("MCP tool bridge schema conversion", () => {
 		expect(tool.parameters.properties?.query?.description).toBe("Search query");
 	});
 
-	it("uses local MCP server config as the only parallel capability source", () => {
+	it("uses trusted MCP config or server capabilities as parallel capability sources", () => {
 		const fromServer = createMcpToolWrapper(
 			"trusted-server",
 			{
@@ -72,6 +72,21 @@ describe("MCP tool bridge schema conversion", () => {
 				inputSchema: { type: "object" },
 			} satisfies McpTool,
 			{ supportsParallelToolCalls: true },
+		);
+		const fromServerCapability = createMcpToolWrapper(
+			"advertising-server",
+			{
+				name: "search",
+				inputSchema: { type: "object" },
+			} satisfies McpTool,
+			{
+				parallelSafety: {
+					supportsParallelToolCalls: true,
+					provenance: "server_capability",
+					maxConcurrency: 3,
+					readOnlyHint: true,
+				},
+			},
 		);
 		const fromToolMeta = createMcpToolWrapper("meta-server", {
 			name: "search",
@@ -88,10 +103,38 @@ describe("MCP tool bridge schema conversion", () => {
 			name: "search",
 			inputSchema: { type: "object" },
 		} satisfies McpTool);
+		const readOnlyWithoutParallelOptIn = createMcpToolWrapper(
+			"serial-read-server",
+			{
+				name: "search",
+				inputSchema: { type: "object" },
+			} satisfies McpTool,
+			{
+				parallelSafety: {
+					supportsParallelToolCalls: false,
+					provenance: "server_capability",
+					readOnlyHint: true,
+				},
+			},
+		);
 
 		expect(fromServer.source?.supportsParallelToolCalls).toBe(true);
+		expect(fromServer.source?.parallelSafetyProvenance).toBe("static_config");
+		expect(fromServerCapability.source).toMatchObject({
+			supportsParallelToolCalls: true,
+			parallelSafetyProvenance: "server_capability",
+			parallelMaxConcurrency: 3,
+		});
+		expect(fromServerCapability.annotations?.readOnlyHint).toBe(true);
 		expect(fromToolMeta.source?.supportsParallelToolCalls).toBe(false);
+		expect(fromToolMeta.source?.parallelSafetyProvenance).toBe("none");
 		expect(plain.source?.supportsParallelToolCalls).toBe(false);
+		expect(readOnlyWithoutParallelOptIn.source?.supportsParallelToolCalls).toBe(
+			false,
+		);
+		expect(readOnlyWithoutParallelOptIn.annotations?.readOnlyHint).toBe(
+			undefined,
+		);
 	});
 });
 

--- a/test/agent/mcp.test.ts
+++ b/test/agent/mcp.test.ts
@@ -601,6 +601,142 @@ describe("MCP client manager", () => {
 		expect(tools).toEqual([]);
 	});
 
+	it("refreshes parallel safety when a server tool list changes", async () => {
+		const manager = createManager();
+		type NotificationHandler = () => void | Promise<void>;
+		const notificationHandlers: NotificationHandler[] = [];
+		let maxConcurrency = 1;
+		const listedTools = [{ name: "search", inputSchema: { type: "object" } }];
+		const client = {
+			close: vi.fn(async () => undefined),
+			getServerCapabilities: () => ({
+				tools: {},
+				experimental: {
+					"evalops.maestro.parallelSafety": {
+						tools: {
+							search: {
+								supportsParallelToolCalls: true,
+								maxConcurrency,
+							},
+						},
+					},
+				},
+			}),
+			listTools: vi.fn(async () => ({ tools: listedTools })),
+			setNotificationHandler: vi.fn(
+				(_schema: unknown, handler: NotificationHandler) => {
+					notificationHandlers.push(handler);
+				},
+			),
+		};
+		const transport = {
+			close: vi.fn(async () => undefined),
+		};
+		const testManager = manager as unknown as {
+			servers: Map<string, unknown>;
+			setupNotificationHandlers(client: unknown, serverName: string): void;
+		};
+		testManager.servers.set("server", {
+			config: { name: "server", transport: "stdio", command: "server-cmd" },
+			client,
+			transport,
+			tools: listedTools,
+			resources: [],
+			prompts: [],
+			promptDetails: [],
+			parallelSafetyByTool: new Map([
+				[
+					"search",
+					{
+						supportsParallelToolCalls: true,
+						provenance: "server_capability",
+						maxConcurrency,
+					},
+				],
+			]),
+			reconnectAttempts: 0,
+		});
+		testManager.setupNotificationHandlers(client, "server");
+		maxConcurrency = 5;
+
+		await notificationHandlers[0]?.();
+
+		expect(client.listTools).toHaveBeenCalledTimes(1);
+		expect(manager.getAllTools()[0]?.parallelSafety).toMatchObject({
+			supportsParallelToolCalls: true,
+			provenance: "server_capability",
+			maxConcurrency: 5,
+		});
+	});
+
+	it("honors a per-tool parallel opt-out over the server default", async () => {
+		const manager = createManager();
+		type NotificationHandler = () => void | Promise<void>;
+		const notificationHandlers: NotificationHandler[] = [];
+		const listedTools = [
+			{ name: "parallel_search", inputSchema: { type: "object" } },
+			{ name: "serial_status", inputSchema: { type: "object" } },
+		];
+		const client = {
+			close: vi.fn(async () => undefined),
+			getServerCapabilities: () => ({
+				tools: {},
+				experimental: {
+					"evalops.maestro.parallelSafety": {
+						supportsParallelToolCalls: true,
+						tools: {
+							serial_status: {
+								supportsParallelToolCalls: false,
+							},
+						},
+					},
+				},
+			}),
+			listTools: vi.fn(async () => ({ tools: listedTools })),
+			setNotificationHandler: vi.fn(
+				(_schema: unknown, handler: NotificationHandler) => {
+					notificationHandlers.push(handler);
+				},
+			),
+		};
+		const transport = {
+			close: vi.fn(async () => undefined),
+		};
+		const testManager = manager as unknown as {
+			servers: Map<string, unknown>;
+			setupNotificationHandlers(client: unknown, serverName: string): void;
+		};
+		testManager.servers.set("server", {
+			config: { name: "server", transport: "stdio", command: "server-cmd" },
+			client,
+			transport,
+			tools: listedTools,
+			resources: [],
+			prompts: [],
+			promptDetails: [],
+			parallelSafetyByTool: new Map(),
+			reconnectAttempts: 0,
+		});
+		testManager.setupNotificationHandlers(client, "server");
+
+		await notificationHandlers[0]?.();
+
+		const tools = manager.getAllTools();
+		expect(
+			tools.find((tool) => tool.tool.name === "parallel_search")
+				?.parallelSafety,
+		).toMatchObject({
+			supportsParallelToolCalls: true,
+			provenance: "server_capability",
+		});
+		expect(
+			tools.find((tool) => tool.tool.name === "serial_status")?.parallelSafety,
+		).toMatchObject({
+			supportsParallelToolCalls: false,
+			provenance: "none",
+		});
+	});
+
 	it("isConnected returns false for unknown server", () => {
 		const manager = createManager();
 		expect(manager.isConnected("unknown")).toBe(false);

--- a/test/agent/provider-transport-provider-tools.test.ts
+++ b/test/agent/provider-transport-provider-tools.test.ts
@@ -1123,14 +1123,14 @@ describe("ProviderTransport provider-owned tool events", () => {
 					toolName: "read",
 					displayName: "Codex dynamic tool: read",
 					summaryLabel: "read",
-					args: { file_path: "/workspace/project/guarded.txt" },
+					args: { file_path: "workspace/project/guarded.txt" },
 					partial: assistant,
 				} satisfies AssistantMessageEvent;
 				const result = await options.executeDynamicTool({
 					type: "toolCall",
 					id: toolCallId,
 					name: "read",
-					arguments: { file_path: "/workspace/project/guarded.txt" },
+					arguments: { file_path: "workspace/project/guarded.txt" },
 				});
 				dynamicResults.push(result);
 				yield {
@@ -1203,14 +1203,14 @@ describe("ProviderTransport provider-owned tool events", () => {
 		expect(dynamicResults).toEqual([
 			{
 				content: [
-					{ type: "text", text: "dynamic:/workspace/project/guarded.txt:1" },
+					{ type: "text", text: "dynamic:workspace/project/guarded.txt:1" },
 				],
 				isError: false,
 				details: undefined,
 			},
 			{
 				content: [
-					{ type: "text", text: "dynamic:/workspace/project/guarded.txt:1" },
+					{ type: "text", text: "dynamic:workspace/project/guarded.txt:1" },
 				],
 				isError: false,
 				details: undefined,
@@ -1262,7 +1262,7 @@ describe("ProviderTransport provider-owned tool events", () => {
 					toolName: "read",
 					displayName: "Codex dynamic tool: read",
 					summaryLabel: "read",
-					args: { path: "/tmp/evalops.txt" },
+					args: { path: "docs/evalops.txt" },
 					partial: assistant,
 				} satisfies AssistantMessageEvent;
 				resultPromises.push(
@@ -1270,7 +1270,7 @@ describe("ProviderTransport provider-owned tool events", () => {
 						type: "toolCall",
 						id: toolCallId,
 						name: "read",
-						arguments: { path: "/tmp/evalops.txt" },
+						arguments: { path: "docs/evalops.txt" },
 					}),
 				);
 			}
@@ -1332,7 +1332,7 @@ describe("ProviderTransport provider-owned tool events", () => {
 		expect(toolExecute).toHaveBeenCalledTimes(1);
 		expect(dynamicResults).toEqual(
 			Array.from({ length: repeatedToolCalls }, () => ({
-				content: [{ type: "text", text: "dynamic:/tmp/evalops.txt:1" }],
+				content: [{ type: "text", text: "dynamic:docs/evalops.txt:1" }],
 				isError: false,
 				details: undefined,
 			})),
@@ -1515,7 +1515,7 @@ describe("ProviderTransport provider-owned tool events", () => {
 					type: "toolCall",
 					id: toolCallId,
 					name: "read",
-					arguments: { path: "/tmp/evalops.txt" },
+					arguments: { path: "docs/evalops.txt" },
 				});
 				yield {
 					type: "provider_tool_execution_end",
@@ -1629,7 +1629,7 @@ describe("ProviderTransport provider-owned tool events", () => {
 					toolCall: {
 						id: `read-call-${streamCount}`,
 						name: "read",
-						arguments: { file_path: "/tmp/evalops.txt" },
+						arguments: { file_path: "docs/evalops.txt" },
 					},
 					partial: assistant,
 				} satisfies AssistantMessageEvent;
@@ -1671,7 +1671,7 @@ describe("ProviderTransport provider-owned tool events", () => {
 					.map((item) => (item.type === "text" ? item.text : ""))
 					.join(""),
 			),
-		).toEqual(Array(repeatedToolCalls).fill("read:/tmp/evalops.txt:1"));
+		).toEqual(Array(repeatedToolCalls).fill("read:docs/evalops.txt:1"));
 		expect(readResults.every((event) => event.isError === false)).toBe(true);
 	});
 
@@ -1716,7 +1716,7 @@ describe("ProviderTransport provider-owned tool events", () => {
 					toolCall: {
 						id: `observed-read-call-${streamCount}`,
 						name: "read",
-						arguments: { file_path: "/tmp/evalops.txt" },
+						arguments: { file_path: "docs/evalops.txt" },
 					},
 					partial: assistant,
 				} satisfies AssistantMessageEvent;
@@ -2181,7 +2181,7 @@ describe("ProviderTransport provider-owned tool events", () => {
 					toolCall: {
 						id: `guarded-read-call-${streamCount}`,
 						name: "read",
-						arguments: { file_path: "/workspace/project/guarded.txt" },
+						arguments: { file_path: "workspace/project/guarded.txt" },
 					},
 					partial: assistant,
 				} satisfies AssistantMessageEvent;
@@ -2239,8 +2239,8 @@ describe("ProviderTransport provider-owned tool events", () => {
 					.join(""),
 			),
 		).toEqual([
-			"guarded:/workspace/project/guarded.txt:1",
-			"guarded:/workspace/project/guarded.txt:1",
+			"guarded:workspace/project/guarded.txt:1",
+			"guarded:workspace/project/guarded.txt:1",
 		]);
 	});
 

--- a/test/agent/provider-transport-tool-concurrency.test.ts
+++ b/test/agent/provider-transport-tool-concurrency.test.ts
@@ -1,3 +1,6 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 import { Type } from "@sinclair/typebox";
@@ -1182,6 +1185,144 @@ describe("ProviderTransport tool scheduling", () => {
 		expect(mutationOverlapCount).toBe(0);
 		expect(earliestVerifyStart).toBeGreaterThanOrEqual(commitRecord.endedAt);
 		expectStartedBeforeFirstEnd(verifyRecords, "verify");
+	});
+
+	it("does not reuse read-only MCP results across adjacent user turns", async () => {
+		let readExecutionCount = 0;
+		const remoteReadTool = {
+			name: "mcp__remote__read",
+			description: "Remote read-only probe.",
+			parameters: Type.Object({ key: Type.String() }),
+			annotations: {
+				readOnlyHint: true,
+			},
+			source: {
+				type: "mcp",
+				server: "remote",
+				tool: "read",
+				supportsParallelToolCalls: true,
+			},
+			execute: async (_toolCallId: string, args: Record<string, unknown>) => {
+				readExecutionCount += 1;
+				return {
+					content: [
+						{
+							type: "text",
+							text: `remote:${String(args.key)}:${readExecutionCount}`,
+						},
+					],
+				};
+			},
+		} satisfies AgentTool & {
+			source: {
+				type: "mcp";
+				server: string;
+				tool: string;
+				supportsParallelToolCalls: boolean;
+			};
+		};
+
+		let streamCount = 0;
+		mocks.createProviderStream.mockImplementation(async function* () {
+			streamCount += 1;
+			const calls =
+				streamCount === 1
+					? [
+							{
+								id: "remote-read-1",
+								name: "mcp__remote__read",
+								arguments: { key: "same" },
+							},
+						]
+					: streamCount === 3
+						? [
+								{
+									id: "remote-read-2",
+									name: "mcp__remote__read",
+									arguments: { key: "same" },
+								},
+							]
+						: undefined;
+			if (calls) {
+				const assistant = assistantMessage([], "toolUse");
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				for (const call of calls) {
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+				}
+				yield {
+					type: "done",
+					reason: "toolUse",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+				return;
+			}
+
+			const assistant = assistantMessage(
+				[{ type: "text", text: "remote read turn complete" }],
+				"stop",
+			);
+			yield {
+				type: "start",
+				partial: assistant,
+			} satisfies AssistantMessageEvent;
+			yield {
+				type: "done",
+				reason: "stop",
+				message: assistant,
+			} satisfies AssistantMessageEvent;
+		});
+
+		const transport = new ProviderTransport({
+			maxConcurrentToolExecutions: 4,
+			platformToolExecutionBridge: false,
+		});
+		const runTurn = (content: string) => {
+			const userMessage: Message = {
+				role: "user",
+				content,
+				timestamp: Date.now(),
+			};
+			return drain(
+				transport.run([userMessage], userMessage, {
+					systemPrompt: "Use the requested tools.",
+					tools: [remoteReadTool],
+					model,
+				}),
+			);
+		};
+
+		const firstEvents = await runTurn("Read remote state.");
+		const secondEvents = await runTurn("Read remote state again.");
+		const toolResultsById = new Map(
+			[...firstEvents, ...secondEvents]
+				.filter(
+					(
+						event,
+					): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+						event.type === "tool_execution_end",
+				)
+				.map((event) => [event.toolCallId, event]),
+		);
+
+		expect(readExecutionCount).toBe(2);
+		expect(toolResultsById.get("remote-read-1")?.scheduling?.cache).toBe(
+			"disabled",
+		);
+		expect(toolResultsById.get("remote-read-2")?.scheduling?.cache).toBe(
+			"disabled",
+		);
 	});
 
 	it("preserves configured concurrency cap for parallel-safe MCP mutations", async () => {
@@ -2768,9 +2909,9 @@ describe("ProviderTransport tool scheduling", () => {
 		let writeExecutionCount = 0;
 
 		const readProbeTool: AgentTool = {
-			name: "cacheable_read_probe",
-			description: "Cacheable read-only probe.",
-			parameters: Type.Object({ key: Type.String() }),
+			name: "read",
+			description: "Cacheable repo read probe.",
+			parameters: Type.Object({ path: Type.String() }),
 			annotations: {
 				readOnlyHint: true,
 			},
@@ -2781,7 +2922,7 @@ describe("ProviderTransport tool scheduling", () => {
 					content: [
 						{
 							type: "text",
-							text: `read:${String(args.key)}:${readExecutionCount}`,
+							text: `read:${String(args.path)}:${readExecutionCount}`,
 						},
 					],
 				};
@@ -2818,15 +2959,15 @@ describe("ProviderTransport tool scheduling", () => {
 				1: [
 					{
 						id: "read-1",
-						name: "cacheable_read_probe",
-						arguments: { key: "same" },
+						name: "read",
+						arguments: { path: "same.txt" },
 					},
 				],
 				2: [
 					{
 						id: "read-2",
-						name: "cacheable_read_probe",
-						arguments: { key: "same" },
+						name: "read",
+						arguments: { path: "same.txt" },
 					},
 				],
 				3: [
@@ -2837,15 +2978,15 @@ describe("ProviderTransport tool scheduling", () => {
 					},
 					{
 						id: "read-3",
-						name: "cacheable_read_probe",
-						arguments: { key: "same" },
+						name: "read",
+						arguments: { path: "same.txt" },
 					},
 				],
 				4: [
 					{
 						id: "read-4",
-						name: "cacheable_read_probe",
-						arguments: { key: "same" },
+						name: "read",
+						arguments: { path: "same.txt" },
 					},
 				],
 			};
@@ -2925,6 +3066,1680 @@ describe("ProviderTransport tool scheduling", () => {
 		expect(toolResultsById.get("read-2")?.scheduling?.reason).toBe("cache_hit");
 		expect(toolResultsById.get("read-3")?.scheduling?.cache).toBe("miss");
 		expect(toolResultsById.get("read-4")?.scheduling?.cache).toBe("hit");
+	});
+
+	it("reuses read-only results across adjacent user turns and invalidates after mutation", async () => {
+		let readExecutionCount = 0;
+		let writeExecutionCount = 0;
+		const readProbeTool: AgentTool = {
+			name: "read",
+			description: "Adjacent-turn cacheable repo read probe.",
+			parameters: Type.Object({ path: Type.String() }),
+			annotations: {
+				readOnlyHint: true,
+			},
+			execute: async (_toolCallId, args) => {
+				readExecutionCount += 1;
+				return {
+					content: [
+						{
+							type: "text",
+							text: `read:${String(args.path)}:${readExecutionCount}`,
+						},
+					],
+				};
+			},
+		};
+		const writeProbeTool: AgentTool = {
+			name: "adjacent_cache_write",
+			description: "Mutation probe that invalidates adjacent-turn cache.",
+			parameters: Type.Object({ label: Type.String() }),
+			annotations: {
+				readOnlyHint: false,
+				destructiveHint: true,
+			},
+			execute: async (_toolCallId, args) => {
+				writeExecutionCount += 1;
+				return {
+					content: [{ type: "text", text: `write:${String(args.label)}` }],
+				};
+			},
+		};
+
+		let streamCount = 0;
+		mocks.createProviderStream.mockImplementation(async function* () {
+			streamCount += 1;
+			const toolUseTurns: Record<
+				number,
+				Array<{
+					id: string;
+					name: string;
+					arguments: Record<string, unknown>;
+				}>
+			> = {
+				1: [
+					{
+						id: "adjacent-read-1",
+						name: "read",
+						arguments: { path: "same.txt" },
+					},
+				],
+				3: [
+					{
+						id: "adjacent-read-2",
+						name: "read",
+						arguments: { path: "same.txt" },
+					},
+				],
+				5: [
+					{
+						id: "adjacent-write-1",
+						name: "adjacent_cache_write",
+						arguments: { label: "invalidate" },
+					},
+				],
+				7: [
+					{
+						id: "adjacent-read-3",
+						name: "read",
+						arguments: { path: "same.txt" },
+					},
+				],
+			};
+			const calls = toolUseTurns[streamCount];
+			if (calls) {
+				const assistant = assistantMessage([], "toolUse");
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				for (const call of calls) {
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+				}
+				yield {
+					type: "done",
+					reason: "toolUse",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+				return;
+			}
+
+			const assistant = assistantMessage(
+				[{ type: "text", text: "adjacent cache turn complete" }],
+				"stop",
+			);
+			yield {
+				type: "start",
+				partial: assistant,
+			} satisfies AssistantMessageEvent;
+			yield {
+				type: "done",
+				reason: "stop",
+				message: assistant,
+			} satisfies AssistantMessageEvent;
+		});
+
+		const transport = new ProviderTransport({
+			maxConcurrentToolExecutions: 4,
+			platformToolExecutionBridge: false,
+		});
+		const tools = [readProbeTool, writeProbeTool];
+		const runTurn = (content: string) => {
+			const userMessage: Message = {
+				role: "user",
+				content,
+				timestamp: Date.now(),
+			};
+			return drain(
+				transport.run([userMessage], userMessage, {
+					systemPrompt: "Use the requested tools.",
+					tools,
+					model,
+				}),
+			);
+		};
+
+		const firstEvents = await runTurn("Read the same key.");
+		const secondEvents = await runTurn("Read the same key again.");
+		const mutationEvents = await runTurn("Mutate state.");
+		const thirdReadEvents = await runTurn("Read the same key after mutation.");
+
+		const toolResultsById = new Map(
+			[...firstEvents, ...secondEvents, ...mutationEvents, ...thirdReadEvents]
+				.filter(
+					(
+						event,
+					): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+						event.type === "tool_execution_end",
+				)
+				.map((event) => [event.toolCallId, event]),
+		);
+
+		expect(readExecutionCount).toBe(2);
+		expect(writeExecutionCount).toBe(1);
+		expect(toolResultsById.get("adjacent-read-1")?.scheduling?.cache).toBe(
+			"miss",
+		);
+		expect(toolResultsById.get("adjacent-read-2")?.scheduling?.cache).toBe(
+			"hit",
+		);
+		expect(toolResultsById.get("adjacent-read-2")?.scheduling?.reason).toBe(
+			"cache_hit",
+		);
+		expect(toolResultsById.get("adjacent-write-1")?.scheduling?.cache).toBe(
+			"disabled",
+		);
+		expect(toolResultsById.get("adjacent-read-3")?.scheduling?.cache).toBe(
+			"miss",
+		);
+	});
+
+	it("clears adjacent-turn cache when the tool registry changes", async () => {
+		let firstReadExecutionCount = 0;
+		let secondReadExecutionCount = 0;
+		const makeReadProbeTool = (
+			label: string,
+			onExecute: () => number,
+		): AgentTool => ({
+			name: "read",
+			description: `Registry-sensitive ${label} read probe.`,
+			parameters: Type.Object({ path: Type.String() }),
+			annotations: {
+				readOnlyHint: true,
+			},
+			execute: async (_toolCallId, args) => {
+				const count = onExecute();
+				return {
+					content: [
+						{
+							type: "text",
+							text: `${label}:${String(args.path)}:${count}`,
+						},
+					],
+				};
+			},
+		});
+		const firstReadProbeTool = makeReadProbeTool("first", () => {
+			firstReadExecutionCount += 1;
+			return firstReadExecutionCount;
+		});
+		const secondReadProbeTool = makeReadProbeTool("second", () => {
+			secondReadExecutionCount += 1;
+			return secondReadExecutionCount;
+		});
+
+		let streamCount = 0;
+		mocks.createProviderStream.mockImplementation(async function* () {
+			streamCount += 1;
+			const toolUseTurns: Record<
+				number,
+				Array<{
+					id: string;
+					name: string;
+					arguments: Record<string, unknown>;
+				}>
+			> = {
+				1: [
+					{
+						id: "registry-read-1",
+						name: "read",
+						arguments: { path: "same.txt" },
+					},
+				],
+				3: [
+					{
+						id: "registry-read-2",
+						name: "read",
+						arguments: { path: "same.txt" },
+					},
+				],
+			};
+			const calls = toolUseTurns[streamCount];
+			if (calls) {
+				const assistant = assistantMessage([], "toolUse");
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				for (const call of calls) {
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+				}
+				yield {
+					type: "done",
+					reason: "toolUse",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+				return;
+			}
+
+			const assistant = assistantMessage(
+				[{ type: "text", text: "registry cache turn complete" }],
+				"stop",
+			);
+			yield {
+				type: "start",
+				partial: assistant,
+			} satisfies AssistantMessageEvent;
+			yield {
+				type: "done",
+				reason: "stop",
+				message: assistant,
+			} satisfies AssistantMessageEvent;
+		});
+
+		const transport = new ProviderTransport({
+			maxConcurrentToolExecutions: 4,
+			platformToolExecutionBridge: false,
+		});
+		const runTurn = (tool: AgentTool, content: string) => {
+			const userMessage: Message = {
+				role: "user",
+				content,
+				timestamp: Date.now(),
+			};
+			return drain(
+				transport.run([userMessage], userMessage, {
+					systemPrompt: "Use the requested tool.",
+					tools: [tool],
+					model,
+				}),
+			);
+		};
+
+		const firstEvents = await runTurn(firstReadProbeTool, "Read the same key.");
+		const secondEvents = await runTurn(
+			secondReadProbeTool,
+			"Read the same key with a new tool definition.",
+		);
+
+		const toolResultsById = new Map(
+			[...firstEvents, ...secondEvents]
+				.filter(
+					(
+						event,
+					): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+						event.type === "tool_execution_end",
+				)
+				.map((event) => [event.toolCallId, event]),
+		);
+
+		expect(firstReadExecutionCount).toBe(1);
+		expect(secondReadExecutionCount).toBe(1);
+		expect(toolResultsById.get("registry-read-1")?.scheduling?.cache).toBe(
+			"miss",
+		);
+		expect(toolResultsById.get("registry-read-2")?.scheduling?.cache).toBe(
+			"miss",
+		);
+		expect(toolResultsById.get("registry-read-2")?.result.content).toEqual([
+			{ type: "text", text: "second:same.txt:1" },
+		]);
+	});
+
+	it("does not reuse adjacent-turn read results for git-ignored paths", async () => {
+		const tempDir = mkdtempSync(`${tmpdir()}/maestro-cache-ignored-`);
+		try {
+			execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+			writeFileSync(resolve(tempDir, ".gitignore"), ".env\n");
+			execFileSync("git", ["add", ".gitignore"], {
+				cwd: tempDir,
+				stdio: "ignore",
+			});
+			execFileSync(
+				"git",
+				[
+					"-c",
+					"user.name=Maestro Test",
+					"-c",
+					"user.email=maestro@example.com",
+					"commit",
+					"-m",
+					"init",
+				],
+				{ cwd: tempDir, stdio: "ignore" },
+			);
+			writeFileSync(resolve(tempDir, ".env"), "first");
+
+			let readExecutionCount = 0;
+			const readProbeTool: AgentTool = {
+				name: "read",
+				description: "Adjacent-turn ignored repo read probe.",
+				parameters: Type.Object({ path: Type.String() }),
+				annotations: {
+					readOnlyHint: true,
+				},
+				execute: async (_toolCallId, args) => {
+					readExecutionCount += 1;
+					return {
+						content: [
+							{
+								type: "text",
+								text: `ignored:${String(args.path)}:${readExecutionCount}`,
+							},
+						],
+					};
+				},
+			};
+
+			let streamCount = 0;
+			mocks.createProviderStream.mockImplementation(async function* () {
+				streamCount += 1;
+				const call =
+					streamCount === 1
+						? {
+								id: "ignored-read-1",
+								name: "read",
+								arguments: { path: ".env" },
+							}
+						: streamCount === 3
+							? {
+									id: "ignored-read-2",
+									name: "read",
+									arguments: { path: ".env" },
+								}
+							: undefined;
+				if (call) {
+					const assistant = assistantMessage([], "toolUse");
+					yield {
+						type: "start",
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					yield {
+						type: "done",
+						reason: "toolUse",
+						message: assistant,
+					} satisfies AssistantMessageEvent;
+					return;
+				}
+
+				const assistant = assistantMessage(
+					[{ type: "text", text: "ignored cache turn complete" }],
+					"stop",
+				);
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				yield {
+					type: "done",
+					reason: "stop",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+			});
+
+			const transport = new ProviderTransport({
+				cwd: tempDir,
+				maxConcurrentToolExecutions: 4,
+				platformToolExecutionBridge: false,
+			});
+			const runTurn = (content: string) => {
+				const userMessage: Message = {
+					role: "user",
+					content,
+					timestamp: Date.now(),
+				};
+				return drain(
+					transport.run([userMessage], userMessage, {
+						systemPrompt: "Use the requested tools.",
+						tools: [readProbeTool],
+						model,
+					}),
+				);
+			};
+
+			const firstEvents = await runTurn("Read the ignored file.");
+			writeFileSync(resolve(tempDir, ".env"), "second");
+			const secondEvents = await runTurn("Read the ignored file again.");
+
+			const toolResultsById = new Map(
+				[...firstEvents, ...secondEvents]
+					.filter(
+						(
+							event,
+						): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+							event.type === "tool_execution_end",
+					)
+					.map((event) => [event.toolCallId, event]),
+			);
+
+			expect(readExecutionCount).toBe(2);
+			expect(toolResultsById.get("ignored-read-1")?.scheduling?.cache).toBe(
+				"disabled",
+			);
+			expect(toolResultsById.get("ignored-read-2")?.scheduling?.cache).toBe(
+				"disabled",
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not reuse status results when ignored entries are requested", async () => {
+		const tempDir = mkdtempSync(`${tmpdir()}/maestro-cache-status-ignored-`);
+		try {
+			execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+			writeFileSync(resolve(tempDir, ".gitignore"), "*.log\n");
+			execFileSync("git", ["add", ".gitignore"], {
+				cwd: tempDir,
+				stdio: "ignore",
+			});
+			execFileSync(
+				"git",
+				[
+					"-c",
+					"user.name=Maestro Test",
+					"-c",
+					"user.email=maestro@example.com",
+					"commit",
+					"-m",
+					"init",
+				],
+				{ cwd: tempDir, stdio: "ignore" },
+			);
+
+			let statusExecutionCount = 0;
+			const statusTool: AgentTool = {
+				name: "status",
+				description: "Status probe that can include ignored entries.",
+				parameters: Type.Object({ includeIgnored: Type.Boolean() }),
+				annotations: {
+					readOnlyHint: true,
+				},
+				execute: async (_toolCallId, args) => {
+					statusExecutionCount += 1;
+					return {
+						content: [
+							{
+								type: "text",
+								text: `status:${String(args.includeIgnored)}:${statusExecutionCount}`,
+							},
+						],
+					};
+				},
+			};
+
+			let streamCount = 0;
+			mocks.createProviderStream.mockImplementation(async function* () {
+				streamCount += 1;
+				const call =
+					streamCount === 1
+						? {
+								id: "status-ignored-1",
+								name: "status",
+								arguments: { includeIgnored: true },
+							}
+						: streamCount === 3
+							? {
+									id: "status-ignored-2",
+									name: "status",
+									arguments: { includeIgnored: true },
+								}
+							: undefined;
+				if (call) {
+					const assistant = assistantMessage([], "toolUse");
+					yield {
+						type: "start",
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					yield {
+						type: "done",
+						reason: "toolUse",
+						message: assistant,
+					} satisfies AssistantMessageEvent;
+					return;
+				}
+
+				const assistant = assistantMessage(
+					[{ type: "text", text: "status ignored cache turn complete" }],
+					"stop",
+				);
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				yield {
+					type: "done",
+					reason: "stop",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+			});
+
+			const transport = new ProviderTransport({
+				cwd: tempDir,
+				maxConcurrentToolExecutions: 4,
+				platformToolExecutionBridge: false,
+			});
+			const runTurn = (content: string) => {
+				const userMessage: Message = {
+					role: "user",
+					content,
+					timestamp: Date.now(),
+				};
+				return drain(
+					transport.run([userMessage], userMessage, {
+						systemPrompt: "Use the requested tools.",
+						tools: [statusTool],
+						model,
+					}),
+				);
+			};
+
+			const firstEvents = await runTurn("Show ignored status.");
+			writeFileSync(resolve(tempDir, "app.log"), "ignored\n");
+			const secondEvents = await runTurn("Show ignored status again.");
+
+			const toolResultsById = new Map(
+				[...firstEvents, ...secondEvents]
+					.filter(
+						(
+							event,
+						): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+							event.type === "tool_execution_end",
+					)
+					.map((event) => [event.toolCallId, event]),
+			);
+
+			expect(statusExecutionCount).toBe(2);
+			expect(toolResultsById.get("status-ignored-1")?.scheduling?.cache).toBe(
+				"disabled",
+			);
+			expect(toolResultsById.get("status-ignored-2")?.scheduling?.cache).toBe(
+				"disabled",
+			);
+			expect(toolResultsById.get("status-ignored-2")?.result.content).toEqual([
+				{ type: "text", text: "status:true:2" },
+			]);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("reuses adjacent-turn read results for visible repo paths", async () => {
+		const tempDir = mkdtempSync(`${tmpdir()}/maestro-cache-visible-`);
+		try {
+			execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+			writeFileSync(resolve(tempDir, "tracked.txt"), "tracked");
+			execFileSync("git", ["add", "tracked.txt"], {
+				cwd: tempDir,
+				stdio: "ignore",
+			});
+			execFileSync(
+				"git",
+				[
+					"-c",
+					"user.name=Maestro Test",
+					"-c",
+					"user.email=maestro@example.com",
+					"commit",
+					"-m",
+					"init",
+				],
+				{ cwd: tempDir, stdio: "ignore" },
+			);
+
+			let readExecutionCount = 0;
+			const readProbeTool: AgentTool = {
+				name: "read",
+				description: "Adjacent-turn visible repo read probe.",
+				parameters: Type.Object({ path: Type.String() }),
+				annotations: {
+					readOnlyHint: true,
+				},
+				execute: async (_toolCallId, args) => {
+					readExecutionCount += 1;
+					return {
+						content: [
+							{
+								type: "text",
+								text: `visible:${String(args.path)}:${readExecutionCount}`,
+							},
+						],
+					};
+				},
+			};
+
+			let streamCount = 0;
+			mocks.createProviderStream.mockImplementation(async function* () {
+				streamCount += 1;
+				const call =
+					streamCount === 1
+						? {
+								id: "visible-read-1",
+								name: "read",
+								arguments: { path: "tracked.txt" },
+							}
+						: streamCount === 3
+							? {
+									id: "visible-read-2",
+									name: "read",
+									arguments: { path: "tracked.txt" },
+								}
+							: undefined;
+				if (call) {
+					const assistant = assistantMessage([], "toolUse");
+					yield {
+						type: "start",
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					yield {
+						type: "done",
+						reason: "toolUse",
+						message: assistant,
+					} satisfies AssistantMessageEvent;
+					return;
+				}
+
+				const assistant = assistantMessage(
+					[{ type: "text", text: "visible cache turn complete" }],
+					"stop",
+				);
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				yield {
+					type: "done",
+					reason: "stop",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+			});
+
+			const transport = new ProviderTransport({
+				cwd: tempDir,
+				maxConcurrentToolExecutions: 4,
+				platformToolExecutionBridge: false,
+			});
+			const runTurn = (content: string) => {
+				const userMessage: Message = {
+					role: "user",
+					content,
+					timestamp: Date.now(),
+				};
+				return drain(
+					transport.run([userMessage], userMessage, {
+						systemPrompt: "Use the requested tools.",
+						tools: [readProbeTool],
+						model,
+					}),
+				);
+			};
+
+			const firstEvents = await runTurn("Read the visible file.");
+			const secondEvents = await runTurn("Read the visible file again.");
+
+			const toolResultsById = new Map(
+				[...firstEvents, ...secondEvents]
+					.filter(
+						(
+							event,
+						): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+							event.type === "tool_execution_end",
+					)
+					.map((event) => [event.toolCallId, event]),
+			);
+
+			expect(readExecutionCount).toBe(1);
+			expect(toolResultsById.get("visible-read-1")?.scheduling?.cache).toBe(
+				"miss",
+			);
+			expect(toolResultsById.get("visible-read-2")?.scheduling?.cache).toBe(
+				"hit",
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("invalidates adjacent-turn read results when dirty file contents change", async () => {
+		const tempDir = mkdtempSync(`${tmpdir()}/maestro-cache-dirty-`);
+		try {
+			execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+			writeFileSync(resolve(tempDir, "tracked.txt"), "base");
+			execFileSync("git", ["add", "tracked.txt"], {
+				cwd: tempDir,
+				stdio: "ignore",
+			});
+			execFileSync(
+				"git",
+				[
+					"-c",
+					"user.name=Maestro Test",
+					"-c",
+					"user.email=maestro@example.com",
+					"commit",
+					"-m",
+					"init",
+				],
+				{ cwd: tempDir, stdio: "ignore" },
+			);
+			writeFileSync(resolve(tempDir, "tracked.txt"), "dirty-one");
+
+			let readExecutionCount = 0;
+			const readProbeTool: AgentTool = {
+				name: "read",
+				description: "Adjacent-turn dirty repo read probe.",
+				parameters: Type.Object({ path: Type.String() }),
+				annotations: {
+					readOnlyHint: true,
+				},
+				execute: async (_toolCallId, args) => {
+					readExecutionCount += 1;
+					return {
+						content: [
+							{
+								type: "text",
+								text: `dirty:${String(args.path)}:${readExecutionCount}`,
+							},
+						],
+					};
+				},
+			};
+
+			let streamCount = 0;
+			mocks.createProviderStream.mockImplementation(async function* () {
+				streamCount += 1;
+				const call =
+					streamCount === 1
+						? {
+								id: "dirty-read-1",
+								name: "read",
+								arguments: { path: "tracked.txt" },
+							}
+						: streamCount === 3
+							? {
+									id: "dirty-read-2",
+									name: "read",
+									arguments: { path: "tracked.txt" },
+								}
+							: undefined;
+				if (call) {
+					const assistant = assistantMessage([], "toolUse");
+					yield {
+						type: "start",
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					yield {
+						type: "done",
+						reason: "toolUse",
+						message: assistant,
+					} satisfies AssistantMessageEvent;
+					return;
+				}
+
+				const assistant = assistantMessage(
+					[{ type: "text", text: "dirty cache turn complete" }],
+					"stop",
+				);
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				yield {
+					type: "done",
+					reason: "stop",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+			});
+
+			const transport = new ProviderTransport({
+				cwd: tempDir,
+				maxConcurrentToolExecutions: 4,
+				platformToolExecutionBridge: false,
+			});
+			const runTurn = (content: string) => {
+				const userMessage: Message = {
+					role: "user",
+					content,
+					timestamp: Date.now(),
+				};
+				return drain(
+					transport.run([userMessage], userMessage, {
+						systemPrompt: "Use the requested tools.",
+						tools: [readProbeTool],
+						model,
+					}),
+				);
+			};
+
+			const firstEvents = await runTurn("Read the dirty file.");
+			writeFileSync(resolve(tempDir, "tracked.txt"), "dirty-two");
+			const secondEvents = await runTurn("Read the dirty file again.");
+
+			const toolResultsById = new Map(
+				[...firstEvents, ...secondEvents]
+					.filter(
+						(
+							event,
+						): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+							event.type === "tool_execution_end",
+					)
+					.map((event) => [event.toolCallId, event]),
+			);
+
+			expect(readExecutionCount).toBe(2);
+			expect(toolResultsById.get("dirty-read-1")?.scheduling?.cache).toBe(
+				"miss",
+			);
+			expect(toolResultsById.get("dirty-read-2")?.scheduling?.cache).toBe(
+				"miss",
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not reuse adjacent-turn results while a submodule worktree is dirty", async () => {
+		const tempDir = mkdtempSync(`${tmpdir()}/maestro-cache-submodule-`);
+		try {
+			const submoduleSourceDir = resolve(tempDir, "submodule-source");
+			const rootDir = resolve(tempDir, "root");
+			mkdirSync(submoduleSourceDir);
+			mkdirSync(rootDir);
+			execFileSync("git", ["init"], {
+				cwd: submoduleSourceDir,
+				stdio: "ignore",
+			});
+			writeFileSync(resolve(submoduleSourceDir, "tracked.txt"), "base");
+			execFileSync("git", ["add", "tracked.txt"], {
+				cwd: submoduleSourceDir,
+				stdio: "ignore",
+			});
+			execFileSync(
+				"git",
+				[
+					"-c",
+					"user.name=Maestro Test",
+					"-c",
+					"user.email=maestro@example.com",
+					"commit",
+					"-m",
+					"init",
+				],
+				{ cwd: submoduleSourceDir, stdio: "ignore" },
+			);
+
+			execFileSync("git", ["init"], { cwd: rootDir, stdio: "ignore" });
+			execFileSync(
+				"git",
+				[
+					"-c",
+					"protocol.file.allow=always",
+					"submodule",
+					"add",
+					submoduleSourceDir,
+					"vendor/lib",
+				],
+				{ cwd: rootDir, stdio: "ignore" },
+			);
+			execFileSync(
+				"git",
+				[
+					"-c",
+					"user.name=Maestro Test",
+					"-c",
+					"user.email=maestro@example.com",
+					"commit",
+					"-m",
+					"add submodule",
+				],
+				{ cwd: rootDir, stdio: "ignore" },
+			);
+			writeFileSync(resolve(rootDir, "vendor/lib/tracked.txt"), "dirty-one");
+
+			let readExecutionCount = 0;
+			const readProbeTool: AgentTool = {
+				name: "read",
+				description: "Adjacent-turn submodule read probe.",
+				parameters: Type.Object({ path: Type.String() }),
+				annotations: {
+					readOnlyHint: true,
+				},
+				execute: async (_toolCallId, args) => {
+					readExecutionCount += 1;
+					return {
+						content: [
+							{
+								type: "text",
+								text: `submodule:${String(args.path)}:${readExecutionCount}`,
+							},
+						],
+					};
+				},
+			};
+
+			let streamCount = 0;
+			mocks.createProviderStream.mockImplementation(async function* () {
+				streamCount += 1;
+				const call =
+					streamCount === 1
+						? {
+								id: "submodule-read-1",
+								name: "read",
+								arguments: { path: "vendor/lib/tracked.txt" },
+							}
+						: streamCount === 3
+							? {
+									id: "submodule-read-2",
+									name: "read",
+									arguments: { path: "vendor/lib/tracked.txt" },
+								}
+							: undefined;
+				if (call) {
+					const assistant = assistantMessage([], "toolUse");
+					yield {
+						type: "start",
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					yield {
+						type: "done",
+						reason: "toolUse",
+						message: assistant,
+					} satisfies AssistantMessageEvent;
+					return;
+				}
+
+				const assistant = assistantMessage(
+					[{ type: "text", text: "submodule cache turn complete" }],
+					"stop",
+				);
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				yield {
+					type: "done",
+					reason: "stop",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+			});
+
+			const transport = new ProviderTransport({
+				cwd: rootDir,
+				maxConcurrentToolExecutions: 4,
+				platformToolExecutionBridge: false,
+			});
+			const runTurn = (content: string) => {
+				const userMessage: Message = {
+					role: "user",
+					content,
+					timestamp: Date.now(),
+				};
+				return drain(
+					transport.run([userMessage], userMessage, {
+						systemPrompt: "Use the requested tools.",
+						tools: [readProbeTool],
+						model,
+					}),
+				);
+			};
+
+			const firstEvents = await runTurn("Read the dirty submodule file.");
+			writeFileSync(resolve(rootDir, "vendor/lib/tracked.txt"), "dirty-two");
+			const secondEvents = await runTurn(
+				"Read the dirty submodule file again.",
+			);
+
+			const toolResultsById = new Map(
+				[...firstEvents, ...secondEvents]
+					.filter(
+						(
+							event,
+						): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+							event.type === "tool_execution_end",
+					)
+					.map((event) => [event.toolCallId, event]),
+			);
+
+			expect(readExecutionCount).toBe(2);
+			expect(toolResultsById.get("submodule-read-1")?.scheduling?.cache).toBe(
+				"disabled",
+			);
+			expect(toolResultsById.get("submodule-read-2")?.scheduling?.cache).toBe(
+				"disabled",
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not reuse diff results when a custom cwd is outside the repo snapshot", async () => {
+		let diffExecutionCount = 0;
+		const diffTool: AgentTool = {
+			name: "diff",
+			description: "Diff probe with an optional custom working directory.",
+			parameters: Type.Object({
+				cwd: Type.Optional(Type.String()),
+				path: Type.String(),
+			}),
+			annotations: {
+				readOnlyHint: true,
+			},
+			execute: async (_toolCallId, args) => {
+				diffExecutionCount += 1;
+				return {
+					content: [
+						{
+							type: "text",
+							text: `diff:${String(args.cwd)}:${String(args.path)}:${diffExecutionCount}`,
+						},
+					],
+				};
+			},
+		};
+		const externalCwd = resolve(tmpdir(), "maestro-other-repo");
+
+		let streamCount = 0;
+		mocks.createProviderStream.mockImplementation(async function* () {
+			streamCount += 1;
+			const toolUseTurns: Record<
+				number,
+				Array<{
+					id: string;
+					name: string;
+					arguments: Record<string, unknown>;
+				}>
+			> = {
+				1: [
+					{
+						id: "diff-read-1",
+						name: "diff",
+						arguments: { cwd: externalCwd, path: "same.txt" },
+					},
+				],
+				3: [
+					{
+						id: "diff-read-2",
+						name: "diff",
+						arguments: { cwd: externalCwd, path: "same.txt" },
+					},
+				],
+			};
+			const calls = toolUseTurns[streamCount];
+			if (calls) {
+				const assistant = assistantMessage([], "toolUse");
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				for (const call of calls) {
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+				}
+				yield {
+					type: "done",
+					reason: "toolUse",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+				return;
+			}
+
+			const assistant = assistantMessage(
+				[{ type: "text", text: "diff reads complete" }],
+				"stop",
+			);
+			yield {
+				type: "start",
+				partial: assistant,
+			} satisfies AssistantMessageEvent;
+			yield {
+				type: "done",
+				reason: "stop",
+				message: assistant,
+			} satisfies AssistantMessageEvent;
+		});
+
+		const transport = new ProviderTransport({
+			maxConcurrentToolExecutions: 4,
+			platformToolExecutionBridge: false,
+		});
+		const runTurn = (content: string) => {
+			const userMessage: Message = {
+				role: "user",
+				content,
+				timestamp: Date.now(),
+			};
+			return drain(
+				transport.run([userMessage], userMessage, {
+					systemPrompt: "Use the requested tools.",
+					tools: [diffTool],
+					model,
+				}),
+			);
+		};
+
+		const firstEvents = await runTurn("Read external diff.");
+		const secondEvents = await runTurn("Read external diff again.");
+		const toolResultsById = new Map(
+			[...firstEvents, ...secondEvents]
+				.filter(
+					(
+						event,
+					): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+						event.type === "tool_execution_end",
+				)
+				.map((event) => [event.toolCallId, event]),
+		);
+
+		expect(diffExecutionCount).toBe(2);
+		expect(toolResultsById.get("diff-read-1")?.scheduling?.cache).toBe(
+			"disabled",
+		);
+		expect(toolResultsById.get("diff-read-2")?.scheduling?.cache).toBe(
+			"disabled",
+		);
+	});
+
+	it("does not reuse external read-only results across adjacent user turns", async () => {
+		let mcpReadExecutionCount = 0;
+		let apiReadExecutionCount = 0;
+		const mcpReadTool = {
+			name: "mcp__remote_service__read",
+			description: "Read-only MCP probe with remote freshness.",
+			parameters: Type.Object({ key: Type.String() }),
+			annotations: {
+				readOnlyHint: true,
+			},
+			source: {
+				type: "mcp",
+				server: "remote-service",
+				tool: "read",
+				supportsParallelToolCalls: true,
+			},
+			execute: async (_toolCallId: string, args: Record<string, unknown>) => {
+				mcpReadExecutionCount += 1;
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `mcp:${String(args.key)}:${mcpReadExecutionCount}`,
+						},
+					],
+				};
+			},
+		} satisfies AgentTool;
+		const apiReadTool = {
+			name: "open_world_read_probe",
+			description: "Read-only API probe with open-world freshness.",
+			parameters: Type.Object({ key: Type.String() }),
+			annotations: {
+				readOnlyHint: true,
+				openWorldHint: true,
+			},
+			execute: async (_toolCallId: string, args: Record<string, unknown>) => {
+				apiReadExecutionCount += 1;
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `api:${String(args.key)}:${apiReadExecutionCount}`,
+						},
+					],
+				};
+			},
+		} satisfies AgentTool;
+
+		let streamCount = 0;
+		mocks.createProviderStream.mockImplementation(async function* () {
+			streamCount += 1;
+			const toolUseTurns: Record<
+				number,
+				Array<{
+					id: string;
+					name: string;
+					arguments: Record<string, unknown>;
+				}>
+			> = {
+				1: [
+					{
+						id: "mcp-read-1",
+						name: "mcp__remote_service__read",
+						arguments: { key: "same" },
+					},
+					{
+						id: "api-read-1",
+						name: "open_world_read_probe",
+						arguments: { key: "same" },
+					},
+				],
+				3: [
+					{
+						id: "mcp-read-2",
+						name: "mcp__remote_service__read",
+						arguments: { key: "same" },
+					},
+					{
+						id: "api-read-2",
+						name: "open_world_read_probe",
+						arguments: { key: "same" },
+					},
+				],
+			};
+			const calls = toolUseTurns[streamCount];
+			if (calls) {
+				const assistant = assistantMessage([], "toolUse");
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				for (const call of calls) {
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+				}
+				yield {
+					type: "done",
+					reason: "toolUse",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+				return;
+			}
+
+			const assistant = assistantMessage(
+				[{ type: "text", text: "external reads complete" }],
+				"stop",
+			);
+			yield {
+				type: "start",
+				partial: assistant,
+			} satisfies AssistantMessageEvent;
+			yield {
+				type: "done",
+				reason: "stop",
+				message: assistant,
+			} satisfies AssistantMessageEvent;
+		});
+
+		const transport = new ProviderTransport({
+			maxConcurrentToolExecutions: 4,
+			platformToolExecutionBridge: false,
+		});
+		const tools = [mcpReadTool, apiReadTool];
+		const runTurn = (content: string) => {
+			const userMessage: Message = {
+				role: "user",
+				content,
+				timestamp: Date.now(),
+			};
+			return drain(
+				transport.run([userMessage], userMessage, {
+					systemPrompt: "Use the requested tools.",
+					tools,
+					model,
+				}),
+			);
+		};
+
+		const firstEvents = await runTurn("Read external state.");
+		const secondEvents = await runTurn("Read external state again.");
+
+		const toolResultsById = new Map(
+			[...firstEvents, ...secondEvents]
+				.filter(
+					(
+						event,
+					): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+						event.type === "tool_execution_end",
+				)
+				.map((event) => [event.toolCallId, event]),
+		);
+
+		expect(mcpReadExecutionCount).toBe(2);
+		expect(apiReadExecutionCount).toBe(2);
+		expect(toolResultsById.get("mcp-read-1")?.scheduling?.cache).toBe(
+			"disabled",
+		);
+		expect(toolResultsById.get("mcp-read-2")?.scheduling?.cache).toBe(
+			"disabled",
+		);
+		expect(toolResultsById.get("api-read-1")?.scheduling?.cache).toBe(
+			"disabled",
+		);
+		expect(toolResultsById.get("api-read-2")?.scheduling?.cache).toBe(
+			"disabled",
+		);
+	});
+
+	it("does not reuse diff results with a custom cwd across adjacent user turns", async () => {
+		let diffExecutionCount = 0;
+		const diffTool: AgentTool = {
+			name: "diff",
+			description: "Diff probe with a caller-selected working tree.",
+			parameters: Type.Object({ cwd: Type.String() }),
+			annotations: {
+				readOnlyHint: true,
+			},
+			execute: async (_toolCallId, args) => {
+				diffExecutionCount += 1;
+				return {
+					content: [
+						{
+							type: "text",
+							text: `diff:${String(args.cwd)}:${diffExecutionCount}`,
+						},
+					],
+				};
+			},
+		};
+
+		let streamCount = 0;
+		mocks.createProviderStream.mockImplementation(async function* () {
+			streamCount += 1;
+			const calls =
+				streamCount === 1
+					? [
+							{
+								id: "diff-1",
+								name: "diff",
+								arguments: { cwd: "/tmp/other-repo" },
+							},
+						]
+					: streamCount === 3
+						? [
+								{
+									id: "diff-2",
+									name: "diff",
+									arguments: { cwd: "/tmp/other-repo" },
+								},
+							]
+						: undefined;
+			if (calls) {
+				const assistant = assistantMessage([], "toolUse");
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				for (const call of calls) {
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: call.id,
+							name: call.name,
+							arguments: call.arguments,
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+				}
+				yield {
+					type: "done",
+					reason: "toolUse",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+				return;
+			}
+
+			const assistant = assistantMessage(
+				[{ type: "text", text: "diff turn complete" }],
+				"stop",
+			);
+			yield {
+				type: "start",
+				partial: assistant,
+			} satisfies AssistantMessageEvent;
+			yield {
+				type: "done",
+				reason: "stop",
+				message: assistant,
+			} satisfies AssistantMessageEvent;
+		});
+
+		const transport = new ProviderTransport({
+			maxConcurrentToolExecutions: 4,
+			platformToolExecutionBridge: false,
+		});
+		const runTurn = (content: string) => {
+			const userMessage: Message = {
+				role: "user",
+				content,
+				timestamp: Date.now(),
+			};
+			return drain(
+				transport.run([userMessage], userMessage, {
+					systemPrompt: "Use the requested tools.",
+					tools: [diffTool],
+					model,
+				}),
+			);
+		};
+
+		const firstEvents = await runTurn("Diff another repo.");
+		const secondEvents = await runTurn("Diff another repo again.");
+		const toolResultsById = new Map(
+			[...firstEvents, ...secondEvents]
+				.filter(
+					(
+						event,
+					): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+						event.type === "tool_execution_end",
+				)
+				.map((event) => [event.toolCallId, event]),
+		);
+
+		expect(diffExecutionCount).toBe(2);
+		expect(toolResultsById.get("diff-1")?.scheduling?.cache).toBe("disabled");
+		expect(toolResultsById.get("diff-2")?.scheduling?.cache).toBe("disabled");
+	});
+
+	it("does not reuse adjacent-turn results when git snapshot probing fails", async () => {
+		const tempDir = mkdtempSync(`${tmpdir()}/maestro-cache-no-git-`);
+		try {
+			let readExecutionCount = 0;
+			const readProbeTool: AgentTool = {
+				name: "read",
+				description: "Repo read probe for non-git cache fallback.",
+				parameters: Type.Object({ path: Type.String() }),
+				annotations: {
+					readOnlyHint: true,
+				},
+				execute: async (_toolCallId, args) => {
+					readExecutionCount += 1;
+					return {
+						content: [
+							{
+								type: "text",
+								text: `read:${String(args.path)}:${readExecutionCount}`,
+							},
+						],
+					};
+				},
+			};
+
+			let streamCount = 0;
+			mocks.createProviderStream.mockImplementation(async function* () {
+				streamCount += 1;
+				const toolUseTurns: Record<
+					number,
+					Array<{
+						id: string;
+						name: string;
+						arguments: Record<string, unknown>;
+					}>
+				> = {
+					1: [
+						{
+							id: "snapshotless-read-1",
+							name: "read",
+							arguments: { path: "same.txt" },
+						},
+					],
+					3: [
+						{
+							id: "snapshotless-read-2",
+							name: "read",
+							arguments: { path: "same.txt" },
+						},
+					],
+				};
+				const calls = toolUseTurns[streamCount];
+				if (calls) {
+					const assistant = assistantMessage([], "toolUse");
+					yield {
+						type: "start",
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+					for (const call of calls) {
+						yield {
+							type: "toolcall_end",
+							toolCall: {
+								type: "toolCall",
+								id: call.id,
+								name: call.name,
+								arguments: call.arguments,
+							},
+							partial: assistant,
+						} satisfies AssistantMessageEvent;
+					}
+					yield {
+						type: "done",
+						reason: "toolUse",
+						message: assistant,
+					} satisfies AssistantMessageEvent;
+					return;
+				}
+
+				const assistant = assistantMessage(
+					[{ type: "text", text: "snapshotless cache turn complete" }],
+					"stop",
+				);
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				yield {
+					type: "done",
+					reason: "stop",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+			});
+
+			const transport = new ProviderTransport({
+				maxConcurrentToolExecutions: 4,
+				platformToolExecutionBridge: false,
+				cwd: tempDir,
+			});
+			const tools = [readProbeTool];
+			const runTurn = (content: string) => {
+				const userMessage: Message = {
+					role: "user",
+					content,
+					timestamp: Date.now(),
+				};
+				return drain(
+					transport.run([userMessage], userMessage, {
+						systemPrompt: "Use the requested tools.",
+						tools,
+						model,
+					}),
+				);
+			};
+
+			const firstEvents = await runTurn("Read the same key.");
+			const secondEvents = await runTurn("Read the same key again.");
+
+			const toolResultsById = new Map(
+				[...firstEvents, ...secondEvents]
+					.filter(
+						(
+							event,
+						): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+							event.type === "tool_execution_end",
+					)
+					.map((event) => [event.toolCallId, event]),
+			);
+
+			expect(readExecutionCount).toBe(2);
+			expect(
+				toolResultsById.get("snapshotless-read-1")?.scheduling?.cache,
+			).toBe("disabled");
+			expect(
+				toolResultsById.get("snapshotless-read-2")?.scheduling?.cache,
+			).toBe("disabled");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("preserves configured concurrency cap for parallel-safe MCP mutations", async () => {
@@ -3042,6 +4857,139 @@ describe("ProviderTransport tool scheduling", () => {
 		expect(maxActiveMutations).toBe(1);
 		expect(records[1]?.startedAt).toBeGreaterThanOrEqual(
 			records[0]?.endedAt ?? 0,
+		);
+	});
+
+	it("applies MCP max concurrency cap to read-only lanes", async () => {
+		const records: TimedToolRecord[] = [];
+		let activeReads = 0;
+		let maxActiveReads = 0;
+
+		const readOnlyTool = {
+			name: "mcp__limited_remote__read",
+			description: "Read-only remote probe with a narrow server-side cap.",
+			parameters: Type.Object({ slot: Type.Integer() }),
+			annotations: {
+				readOnlyHint: true,
+			},
+			source: {
+				type: "mcp",
+				server: "limited-remote",
+				tool: "read",
+				supportsParallelToolCalls: true,
+				parallelSafetyProvenance: "server_capability",
+				parallelMaxConcurrency: 1,
+			},
+			execute: async (toolCallId: string, args: Record<string, unknown>) => {
+				activeReads += 1;
+				maxActiveReads = Math.max(maxActiveReads, activeReads);
+				const record: TimedToolRecord = {
+					id: toolCallId,
+					phase: "inspect",
+					startedAt: performance.now(),
+				};
+				records.push(record);
+				await sleep(60);
+				record.endedAt = performance.now();
+				activeReads -= 1;
+				return {
+					content: [{ type: "text", text: `read:${String(args.slot)}` }],
+				};
+			},
+		} satisfies AgentTool;
+
+		let streamCount = 0;
+		mocks.createProviderStream.mockImplementation(async function* () {
+			streamCount += 1;
+			if (streamCount === 1) {
+				const assistant = assistantMessage([], "toolUse");
+				yield {
+					type: "start",
+					partial: assistant,
+				} satisfies AssistantMessageEvent;
+				for (const slot of [1, 2, 3]) {
+					yield {
+						type: "toolcall_end",
+						toolCall: {
+							type: "toolCall",
+							id: `read-${slot}`,
+							name: "mcp__limited_remote__read",
+							arguments: { slot },
+						},
+						partial: assistant,
+					} satisfies AssistantMessageEvent;
+				}
+				yield {
+					type: "done",
+					reason: "toolUse",
+					message: assistant,
+				} satisfies AssistantMessageEvent;
+				return;
+			}
+
+			const assistant = assistantMessage(
+				[{ type: "text", text: "reads complete" }],
+				"stop",
+			);
+			yield {
+				type: "start",
+				partial: assistant,
+			} satisfies AssistantMessageEvent;
+			yield {
+				type: "done",
+				reason: "stop",
+				message: assistant,
+			} satisfies AssistantMessageEvent;
+		});
+
+		const userMessage: Message = {
+			role: "user",
+			content: "Run three capped read-only probes.",
+			timestamp: Date.now(),
+		};
+		const transport = new ProviderTransport({
+			maxConcurrentToolExecutions: 4,
+			platformToolExecutionBridge: false,
+		});
+
+		const events = await drain(
+			transport.run([userMessage], userMessage, {
+				systemPrompt: "Use the requested tools.",
+				tools: [readOnlyTool],
+				model,
+			}),
+		);
+
+		const toolStartsById = new Map(
+			events
+				.filter(
+					(
+						event,
+					): event is Extract<AgentEvent, { type: "tool_execution_start" }> =>
+						event.type === "tool_execution_start",
+				)
+				.map((event) => [event.toolCallId, event]),
+		);
+		const toolResults = events.filter(
+			(event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+				event.type === "tool_execution_end",
+		);
+
+		expect(toolResults).toHaveLength(3);
+		expect(records).toHaveLength(3);
+		expect(maxActiveReads).toBe(1);
+		for (const slot of [1, 2, 3]) {
+			expect(toolStartsById.get(`read-${slot}`)?.scheduling).toMatchObject({
+				classification: "read_only",
+				reason: "read_only_tool",
+				concurrencyLimit: 1,
+			});
+		}
+		expect(records[1]?.startedAt).toBeGreaterThanOrEqual(
+			records[0]?.endedAt ?? 0,
+		);
+		expect(records[2]?.startedAt).toBeGreaterThanOrEqual(
+			records[1]?.endedAt ?? 0,
 		);
 	});
 });

--- a/test/cli/commands/a2a.test.ts
+++ b/test/cli/commands/a2a.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	handleA2ACommand,
@@ -24,6 +25,16 @@ function headersToRecord(
 	headers: HeadersInit | undefined,
 ): Record<string, string> {
 	return Object.fromEntries(new Headers(headers).entries());
+}
+
+function decodePayload(encoded: unknown): Record<string, unknown> {
+	if (typeof encoded !== "string") {
+		return {};
+	}
+	return JSON.parse(Buffer.from(encoded, "base64").toString("utf8")) as Record<
+		string,
+		unknown
+	>;
 }
 
 function stubAgentRegistryEnv(): void {
@@ -73,6 +84,32 @@ function mockAgentRegistryFetch(): AgentRegistryCall[] {
 							taskId: "task_1",
 							state: "working",
 							controlId: body.idempotencyKey ?? "control_1",
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (operation === "Delegate") {
+				return new Response(
+					JSON.stringify({
+						delegation: {
+							id: "delegation_1",
+							workspaceId: body.workspaceId,
+							fromAgentId: body.fromAgentId,
+							toAgentId: body.toAgentId ?? "maestro-child",
+							requiredCapability: body.requiredCapability,
+							status: "DELEGATION_STATUS_PENDING",
+							a2aTaskId: "remote_task_1",
+							a2aMessageId: "a2a-delegation_1",
+							a2aEndpointUrl: "https://worker-b.test/message:send",
+							a2aDispatchStatus: "submitted",
+							a2aSkillId: body.a2aSkillId,
+							a2aResumeWaitContracts: [
+								{
+									type: "a2a.task.completed",
+									delegation_id: "delegation_1",
+								},
+							],
 						},
 					}),
 					{ status: 200, headers: { "Content-Type": "application/json" } },
@@ -334,6 +371,48 @@ describe("A2A CLI command helpers", () => {
 		expect(parsed.flags.get("--workspace-id")).toBe("ws_control");
 	});
 
+	it("parses Platform-owned A2A delegation flags", () => {
+		const parsed = parseA2AArgs([
+			"delegate",
+			"--platform",
+			"--from-agent-id",
+			"maestro-parent",
+			"--to-agent-id",
+			"maestro-child",
+			"--capability",
+			"code:review",
+			"--skill",
+			"maestro.subagent.code-review",
+			"--workspace-id",
+			"ws_delegate",
+			"--objective-id",
+			"objective_1",
+			"--workflow-run-id",
+			"run_1",
+			"--workflow-step-id",
+			"step_1",
+			"--reason",
+			"review requested",
+			"--json",
+			"review",
+			"the",
+			"patch",
+		]);
+
+		expect(parsed.positionals).toEqual(["delegate", "review", "the", "patch"]);
+		expect(parsed.flags.get("--platform")).toBe(true);
+		expect(parsed.flags.get("--from-agent-id")).toBe("maestro-parent");
+		expect(parsed.flags.get("--to-agent-id")).toBe("maestro-child");
+		expect(parsed.flags.get("--capability")).toBe("code:review");
+		expect(parsed.flags.get("--skill")).toBe("maestro.subagent.code-review");
+		expect(parsed.flags.get("--workspace-id")).toBe("ws_delegate");
+		expect(parsed.flags.get("--objective-id")).toBe("objective_1");
+		expect(parsed.flags.get("--workflow-run-id")).toBe("run_1");
+		expect(parsed.flags.get("--workflow-step-id")).toBe("step_1");
+		expect(parsed.flags.get("--reason")).toBe("review requested");
+		expect(parsed.flags.get("--json")).toBe(true);
+	});
+
 	it("routes the Platform A2A publish alias through registration", async () => {
 		stubAgentRegistryEnv();
 		muteConsole();
@@ -475,6 +554,74 @@ describe("A2A CLI command helpers", () => {
 				"x-workspace-id": "ws_control",
 			}),
 		);
+	});
+
+	it("routes Platform-owned A2A delegation through AgentService", async () => {
+		stubAgentRegistryEnv();
+		muteConsole();
+		const calls = mockAgentRegistryFetch();
+
+		await handleA2ACommand([
+			"delegate",
+			"--platform",
+			"--from-agent-id",
+			"maestro-parent",
+			"--to-agent-id",
+			"maestro-child",
+			"--capability",
+			"code:review",
+			"--skill",
+			"maestro.subagent.code-review",
+			"--workspace-id",
+			"ws_delegate",
+			"--objective-id",
+			"objective_1",
+			"--workflow-run-id",
+			"run_1",
+			"--workflow-step-id",
+			"step_1",
+			"--reason",
+			"review requested",
+			"--role",
+			"reviewer",
+			"--cwd",
+			"/repo",
+			"--json",
+			"review",
+			"the",
+			"patch",
+		]);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toMatchObject({
+			operation: "Delegate",
+			body: {
+				workspaceId: "ws_delegate",
+				fromAgentId: "maestro-parent",
+				toAgentId: "maestro-child",
+				requiredCapability: "code:review",
+				a2aSkillId: "maestro.subagent.code-review",
+				objectiveId: "objective_1",
+				workflowRunId: "run_1",
+				workflowStepId: "step_1",
+				reason: "review requested",
+			},
+		});
+		expect(calls[0]?.headers).toEqual(
+			expect.objectContaining({
+				"x-workspace-id": "ws_delegate",
+			}),
+		);
+		expect(decodePayload(calls[0]?.body.contextPayload)).toMatchObject({
+			requestKind: "maestro-peer-delegation",
+			transport: "platform-a2a",
+			prompt: "review the patch",
+			source: "maestro-cli",
+			role: "reviewer",
+			cwd: "/repo",
+			a2aSkillId: "maestro.subagent.code-review",
+			requiredCapability: "code:review",
+		});
 	});
 
 	it("reads Platform A2A delegation graphs through AgentService", async () => {

--- a/test/guardian/guardian-runner.test.ts
+++ b/test/guardian/guardian-runner.test.ts
@@ -184,4 +184,51 @@ describe("guardian runner", () => {
 		const toolNames = result.toolResults.map((t) => t.tool);
 		expect(toolNames).not.toContain("semgrep");
 	});
+
+	it("runs semgrep with bounded concurrency and metrics disabled", async () => {
+		process.env.MAESTRO_GUARDIAN = "1";
+		const calls: Array<{
+			cmd: string;
+			args: readonly string[];
+			env?: NodeJS.ProcessEnv;
+		}> = [];
+		mockSpawn.mockImplementation(
+			(
+				cmd: string,
+				args?: ReadonlyArray<string>,
+				options?: { env?: NodeJS.ProcessEnv },
+			) => {
+				const normalizedArgs = args ?? [];
+				calls.push({ cmd, args: normalizedArgs, env: options?.env });
+				const joined = normalizedArgs.join(" ");
+				if (cmd === "git" && joined.includes("diff --name-only --cached")) {
+					return { status: 0, stdout: "src/index.ts\n", stderr: "" };
+				}
+				if (cmd === "git" && joined.includes("show :")) {
+					return { status: 0, stdout: "export const x = 1;\n", stderr: "" };
+				}
+				if (cmd === "semgrep" && joined.includes("--version")) {
+					return { status: 0, stdout: "1.145.0\n", stderr: "" };
+				}
+				if (cmd === "semgrep" && joined.includes("scan")) {
+					return { status: 0, stdout: "{}", stderr: "" };
+				}
+				return { status: 1, stdout: "", stderr: "" };
+			},
+		);
+
+		const result = await runGuardian({
+			target: "staged",
+			trigger: "test",
+		});
+
+		expect(result.status).toBe("passed");
+		const semgrepScan = calls.find(
+			(call) => call.cmd === "semgrep" && call.args.includes("scan"),
+		);
+		expect(semgrepScan?.args).toEqual(
+			expect.arrayContaining(["--jobs", "1", "--metrics=off"]),
+		);
+		expect(semgrepScan?.env?.SEMGREP_SEND_METRICS).toBe("off");
+	});
 });

--- a/test/platform/a2a-platform-delegation-live.test.ts
+++ b/test/platform/a2a-platform-delegation-live.test.ts
@@ -1,0 +1,915 @@
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+	type PlatformA2ALiveSmokeDependencies,
+	type PlatformA2ALiveSmokeEvidence,
+	resolvePlatformA2ALiveSmokeEnv,
+	runPlatformA2ADelegationLiveSmoke,
+	sha256Hex,
+} from "../../scripts/smoke-platform-a2a-delegation-live.js";
+import { verifyPlatformA2ALiveEvidenceFile } from "../../scripts/verify-platform-a2a-live-evidence.js";
+import {
+	PlatformA2ADelegationTaskControlModeValue,
+	type PlatformAgentRegistryA2APeerCandidate,
+	type PlatformAgentRegistryGetA2ADelegationGraphResult,
+} from "../../src/platform/agent-registry-client.js";
+
+const baseEnv = {
+	MAESTRO_AGENT_REGISTRY_SERVICE_URL: "https://platform.test",
+	MAESTRO_AGENT_REGISTRY_SERVICE_TOKEN: "registry-token",
+	MAESTRO_AGENT_REGISTRY_ORG_ID: "org_1",
+	MAESTRO_AGENT_REGISTRY_WORKSPACE_ID: "ws_1",
+	MAESTRO_A2A_LIVE_FROM_AGENT_ID: "maestro-origin",
+	MAESTRO_A2A_LIVE_TO_AGENT_ID: "maestro-target",
+	MAESTRO_A2A_LIVE_SKILL_ID: "maestro.subagent.repo-explorer",
+	MAESTRO_A2A_LIVE_OBSERVE_INTERVAL_MS: "1",
+	MAESTRO_A2A_LIVE_TASK_INTERVAL_MS: "1",
+} satisfies Record<string, string>;
+
+function peer(
+	id: string,
+	endpointUrl: string,
+): PlatformAgentRegistryA2APeerCandidate {
+	return {
+		agent: {
+			id,
+			workspaceId: "ws_1",
+			name: id,
+			agentType: "maestro",
+			status: "AGENT_STATUS_IDLE",
+			activeConfigVersion: 7,
+			lastHeartbeatAt: "2026-05-21T19:59:30.000Z",
+			a2a: {
+				publicEndpointUrl: endpointUrl,
+				agentCardUrl: `${endpointUrl}/.well-known/agent-card.json`,
+				agentCardObservedAt: "2026-05-21T19:59:40.000Z",
+				protocolBinding: "HTTP+JSON",
+				protocolVersion: "1.0",
+				skills: [{ id: "maestro.subagent.repo-explorer" }],
+			},
+			capacity: {
+				current: 0,
+				max: 4,
+				remaining: 4,
+			},
+		},
+		endpointUrl,
+		endpointKind: "public",
+		agentCardUrl: `${endpointUrl}/.well-known/agent-card.json`,
+		protocolBinding: "HTTP+JSON",
+		protocolVersion: "1.0",
+		skills: [{ id: "maestro.subagent.repo-explorer" }],
+	};
+}
+
+function graph(
+	a2aTaskId?: string,
+): PlatformAgentRegistryGetA2ADelegationGraphResult {
+	return {
+		rootDelegationId: "delegation_1",
+		total: 1,
+		truncated: false,
+		nodes: [
+			{
+				depth: 0,
+				childCount: 0,
+				terminal: false,
+				delegation: {
+					id: "delegation_1",
+					workspaceId: "ws_1",
+					fromAgentId: "maestro-origin",
+					toAgentId: "maestro-target",
+					status: "DELEGATION_STATUS_ACCEPTED",
+					a2aTaskId,
+					a2aDispatchStatus: a2aTaskId ? "dispatched" : "pending",
+					a2aEndpointUrl: "https://target.test/a2a",
+					a2aSkillId: "maestro.subagent.repo-explorer",
+					a2aRootDelegationId: "delegation_1",
+				},
+			},
+		],
+		edges: [],
+	};
+}
+
+describe("Platform A2A live delegation smoke", () => {
+	it("fails before network work when required env is missing", () => {
+		expect(() => resolvePlatformA2ALiveSmokeEnv({})).toThrow(
+			/MAESTRO_AGENT_REGISTRY_SERVICE_URL/,
+		);
+	});
+
+	it("runs the live proof path and writes redacted evidence", async () => {
+		let writtenEvidence: PlatformA2ALiveSmokeEvidence | undefined;
+		const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+			now: () => new Date("2026-05-21T20:00:00.000Z"),
+			sleep: vi.fn(async () => undefined),
+			log: vi.fn(),
+			gitSha: () => "1234567890abcdef1234567890abcdef12345678",
+			resolveConfig: vi.fn(async () => ({
+				baseUrl: "https://process-config.test",
+				token: ["process", "config", "token"].join("-"),
+				organizationId: "process-org",
+				workspaceId: "process-workspace",
+				timeoutMs: 2_000,
+				maxAttempts: 1,
+			})),
+			listPeers: vi.fn(async () => [
+				peer("maestro-origin", "https://origin.test/a2a"),
+				peer("maestro-target", "https://target.test/a2a"),
+			]),
+			delegate: vi.fn(async () => ({
+				delegation: {
+					id: "delegation_1",
+					workspaceId: "ws_1",
+					fromAgentId: "maestro-origin",
+					toAgentId: "maestro-target",
+					status: "DELEGATION_STATUS_ACCEPTED",
+				},
+			})),
+			getGraph: vi
+				.fn()
+				.mockResolvedValueOnce(graph())
+				.mockResolvedValueOnce(graph("task_1")),
+			control: vi.fn(async () => ({
+				delegation: graph("task_1").nodes[0]?.delegation,
+				remoteTask: {
+					taskId: "task_1",
+					state: "TASK_STATE_WORKING",
+					controlId: "control_1",
+					controlMode: PlatformA2ADelegationTaskControlModeValue.Collect,
+					queuedForWorker: true,
+					observedAt: "2026-05-21T20:00:01.000Z",
+				},
+			})),
+			getTask: vi
+				.fn()
+				.mockResolvedValueOnce({
+					id: "task_1",
+					contextId: "ctx_1",
+					status: { state: "TASK_STATE_WORKING" },
+				})
+				.mockResolvedValueOnce({
+					id: "task_1",
+					contextId: "ctx_1",
+					status: { state: "TASK_STATE_COMPLETED" },
+				}),
+			writeEvidence: vi.fn(async (_outputDir, evidence) => {
+				writtenEvidence = evidence;
+				return "/tmp/platform-a2a-delegation-live/evidence.json";
+			}),
+		};
+
+		const result = await runPlatformA2ADelegationLiveSmoke({
+			env: {
+				...baseEnv,
+				GITHUB_REPOSITORY: "evalops/maestro-internal",
+				GITHUB_RUN_ID: "26252628231",
+				GITHUB_SHA: "1234567890abcdef1234567890abcdef12345678",
+				GITHUB_REF: "refs/pull/2070/merge",
+				GITHUB_EVENT_NAME: "pull_request",
+				GITHUB_SERVER_URL: "https://github.com",
+			},
+			dependencies,
+		});
+
+		expect(result.evidencePath).toBe(
+			"/tmp/platform-a2a-delegation-live/evidence.json",
+		);
+		expect(result.evidence).toMatchObject({
+			live: true,
+			workspaceId: "ws_1",
+			inputs: {
+				promptHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+			},
+			maestro: {
+				gitSha: "1234567890abcdef1234567890abcdef12345678",
+			},
+			github: {
+				repository: "evalops/maestro-internal",
+				runId: "26252628231",
+				runUrl:
+					"https://github.com/evalops/maestro-internal/actions/runs/26252628231",
+				sha: "1234567890abcdef1234567890abcdef12345678",
+				pullRequestNumber: 2070,
+				pullRequestUrl: "https://github.com/evalops/maestro-internal/pull/2070",
+			},
+			delegation: {
+				id: "delegation_1",
+				a2aTaskId: "task_1",
+			},
+			task: {
+				id: "task_1",
+				state: "TASK_STATE_COMPLETED",
+				terminal: true,
+			},
+		});
+		expect(JSON.stringify(writtenEvidence)).not.toContain("registry-token");
+		expect(JSON.stringify(writtenEvidence)).not.toContain(
+			"acknowledge delegation",
+		);
+		expect(dependencies.listPeers).toHaveBeenCalledWith(
+			expect.objectContaining({
+				workspaceId: "ws_1",
+				skillId: "maestro.subagent.repo-explorer",
+				requireA2ADispatch: true,
+				eligibleForDelegation: true,
+			}),
+			expect.objectContaining({
+				config: expect.objectContaining({
+					baseUrl: "https://platform.test",
+					token: "registry-token",
+					organizationId: "org_1",
+					workspaceId: "ws_1",
+				}),
+			}),
+		);
+		expect(dependencies.sleep).toHaveBeenCalled();
+	});
+
+	it("retries transient delegation graph lookup failures", async () => {
+		const sleep = vi.fn(async () => undefined);
+		const getGraph = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("upstream timeout"))
+			.mockResolvedValueOnce(graph("task_1"));
+		const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+			now: () => new Date("2026-05-21T20:00:00.000Z"),
+			sleep,
+			log: vi.fn(),
+			gitSha: () => "1234567890abcdef1234567890abcdef12345678",
+			resolveConfig: vi.fn(async () => ({
+				baseUrl: "https://platform.test",
+				token: "registry-token",
+				organizationId: "org_1",
+				workspaceId: "ws_1",
+				timeoutMs: 2_000,
+				maxAttempts: 1,
+			})),
+			listPeers: vi.fn(async () => [
+				peer("maestro-origin", "https://origin.test/a2a"),
+				peer("maestro-target", "https://target.test/a2a"),
+			]),
+			delegate: vi.fn(async () => ({
+				delegation: {
+					id: "delegation_1",
+					workspaceId: "ws_1",
+					fromAgentId: "maestro-origin",
+					toAgentId: "maestro-target",
+					status: "DELEGATION_STATUS_ACCEPTED",
+				},
+			})),
+			getGraph,
+			control: vi.fn(async () => ({
+				delegation: graph("task_1").nodes[0]?.delegation,
+				remoteTask: {
+					taskId: "task_1",
+					state: "TASK_STATE_COMPLETED",
+					controlMode: PlatformA2ADelegationTaskControlModeValue.Collect,
+				},
+			})),
+			getTask: vi.fn(async () => ({
+				id: "task_1",
+				contextId: "ctx_1",
+				status: { state: "TASK_STATE_COMPLETED" },
+			})),
+			writeEvidence: vi.fn(async () => {
+				return "/tmp/platform-a2a-delegation-live/evidence.json";
+			}),
+		};
+
+		await runPlatformA2ADelegationLiveSmoke({
+			env: {
+				...baseEnv,
+				MAESTRO_A2A_LIVE_OBSERVE_ATTEMPTS: "2",
+			},
+			dependencies,
+		});
+
+		expect(getGraph).toHaveBeenCalledTimes(2);
+		expect(sleep).toHaveBeenCalledWith(1);
+	});
+
+	it("discovers the origin peer without target skill filters", async () => {
+		const origin = peer("maestro-origin", "https://origin.test/a2a");
+		origin.skills = [];
+		if (origin.agent.a2a) {
+			origin.agent.a2a.skills = [];
+		}
+		const target = peer("maestro-target", "https://target.test/a2a");
+		const listPeers = vi
+			.fn()
+			.mockResolvedValueOnce([target])
+			.mockResolvedValueOnce([origin]);
+		const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+			now: () => new Date("2026-05-21T20:00:00.000Z"),
+			sleep: vi.fn(async () => undefined),
+			log: vi.fn(),
+			gitSha: () => "1234567890abcdef1234567890abcdef12345678",
+			resolveConfig: vi.fn(async () => ({
+				baseUrl: "https://platform.test",
+				token: "registry-token",
+				organizationId: "org_1",
+				workspaceId: "ws_1",
+				timeoutMs: 2_000,
+				maxAttempts: 1,
+			})),
+			listPeers,
+			delegate: vi.fn(async () => ({
+				delegation: {
+					id: "delegation_1",
+					workspaceId: "ws_1",
+					fromAgentId: "maestro-origin",
+					toAgentId: "maestro-target",
+					status: "DELEGATION_STATUS_ACCEPTED",
+				},
+			})),
+			getGraph: vi.fn(async () => graph("task_1")),
+			control: vi.fn(async () => ({
+				delegation: graph("task_1").nodes[0]?.delegation,
+				remoteTask: {
+					taskId: "task_1",
+					state: "TASK_STATE_COMPLETED",
+					controlMode: PlatformA2ADelegationTaskControlModeValue.Collect,
+				},
+			})),
+			getTask: vi.fn(async () => ({
+				id: "task_1",
+				contextId: "ctx_1",
+				status: { state: "TASK_STATE_COMPLETED" },
+			})),
+			writeEvidence: vi.fn(async () => {
+				return "/tmp/platform-a2a-delegation-live/evidence.json";
+			}),
+		};
+
+		const result = await runPlatformA2ADelegationLiveSmoke({
+			env: baseEnv,
+			dependencies,
+		});
+
+		expect(result.evidence.peers.origin.agentId).toBe("maestro-origin");
+		expect(result.evidence.peers.target.agentId).toBe("maestro-target");
+		expect(listPeers).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				workspaceId: "ws_1",
+				skillId: "maestro.subagent.repo-explorer",
+				requireA2ADispatch: true,
+				eligibleForDelegation: true,
+			}),
+			expect.any(Object),
+		);
+		expect(listPeers.mock.calls[1]?.[0]).toEqual({
+			workspaceId: "ws_1",
+			limit: 100,
+			requireA2ADispatch: true,
+		});
+	});
+
+	it("fails after exhausting transient delegation graph lookup retries", async () => {
+		const sleep = vi.fn(async () => undefined);
+		const getGraph = vi.fn(async () => {
+			throw new Error("upstream timeout");
+		});
+		const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+			now: () => new Date("2026-05-21T20:00:00.000Z"),
+			sleep,
+			log: vi.fn(),
+			resolveConfig: vi.fn(async () => ({
+				baseUrl: "https://platform.test",
+				token: "registry-token",
+				organizationId: "org_1",
+				workspaceId: "ws_1",
+				timeoutMs: 2_000,
+				maxAttempts: 1,
+			})),
+			listPeers: vi.fn(async () => [
+				peer("maestro-origin", "https://origin.test/a2a"),
+				peer("maestro-target", "https://target.test/a2a"),
+			]),
+			delegate: vi.fn(async () => ({
+				delegation: { id: "delegation_1" },
+			})),
+			getGraph,
+		};
+
+		await expect(
+			runPlatformA2ADelegationLiveSmoke({
+				env: {
+					...baseEnv,
+					MAESTRO_A2A_LIVE_OBSERVE_ATTEMPTS: "2",
+				},
+				dependencies,
+			}),
+		).rejects.toThrow(/upstream timeout/);
+
+		expect(getGraph).toHaveBeenCalledTimes(2);
+		expect(sleep).toHaveBeenCalledTimes(1);
+		expect(sleep).toHaveBeenCalledWith(1);
+	});
+
+	it("fails before writing evidence when control omits the remote task id", async () => {
+		const writeEvidence = vi.fn(async () => {
+			return "/tmp/platform-a2a-delegation-live/evidence.json";
+		});
+		const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+			now: () => new Date("2026-05-21T20:00:00.000Z"),
+			sleep: vi.fn(async () => undefined),
+			log: vi.fn(),
+			gitSha: () => "1234567890abcdef1234567890abcdef12345678",
+			resolveConfig: vi.fn(async () => ({
+				baseUrl: "https://platform.test",
+				token: "registry-token",
+				organizationId: "org_1",
+				workspaceId: "ws_1",
+				timeoutMs: 2_000,
+				maxAttempts: 1,
+			})),
+			listPeers: vi.fn(async () => [
+				peer("maestro-origin", "https://origin.test/a2a"),
+				peer("maestro-target", "https://target.test/a2a"),
+			]),
+			delegate: vi.fn(async () => ({
+				delegation: {
+					id: "delegation_1",
+					workspaceId: "ws_1",
+					fromAgentId: "maestro-origin",
+					toAgentId: "maestro-target",
+					status: "DELEGATION_STATUS_ACCEPTED",
+				},
+			})),
+			getGraph: vi.fn(async () => graph("task_1")),
+			control: vi.fn(async () => ({
+				delegation: graph("task_1").nodes[0]?.delegation,
+			})),
+			getTask: vi.fn(async () => ({
+				id: "task_1",
+				contextId: "ctx_1",
+				status: { state: "TASK_STATE_COMPLETED" },
+			})),
+			writeEvidence,
+		};
+
+		await expect(
+			runPlatformA2ADelegationLiveSmoke({
+				env: baseEnv,
+				dependencies,
+			}),
+		).rejects.toThrow(/did not return remoteTask\.taskId/);
+
+		expect(writeEvidence).not.toHaveBeenCalled();
+	});
+
+	it("retries transient remote task fetch failures during observation", async () => {
+		const sleep = vi.fn(async () => undefined);
+		const getTask = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("remote task not propagated yet"))
+			.mockResolvedValueOnce({
+				id: "task_1",
+				contextId: "ctx_1",
+				status: { state: "TASK_STATE_COMPLETED" },
+			});
+		const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+			now: () => new Date("2026-05-21T20:00:00.000Z"),
+			sleep,
+			log: vi.fn(),
+			gitSha: () => "1234567890abcdef1234567890abcdef12345678",
+			resolveConfig: vi.fn(async () => ({
+				baseUrl: "https://platform.test",
+				token: "registry-token",
+				organizationId: "org_1",
+				workspaceId: "ws_1",
+				timeoutMs: 2_000,
+				maxAttempts: 1,
+			})),
+			listPeers: vi.fn(async () => [
+				peer("maestro-origin", "https://origin.test/a2a"),
+				peer("maestro-target", "https://target.test/a2a"),
+			]),
+			delegate: vi.fn(async () => ({
+				delegation: {
+					id: "delegation_1",
+					workspaceId: "ws_1",
+					fromAgentId: "maestro-origin",
+					toAgentId: "maestro-target",
+					status: "DELEGATION_STATUS_ACCEPTED",
+				},
+			})),
+			getGraph: vi.fn(async () => graph("task_1")),
+			control: vi.fn(async () => ({
+				delegation: graph("task_1").nodes[0]?.delegation,
+				remoteTask: {
+					taskId: "task_1",
+					state: "TASK_STATE_COMPLETED",
+					controlMode: PlatformA2ADelegationTaskControlModeValue.Collect,
+				},
+			})),
+			getTask,
+			writeEvidence: vi.fn(async () => {
+				return "/tmp/platform-a2a-delegation-live/evidence.json";
+			}),
+		};
+
+		const result = await runPlatformA2ADelegationLiveSmoke({
+			env: {
+				...baseEnv,
+				MAESTRO_A2A_LIVE_TASK_ATTEMPTS: "2",
+			},
+			dependencies,
+		});
+
+		expect(result.evidence.task.id).toBe("task_1");
+		expect(getTask).toHaveBeenCalledTimes(2);
+		expect(sleep).toHaveBeenCalledWith(1);
+	});
+
+	it("uses supplied env credentials for Platform calls", async () => {
+		let writtenEvidence: PlatformA2ALiveSmokeEvidence | undefined;
+		const listPeers = vi.fn(async () => [
+			peer("maestro-origin", "https://origin.test/a2a"),
+			peer("maestro-target", "https://target.test/a2a"),
+		]);
+		const delegate = vi.fn(async () => ({
+			delegation: {
+				id: "delegation_1",
+				workspaceId: "ws_1",
+				fromAgentId: "maestro-origin",
+				toAgentId: "maestro-target",
+				status: "DELEGATION_STATUS_ACCEPTED",
+			},
+		}));
+		const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+			now: () => new Date("2026-05-21T20:00:00.000Z"),
+			sleep: vi.fn(async () => undefined),
+			log: vi.fn(),
+			gitSha: () => "1234567890abcdef1234567890abcdef12345678",
+			resolveConfig: vi.fn(async () => null),
+			listPeers,
+			delegate,
+			getGraph: vi.fn(async () => graph("task_1")),
+			control: vi.fn(async () => ({
+				delegation: graph("task_1").nodes[0]?.delegation,
+				remoteTask: {
+					taskId: "task_1",
+					state: "TASK_STATE_COMPLETED",
+					controlMode: PlatformA2ADelegationTaskControlModeValue.Collect,
+				},
+			})),
+			getTask: vi.fn(async () => ({
+				id: "task_1",
+				contextId: "ctx_1",
+				status: { state: "TASK_STATE_COMPLETED" },
+			})),
+			writeEvidence: vi.fn(async (_outputDir, evidence) => {
+				writtenEvidence = evidence;
+				return "/tmp/platform-a2a-delegation-live/evidence.json";
+			}),
+		};
+
+		await runPlatformA2ADelegationLiveSmoke({
+			env: {
+				...baseEnv,
+				MAESTRO_AGENT_REGISTRY_SERVICE_URL: "https://env-platform.test",
+				MAESTRO_AGENT_REGISTRY_SERVICE_TOKEN: "env-registry-token",
+				GITHUB_EVENT_NAME: "push",
+				GITHUB_REF: "refs/heads/release/2026",
+				GITHUB_REF_NAME: "release/2026",
+				GITHUB_REPOSITORY: "evalops/maestro-internal",
+			},
+			dependencies,
+		});
+
+		expect(listPeers).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({
+				config: expect.objectContaining({
+					baseUrl: "https://env-platform.test",
+					token: "env-registry-token",
+					organizationId: "org_1",
+					workspaceId: "ws_1",
+				}),
+			}),
+		);
+		expect(delegate).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({
+				config: expect.objectContaining({
+					baseUrl: "https://env-platform.test",
+					token: "env-registry-token",
+				}),
+			}),
+		);
+		expect(writtenEvidence?.github).toMatchObject({
+			eventName: "push",
+			ref: "refs/heads/release/2026",
+			repository: "evalops/maestro-internal",
+		});
+		expect(writtenEvidence?.github?.pullRequestNumber).toBeUndefined();
+		expect(writtenEvidence?.github?.pullRequestUrl).toBeUndefined();
+	});
+
+	it("records an invalid-token rejection when the negative auth probe is required", async () => {
+		const listPeers = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("401 unauthorized"))
+			.mockResolvedValueOnce([
+				peer("maestro-origin", "https://origin.test/a2a"),
+				peer("maestro-target", "https://target.test/a2a"),
+			]);
+		const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+			now: () => new Date("2026-05-21T20:00:00.000Z"),
+			sleep: vi.fn(async () => undefined),
+			log: vi.fn(),
+			gitSha: () => "1234567890abcdef1234567890abcdef12345678",
+			resolveConfig: vi.fn(async () => ({
+				baseUrl: "https://platform.test",
+				token: "registry-token",
+				organizationId: "org_1",
+				workspaceId: "ws_1",
+				timeoutMs: 2_000,
+				maxAttempts: 1,
+			})),
+			listPeers,
+			delegate: vi.fn(async () => ({
+				delegation: {
+					id: "delegation_1",
+					workspaceId: "ws_1",
+					fromAgentId: "maestro-origin",
+					toAgentId: "maestro-target",
+					status: "DELEGATION_STATUS_ACCEPTED",
+				},
+			})),
+			getGraph: vi.fn(async () => graph("task_1")),
+			control: vi.fn(async () => ({
+				delegation: graph("task_1").nodes[0]?.delegation,
+				remoteTask: {
+					taskId: "task_1",
+					state: "TASK_STATE_COMPLETED",
+					controlMode: PlatformA2ADelegationTaskControlModeValue.Collect,
+				},
+			})),
+			getTask: vi.fn(async () => ({
+				id: "task_1",
+				contextId: "ctx_1",
+				status: { state: "TASK_STATE_COMPLETED" },
+			})),
+			writeEvidence: vi.fn(async (_outputDir, _evidence) => {
+				return "/tmp/platform-a2a-delegation-live/evidence.json";
+			}),
+		};
+
+		const result = await runPlatformA2ADelegationLiveSmoke({
+			env: {
+				...baseEnv,
+				MAESTRO_A2A_LIVE_REQUIRE_INVALID_TOKEN_PROBE: "true",
+			},
+			dependencies,
+		});
+
+		expect(result.evidence.negativeAuthProbe).toEqual({
+			surface: "platform-agent-registry-peer-discovery",
+			rejected: true,
+			errorClass: "unauthorized",
+			observedAt: "2026-05-21T20:00:00.000Z",
+		});
+		expect(listPeers).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({ limit: 1, workspaceId: "ws_1" }),
+			expect.objectContaining({
+				config: expect.objectContaining({
+					token: [
+						"maestro",
+						"a2a",
+						"live",
+						"smoke",
+						"rejected",
+						"auth",
+						"probe",
+					].join("-"),
+				}),
+			}),
+		);
+		expect(listPeers).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ limit: 100, workspaceId: "ws_1" }),
+			expect.objectContaining({
+				config: expect.objectContaining({ token: "registry-token" }),
+			}),
+		);
+	});
+
+	it("refuses live proof evidence when the invalid-token probe is accepted", async () => {
+		const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+			resolveConfig: vi.fn(async () => ({
+				baseUrl: "https://platform.test",
+				token: "registry-token",
+				organizationId: "org_1",
+				workspaceId: "ws_1",
+				timeoutMs: 2_000,
+				maxAttempts: 1,
+			})),
+			listPeers: vi.fn(async () => []),
+		};
+
+		await expect(
+			runPlatformA2ADelegationLiveSmoke({
+				env: {
+					...baseEnv,
+					MAESTRO_A2A_LIVE_REQUIRE_INVALID_TOKEN_PROBE: "true",
+				},
+				dependencies,
+			}),
+		).rejects.toThrow(/invalid-token probe was accepted/);
+	});
+
+	it("writes evidence with a SHA-256 sidecar for later signed-bundle binding", async () => {
+		const outputDir = await mkdtemp(join(tmpdir(), "maestro-a2a-live-proof-"));
+		try {
+			const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+				now: () => new Date("2026-05-21T20:00:00.000Z"),
+				sleep: vi.fn(async () => undefined),
+				log: vi.fn(),
+				gitSha: () => "1234567890abcdef1234567890abcdef12345678",
+				resolveConfig: vi.fn(async () => ({
+					baseUrl: "https://platform.test",
+					token: "registry-token",
+					organizationId: "org_1",
+					workspaceId: "ws_1",
+					timeoutMs: 2_000,
+					maxAttempts: 1,
+				})),
+				listPeers: vi.fn(async () => [
+					peer("maestro-origin", "https://origin.test/a2a"),
+					peer("maestro-target", "https://target.test/a2a"),
+				]),
+				delegate: vi.fn(async () => ({
+					delegation: {
+						id: "delegation_1",
+						workspaceId: "ws_1",
+						fromAgentId: "maestro-origin",
+						toAgentId: "maestro-target",
+						status: "DELEGATION_STATUS_ACCEPTED",
+					},
+				})),
+				getGraph: vi.fn(async () => graph("task_1")),
+				control: vi.fn(async () => ({
+					delegation: graph("task_1").nodes[0]?.delegation,
+					remoteTask: {
+						taskId: "task_1",
+						state: "TASK_STATE_COMPLETED",
+						controlMode: PlatformA2ADelegationTaskControlModeValue.Collect,
+					},
+				})),
+				getTask: vi.fn(async () => ({
+					id: "task_1",
+					contextId: "ctx_1",
+					status: { state: "TASK_STATE_COMPLETED" },
+				})),
+			};
+
+			const result = await runPlatformA2ADelegationLiveSmoke({
+				env: {
+					...baseEnv,
+					MAESTRO_A2A_LIVE_EVIDENCE_DIR: outputDir,
+				},
+				dependencies,
+			});
+
+			const evidenceBytes = await readFile(result.evidencePath, "utf8");
+			const sidecar = await readFile(`${result.evidencePath}.sha256`, "utf8");
+			expect(sidecar).toBe(`${sha256Hex(evidenceBytes)}  evidence.json\n`);
+			expect(evidenceBytes).not.toContain("registry-token");
+			expect(evidenceBytes).not.toContain("acknowledge delegation");
+		} finally {
+			await rm(outputDir, { force: true, recursive: true });
+		}
+	});
+
+	it("writes an Ed25519 detached signature sidecar when a signing key is configured", async () => {
+		const outputDir = await mkdtemp(join(tmpdir(), "maestro-a2a-live-proof-"));
+		try {
+			const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+			const privateKeyPem = privateKey.export({
+				format: "pem",
+				type: "pkcs8",
+			}) as string;
+			const publicKeyPem = publicKey.export({
+				format: "pem",
+				type: "spki",
+			}) as string;
+			const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+				now: () => new Date("2026-05-21T20:00:00.000Z"),
+				sleep: vi.fn(async () => undefined),
+				log: vi.fn(),
+				gitSha: () => "1234567890abcdef1234567890abcdef12345678",
+				resolveConfig: vi.fn(async () => ({
+					baseUrl: "https://platform.test",
+					token: "registry-token",
+					organizationId: "org_1",
+					workspaceId: "ws_1",
+					timeoutMs: 2_000,
+					maxAttempts: 1,
+				})),
+				listPeers: vi.fn(async () => [
+					peer("maestro-origin", "https://origin.test/a2a"),
+					peer("maestro-target", "https://target.test/a2a"),
+				]),
+				delegate: vi.fn(async () => ({
+					delegation: {
+						id: "delegation_1",
+						workspaceId: "ws_1",
+						fromAgentId: "maestro-origin",
+						toAgentId: "maestro-target",
+						status: "DELEGATION_STATUS_ACCEPTED",
+					},
+				})),
+				getGraph: vi.fn(async () => graph("task_1")),
+				control: vi.fn(async () => ({
+					delegation: graph("task_1").nodes[0]?.delegation,
+					remoteTask: {
+						taskId: "task_1",
+						state: "TASK_STATE_COMPLETED",
+						controlMode: PlatformA2ADelegationTaskControlModeValue.Collect,
+					},
+				})),
+				getTask: vi.fn(async () => ({
+					id: "task_1",
+					contextId: "ctx_1",
+					status: { state: "TASK_STATE_COMPLETED" },
+				})),
+			};
+
+			const result = await runPlatformA2ADelegationLiveSmoke({
+				env: {
+					...baseEnv,
+					MAESTRO_A2A_LIVE_EVIDENCE_DIR: outputDir,
+					MAESTRO_A2A_LIVE_EVIDENCE_SIGNING_PRIVATE_KEY: privateKeyPem,
+					MAESTRO_A2A_LIVE_EVIDENCE_SIGNING_KEY_ID: "platform-live-smoke-ci",
+				},
+				dependencies,
+			});
+
+			const signature = JSON.parse(
+				await readFile(`${result.evidencePath}.sig.json`, "utf8"),
+			) as Record<string, unknown>;
+			expect(signature).toMatchObject({
+				protocolVersion:
+					"evalops.maestro.platform-a2a-live-evidence-signature.v1",
+				algorithm: "ed25519",
+				keyId: "platform-live-smoke-ci",
+				evidenceSha256: sha256Hex(await readFile(result.evidencePath, "utf8")),
+			});
+			await expect(
+				verifyPlatformA2ALiveEvidenceFile(result.evidencePath, {
+					publicKeyPem,
+					requireSignature: true,
+				}),
+			).resolves.toMatchObject({
+				signature: {
+					keyId: "platform-live-smoke-ci",
+					verified: true,
+				},
+			});
+		} finally {
+			await rm(outputDir, { force: true, recursive: true });
+		}
+	});
+
+	it("turns missing graph support into an explicit Platform readiness failure", async () => {
+		const dependencies: Partial<PlatformA2ALiveSmokeDependencies> = {
+			now: () => new Date("2026-05-21T20:00:00.000Z"),
+			sleep: vi.fn(async () => undefined),
+			log: vi.fn(),
+			resolveConfig: vi.fn(async () => ({
+				baseUrl: "https://platform.test",
+				token: "registry-token",
+				organizationId: "org_1",
+				workspaceId: "ws_1",
+				timeoutMs: 2_000,
+				maxAttempts: 1,
+			})),
+			listPeers: vi.fn(async () => [
+				peer("maestro-origin", "https://origin.test/a2a"),
+				peer("maestro-target", "https://target.test/a2a"),
+			]),
+			delegate: vi.fn(async () => ({
+				delegation: { id: "delegation_1" },
+			})),
+			getGraph: vi.fn(async () => {
+				throw new Error("connect 404 unknown method");
+			}),
+		};
+
+		await expect(
+			runPlatformA2ADelegationLiveSmoke({
+				env: baseEnv,
+				dependencies,
+			}),
+		).rejects.toThrow(/does not support A2A delegation graph yet/);
+	});
+});

--- a/test/platform/a2a-platform-live-evidence-verify.test.ts
+++ b/test/platform/a2a-platform-live-evidence-verify.test.ts
@@ -1,0 +1,581 @@
+import {
+	createHash,
+	createPublicKey,
+	generateKeyPairSync,
+	sign as signBytes,
+} from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { verifyPlatformA2ALiveEvidenceFile } from "../../scripts/verify-platform-a2a-live-evidence.js";
+import { getPackageName } from "../../src/package-metadata.js";
+
+const joinParts = (...parts: string[]) => parts.join("");
+const packageName = getPackageName();
+
+function evidence(
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		protocolVersion: "evalops.maestro.platform-a2a-live-smoke.v1",
+		eventType: "platform_a2a_delegation_live_smoke",
+		live: true,
+		workspaceId: "ws_1",
+		organizationId: "org_1",
+		platformEndpoint: "https://platform.test",
+		maestro: {
+			gitSha: "1234567890abcdef1234567890abcdef12345678",
+			cliPackage: packageName,
+		},
+		github: {
+			repository: "evalops/maestro-internal",
+			runId: "26252628231",
+			runUrl:
+				"https://github.com/evalops/maestro-internal/actions/runs/26252628231",
+			sha: "1234567890abcdef1234567890abcdef12345678",
+			pullRequestNumber: 2070,
+			pullRequestUrl: "https://github.com/evalops/maestro-internal/pull/2070",
+		},
+		inputs: {
+			fromAgentId: "maestro-origin",
+			toAgentId: "maestro-target",
+			promptHash: "a".repeat(64),
+		},
+		peers: {
+			origin: {
+				agentId: "maestro-origin",
+				endpointUrl: "https://origin.test/a2a",
+			},
+			target: {
+				agentId: "maestro-target",
+				endpointUrl: "https://target.test/a2a",
+			},
+		},
+		delegation: {
+			id: "delegation_1",
+			a2aTaskId: "task_1",
+		},
+		graph: {
+			nodes: [{ delegationId: "delegation_1", a2aTaskId: "task_1" }],
+			edges: [],
+		},
+		control: {
+			mode: "A2A_DELEGATION_TASK_CONTROL_MODE_COLLECT",
+			taskId: "task_1",
+		},
+		task: {
+			id: "task_1",
+			state: "TASK_STATE_COMPLETED",
+			terminal: true,
+		},
+		redaction: {
+			rawTokensWithheld: true,
+			rawPayloadsWithheld: true,
+		},
+		...overrides,
+	};
+}
+
+async function writeEvidenceBundle(
+	dir: string,
+	payload: Record<string, unknown>,
+	sidecarOverride?: string,
+	signature?: Record<string, unknown>,
+): Promise<string> {
+	const path = join(dir, "evidence.json");
+	const bytes = `${JSON.stringify(payload, null, 2)}\n`;
+	const digest = createHash("sha256").update(bytes).digest("hex");
+	await writeFile(path, bytes);
+	await writeFile(
+		`${path}.sha256`,
+		sidecarOverride ?? `${digest}  evidence.json\n`,
+	);
+	if (signature) {
+		await writeFile(
+			`${path}.sig.json`,
+			`${JSON.stringify(signature, null, 2)}\n`,
+		);
+	}
+	return path;
+}
+
+function signedEvidenceSidecar(
+	bytes: string,
+	privateKeyPem: string,
+	publicKeyPem: string,
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	const publicDer = createPublicKey(publicKeyPem).export({
+		format: "der",
+		type: "spki",
+	});
+	return {
+		protocolVersion: "evalops.maestro.platform-a2a-live-evidence-signature.v1",
+		algorithm: "ed25519",
+		evidenceSha256: createHash("sha256").update(bytes).digest("hex"),
+		signature: signBytes(null, Buffer.from(bytes), privateKeyPem).toString(
+			"base64",
+		),
+		keyId: "platform-live-smoke-ci",
+		publicKeyFingerprintSha256: createHash("sha256")
+			.update(publicDer)
+			.digest("hex"),
+		signedAt: "2026-05-21T20:00:00.000Z",
+		...overrides,
+	};
+}
+
+describe("Platform A2A live evidence verifier", () => {
+	it("accepts a hash-linked live evidence bundle", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(dir, evidence());
+			await expect(
+				verifyPlatformA2ALiveEvidenceFile(path),
+			).resolves.toMatchObject({
+				path,
+				protocolVersion: "evalops.maestro.platform-a2a-live-smoke.v1",
+				gitSha: "1234567890abcdef1234567890abcdef12345678",
+				delegationId: "delegation_1",
+				a2aTaskId: "task_1",
+				githubRunId: "26252628231",
+				githubPullRequestNumber: 2070,
+				evidenceSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+			});
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects digest mismatches", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence(),
+				`${"0".repeat(64)}  evidence.json\n`,
+			);
+			await expect(verifyPlatformA2ALiveEvidenceFile(path)).rejects.toThrow(
+				/digest mismatch/,
+			);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects delegation and task id mismatches", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence({
+					task: {
+						id: "task_2",
+						state: "TASK_STATE_COMPLETED",
+						terminal: true,
+					},
+				}),
+			);
+			await expect(verifyPlatformA2ALiveEvidenceFile(path)).rejects.toThrow(
+				/delegation\.a2aTaskId task_1 does not match task\.id task_2/,
+			);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects graph nodes that do not include the declared delegation", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence({
+					graph: {
+						nodes: [{ delegationId: "delegation_other", a2aTaskId: "task_1" }],
+						edges: [],
+					},
+				}),
+			);
+			await expect(verifyPlatformA2ALiveEvidenceFile(path)).rejects.toThrow(
+				/graph does not include delegation\.id delegation_1/,
+			);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects control task ids that do not match the verified task", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence({
+					control: {
+						mode: "A2A_DELEGATION_TASK_CONTROL_MODE_COLLECT",
+						taskId: "task_other",
+					},
+				}),
+			);
+			await expect(verifyPlatformA2ALiveEvidenceFile(path)).rejects.toThrow(
+				/control\.taskId task_other does not match task\.id task_1/,
+			);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects delegation inputs that do not match declared peers", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence({
+					inputs: {
+						fromAgentId: "maestro-other-origin",
+						toAgentId: "maestro-target",
+						promptHash: "a".repeat(64),
+					},
+				}),
+			);
+			await expect(verifyPlatformA2ALiveEvidenceFile(path)).rejects.toThrow(
+				/inputs\.fromAgentId maestro-other-origin does not match peers\.origin\.agentId maestro-origin/,
+			);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("dereferences GitHub run and PR evidence when required", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const paths: string[] = [];
+			const path = await writeEvidenceBundle(dir, evidence());
+			await expect(
+				verifyPlatformA2ALiveEvidenceFile(path, {
+					requireDereferenceableGithub: true,
+					githubApiClient: async (apiPath) => {
+						paths.push(apiPath);
+						if (
+							apiPath ===
+							"/repos/evalops/maestro-internal/actions/runs/26252628231"
+						) {
+							return { id: 26252628231 };
+						}
+						if (apiPath === "/repos/evalops/maestro-internal/pulls/2070") {
+							return { number: 2070 };
+						}
+						throw new Error(`unexpected GitHub API path ${apiPath}`);
+					},
+				}),
+			).resolves.toMatchObject({
+				githubDereferenced: true,
+				githubPullRequestNumber: 2070,
+				githubRunId: "26252628231",
+			});
+			expect(paths).toEqual([
+				"/repos/evalops/maestro-internal/actions/runs/26252628231",
+				"/repos/evalops/maestro-internal/pulls/2070",
+			]);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("dereferences GHES evidence through the evidence server API host", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		const originalFetch = globalThis.fetch;
+		const urls: string[] = [];
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence({
+					github: {
+						repository: "evalops/maestro-internal",
+						serverUrl: "https://github.example.com",
+						runId: "26252628231",
+						runUrl:
+							"https://github.example.com/evalops/maestro-internal/actions/runs/26252628231",
+						sha: "1234567890abcdef1234567890abcdef12345678",
+						pullRequestNumber: 2070,
+						pullRequestUrl:
+							"https://github.example.com/evalops/maestro-internal/pull/2070",
+					},
+				}),
+			);
+			globalThis.fetch = (async (input) => {
+				const url = String(input);
+				urls.push(url);
+				if (url.endsWith("/actions/runs/26252628231")) {
+					return new Response(JSON.stringify({ id: 26252628231 }), {
+						headers: { "content-type": "application/json" },
+						status: 200,
+					});
+				}
+				if (url.endsWith("/pulls/2070")) {
+					return new Response(JSON.stringify({ number: 2070 }), {
+						headers: { "content-type": "application/json" },
+						status: 200,
+					});
+				}
+				return new Response(JSON.stringify({ message: "not found" }), {
+					status: 404,
+				});
+			}) as typeof fetch;
+
+			await expect(
+				verifyPlatformA2ALiveEvidenceFile(path, {
+					requireDereferenceableGithub: true,
+				}),
+			).resolves.toMatchObject({
+				githubDereferenced: true,
+				githubPullRequestNumber: 2070,
+				githubRunId: "26252628231",
+			});
+			expect(urls).toEqual([
+				"https://github.example.com/api/v3/repos/evalops/maestro-internal/actions/runs/26252628231",
+				"https://github.example.com/api/v3/repos/evalops/maestro-internal/pulls/2070",
+			]);
+		} finally {
+			globalThis.fetch = originalFetch;
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("accepts invalid-token rejection evidence when required", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence({
+					negativeAuthProbe: {
+						surface: "platform-agent-registry-peer-discovery",
+						rejected: true,
+						errorClass: "forbidden",
+						observedAt: "2026-05-21T20:00:00.000Z",
+					},
+				}),
+			);
+			await expect(
+				verifyPlatformA2ALiveEvidenceFile(path, {
+					requireNegativeAuthProbe: true,
+				}),
+			).resolves.toMatchObject({
+				negativeAuthProbe: {
+					surface: "platform-agent-registry-peer-discovery",
+					rejected: true,
+					errorClass: "forbidden",
+				},
+			});
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects missing invalid-token evidence when required", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(dir, evidence());
+			await expect(
+				verifyPlatformA2ALiveEvidenceFile(path, {
+					requireNegativeAuthProbe: true,
+				}),
+			).rejects.toThrow(/requires invalid-token rejection evidence/);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects invalid-token evidence that is not rejected", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence({
+					negativeAuthProbe: {
+						surface: "platform-agent-registry-peer-discovery",
+						rejected: false,
+						errorClass: "forbidden",
+						observedAt: "2026-05-21T20:00:00.000Z",
+					},
+				}),
+			);
+			await expect(verifyPlatformA2ALiveEvidenceFile(path)).rejects.toThrow(
+				/not marked rejected/,
+			);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects GitHub metadata that does not resolve when dereference is required", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(dir, evidence());
+			await expect(
+				verifyPlatformA2ALiveEvidenceFile(path, {
+					requireDereferenceableGithub: true,
+					githubApiClient: async () => {
+						throw new Error("HTTP 404 not found");
+					},
+				}),
+			).rejects.toThrow(/HTTP 404 not found/);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("accepts a signed live evidence bundle when signature verification is required", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+			const privateKeyPem = privateKey.export({
+				format: "pem",
+				type: "pkcs8",
+			}) as string;
+			const publicKeyPem = publicKey.export({
+				format: "pem",
+				type: "spki",
+			}) as string;
+			const payload = evidence();
+			const bytes = `${JSON.stringify(payload, null, 2)}\n`;
+			const path = await writeEvidenceBundle(
+				dir,
+				payload,
+				undefined,
+				signedEvidenceSidecar(bytes, privateKeyPem, publicKeyPem),
+			);
+			await expect(
+				verifyPlatformA2ALiveEvidenceFile(path, {
+					publicKeyPem,
+					requireSignature: true,
+				}),
+			).resolves.toMatchObject({
+				signature: {
+					algorithm: "ed25519",
+					keyId: "platform-live-smoke-ci",
+					verified: true,
+				},
+			});
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects missing signatures when signature verification is required", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(dir, evidence());
+			await expect(
+				verifyPlatformA2ALiveEvidenceFile(path, { requireSignature: true }),
+			).rejects.toThrow(/requires a detached signature sidecar/);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects tampered detached signatures", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+			const privateKeyPem = privateKey.export({
+				format: "pem",
+				type: "pkcs8",
+			}) as string;
+			const publicKeyPem = publicKey.export({
+				format: "pem",
+				type: "spki",
+			}) as string;
+			const payload = evidence();
+			const bytes = `${JSON.stringify(payload, null, 2)}\n`;
+			const path = await writeEvidenceBundle(
+				dir,
+				payload,
+				undefined,
+				signedEvidenceSidecar(bytes, privateKeyPem, publicKeyPem, {
+					signature: Buffer.from("not the signed evidence").toString("base64"),
+				}),
+			);
+			await expect(
+				verifyPlatformA2ALiveEvidenceFile(path, {
+					publicKeyPem,
+					requireSignature: true,
+				}),
+			).rejects.toThrow(/detached signature is invalid/);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects production-looking evidence with synthetic git SHAs", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence({
+					maestro: {
+						gitSha: joinParts(
+							"9f3a",
+							"20260520222033",
+							"c0de",
+							"5afe",
+							"00000000000001",
+						),
+						cliPackage: packageName,
+					},
+				}),
+			);
+			await expect(verifyPlatformA2ALiveEvidenceFile(path)).rejects.toThrow(
+				/synthetic/,
+			);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects production-looking evidence with synthetic GitHub identifiers", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence({
+					github: {
+						repository: "evalops/maestro-internal",
+						runId: joinParts("gha-run-", "20260520T222033Z", "-local"),
+						pullRequest: joinParts(
+							"evalops/platform#",
+							"prod-pr-lane-",
+							"20260520T222033Z",
+							"-local",
+						),
+						sha: "1234567890abcdef1234567890abcdef12345678",
+					},
+				}),
+			);
+			await expect(verifyPlatformA2ALiveEvidenceFile(path)).rejects.toThrow(
+				/positive integer id|integer PR number/,
+			);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("rejects local proof ids in live evidence", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-evidence-"));
+		try {
+			const path = await writeEvidenceBundle(
+				dir,
+				evidence({
+					proof: {
+						id: "platform-a2a-proof-local",
+					},
+				}),
+			);
+			await expect(verifyPlatformA2ALiveEvidenceFile(path)).rejects.toThrow(
+				/local synthetic proof id/,
+			);
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
+	});
+});

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import {
@@ -347,11 +347,21 @@ describe("ci workflow guardrails", () => {
 				encoding: "utf8",
 			}),
 		) as Workflow;
-		const setupRustStep = workflow.jobs?.["pr-checks"]?.steps?.find(
+		const isInternalReleaseMirrorSource = existsSync(
+			new URL("../../.github/release-mirror-manifest.json", import.meta.url),
+		);
+		const prChecksJob = workflow.jobs?.["pr-checks"];
+		const setupRustStep = prChecksJob?.steps?.find(
 			(step) => step.uses === "./.github/actions/setup-rust",
 		);
+		const isPublicMirrorPrChecks =
+			workflow.jobs?.changes === undefined &&
+			workflow.jobs?.["public-release-mirror"] === undefined &&
+			prChecksJob?.["runs-on"] ===
+				"${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}";
 
 		if (!setupRustStep) {
+			expect(isPublicMirrorPrChecks).toBe(true);
 			const rustHostedSteps =
 				workflow.jobs?.["rust-hosted-conformance"]?.steps ?? [];
 			expect(
@@ -362,6 +372,10 @@ describe("ci workflow guardrails", () => {
 			return;
 		}
 
+		if (isInternalReleaseMirrorSource) {
+			expect(workflow.jobs?.changes).toBeDefined();
+			expect(workflow.jobs?.["public-release-mirror"]).toBeDefined();
+		}
 		expect(setupRustStep?.if).toBe(
 			"${{ github.event_name != 'pull_request' || needs.changes.outputs.ci_infrastructure_only != 'true' }}",
 		);
@@ -467,7 +481,7 @@ describe("ci workflow guardrails", () => {
 		);
 	});
 
-	it("runs the Nix hash updater with a hosted sudo-capable fallback", () => {
+	it("runs the Nix hash updater on a hosted sudo-capable runner", () => {
 		const workflow = parse(
 			readFileSync(
 				new URL("../../.github/workflows/update-nix-hash.yml", import.meta.url),
@@ -483,12 +497,10 @@ describe("ci workflow guardrails", () => {
 			"ubuntu-latest",
 			"${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}",
 		]).toContain(job?.["runs-on"]);
-		expect(installNixStep?.with?.nix_path).toBe(
-			"nixpkgs=channel:nixos-unstable",
-		);
-		if (installNixStep?.with && "enable_kvm" in installNixStep.with) {
-			expect(installNixStep.with.enable_kvm).toBe(false);
-		}
+		expect(installNixStep?.with).toMatchObject({
+			enable_kvm: false,
+			nix_path: "nixpkgs=channel:nixos-unstable",
+		});
 	});
 });
 

--- a/test/telemetry/telemetry-report.test.ts
+++ b/test/telemetry/telemetry-report.test.ts
@@ -10,6 +10,34 @@ const execFileAsync = promisify(execFile);
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 describe("telemetry-report", () => {
+	it("resolves relative telemetry env paths from the process cwd", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-telemetry-report-"));
+		await writeFile(
+			join(dir, "relative-env.log"),
+			JSON.stringify({ type: "tool_phase_summary" }),
+		);
+
+		const { stdout } = await execFileAsync(
+			process.execPath,
+			[join(repoRoot, "scripts/telemetry-report.js"), "--json"],
+			{
+				cwd: dir,
+				env: {
+					...process.env,
+					MAESTRO_TELEMETRY_FILE: "relative-env.log",
+				},
+			},
+		);
+		const report = JSON.parse(stdout);
+
+		expect(report).toMatchObject({
+			logPath: "relative-env.log",
+			sourceCount: 1,
+			lineCount: 1,
+			parsedEventCount: 1,
+		});
+	});
+
 	it("prefers canonical tool scheduling over raw phase summaries", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "maestro-telemetry-report-"));
 		const logPath = join(dir, "telemetry.log");
@@ -33,6 +61,23 @@ describe("telemetry-report", () => {
 							blocked_by_mutation: 1,
 						},
 					},
+					tools: [
+						{
+							name: "write",
+							callId: "call-1",
+							durationMs: 9,
+							success: true,
+							scheduling: {
+								callId: "call-1",
+								toolName: "write",
+								emittedIndex: 0,
+								decision: "delayed",
+								reason: "blocked_by_mutation",
+								schedulerWaitMs: 7,
+								blockedByMutation: true,
+							},
+						},
+					],
 				}),
 				JSON.stringify({
 					type: "tool_phase_summary",
@@ -86,6 +131,16 @@ describe("telemetry-report", () => {
 		expect(report.toolScheduling.topSerializationReasons).toEqual([
 			{ reason: "blocked_by_mutation", count: 1 },
 		]);
+		expect(report.toolScheduling.serializationReasonTiming).toEqual([
+			{
+				reason: "blocked_by_mutation",
+				count: 1,
+				totalWaitMs: 7,
+				averageWaitMs: 7,
+			},
+		]);
+		expect(report.toolScheduling.dedupedRawToolPhaseSummaryCount).toBe(1);
+		expect(JSON.stringify(report)).not.toContain("src/private.ts");
 	});
 
 	it("keeps unscoped raw phase summaries alongside canonical scheduling rollups", async () => {
@@ -330,5 +385,133 @@ describe("telemetry-report", () => {
 		expect(report.toolScheduling.topSerializationReasons).toEqual([
 			{ reason: "single_read_only_call", count: 1 },
 		]);
+	});
+
+	it("reports no-scheduling telemetry as a collection gap", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-telemetry-report-"));
+		const logPath = join(dir, "telemetry.log");
+		await writeFile(
+			logPath,
+			[
+				JSON.stringify({
+					type: "canonical-turn",
+					turnId: "turn-1",
+					tools: [],
+				}),
+				JSON.stringify({
+					type: "tool-execution",
+					success: true,
+					durationMs: 25,
+				}),
+			].join("\n"),
+		);
+
+		const { stdout } = await execFileAsync(
+			process.execPath,
+			["scripts/telemetry-report.js", logPath, "--json"],
+			{ cwd: repoRoot },
+		);
+		const report = JSON.parse(stdout);
+
+		expect(report.toolScheduling).toMatchObject({
+			hasSchedulingData: false,
+			schedulingCoverageRatio: 0,
+		});
+		expect(report.toolScheduling.nextActions).toEqual([
+			{
+				id: "collect_real_tool_phase_telemetry",
+				reason:
+					"No canonical toolScheduling or raw tool_phase_summary events were found.",
+			},
+		]);
+	});
+
+	it("aggregates telemetry directories without leaking tool args", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-telemetry-report-"));
+		await writeFile(
+			join(dir, "a.log"),
+			[
+				JSON.stringify({
+					type: "tool_phase_summary",
+					modelToolCallCount: 1,
+					modelEmittedToolCallCount: 1,
+					schedulableWaveCount: 1,
+					parallelizedCallCount: 0,
+					actuallyParallelizedCallCount: 0,
+					serializedCallCount: 1,
+					delayedCallCount: 0,
+					blockedByMutationCount: 0,
+					mcpOptInCallCount: 0,
+					mcpOptInUseCount: 0,
+					cacheHitCount: 0,
+					totalToolWaitMs: 0,
+					toolWaitTimeMs: 0,
+					serializationReasons: {
+						single_read_only_call: 1,
+					},
+					decisions: [
+						{
+							toolCallId: "call-1",
+							toolName: "read",
+							emittedIndex: 0,
+							outcome: "serialized",
+							decision: "serialized",
+							reason: "single_read_only_call",
+							waitMs: 0,
+							schedulerWaitMs: 0,
+							args: { file_path: "src/private.ts" },
+						},
+					],
+				}),
+			].join("\n"),
+		);
+		await writeFile(
+			join(dir, "b.jsonl"),
+			[
+				JSON.stringify({
+					type: "tool_phase_summary",
+					modelToolCallCount: 2,
+					modelEmittedToolCallCount: 2,
+					schedulableWaveCount: 1,
+					parallelizedCallCount: 2,
+					actuallyParallelizedCallCount: 2,
+					serializedCallCount: 0,
+					delayedCallCount: 0,
+					blockedByMutationCount: 0,
+					mcpOptInCallCount: 0,
+					mcpOptInUseCount: 0,
+					cacheHitCount: 1,
+					totalToolWaitMs: 0,
+					toolWaitTimeMs: 0,
+					serializationReasons: {},
+					decisions: [],
+				}),
+			].join("\n"),
+		);
+
+		const { stdout } = await execFileAsync(
+			process.execPath,
+			["scripts/telemetry-report.js", dir, "--json"],
+			{ cwd: repoRoot },
+		);
+		const report = JSON.parse(stdout);
+
+		expect(report).toMatchObject({
+			sourceCount: 2,
+			lineCount: 2,
+			parsedEventCount: 2,
+		});
+		expect(report.toolScheduling).toMatchObject({
+			modelToolCallCount: 3,
+			modelSingletonTurnCount: 1,
+			modelMultiCallTurnCount: 1,
+			avoidableSingletonCount: 1,
+			cacheHitCount: 1,
+		});
+		expect(report.toolScheduling.nextActions[0]).toMatchObject({
+			id: "batch_shaping_feedback",
+		});
+		expect(JSON.stringify(report)).not.toContain("file_path");
+		expect(JSON.stringify(report)).not.toContain("src/private.ts");
 	});
 });


### PR DESCRIPTION
## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `f2b597cdc853a2cb85eba940f8554a92d5ebe48a`
- last generated public sync base: `a5c3f625869e66ef9349cefc1f1498b764eb9264`
- previewed public-tree drift: `48` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (f2b597cdc853)`
- public projection: `https://github.com/evalops/maestro@main (a5c3f625869e)`
- files to copy or update: `48`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update .github/actions/setup-rust/action.yml
- copy/update CHANGELOG.md
- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update docs/protocols/a2a-peer-pairing.md
- copy/update docs/protocols/a2a-swarm-stage-gates.json
- copy/update docs/protocols/a2a-swarm-stage-gates.md
- copy/update evals/tools/batch-shaping-cases.json
- copy/update openapi.json
- copy/update package.json
- copy/update packages/ai/package.json
- copy/update packages/consumer-sdk/package.json
- copy/update packages/contracts/package.json
- copy/update packages/core/package.json
- copy/update packages/desktop/package.json
- copy/update packages/github-agent/package.json
- copy/update packages/governance-mcp-server/package.json
- copy/update packages/governance/package.json
- copy/update packages/memory/package.json
- copy/update packages/slack-agent-ui/package.json
- copy/update packages/slack-agent/package.json
- copy/update packages/tui-rs/Cargo.toml
- copy/update packages/tui-rs/src/agent/native.rs
- copy/update packages/tui-rs/src/tools/batch.rs
- copy/update packages/tui/package.json
- copy/update packages/vscode-extension/package.json
- ... 23 more

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update .github/actions/setup-rust/action.yml
- copy/update CHANGELOG.md
- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update docs/protocols/a2a-peer-pairing.md
- copy/update docs/protocols/a2a-swarm-stage-gates.json
- copy/update docs/protocols/a2a-swarm-stage-gates.md
- copy/update evals/tools/batch-shaping-cases.json
- copy/update openapi.json
- copy/update package.json
- copy/update packages/ai/package.json
- copy/update packages/consumer-sdk/package.json
- copy/update packages/contracts/package.json
- copy/update packages/core/package.json
- copy/update packages/desktop/package.json
- copy/update packages/github-agent/package.json
- copy/update packages/governance-mcp-server/package.json
- copy/update packages/governance/package.json
- copy/update packages/memory/package.json
- copy/update packages/slack-agent-ui/package.json
- copy/update packages/slack-agent/package.json

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@f2b597cdc853a2cb85eba940f8554a92d5ebe48a`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #479 to internal source `f2b597cdc853a2cb85eba940f8554a92d5ebe48a`