### PR TITLE
fix: bundle runtime workspaces without registry deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,94 +148,6 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Publish runtime workspace packages to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_PUBLISH_AUTH_MODE: ${{ vars.NPM_PUBLISH_AUTH_MODE || 'auto' }}
-        run: |
-          set -euo pipefail
-          NPM_TOKEN_FALLBACK="${NODE_AUTH_TOKEN:-}"
-
-          package_name() {
-            node -p "require('./$1/package.json').name"
-          }
-
-          package_version() {
-            node -p "require('./$1/package.json').version"
-          }
-
-          package_is_published() {
-            local package_dir="$1"
-            local name version
-            name="$(package_name "$package_dir")"
-            version="$(package_version "$package_dir")"
-            npm view "${name}@${version}" version --json >/dev/null 2>&1
-          }
-
-          publish_with_token() {
-            local package_dir="$1"
-            if [ -z "${NPM_TOKEN_FALLBACK:-}" ]; then
-              echo "::error::NPM_PUBLISH_AUTH_MODE=token requires the NPM_TOKEN secret."
-              exit 1
-            fi
-
-            echo "Publishing $(package_name "$package_dir") with NPM_TOKEN fallback."
-            printf "//registry.npmjs.org/:_authToken=%s\n" "$NPM_TOKEN_FALLBACK" > ~/.npmrc
-            NODE_AUTH_TOKEN="$NPM_TOKEN_FALLBACK" npm publish "./$package_dir" --access public --provenance
-          }
-
-          publish_with_trusted_publisher() {
-            local package_dir="$1"
-            echo "Publishing $(package_name "$package_dir") with npm trusted publishing."
-            unset NODE_AUTH_TOKEN
-            rm -f ~/.npmrc
-            npm publish "./$package_dir" --access public
-          }
-
-          publish_package_dir() {
-            local package_dir="$1"
-            local name version
-            name="$(package_name "$package_dir")"
-            version="$(package_version "$package_dir")"
-
-            if package_is_published "$package_dir"; then
-              echo "${name}@${version} is already published; skipping."
-              return
-            fi
-
-            case "${NPM_PUBLISH_AUTH_MODE}" in
-              auto|"")
-                echo "Attempting trusted publishing for ${name}@${version}; NPM_TOKEN is only a fallback."
-                trusted_status=0
-                publish_with_trusted_publisher "$package_dir" || trusted_status=$?
-                if [ "$trusted_status" -eq 0 ]; then
-                  return
-                fi
-
-                if [ -z "${NPM_TOKEN_FALLBACK:-}" ]; then
-                  echo "::error::Trusted publishing failed for ${name}@${version} and no NPM_TOKEN fallback is configured."
-                  exit "$trusted_status"
-                fi
-
-                echo "::warning::Trusted publishing failed for ${name}@${version}; falling back to NPM_TOKEN."
-                publish_with_token "$package_dir"
-                ;;
-              token)
-                publish_with_token "$package_dir"
-                ;;
-              trusted)
-                publish_with_trusted_publisher "$package_dir"
-                ;;
-              *)
-                echo "::error::Unsupported NPM_PUBLISH_AUTH_MODE '${NPM_PUBLISH_AUTH_MODE}'. Use auto, token, or trusted."
-                exit 1
-                ;;
-            esac
-          }
-
-          publish_package_dir packages/contracts
-          publish_package_dir packages/tui
-
       - id: pack
         run: |
           set -euo pipefail
@@ -245,6 +157,8 @@ jobs:
           echo "tarball=$FILE" >> "$GITHUB_OUTPUT"
 
       - name: Smoke-test packed CLI
+        env:
+          MAESTRO_INSTALL_AUDIT_LEVEL: critical
         run: node scripts/smoke-packed-cli.js "${{ steps.pack.outputs.tarball }}"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -393,6 +307,7 @@ jobs:
 
       - name: Verify published package from npm
         env:
+          MAESTRO_INSTALL_AUDIT_LEVEL: critical
           MAESTRO_REGISTRY_POLL_ATTEMPTS: "120"
           MAESTRO_REGISTRY_POLL_DELAY_MS: "5000"
         run: node scripts/smoke-registry-install.js

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "ci:plan": "node scripts/plan-ci-checks.mjs",
     "pr:ready": "node scripts/pr-ready-to-merge.mjs",
     "pr:feedback": "node scripts/pr-feedback-audit.mjs",
-    "verify:runtime-deps": "node scripts/check-runtime-deps.js && node scripts/check-docker-runtime-workspaces.mjs",
+    "verify:runtime-deps": "node scripts/check-runtime-deps.js && node scripts/check-docker-runtime-workspaces.mjs && node scripts/check-packed-bundled-workspaces.mjs",
     "tui": "npm run cli",
     "verify": "npm run format && npm run lint && npm run test && npm run build && npm run smoke && npm run telemetry:report",
     "smoke": "node scripts/smoke-cli.js",

--- a/package.json
+++ b/package.json
@@ -161,8 +161,6 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1020.0",
     "@crosscopy/clipboard": "^0.2.8",
     "@daytonaio/sdk": "^0.155.0",
-    "@evalops/contracts": "^0.10.20",
-    "@evalops/tui": "^0.10.20",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.75.0",

--- a/scripts/check-packed-bundled-workspaces.mjs
+++ b/scripts/check-packed-bundled-workspaces.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// @ts-check
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	getWorkspacePackages,
+	loadRootPackage,
+} from "./workspace-utils.js";
+
+const rootPackage = loadRootPackage();
+const bundled = Array.isArray(rootPackage.bundleDependencies)
+	? rootPackage.bundleDependencies
+	: [];
+const workspacePackages = await getWorkspacePackages(rootPackage);
+const workspaceNames = new Set(
+	workspacePackages.map((workspacePackage) => workspacePackage.name),
+);
+const bundledWorkspaceNames = bundled.filter((name) => workspaceNames.has(name));
+
+if (bundledWorkspaceNames.length === 0) {
+	console.log("No bundled workspace packages declared.");
+	process.exit(0);
+}
+
+const packDir = mkdtempSync(join(tmpdir(), "maestro-packed-workspaces-"));
+
+try {
+	const pack = spawnSync(
+		"npm",
+		["pack", "--silent", "--pack-destination", packDir],
+		{
+			cwd: process.cwd(),
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "pipe"],
+		},
+	);
+	if (pack.status !== 0) {
+		console.error("npm pack failed while checking bundled workspaces.");
+		if (pack.stdout) console.error(pack.stdout.trim());
+		if (pack.stderr) console.error(pack.stderr.trim());
+		process.exit(pack.status ?? 1);
+	}
+
+	const tarballs = readdirSync(packDir).filter((file) => file.endsWith(".tgz"));
+	if (tarballs.length !== 1) {
+		console.error(
+			`Expected npm pack to create one tarball, found ${tarballs.length}.`,
+		);
+		process.exit(1);
+	}
+
+	const tarballPath = join(packDir, tarballs[0]);
+	const listing = spawnSync("tar", ["-tzf", tarballPath], {
+		encoding: "utf-8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	if (listing.status !== 0) {
+		console.error(`Failed to inspect packed tarball ${tarballs[0]}.`);
+		if (listing.stderr) console.error(listing.stderr.trim());
+		process.exit(listing.status ?? 1);
+	}
+
+	const entries = new Set(listing.stdout.split(/\r?\n/).filter(Boolean));
+	const missing = bundledWorkspaceNames.filter(
+		(name) => !entries.has(`package/node_modules/${name}/package.json`),
+	);
+	if (missing.length > 0) {
+		console.error("Packed tarball is missing bundled workspace packages:");
+		for (const name of missing.sort()) {
+			console.error(`- ${name}`);
+		}
+		process.exit(1);
+	}
+
+	console.log(
+		`Verified packed tarball includes bundled workspaces: ${bundledWorkspaceNames
+			.slice()
+			.sort()
+			.join(", ")}.`,
+	);
+} finally {
+	rmSync(packDir, { recursive: true, force: true });
+}

--- a/scripts/validate-public-package-deps.js
+++ b/scripts/validate-public-package-deps.js
@@ -15,10 +15,19 @@ if (rootPackage.private === true) {
 }
 
 const workspacePackages = await getWorkspacePackages(rootPackage);
+const workspaceNames = new Set(
+	workspacePackages.map((workspacePackage) => workspacePackage.name),
+);
 const privateWorkspaceNames = new Set(
 	workspacePackages
 		.filter((workspacePackage) => workspacePackage.data.private === true)
 		.map((workspacePackage) => workspacePackage.name),
+);
+const bundled = Array.isArray(rootPackage.bundleDependencies)
+	? rootPackage.bundleDependencies
+	: [];
+const bundledWorkspaceNames = new Set(
+	bundled.filter((name) => workspaceNames.has(name)),
 );
 
 const dependencySections = [
@@ -28,6 +37,7 @@ const dependencySections = [
 ];
 
 const offenders = [];
+const bundledDependencyOffenders = [];
 
 for (const section of dependencySections) {
 	const deps = rootPackage[section];
@@ -38,15 +48,9 @@ for (const section of dependencySections) {
 		if (privateWorkspaceNames.has(name)) {
 			offenders.push(`${section}.${name}`);
 		}
-	}
-}
-
-const bundled = Array.isArray(rootPackage.bundleDependencies)
-	? rootPackage.bundleDependencies
-	: [];
-for (const name of bundled) {
-	if (privateWorkspaceNames.has(name)) {
-		offenders.push(`bundleDependencies[].${name}`);
+		if (bundledWorkspaceNames.has(name)) {
+			bundledDependencyOffenders.push(`${section}.${name}`);
+		}
 	}
 }
 
@@ -63,6 +67,19 @@ if (offenders.length > 0) {
 	process.exit(1);
 }
 
+if (bundledDependencyOffenders.length > 0) {
+	console.error(
+		`${rootName} is public but declares bundled workspace packages as install-time dependencies:`,
+	);
+	for (const offender of bundledDependencyOffenders.sort()) {
+		console.error(`- ${offender}`);
+	}
+	console.error(
+		"Keep bundled workspace packages in bundleDependencies only so package managers do not resolve them from the registry.",
+	);
+	process.exit(1);
+}
+
 console.log(
-	`${rootName} does not reference private workspace packages in public dependency metadata.`,
+	`${rootName} does not reference forbidden workspace package dependency metadata.`,
 );

--- a/scripts/validate-public-package-deps.js
+++ b/scripts/validate-public-package-deps.js
@@ -48,9 +48,10 @@ for (const section of dependencySections) {
 		if (privateWorkspaceNames.has(name)) {
 			offenders.push(`${section}.${name}`);
 		}
-		if (bundledWorkspaceNames.has(name)) {
-			bundledDependencyOffenders.push(`${section}.${name}`);
+		if (!bundledWorkspaceNames.has(name)) {
+			continue;
 		}
+		bundledDependencyOffenders.push(`${section}.${name}`);
 	}
 }
 
@@ -75,7 +76,7 @@ if (bundledDependencyOffenders.length > 0) {
 		console.error(`- ${offender}`);
 	}
 	console.error(
-		"Keep bundled workspace packages in bundleDependencies only so package managers do not resolve them from the registry.",
+		"Keep bundled workspace packages in bundleDependencies only so package managers do not resolve them from the registry; check-packed-bundled-workspaces verifies npm still packs them under node_modules.",
 	);
 	process.exit(1);
 }


### PR DESCRIPTION
## Summary
- remove @evalops/contracts and @evalops/tui from root install-time dependencies while preserving bundleDependencies
- stop the public release workflow from trying to publish the private runtime workspaces
- keep packed and registry install canaries, including Bun, while failing audit only on critical advisories

Source-of-truth PR: https://github.com/evalops/maestro-internal/pull/2095

## Verification
- bun install --frozen-lockfile
- actionlint .github/workflows/release.yml
- npm run release:check
- npm run verify:runtime-deps
- MAESTRO_INSTALL_AUDIT_LEVEL=critical node scripts/smoke-packed-cli.js evalops-maestro-0.10.20.tgz
- npm install local tarball and node_modules/.bin/maestro --version
- bun add local tarball and node_modules/.bin/maestro --version