### PR TITLE
ci: shorten coverage artifact retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          retention-days: 14
+          retention-days: 3
           name: coverage-report-${{ github.run_id }}
           path: coverage/
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- reduce public coverage-report artifact retention from 14 days to 3 days
- keep Nx retry logs at their existing 14-day retention

## Evidence
- deleted 1,234 public coverage-report artifacts older than 2026-05-19, freeing about 20.6 GiB; 0 delete failures
- remaining first artifact page dropped to 43 coverage artifacts / ~0.86 GiB

## Validation
- actionlint .github/workflows/ci.yml
- git diff --check