### PR TITLE
Expose release deprecation scripts

### DIFF
--- a/docs/release-ops.md
+++ b/docs/release-ops.md
@@ -56,5 +56,6 @@
 
 - Verify a published package manually with `npm run release:verify:published -- --package <name> --version <version>`.
 - Deprecate a bad version or temporary package path from a logged-in machine with `npm run release:deprecate -- --range <version-or-range>`.
+- For the broken `@evalops/maestro@0.10.20` package, run `npm run release:deprecate -- --range 0.10.20 --message "Broken release: install @evalops/maestro@0.10.21 or newer."` from an npm-authenticated machine.
 - Add `--replacement-package @evalops/maestro` when retiring the temporary namespace, or provide `--message` for a custom rollback notice.
 - Use `--dry-run` first to inspect the exact `npm deprecate` command before making registry changes.

--- a/package.json
+++ b/package.json
@@ -101,6 +101,8 @@
     "verify-build:packages": "VERIFY_PACKAGES=1 bun scripts/verify-build.ts",
     "release:check": "node scripts/release-readiness.js release",
     "release:check:ci": "node scripts/release-readiness.js ci",
+    "release:verify:published": "node scripts/smoke-registry-install.js",
+    "release:deprecate": "node scripts/deprecate-release.js",
     "ci:plan": "node scripts/plan-ci-checks.mjs",
     "pr:ready": "node scripts/pr-ready-to-merge.mjs",
     "pr:feedback": "node scripts/pr-feedback-audit.mjs",

--- a/scripts/smoke-registry-install.js
+++ b/scripts/smoke-registry-install.js
@@ -75,6 +75,7 @@ const pollDelayMs = Number.parseInt(
 	process.env.MAESTRO_REGISTRY_POLL_DELAY_MS ?? "5000",
 	10,
 );
+const installAuditLevel = process.env.MAESTRO_INSTALL_AUDIT_LEVEL ?? "critical";
 
 function sleep(milliseconds) {
 	return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -145,6 +146,7 @@ async function main() {
 		});
 		assertInstalledMetadata(tempDir, `${packageSpec} via npm`);
 		runInstalledPackageAudit(tempDir, {
+			auditLevel: installAuditLevel,
 			label: packageSpec,
 		});
 		runInstalledCliSmoke(tempDir, {


### PR DESCRIPTION
## Summary
- expose the documented `release:verify:published` and `release:deprecate` npm scripts in the public package
- make registry install smoke default to the release workflow's critical-only audit gate for manual verification
- document the exact `0.10.20` deprecation command for an npm-authenticated operator

## Test Plan
- npm run release:deprecate -- --range 0.10.20 --message "Broken release: install @evalops/maestro@0.10.21 or newer." --dry-run
- MAESTRO_REGISTRY_POLL_ATTEMPTS=1 MAESTRO_SKIP_BUN_INSTALL_SMOKE=1 npm run release:verify:published -- --version 0.10.21
- node --check scripts/smoke-registry-install.js && node --check scripts/deprecate-release.js
- git diff --check
- pre-commit hook: Guardian, biome, lint:evals, contract checks, codegen checks, TypeScript build, dist compile

## Rollback
- Revert this PR to remove the convenience npm scripts and restore the previous registry-smoke audit default.

## Source
- Internal package.json generator companion: https://github.com/evalops/maestro-internal/pull/2105
- Private release-fix context: https://github.com/evalops/maestro-internal/pull/2096