### PR TITLE
Mirror release workspace scan fallback

### DIFF
--- a/scripts/workspace-utils.js
+++ b/scripts/workspace-utils.js
@@ -6,7 +6,12 @@
  * Plain JS for direct Node execution; typed via JSDoc for safety.
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	readFileSync,
+	readdirSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname, join, resolve as resolvePath } from "node:path";
 
 /**
@@ -93,21 +98,85 @@ function getWorkspaceGlobs(rootPackage) {
 	throw new Error("Unsupported workspace configuration in package.json");
 }
 
+function segmentPatternToRegExp(segment) {
+	return new RegExp(
+		`^${segment.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*")}$`,
+	);
+}
+
+function listDirectories(path) {
+	try {
+		return readdirSync(path, { withFileTypes: true })
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => join(path, entry.name));
+	} catch {
+		return [];
+	}
+}
+
+function expandWorkspacePattern(rootDir, pattern) {
+	const segments = pattern.split(/[\\/]+/u).filter(Boolean);
+	let directories = [rootDir];
+
+	for (const segment of segments) {
+		if (segment === "**") {
+			const descendants = [];
+			const visit = (dir) => {
+				for (const child of listDirectories(dir)) {
+					descendants.push(child);
+					visit(child);
+				}
+			};
+			for (const dir of directories) {
+				visit(dir);
+			}
+			directories = descendants;
+			continue;
+		}
+
+		if (segment.includes("*")) {
+			const regexp = segmentPatternToRegExp(segment);
+			directories = directories.flatMap((dir) =>
+				listDirectories(dir).filter((child) =>
+					regexp.test(child.split(/[\\/]/u).pop() ?? ""),
+				),
+			);
+			continue;
+		}
+
+		directories = directories
+			.map((dir) => join(dir, segment))
+			.filter((dir) => existsSync(dir));
+	}
+
+	return directories
+		.map((dir) => join(dir, "package.json"))
+		.filter((path) => existsSync(path))
+		.map((path) => resolvePath(path));
+}
+
+async function resolveWorkspacePackagePathsWithGlob(rootDir, globs) {
+	try {
+		const { globSync } = await import("glob");
+		return globs.flatMap((pattern) =>
+			globSync(join(pattern, "package.json"), {
+				cwd: rootDir,
+				absolute: true,
+				nodir: true,
+			}).map((p) => resolvePath(p)),
+		);
+	} catch {
+		return globs.flatMap((pattern) => expandWorkspacePattern(rootDir, pattern));
+	}
+}
+
 /**
  * @param {Record<string, unknown>} rootPackage
  */
 export async function getWorkspacePackagePaths(rootPackage) {
-	const { globSync } = await import("glob");
 	const globs = getWorkspaceGlobs(rootPackage);
-	const paths = new Set(
-		globs.flatMap((pattern) =>
-			globSync(join(pattern, "package.json"), {
-				cwd: getRootContext().rootDir,
-				absolute: true,
-				nodir: true,
-			}).map((p) => resolvePath(p)),
-		),
-	);
+	const { rootDir } = getRootContext();
+	const paths = new Set(await resolveWorkspacePackagePathsWithGlob(rootDir, globs));
 
 	if (paths.size === 0) {
 		throw new Error("No workspace package.json files found");

--- a/scripts/workspace-utils.js
+++ b/scripts/workspace-utils.js
@@ -120,7 +120,7 @@ function expandWorkspacePattern(rootDir, pattern) {
 
 	for (const segment of segments) {
 		if (segment === "**") {
-			const descendants = [];
+			const descendants = [...directories];
 			const visit = (dir) => {
 				for (const child of listDirectories(dir)) {
 					descendants.push(child);
@@ -130,7 +130,7 @@ function expandWorkspacePattern(rootDir, pattern) {
 			for (const dir of directories) {
 				visit(dir);
 			}
-			directories = descendants;
+			directories = Array.from(new Set(descendants));
 			continue;
 		}
 

--- a/scripts/workspace-utils.js
+++ b/scripts/workspace-utils.js
@@ -98,10 +98,34 @@ function getWorkspaceGlobs(rootPackage) {
 	throw new Error("Unsupported workspace configuration in package.json");
 }
 
+function escapeRegExp(value) {
+	return value.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function segmentHasPatternSyntax(segment) {
+	return segment.includes("*") || /\{[^{}]+,[^{}]*\}/u.test(segment);
+}
+
 function segmentPatternToRegExp(segment) {
-	return new RegExp(
-		`^${segment.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*")}$`,
-	);
+	let pattern = "";
+	for (let index = 0; index < segment.length; index += 1) {
+		const char = segment[index];
+		if (char === "*") {
+			pattern += "[^/]*";
+			continue;
+		}
+		if (char === "{") {
+			const end = segment.indexOf("}", index + 1);
+			const body = end === -1 ? "" : segment.slice(index + 1, end);
+			if (body.includes(",")) {
+				pattern += `(?:${body.split(",").map(escapeRegExp).join("|")})`;
+				index = end;
+				continue;
+			}
+		}
+		pattern += escapeRegExp(char);
+	}
+	return new RegExp(`^${pattern}$`);
 }
 
 function listDirectories(path) {
@@ -134,7 +158,7 @@ function expandWorkspacePattern(rootDir, pattern) {
 			continue;
 		}
 
-		if (segment.includes("*")) {
+		if (segmentHasPatternSyntax(segment)) {
 			const regexp = segmentPatternToRegExp(segment);
 			directories = directories.flatMap((dir) =>
 				listDirectories(dir).filter((child) =>

--- a/test/scripts/workspace-utils.test.ts
+++ b/test/scripts/workspace-utils.test.ts
@@ -38,6 +38,18 @@ function writePackage(root: string, relativePath: string) {
 	);
 }
 
+function readWorkspacePaths(root: string) {
+	const output = execFileSync(process.execPath, ["--input-type=module"], {
+		cwd: root,
+		encoding: "utf8",
+		input: [
+			'import { getWorkspacePackagePaths, loadRootPackage } from "./scripts/workspace-utils.js";',
+			"console.log(JSON.stringify(await getWorkspacePackagePaths(loadRootPackage())));",
+		].join("\n"),
+	});
+	return JSON.parse(output).sort();
+}
+
 describe("getWorkspacePackagePaths", () => {
 	afterEach(() => {
 		for (const fixture of fixtures.splice(0)) {
@@ -59,17 +71,28 @@ describe("getWorkspacePackagePaths", () => {
 		writePackage(root, "packages/pkg-a");
 		writePackage(root, "packages/nested/pkg-b");
 
-		const output = execFileSync(process.execPath, ["--input-type=module"], {
-			cwd: root,
-			encoding: "utf8",
-			input: [
-				'import { getWorkspacePackagePaths, loadRootPackage } from "./scripts/workspace-utils.js";',
-				"console.log(JSON.stringify(await getWorkspacePackagePaths(loadRootPackage())));",
-			].join("\n"),
-		});
-
-		expect(JSON.parse(output).sort()).toEqual([
+		expect(readWorkspacePaths(root)).toEqual([
 			realpathSync(resolve(root, "packages/nested/pkg-b/package.json")),
+			realpathSync(resolve(root, "packages/pkg-a/package.json")),
+		]);
+	});
+
+	it("treats brace segments as alternatives without glob installed", () => {
+		const root = makeFixture();
+		copyScript(root, "workspace-utils.js");
+		writeFileSync(
+			join(root, "package.json"),
+			JSON.stringify({
+				name: "fixture",
+				type: "module",
+				workspaces: ["{packages,apps}/*"],
+			}),
+		);
+		writePackage(root, "apps/app-a");
+		writePackage(root, "packages/pkg-a");
+
+		expect(readWorkspacePaths(root)).toEqual([
+			realpathSync(resolve(root, "apps/app-a/package.json")),
 			realpathSync(resolve(root, "packages/pkg-a/package.json")),
 		]);
 	});


### PR DESCRIPTION
## Summary
- mirror the release workspace scan fallback from the internal install-gate PR
- allow public release verification scripts to enumerate workspace package metadata before repo dependencies are installed

## Test Plan
- MAESTRO_REGISTRY_POLL_ATTEMPTS=1 npm run release:verify:published -- --version 0.10.21
- node --check scripts/workspace-utils.js
- git diff --check

## Rollback
- Revert this PR to restore the previous glob-only workspace scan behavior.

## Source
- Internal companion: https://github.com/evalops/maestro-internal/pull/2100