### PR TITLE
Mirror release readiness pack smoke

### DIFF
--- a/scripts/release-readiness.js
+++ b/scripts/release-readiness.js
@@ -26,6 +26,12 @@ function maybeRunScript(name) {
 	run(`npm run ${name}`);
 }
 
+function removeStandaloneBinaryArtifacts() {
+	for (const artifact of ["dist/maestro-bun", "dist/maestro-bun-bytecode"]) {
+		rmSync(resolve(process.cwd(), artifact), { force: true });
+	}
+}
+
 function runPackSmoke() {
 	const smokeScriptPath = resolve(process.cwd(), "scripts/smoke-packed-cli.js");
 	if (!existsSync(smokeScriptPath)) {
@@ -33,6 +39,7 @@ function runPackSmoke() {
 		return;
 	}
 
+	removeStandaloneBinaryArtifacts();
 	const tarball = execSync("npm pack --silent", { encoding: "utf8" })
 		.trim()
 		.split("\n")
@@ -81,6 +88,9 @@ function runReleaseChecks() {
 }
 
 switch (mode) {
+	case "pack-smoke":
+		runPackSmoke();
+		break;
 	case "ci":
 		runCiChecks();
 		break;

--- a/scripts/workspace-utils.js
+++ b/scripts/workspace-utils.js
@@ -102,6 +102,14 @@ function escapeRegExp(value) {
 	return value.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function globTokenPattern(value) {
+	let pattern = "";
+	for (const char of value) {
+		pattern += char === "*" ? "[^/]*" : escapeRegExp(char);
+	}
+	return pattern;
+}
+
 function segmentHasPatternSyntax(segment) {
 	return segment.includes("*") || /\{[^{}]+,[^{}]*\}/u.test(segment);
 }
@@ -118,7 +126,7 @@ function segmentPatternToRegExp(segment) {
 			const end = segment.indexOf("}", index + 1);
 			const body = end === -1 ? "" : segment.slice(index + 1, end);
 			if (body.includes(",")) {
-				pattern += `(?:${body.split(",").map(escapeRegExp).join("|")})`;
+				pattern += `(?:${body.split(",").map(globTokenPattern).join("|")})`;
 				index = end;
 				continue;
 			}

--- a/test/scripts/workspace-utils.test.ts
+++ b/test/scripts/workspace-utils.test.ts
@@ -77,7 +77,7 @@ describe("getWorkspacePackagePaths", () => {
 		]);
 	});
 
-	it("treats brace segments as alternatives without glob installed", () => {
+	it("treats brace segments as alternatives with wildcards without glob installed", () => {
 		const root = makeFixture();
 		copyScript(root, "workspace-utils.js");
 		writeFileSync(
@@ -85,14 +85,14 @@ describe("getWorkspacePackagePaths", () => {
 			JSON.stringify({
 				name: "fixture",
 				type: "module",
-				workspaces: ["{packages,apps}/*"],
+				workspaces: ["{packages,apps-*}/*"],
 			}),
 		);
-		writePackage(root, "apps/app-a");
+		writePackage(root, "apps-web/app-a");
 		writePackage(root, "packages/pkg-a");
 
 		expect(readWorkspacePaths(root)).toEqual([
-			realpathSync(resolve(root, "apps/app-a/package.json")),
+			realpathSync(resolve(root, "apps-web/app-a/package.json")),
 			realpathSync(resolve(root, "packages/pkg-a/package.json")),
 		]);
 	});


### PR DESCRIPTION
## Summary
- sync release-readiness pack-smoke cleanup from internal main/#2100
- recreate the matching public branch so internal public-release-mirror resolves the branch instead of falling back to main

## Test plan
- node scripts/sync-release-mirror.mjs --check --source /Users/jonathanhaas/.codex-worktrees/maestro-internal-e2e-gates-20260523 --target /Users/jonathanhaas/.codex-worktrees/maestro-public-registry-e2e-gates-20260523
- node ./scripts/run-vitest.js --run test/scripts/workspace-utils.test.ts

## Source
- Internal companion: https://github.com/evalops/maestro-internal/pull/2100