### PR TITLE
Mirror reconciled workspace release helpers

### DIFF
--- a/scripts/release-readiness.js
+++ b/scripts/release-readiness.js
@@ -26,6 +26,12 @@ function maybeRunScript(name) {
 	run(`npm run ${name}`);
 }
 
+function removeStandaloneBinaryArtifacts() {
+	for (const artifact of ["dist/maestro-bun", "dist/maestro-bun-bytecode"]) {
+		rmSync(resolve(process.cwd(), artifact), { force: true });
+	}
+}
+
 function runPackSmoke() {
 	const smokeScriptPath = resolve(process.cwd(), "scripts/smoke-packed-cli.js");
 	if (!existsSync(smokeScriptPath)) {
@@ -33,6 +39,7 @@ function runPackSmoke() {
 		return;
 	}
 
+	removeStandaloneBinaryArtifacts();
 	const tarball = execSync("npm pack --silent", { encoding: "utf8" })
 		.trim()
 		.split("\n")
@@ -81,6 +88,9 @@ function runReleaseChecks() {
 }
 
 switch (mode) {
+	case "pack-smoke":
+		runPackSmoke();
+		break;
 	case "ci":
 		runCiChecks();
 		break;

--- a/scripts/workspace-utils.js
+++ b/scripts/workspace-utils.js
@@ -116,14 +116,14 @@ function segmentPatternSource(segment) {
 		}
 		if (char === "{") {
 			const end = segment.indexOf("}", index + 1);
-		const body = end === -1 ? "" : segment.slice(index + 1, end);
-		if (body.includes(",")) {
-			pattern += `(?:${body.split(",").map(segmentPatternSource).join("|")})`;
-			index = end;
-			continue;
+			const body = end === -1 ? "" : segment.slice(index + 1, end);
+			if (body.includes(",")) {
+				pattern += `(?:${body.split(",").map(segmentPatternSource).join("|")})`;
+				index = end;
+				continue;
+			}
 		}
-	}
-	pattern += escapeRegExp(char);
+		pattern += escapeRegExp(char);
 	}
 	return pattern;
 }

--- a/scripts/workspace-utils.js
+++ b/scripts/workspace-utils.js
@@ -106,7 +106,7 @@ function segmentHasPatternSyntax(segment) {
 	return segment.includes("*") || /\{[^{}]+,[^{}]*\}/u.test(segment);
 }
 
-function segmentPatternToRegExp(segment) {
+function segmentPatternSource(segment) {
 	let pattern = "";
 	for (let index = 0; index < segment.length; index += 1) {
 		const char = segment[index];
@@ -116,16 +116,20 @@ function segmentPatternToRegExp(segment) {
 		}
 		if (char === "{") {
 			const end = segment.indexOf("}", index + 1);
-			const body = end === -1 ? "" : segment.slice(index + 1, end);
-			if (body.includes(",")) {
-				pattern += `(?:${body.split(",").map(escapeRegExp).join("|")})`;
-				index = end;
-				continue;
-			}
+		const body = end === -1 ? "" : segment.slice(index + 1, end);
+		if (body.includes(",")) {
+			pattern += `(?:${body.split(",").map(segmentPatternSource).join("|")})`;
+			index = end;
+			continue;
 		}
-		pattern += escapeRegExp(char);
 	}
-	return new RegExp(`^${pattern}$`);
+	pattern += escapeRegExp(char);
+	}
+	return pattern;
+}
+
+function segmentPatternToRegExp(segment) {
+	return new RegExp(`^${segmentPatternSource(segment)}$`);
 }
 
 function listDirectories(path) {


### PR DESCRIPTION
Summary\n- Mirror the release-helper and workspace-utils public projection for https://github.com/evalops/maestro-internal/pull/2107.\n- Keep public release-readiness parity aligned with the internal release helper branch.\n\nTest Plan\n- node scripts/sync-release-mirror.mjs --check --source /Users/jonathanhaas/.codex-worktrees/maestro-internal-reconcile-public-workspace-utils-20260523 --target /Users/jonathanhaas/.codex-worktrees/maestro-public-reconcile-workspace-utils-20260523\n\nRollback\n- Revert this PR; internal public-release-mirror checks should remain held until a replacement public projection is available.