### PR TITLE
fix: keep helper pack smoke buildless

### DIFF
--- a/scripts/release-readiness.js
+++ b/scripts/release-readiness.js
@@ -32,16 +32,6 @@ function removeStandaloneBinaryArtifacts() {
 	}
 }
 
-function ensurePackedCliArtifacts() {
-	const cliArtifact = resolve(process.cwd(), "dist/cli.js");
-	if (existsSync(cliArtifact)) {
-		return;
-	}
-
-	console.log("Building package before packed CLI smoke (dist/cli.js missing).");
-	run("npm run build");
-}
-
 function runPackSmoke() {
 	const smokeScriptPath = resolve(process.cwd(), "scripts/smoke-packed-cli.js");
 	if (!existsSync(smokeScriptPath)) {
@@ -50,7 +40,6 @@ function runPackSmoke() {
 	}
 
 	removeStandaloneBinaryArtifacts();
-	ensurePackedCliArtifacts();
 	const tarball = execSync("npm pack --silent", { encoding: "utf8" })
 		.trim()
 		.split("\n")


### PR DESCRIPTION
## Summary
- mirror the internal release-readiness helper smoke behavior for evalops/maestro-internal#2108
- remove the temporary build-before-pack fallback so the public release mirror matches the internal branch

## Test Plan
- node --check scripts/release-readiness.js
- cmp scripts/release-readiness.js /tmp/internal-2108-release-readiness.js