### PR TITLE
ci: allow eval test shards to finish

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -67,7 +67,7 @@ jobs:
       - run: npx nx run maestro:build:all
       - run: npx nx run maestro:lint
       - name: Run tests
-        timeout-minutes: 15
+        timeout-minutes: 25
         run: bunx vitest --run --reporter=verbose --no-file-parallelism --shard=${{ matrix.chunkIndex }}/2
       - name: Run evals chunk
         timeout-minutes: 45


### PR DESCRIPTION
## Summary
- Increase the eval workflow test-shard timeout from 15 to 25 minutes so shards that finish near the boundary can exit cleanly.
- Matches the internal workflow fix currently on the operator-control PR branch.

## Test plan
- git diff --check
- commit hook validation, including biome, eval fixture checks, TS/Rust session-wire contract checks, codegen checks, and build