### PR TITLE
Mirror reusable read cache stabilization

### DIFF
--- a/src/agent/transport.ts
+++ b/src/agent/transport.ts
@@ -145,6 +145,8 @@ type ReusableToolResultCacheGeneration = {
 	value: number;
 };
 
+const GIT_SNAPSHOT_COMMAND_TIMEOUT_MS = 5_000;
+
 function hashReusableToolResultSnapshot(value: string | Buffer): string {
 	return createHash("sha256").update(value).digest("hex");
 }
@@ -153,7 +155,7 @@ function readGitSnapshotBuffer(cwd: string, args: string[]): Buffer {
 	return execFileSync("git", args, {
 		cwd,
 		stdio: ["ignore", "pipe", "ignore"],
-		timeout: 1_000,
+		timeout: GIT_SNAPSHOT_COMMAND_TIMEOUT_MS,
 	});
 }
 


### PR DESCRIPTION
Summary
- Increase the git snapshot helper timeout used by reusable read-result caching to avoid transient Git probe timeouts disabling cache reuse.
- Mirrors the source-of-truth private change in evalops/maestro-internal#2102.

Test Plan
- timeout 300 bunx vitest --run test/agent/provider-transport-provider-tools.test.ts --reporter=verbose
- bunx tsc -p tsconfig.build.json --noEmit
- pre-commit hook: guardian, Semgrep, Biome, contract checks, generated fixture checks, build, compiled CLI

Rollback
- Revert this PR to restore the prior 1s git snapshot command timeout.