### PR TITLE
Mirror failed tool-call event catalog subject

### DIFF
--- a/src/telemetry/maestro-event-bus.ts
+++ b/src/telemetry/maestro-event-bus.ts
@@ -1432,7 +1432,7 @@ export function recordMaestroToolCallCompleted(
 ): void {
 	const completedAt = event.completed_at ?? new Date().toISOString();
 	void publishMaestroCloudEvent<ToolCallResultEventData>(
-		MaestroBusEventType.ToolCallCompleted,
+		toolCallResultEventType(event.status),
 		{
 			correlation: mergeCorrelation(
 				resolveMaestroEventBusConfig(event.env).defaultCorrelation,
@@ -1455,6 +1455,14 @@ export function recordMaestroToolCallCompleted(
 		},
 		{ env: event.env, eventId: event.event_id, time: completedAt },
 	);
+}
+
+function toolCallResultEventType(
+	status: MaestroToolCallStatus,
+): MaestroBusEventType.ToolCallCompleted | MaestroBusEventType.ToolCallFailed {
+	return status === "MAESTRO_TOOL_CALL_STATUS_FAILED"
+		? MaestroBusEventType.ToolCallFailed
+		: MaestroBusEventType.ToolCallCompleted;
 }
 
 export function recordMaestroPromptVariantSelected(
@@ -1783,8 +1791,11 @@ export async function mirrorTelemetryToMaestroEventBus(
 
 	if (event.type === "tool-execution") {
 		const metadata = fields.metadata;
+		const status = fields.success
+			? "MAESTRO_TOOL_CALL_STATUS_SUCCEEDED"
+			: "MAESTRO_TOOL_CALL_STATUS_FAILED";
 		await publishMaestroCloudEvent<ToolCallResultEventData>(
-			MaestroBusEventType.ToolCallCompleted,
+			toolCallResultEventType(status),
 			{
 				correlation: mergeCorrelation(
 					resolveMaestroEventBusConfig().defaultCorrelation,
@@ -1794,9 +1805,7 @@ export async function mirrorTelemetryToMaestroEventBus(
 					stringMetadata(metadata, "toolCallId") ??
 					stringMetadata(metadata, "tool_call_id") ??
 					`${String(fields.toolName ?? "tool")}:${event.timestamp}`,
-				status: fields.success
-					? "MAESTRO_TOOL_CALL_STATUS_SUCCEEDED"
-					: "MAESTRO_TOOL_CALL_STATUS_FAILED",
+				status,
 				duration: durationFromMs(fields.durationMs),
 				error_message: fields.success
 					? undefined

--- a/src/telemetry/maestro-event-catalog.ts
+++ b/src/telemetry/maestro-event-catalog.ts
@@ -9,6 +9,7 @@ export enum MaestroBusEventType {
 	FirewallBlock = "maestro.events.firewall_block",
 	ToolCallAttempted = "maestro.events.tool_call.attempted",
 	ToolCallCompleted = "maestro.events.tool_call.completed",
+	ToolCallFailed = "maestro.events.tool_call.failed",
 	ErrorCaptured = "maestro.events.error.captured",
 	ArtifactCreated = "maestro.events.artifact.created",
 	FinalStatusReported = "maestro.events.final_status.reported",
@@ -135,6 +136,16 @@ export const MAESTRO_BUS_EVENT_CATALOG = {
 		"tool",
 		"ToolCallResult",
 		["meter.maestro-tool-call-events", "skills.maestro-tool-call-completed"],
+	),
+	[MaestroBusEventType.ToolCallFailed]: entry(
+		MaestroBusEventType.ToolCallFailed,
+		"tool",
+		"ToolCallResult",
+		[
+			"meter.maestro-tool-call-events",
+			"release.maestro-tool-failure-gates",
+			"skills.maestro-tool-call-failed",
+		],
 	),
 	[MaestroBusEventType.ErrorCaptured]: entry(
 		MaestroBusEventType.ErrorCaptured,

--- a/test/telemetry/maestro-event-bus.test.ts
+++ b/test/telemetry/maestro-event-bus.test.ts
@@ -625,6 +625,77 @@ describe("maestro event bus", () => {
 		});
 	});
 
+	it("publishes failed tool result CloudEvents on the failure subject", async () => {
+		const published: Array<{ subject: string; payload: string }> = [];
+		setMaestroEventBusTransportForTests({
+			async publish(subject, payload) {
+				published.push({ subject, payload });
+			},
+		});
+
+		recordMaestroToolCallCompleted({
+			tool_call_id: "tool_failed_1",
+			tool_execution_id: "texec_failed_1",
+			status: "MAESTRO_TOOL_CALL_STATUS_FAILED",
+			error_code: "exit_1",
+			error_message: "command failed",
+			completed_at: "2026-04-23T18:02:00.000Z",
+			env: { MAESTRO_EVENT_BUS_URL: "nats://bus.example:4222" },
+		});
+
+		await Promise.resolve();
+
+		expect(published).toHaveLength(1);
+		expect(published[0]?.subject).toBe("maestro.events.tool_call.failed");
+		expect(JSON.parse(published[0]?.payload ?? "{}")).toMatchObject({
+			type: "maestro.events.tool_call.failed",
+			data: {
+				tool_call_id: "tool_failed_1",
+				tool_execution_id: "texec_failed_1",
+				status: "MAESTRO_TOOL_CALL_STATUS_FAILED",
+				error_code: "exit_1",
+				error_message: "command failed",
+			},
+		});
+	});
+
+	it("publishes denied and cancelled tool outcomes on the completion subject", async () => {
+		const published: Array<{ subject: string; payload: string }> = [];
+		setMaestroEventBusTransportForTests({
+			async publish(subject, payload) {
+				published.push({ subject, payload });
+			},
+		});
+
+		for (const status of [
+			"MAESTRO_TOOL_CALL_STATUS_DENIED",
+			"MAESTRO_TOOL_CALL_STATUS_CANCELLED",
+		] as const) {
+			recordMaestroToolCallCompleted({
+				tool_call_id: `tool_${status.toLowerCase()}`,
+				status,
+				completed_at: "2026-04-23T18:03:00.000Z",
+				env: { MAESTRO_EVENT_BUS_URL: "nats://bus.example:4222" },
+			});
+		}
+
+		await Promise.resolve();
+
+		expect(published).toHaveLength(2);
+		for (const [index, status] of [
+			"MAESTRO_TOOL_CALL_STATUS_DENIED",
+			"MAESTRO_TOOL_CALL_STATUS_CANCELLED",
+		].entries()) {
+			expect(published[index]?.subject).toBe(
+				"maestro.events.tool_call.completed",
+			);
+			expect(JSON.parse(published[index]?.payload ?? "{}")).toMatchObject({
+				type: "maestro.events.tool_call.completed",
+				data: { status },
+			});
+		}
+	});
+
 	it("publishes skill invocation CloudEvents with selected skill identity", async () => {
 		const published: Array<{ subject: string; payload: string }> = [];
 		setMaestroEventBusTransportForTests({

--- a/test/telemetry/maestro-event-catalog.test.ts
+++ b/test/telemetry/maestro-event-catalog.test.ts
@@ -61,11 +61,26 @@ describe("maestro event catalog", () => {
 				"release.maestro-install-smoke",
 			],
 		});
+		expect(
+			getMaestroBusEventCatalogEntry(MaestroBusEventType.ToolCallFailed),
+		).toMatchObject({
+			category: "tool",
+			dataSchema: "buf.build/evalops/proto/maestro.v1.ToolCallResult",
+			protoAnyType: "type.googleapis.com/maestro.v1.ToolCallResult",
+			subject: "maestro.events.tool_call.failed",
+			platformConsumers: [
+				"audit.maestro-events",
+				"meter.maestro-tool-call-events",
+				"release.maestro-tool-failure-gates",
+				"skills.maestro-tool-call-failed",
+			],
+		});
 	});
 
 	it("recognizes only cataloged Maestro bus event types", () => {
 		expect(isMaestroBusEventType("maestro.events.eval.scored")).toBe(true);
 		expect(isMaestroBusEventType("maestro.events.error.captured")).toBe(true);
+		expect(isMaestroBusEventType("maestro.events.tool_call.failed")).toBe(true);
 		expect(isMaestroBusEventType("maestro.events.subagent.dispatched")).toBe(
 			true,
 		);
@@ -89,6 +104,22 @@ describe("maestro event catalog", () => {
 				type: MaestroBusEventType.ErrorCaptured,
 			}),
 		]);
+		expect(listMaestroBusEventCatalogByCategory("tool")).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					category: "tool",
+					type: MaestroBusEventType.ToolCallAttempted,
+				}),
+				expect.objectContaining({
+					category: "tool",
+					type: MaestroBusEventType.ToolCallCompleted,
+				}),
+				expect.objectContaining({
+					category: "tool",
+					type: MaestroBusEventType.ToolCallFailed,
+				}),
+			]),
+		);
 		expect(listMaestroBusEventCatalogByCategory("artifact")).toEqual([
 			expect.objectContaining({
 				category: "artifact",


### PR DESCRIPTION
## Summary
- mirror the public release catalog update from evalops/maestro-internal#2127
- add the `maestro.events.tool_call.failed` subject to the public Maestro event catalog
- route failed public tool result events to the failed subject and cover the behavior with telemetry tests

## Test Plan
- `node ./scripts/run-vitest.js --run test/telemetry/maestro-event-catalog.test.ts test/telemetry/maestro-event-bus.test.ts`
- `npx tsc -p tsconfig.build.json --noEmit --pretty false`
- `bunx biome check src/telemetry/maestro-event-catalog.ts src/telemetry/maestro-event-bus.ts test/telemetry/maestro-event-catalog.test.ts test/telemetry/maestro-event-bus.test.ts`
- pre-commit hook passed Guardian, lint/eval surface checks, build, and bun compile

## Rollback
Revert this PR and evalops/maestro-internal#2127 together; failed tool-call outcomes would return to the generic completed subject.
