### PR TITLE
Mirror hosted retry wait coalescing fixture

### DIFF
--- a/src/telemetry/maestro-event-catalog.ts
+++ b/src/telemetry/maestro-event-catalog.ts
@@ -9,6 +9,7 @@ export enum MaestroBusEventType {
 	FirewallBlock = "maestro.events.firewall_block",
 	ToolCallAttempted = "maestro.events.tool_call.attempted",
 	ToolCallCompleted = "maestro.events.tool_call.completed",
+	ToolCallFailed = "maestro.events.tool_call.failed",
 	ErrorCaptured = "maestro.events.error.captured",
 	ArtifactCreated = "maestro.events.artifact.created",
 	FinalStatusReported = "maestro.events.final_status.reported",
@@ -135,6 +136,16 @@ export const MAESTRO_BUS_EVENT_CATALOG = {
 		"tool",
 		"ToolCallResult",
 		["meter.maestro-tool-call-events", "skills.maestro-tool-call-completed"],
+	),
+	[MaestroBusEventType.ToolCallFailed]: entry(
+		MaestroBusEventType.ToolCallFailed,
+		"tool",
+		"ToolCallResult",
+		[
+			"meter.maestro-tool-call-events",
+			"release.maestro-tool-failure-gates",
+			"skills.maestro-tool-call-failed",
+		],
 	),
 	[MaestroBusEventType.ErrorCaptured]: entry(
 		MaestroBusEventType.ErrorCaptured,

--- a/test/server/hosted-agent-runtime-progress.test.ts
+++ b/test/server/hosted-agent-runtime-progress.test.ts
@@ -1761,6 +1761,116 @@ describe("hosted AgentRuntime progress recorder", () => {
 		);
 	});
 
+	it("coalesces tool retry AgentEvents with server-request lifecycle waits", async () => {
+		const { recorder, waitRun, resumeRun, recordEvent } = createRecorder();
+		const retryRequest = {
+			id: "retry_dupe",
+			toolCallId: "call_dupe",
+			toolName: "shell",
+			args: { command: "npm test" },
+			errorMessage: "exit code 1",
+			attempt: 2,
+			maxAttempts: 3,
+			summary: "shell failed again",
+		};
+		const registered: ServerRequestLifecycleEvent = {
+			type: "registered",
+			request: {
+				id: retryRequest.id,
+				kind: "tool_retry",
+				sessionId: "session_1",
+				callId: retryRequest.toolCallId,
+				toolName: retryRequest.toolName,
+				args: {
+					tool_call_id: retryRequest.toolCallId,
+					args: retryRequest.args,
+					error_message: retryRequest.errorMessage,
+					attempt: retryRequest.attempt,
+					max_attempts: retryRequest.maxAttempts,
+					summary: retryRequest.summary,
+				},
+				reason: retryRequest.summary,
+				timestamp: Date.now(),
+				startedAtMs: 4_000,
+				timeoutMs: 60_000,
+			},
+		};
+		const resolved: ServerRequestLifecycleEvent = {
+			type: "resolved",
+			request: registered.request,
+			resolution: "retried",
+			resolvedBy: "user",
+			reason: "transient",
+			resolvedAtMs: 5_000,
+		};
+
+		recorder.recordServerRequestEvent(registered);
+		recorder.recordAgentEvent({
+			type: "tool_retry_required",
+			request: retryRequest,
+		} satisfies AgentEvent);
+		recorder.recordServerRequestEvent(resolved);
+		recorder.recordAgentEvent({
+			type: "tool_retry_resolved",
+			request: retryRequest,
+			decision: {
+				action: "retry",
+				reason: "transient",
+				resolvedBy: "user",
+			},
+		} satisfies AgentEvent);
+		await recorder.flush();
+
+		expect(waitRun).toHaveBeenCalledTimes(1);
+		expect(waitRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				wait: expect.objectContaining({
+					id: "maestro:session_1:wait:retry_dupe",
+					stepId: "maestro:session_1:tool:call_dupe",
+					type: PlatformAgentRunWaitTypeValue.Approval,
+					payload: expect.objectContaining({
+						request_type: "tool_retry",
+						started_at_ms: 4_000,
+					}),
+				}),
+			}),
+		);
+		expect(resumeRun).toHaveBeenCalledTimes(1);
+		expect(resumeRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				waitId: "maestro:session_1:wait:retry_dupe",
+				payload: expect.objectContaining({
+					request_type: "tool_retry",
+					resolution: "retried",
+					resolved_by: "user",
+					resolved_at_ms: 5_000,
+				}),
+			}),
+		);
+		expect(recordEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: "Maestro tool retry required",
+				waitId: "maestro:session_1:wait:retry_dupe",
+				attributes: expect.objectContaining({
+					event_type: "tool_retry_required",
+					attempt: 2,
+					max_attempts: 3,
+				}),
+			}),
+		);
+		expect(recordEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: "Maestro tool retry resolved",
+				waitId: "maestro:session_1:wait:retry_dupe",
+				attributes: expect.objectContaining({
+					event_type: "tool_retry_resolved",
+					resolution: "retry",
+					reason: "transient",
+				}),
+			}),
+		);
+	});
+
 	it("records recovery breadcrumbs for status, compaction, and auto retry", async () => {
 		const { recorder, recordEvent, recordStep } = createRecorder();
 


### PR DESCRIPTION
## Summary
- mirror the hosted AgentRuntime retry-wait coalescing regression fixture from evalops/maestro-internal#2129
- restore the failed tool-call event catalog entry now that evalops/maestro-internal#2127 has merged and public main drifted behind it
- assert raw retry AgentEvents and server-request lifecycle events produce one Platform wait/resume while retaining queryable retry events

## Test Plan
- `node ./scripts/run-vitest.js --run test/server/hosted-agent-runtime-progress.test.ts`
- `bunx biome check test/server/hosted-agent-runtime-progress.test.ts`
- `node scripts/sync-release-mirror.mjs --check --source <internal #2129 worktree> --target <public #523 worktree>`
- commit hook suite from the original public fixture commit: guardian staged scan, Biome, lint/eval/proto/drift/parity checks, build, and bun compile

## Rollback
- Revert this PR and evalops/maestro-internal#2129 together if the mirrored fixture needs to be removed; keep the failed tool-call catalog entry if internal #2127 remains merged.