### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/scripts/codegen-utils.mjs
+++ b/scripts/codegen-utils.mjs
@@ -61,7 +61,7 @@ function resolveRustfmtCommand(command) {
 	}
 	const trimmed = command.trim();
 	if (!trimmed) {
-		return undefined;
+		return null;
 	}
 	if (RUSTFMT_DISABLE_VALUES.has(trimmed.toLowerCase())) {
 		return null;

--- a/scripts/plan-ci-checks.mjs
+++ b/scripts/plan-ci-checks.mjs
@@ -72,6 +72,16 @@ const CI_GUARDRAIL_FILES = new Set([
 	"scripts/summarize-nx-profile.mjs",
 	"test/scripts/ci-guardrails.test.ts",
 ]);
+const CODEGEN_UTILITY_FILES = new Set([
+	"scripts/codegen-utils.mjs",
+	"test/scripts/codegen-utils.test.ts",
+]);
+const CODEGEN_UTILITY_LANE_FILES = new Set([
+	...CODEGEN_UTILITY_FILES,
+	".github/workflows/ci.yml",
+	"scripts/plan-ci-checks.mjs",
+	"test/scripts/ci-guardrails.test.ts",
+]);
 const RUNTIME_PACKAGE_VALIDATOR_FILES = new Set([
 	"scripts/bundle-runtime-deps.mjs",
 	"scripts/check-docker-runtime-workspaces.mjs",
@@ -119,6 +129,7 @@ function shouldSkipCoverageForPath(path) {
 	return (
 		path.startsWith(".github/workflows/") ||
 		(path.startsWith("docs/") && path.endsWith(".md")) ||
+		CODEGEN_UTILITY_FILES.has(path) ||
 		CI_GUARDRAIL_FILES.has(path) ||
 		RELEASE_HELPER_PACKAGE_FILES.has(path) ||
 		RUNTIME_PACKAGE_VALIDATOR_FILES.has(path) ||
@@ -200,6 +211,7 @@ function isRustHostedConformancePath(path) {
 function isLightPrChecksPath(path) {
 	return (
 		isCiInfrastructureOnlyPath(path) ||
+		CODEGEN_UTILITY_FILES.has(path) ||
 		CI_GUARDRAIL_FILES.has(path) ||
 		RELEASE_HELPER_PACKAGE_FILES.has(path) ||
 		RUNTIME_PACKAGE_VALIDATOR_FILES.has(path) ||
@@ -226,6 +238,7 @@ export function planCiChecks({ eventName, labels = [], changedFiles = [] }) {
 	if (!isPullRequest) {
 		return {
 			ciInfrastructureOnly: false,
+			codegenUtilityOnly: false,
 			coverage: true,
 			lightPrChecks: false,
 			releaseHelperOnly: false,
@@ -239,6 +252,7 @@ export function planCiChecks({ eventName, labels = [], changedFiles = [] }) {
 	if (labelSet.has("full-ci")) {
 		return {
 			ciInfrastructureOnly: false,
+			codegenUtilityOnly: false,
 			coverage: true,
 			lightPrChecks: false,
 			releaseHelperOnly: false,
@@ -252,6 +266,9 @@ export function planCiChecks({ eventName, labels = [], changedFiles = [] }) {
 	const files = changedFiles.map(String).map((path) => path.trim()).filter(Boolean);
 	const ciInfrastructureOnly =
 		files.length > 0 && files.every(isFastPrChecksInfrastructurePath);
+	const codegenUtilityOnly =
+		files.some((path) => CODEGEN_UTILITY_FILES.has(path)) &&
+		files.every((path) => CODEGEN_UTILITY_LANE_FILES.has(path));
 	const proofHarnessOnly =
 		files.length > 0 && files.every((path) => isProofHarnessPath(path));
 	const rustSetupActionChanged = files.some(isRustSetupActionPath);
@@ -296,6 +313,7 @@ export function planCiChecks({ eventName, labels = [], changedFiles = [] }) {
 
 	return {
 		ciInfrastructureOnly,
+		codegenUtilityOnly,
 		coverage,
 		lightPrChecks,
 		proofHarnessOnly,
@@ -340,6 +358,7 @@ function writeGitHubOutputs(plan) {
 		[
 			`coverage=${plan.coverage}`,
 			`ci_infrastructure_only=${plan.ciInfrastructureOnly ?? false}`,
+			`codegen_utility_only=${plan.codegenUtilityOnly ?? false}`,
 			`light_pr_checks=${plan.lightPrChecks ?? false}`,
 			`proof_harness_only=${plan.proofHarnessOnly ?? false}`,
 			`release_helper_only=${plan.releaseHelperOnly ?? false}`,
@@ -359,6 +378,7 @@ function writeGitHubSummary(plan, changedFiles) {
 		"## Expensive check plan",
 		"",
 		`- CI infrastructure only: \`${plan.ciInfrastructureOnly ?? false}\``,
+		`- codegen utility only: \`${plan.codegenUtilityOnly ?? false}\``,
 		`- coverage: \`${plan.coverage}\``,
 		`- light PR checks: \`${plan.lightPrChecks ?? false}\``,
 		`- release helper only: \`${plan.releaseHelperOnly ?? false}\``,

--- a/src/telemetry/maestro-event-bus.ts
+++ b/src/telemetry/maestro-event-bus.ts
@@ -1432,7 +1432,7 @@ export function recordMaestroToolCallCompleted(
 ): void {
 	const completedAt = event.completed_at ?? new Date().toISOString();
 	void publishMaestroCloudEvent<ToolCallResultEventData>(
-		MaestroBusEventType.ToolCallCompleted,
+		toolCallResultEventType(event.status),
 		{
 			correlation: mergeCorrelation(
 				resolveMaestroEventBusConfig(event.env).defaultCorrelation,
@@ -1455,6 +1455,14 @@ export function recordMaestroToolCallCompleted(
 		},
 		{ env: event.env, eventId: event.event_id, time: completedAt },
 	);
+}
+
+function toolCallResultEventType(
+	status: MaestroToolCallStatus,
+): MaestroBusEventType.ToolCallCompleted | MaestroBusEventType.ToolCallFailed {
+	return status === "MAESTRO_TOOL_CALL_STATUS_FAILED"
+		? MaestroBusEventType.ToolCallFailed
+		: MaestroBusEventType.ToolCallCompleted;
 }
 
 export function recordMaestroPromptVariantSelected(
@@ -1783,8 +1791,11 @@ export async function mirrorTelemetryToMaestroEventBus(
 
 	if (event.type === "tool-execution") {
 		const metadata = fields.metadata;
+		const status = fields.success
+			? "MAESTRO_TOOL_CALL_STATUS_SUCCEEDED"
+			: "MAESTRO_TOOL_CALL_STATUS_FAILED";
 		await publishMaestroCloudEvent<ToolCallResultEventData>(
-			MaestroBusEventType.ToolCallCompleted,
+			toolCallResultEventType(status),
 			{
 				correlation: mergeCorrelation(
 					resolveMaestroEventBusConfig().defaultCorrelation,
@@ -1794,9 +1805,7 @@ export async function mirrorTelemetryToMaestroEventBus(
 					stringMetadata(metadata, "toolCallId") ??
 					stringMetadata(metadata, "tool_call_id") ??
 					`${String(fields.toolName ?? "tool")}:${event.timestamp}`,
-				status: fields.success
-					? "MAESTRO_TOOL_CALL_STATUS_SUCCEEDED"
-					: "MAESTRO_TOOL_CALL_STATUS_FAILED",
+				status,
 				duration: durationFromMs(fields.durationMs),
 				error_message: fields.success
 					? undefined

--- a/src/telemetry/maestro-event-catalog.ts
+++ b/src/telemetry/maestro-event-catalog.ts
@@ -9,6 +9,7 @@ export enum MaestroBusEventType {
 	FirewallBlock = "maestro.events.firewall_block",
 	ToolCallAttempted = "maestro.events.tool_call.attempted",
 	ToolCallCompleted = "maestro.events.tool_call.completed",
+	ToolCallFailed = "maestro.events.tool_call.failed",
 	ErrorCaptured = "maestro.events.error.captured",
 	ArtifactCreated = "maestro.events.artifact.created",
 	FinalStatusReported = "maestro.events.final_status.reported",
@@ -135,6 +136,16 @@ export const MAESTRO_BUS_EVENT_CATALOG = {
 		"tool",
 		"ToolCallResult",
 		["meter.maestro-tool-call-events", "skills.maestro-tool-call-completed"],
+	),
+	[MaestroBusEventType.ToolCallFailed]: entry(
+		MaestroBusEventType.ToolCallFailed,
+		"tool",
+		"ToolCallResult",
+		[
+			"meter.maestro-tool-call-events",
+			"release.maestro-tool-failure-gates",
+			"skills.maestro-tool-call-failed",
+		],
 	),
 	[MaestroBusEventType.ErrorCaptured]: entry(
 		MaestroBusEventType.ErrorCaptured,

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -117,6 +117,7 @@ describe("planCiChecks", () => {
 			}),
 		).toMatchObject({
 			ciInfrastructureOnly: true,
+			codegenUtilityOnly: false,
 			coverage: false,
 			lightPrChecks: true,
 			prChecks: true,
@@ -134,6 +135,7 @@ describe("planCiChecks", () => {
 			}),
 		).toMatchObject({
 			ciInfrastructureOnly: true,
+			codegenUtilityOnly: false,
 			coverage: false,
 			lightPrChecks: true,
 			prChecks: true,
@@ -356,6 +358,28 @@ describe("planCiChecks", () => {
 			prChecks: true,
 			publicMirror: true,
 			releaseHelperOnly: true,
+			rustHostedConformance: false,
+		});
+	});
+
+	it("routes codegen utility-only PR checks to the light runner lane", () => {
+		expect(
+			planCiChecks({
+				eventName: "pull_request",
+				changedFiles: [
+					".github/workflows/ci.yml",
+					"scripts/codegen-utils.mjs",
+					"scripts/plan-ci-checks.mjs",
+					"test/scripts/ci-guardrails.test.ts",
+					"test/scripts/codegen-utils.test.ts",
+				],
+			}),
+		).toMatchObject({
+			codegenUtilityOnly: true,
+			coverage: false,
+			lightPrChecks: true,
+			prChecks: true,
+			publicMirror: true,
 			rustHostedConformance: false,
 		});
 	});
@@ -841,6 +865,40 @@ describe("ci workflow guardrails", () => {
 		expect(steps[setupJavaIndex]?.with).not.toHaveProperty("cache");
 	});
 
+	it("uses targeted codegen checks instead of Nx for codegen utility-only changes", () => {
+		const workflow = parse(
+			readFileSync(new URL("../../.github/workflows/ci.yml", import.meta.url), {
+				encoding: "utf8",
+			}),
+		) as Workflow;
+		const changesOutputs = workflow.jobs?.changes?.outputs ?? {};
+		const steps = workflow.jobs?.["pr-checks"]?.steps ?? [];
+		const codegenStep = steps.find(
+			(step) => step.name === "Test codegen utilities",
+		);
+		const nxStep = steps.find((step) => step.name === "Test (Nx affected)");
+		const releaseReadinessStep = steps.find(
+			(step) => step.name === "Release readiness (CI mode)",
+		);
+		const isPublicMirrorPrChecks = isPublicValidationWorkflow(workflow);
+
+		if (isPublicMirrorPrChecks) {
+			expect(changesOutputs).not.toHaveProperty("codegen_utility_only");
+			expect(codegenStep).toBeUndefined();
+			expect(nxStep).toBeDefined();
+			return;
+		}
+
+		expect(changesOutputs).toHaveProperty("codegen_utility_only");
+		expect(codegenStep?.if).toContain("codegen_utility_only == 'true'");
+		expect(codegenStep?.run).toContain("test/scripts/codegen-utils.test.ts");
+		expect(codegenStep?.run).toContain("MAESTRO_RUSTFMT=");
+		expect(nxStep?.if).toContain("codegen_utility_only != 'true'");
+		expect(releaseReadinessStep?.if).toContain(
+			"codegen_utility_only != 'true'",
+		);
+	});
+
 	it("keeps dedicated JetBrains Java setup lightweight", () => {
 		const workflow = parse(
 			readFileSync(
@@ -907,7 +965,7 @@ describe("ci workflow guardrails", () => {
 			expect(workflow.jobs?.["public-release-mirror"]).toBeDefined();
 		}
 		const proofHarnessSkipCondition =
-			"${{ github.event_name != 'pull_request' || (needs.changes.outputs.ci_infrastructure_only != 'true' && needs.changes.outputs.proof_harness_only != 'true' && needs.changes.outputs.release_helper_only != 'true') }}";
+			"${{ github.event_name != 'pull_request' || (needs.changes.outputs.ci_infrastructure_only != 'true' && needs.changes.outputs.codegen_utility_only != 'true' && needs.changes.outputs.proof_harness_only != 'true' && needs.changes.outputs.release_helper_only != 'true') }}";
 		expect(setupRustStep?.if).toBe(proofHarnessSkipCondition);
 		expect(
 			prChecksJob?.steps?.find(

--- a/test/scripts/codegen-utils.test.ts
+++ b/test/scripts/codegen-utils.test.ts
@@ -22,7 +22,7 @@ function makeTempDir() {
 }
 
 describe("formatRustWithRustfmt", () => {
-	it.each(["0", "false", "no", "off", "none", "skip", "disabled"])(
+	it.each(["", "  ", "0", "false", "no", "off", "none", "skip", "disabled"])(
 		"treats %s as an explicit formatter opt-out",
 		(value) => {
 			const rootDir = makeTempDir();
@@ -45,7 +45,7 @@ describe("formatRustWithRustfmt", () => {
 
 	it("allows MAESTRO_RUSTFMT to disable generated Rust formatting", () => {
 		const rootDir = makeTempDir();
-		process.env.MAESTRO_RUSTFMT = "off";
+		process.env.MAESTRO_RUSTFMT = "";
 		const source = 'pub fn generated(){println!("ok");}\n';
 
 		const result = formatRustWithRustfmt(

--- a/test/telemetry/maestro-event-bus.test.ts
+++ b/test/telemetry/maestro-event-bus.test.ts
@@ -625,6 +625,77 @@ describe("maestro event bus", () => {
 		});
 	});
 
+	it("publishes failed tool result CloudEvents on the failure subject", async () => {
+		const published: Array<{ subject: string; payload: string }> = [];
+		setMaestroEventBusTransportForTests({
+			async publish(subject, payload) {
+				published.push({ subject, payload });
+			},
+		});
+
+		recordMaestroToolCallCompleted({
+			tool_call_id: "tool_failed_1",
+			tool_execution_id: "texec_failed_1",
+			status: "MAESTRO_TOOL_CALL_STATUS_FAILED",
+			error_code: "exit_1",
+			error_message: "command failed",
+			completed_at: "2026-04-23T18:02:00.000Z",
+			env: { MAESTRO_EVENT_BUS_URL: "nats://bus.example:4222" },
+		});
+
+		await Promise.resolve();
+
+		expect(published).toHaveLength(1);
+		expect(published[0]?.subject).toBe("maestro.events.tool_call.failed");
+		expect(JSON.parse(published[0]?.payload ?? "{}")).toMatchObject({
+			type: "maestro.events.tool_call.failed",
+			data: {
+				tool_call_id: "tool_failed_1",
+				tool_execution_id: "texec_failed_1",
+				status: "MAESTRO_TOOL_CALL_STATUS_FAILED",
+				error_code: "exit_1",
+				error_message: "command failed",
+			},
+		});
+	});
+
+	it("publishes denied and cancelled tool outcomes on the completion subject", async () => {
+		const published: Array<{ subject: string; payload: string }> = [];
+		setMaestroEventBusTransportForTests({
+			async publish(subject, payload) {
+				published.push({ subject, payload });
+			},
+		});
+
+		for (const status of [
+			"MAESTRO_TOOL_CALL_STATUS_DENIED",
+			"MAESTRO_TOOL_CALL_STATUS_CANCELLED",
+		] as const) {
+			recordMaestroToolCallCompleted({
+				tool_call_id: `tool_${status.toLowerCase()}`,
+				status,
+				completed_at: "2026-04-23T18:03:00.000Z",
+				env: { MAESTRO_EVENT_BUS_URL: "nats://bus.example:4222" },
+			});
+		}
+
+		await Promise.resolve();
+
+		expect(published).toHaveLength(2);
+		for (const [index, status] of [
+			"MAESTRO_TOOL_CALL_STATUS_DENIED",
+			"MAESTRO_TOOL_CALL_STATUS_CANCELLED",
+		].entries()) {
+			expect(published[index]?.subject).toBe(
+				"maestro.events.tool_call.completed",
+			);
+			expect(JSON.parse(published[index]?.payload ?? "{}")).toMatchObject({
+				type: "maestro.events.tool_call.completed",
+				data: { status },
+			});
+		}
+	});
+
 	it("publishes skill invocation CloudEvents with selected skill identity", async () => {
 		const published: Array<{ subject: string; payload: string }> = [];
 		setMaestroEventBusTransportForTests({

--- a/test/telemetry/maestro-event-catalog.test.ts
+++ b/test/telemetry/maestro-event-catalog.test.ts
@@ -61,11 +61,26 @@ describe("maestro event catalog", () => {
 				"release.maestro-install-smoke",
 			],
 		});
+		expect(
+			getMaestroBusEventCatalogEntry(MaestroBusEventType.ToolCallFailed),
+		).toMatchObject({
+			category: "tool",
+			dataSchema: "buf.build/evalops/proto/maestro.v1.ToolCallResult",
+			protoAnyType: "type.googleapis.com/maestro.v1.ToolCallResult",
+			subject: "maestro.events.tool_call.failed",
+			platformConsumers: [
+				"audit.maestro-events",
+				"meter.maestro-tool-call-events",
+				"release.maestro-tool-failure-gates",
+				"skills.maestro-tool-call-failed",
+			],
+		});
 	});
 
 	it("recognizes only cataloged Maestro bus event types", () => {
 		expect(isMaestroBusEventType("maestro.events.eval.scored")).toBe(true);
 		expect(isMaestroBusEventType("maestro.events.error.captured")).toBe(true);
+		expect(isMaestroBusEventType("maestro.events.tool_call.failed")).toBe(true);
 		expect(isMaestroBusEventType("maestro.events.subagent.dispatched")).toBe(
 			true,
 		);
@@ -89,6 +104,22 @@ describe("maestro event catalog", () => {
 				type: MaestroBusEventType.ErrorCaptured,
 			}),
 		]);
+		expect(listMaestroBusEventCatalogByCategory("tool")).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					category: "tool",
+					type: MaestroBusEventType.ToolCallAttempted,
+				}),
+				expect.objectContaining({
+					category: "tool",
+					type: MaestroBusEventType.ToolCallCompleted,
+				}),
+				expect.objectContaining({
+					category: "tool",
+					type: MaestroBusEventType.ToolCallFailed,
+				}),
+			]),
+		);
 		expect(listMaestroBusEventCatalogByCategory("artifact")).toEqual([
 			expect.objectContaining({
 				category: "artifact",


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"bccdd7df2691df8ae4189dd4c5b4f760c016a90c"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `bccdd7df2691df8ae4189dd4c5b4f760c016a90c`
- last generated public sync base: `71d1a78a5b7071fd6de4d58f7a5d050c1860399a`
- previewed public-tree drift: `8` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (bccdd7df2691)`
- public projection: `https://github.com/evalops/maestro@main (71d1a78a5b70)`
- files to copy or update: `8`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update scripts/codegen-utils.mjs
- copy/update scripts/plan-ci-checks.mjs
- copy/update src/telemetry/maestro-event-bus.ts
- copy/update src/telemetry/maestro-event-catalog.ts
- copy/update test/scripts/ci-guardrails.test.ts
- copy/update test/scripts/codegen-utils.test.ts
- copy/update test/telemetry/maestro-event-bus.test.ts
- copy/update test/telemetry/maestro-event-catalog.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update scripts/codegen-utils.mjs
- copy/update scripts/plan-ci-checks.mjs
- copy/update src/telemetry/maestro-event-bus.ts
- copy/update src/telemetry/maestro-event-catalog.ts
- copy/update test/scripts/ci-guardrails.test.ts
- copy/update test/scripts/codegen-utils.test.ts
- copy/update test/telemetry/maestro-event-bus.test.ts
- copy/update test/telemetry/maestro-event-catalog.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@bccdd7df2691df8ae4189dd4c5b4f760c016a90c`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #525 to internal source `bccdd7df2691df8ae4189dd4c5b4f760c016a90c`