### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/scripts/smoke-registry-install.js
+++ b/scripts/smoke-registry-install.js
@@ -186,6 +186,11 @@ async function main() {
 			expectedVersion: version,
 			label: "Bun-installed registry CLI",
 		});
+		await runPublishedReplayE2E({
+			cliCommand,
+			installRoot: bunTempDir,
+			packageSpec,
+		});
 
 		console.log(`Smoke-tested ${packageSpec} from Bun.`);
 	} finally {

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -634,6 +634,9 @@ describe("ci workflow guardrails", () => {
 		);
 
 		expect(prCheckTimeouts.get("Test (Nx affected)")).toBe(60);
+		if (!isPublicValidationWorkflow(workflow)) {
+			expect(prCheckTimeouts.get("Release helper package smoke")).toBe(15);
+		}
 		expect(workflow.jobs?.coverage?.["timeout-minutes"]).toBe(75);
 		expect(coverageTimeouts.get("Run tests with coverage")).toBe(60);
 	});
@@ -724,6 +727,7 @@ describe("ci workflow guardrails", () => {
 
 		expect(changesOutputs).toHaveProperty("release_helper_only");
 		expect(helperSmokeStep?.if).toContain("release_helper_only == 'true'");
+		expect(helperSmokeStep?.["timeout-minutes"]).toBe(15);
 		expect(helperSmokeStep?.run).toContain(
 			"node --check scripts/release-readiness.js",
 		);
@@ -807,6 +811,22 @@ describe("ci workflow guardrails", () => {
 		expect(script).toContain("getBunCommand");
 		expect(script).toContain("runNpmInstallSmoke();");
 		expect(script).toContain("runBunInstallSmoke();");
+	});
+
+	it("runs published replay E2E for npm and Bun registry installs", () => {
+		const script = readFileSync(
+			new URL("../../scripts/smoke-registry-install.js", import.meta.url),
+			{ encoding: "utf8" },
+		);
+
+		const replayCalls = [...script.matchAll(/runPublishedReplayE2E\(/g)];
+		expect(replayCalls).toHaveLength(2);
+		expect(script.indexOf("await runPublishedReplayE2E({")).toBeGreaterThan(
+			script.indexOf('npmCommand, ["install", packageSpec]'),
+		);
+		expect(script.lastIndexOf("await runPublishedReplayE2E({")).toBeGreaterThan(
+			script.indexOf('bunCommand, ["add", packageSpec]'),
+		);
 	});
 
 	it("keeps packed CLI smoke enabled independently of package-lock management", () => {


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"f0b95f7661da5207f99748216cb7e3f87d1acfa0"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `f0b95f7661da5207f99748216cb7e3f87d1acfa0`
- last generated public sync base: `17b011822776677532eb66447204efb4606001c9`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (f0b95f7661da)`
- public projection: `https://github.com/evalops/maestro@main (17b011822776)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update test/scripts/ci-guardrails.test.ts
- copy/update scripts/smoke-registry-install.js

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update test/scripts/ci-guardrails.test.ts
- copy/update scripts/smoke-registry-install.js

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@f0b95f7661da5207f99748216cb7e3f87d1acfa0`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #528 to internal source `f0b95f7661da5207f99748216cb7e3f87d1acfa0`