### PR TITLE
ci: harden release canary workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,12 +323,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        continue-on-error: true
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare.outputs.release_tag }}
 
       - name: Notify release channel
+        if: ${{ steps.checkout.outcome == 'success' }}
         continue-on-error: true
         uses: ./.github/actions/release-notify
         with:
@@ -339,3 +342,8 @@ jobs:
           package-name: ${{ needs.prepare.outputs.package_name }}
           package-version: ${{ needs.prepare.outputs.package_version }}
           webhook-url: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+
+      - name: Skip release notification after checkout failure
+        if: ${{ steps.checkout.outcome != 'success' }}
+        run: |
+          echo "Release notification skipped because checkout failed; publish and canary results remain authoritative."


### PR DESCRIPTION
## Summary

- make release notification checkout non-blocking so a Slack notification checkout glitch cannot mark a successful publish as failed
- skip the release notification cleanly when checkout is unavailable
- leave publish and post-publish canary as the authoritative release proof

## Source Signal

- Public release `v0.10.22` run published successfully but ended red: https://github.com/evalops/maestro/actions/runs/26339133758
- `notify` failed on checkout auth after publish/release creation even though npm publish and GitHub release creation had already succeeded.

## Test Plan

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml YAML ok"'`
- `git diff --check`
- commit hook: `bunx biome check . && bun run lint:evals`, generated-contract checks, build/bundle checks

## Rollback

- Revert this PR to restore the previous release workflow. If rolled back, release notification checkout failures can mark a successfully published release red.
