### PR TITLE
test: make published replay canary portable

### DIFF
--- a/scripts/smoke-published-replay-e2e.js
+++ b/scripts/smoke-published-replay-e2e.js
@@ -30,6 +30,18 @@ const timeoutMs = Number.parseInt(
 	process.env.MAESTRO_PUBLISHED_REPLAY_E2E_TIMEOUT_MS ?? "45000",
 	10,
 );
+const replaySandboxModes = [
+	"read-only",
+	"workspace-write",
+	"danger-full-access",
+	"native",
+	"docker",
+	"local",
+	"none",
+];
+// Hosted Linux release runners do not always expose Maestro's native sandbox.
+const replaySandboxMode =
+	process.env.MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE?.trim() || "local";
 
 function fail(message, details) {
 	console.error(message);
@@ -37,6 +49,13 @@ function fail(message, details) {
 		console.error(details);
 	}
 	process.exit(1);
+}
+
+if (!replaySandboxModes.includes(replaySandboxMode)) {
+	fail(
+		`Invalid MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "${replaySandboxMode}"`,
+		`Allowed values: ${replaySandboxModes.join(", ")}`,
+	);
 }
 
 function parseArgs(argv) {
@@ -297,7 +316,7 @@ function runSingleShotMode(binPath, label, mode) {
 				"--approval-mode",
 				"auto",
 				"--sandbox",
-				"workspace-write",
+				replaySandboxMode,
 				"--tools",
 				"read",
 				PROMPT_TEXT,
@@ -413,7 +432,7 @@ function runRpcMode(binPath) {
 				"--approval-mode",
 				"auto",
 				"--sandbox",
-				"workspace-write",
+				replaySandboxMode,
 				"--tools",
 				"read",
 			],


### PR DESCRIPTION
## Summary

- mirror the internal published replay smoke fix from evalops/maestro-internal#2134
- default the published replay canary to Maestro's portable `local` sandbox on hosted runners
- keep `MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE` available for stricter runner environments with native sandbox support

## Source Signal

- Internal PR: https://github.com/evalops/maestro-internal/pull/2134
- Public release `v0.10.22` run failed after publish in `post-publish-canary`: https://github.com/evalops/maestro/actions/runs/26339133758/job/77538990094
- Root cause: hosted Ubuntu lacked native sandbox support for the hardcoded `workspace-write` canary sandbox.

## Test Plan

- `node --check scripts/smoke-published-replay-e2e.js`
- `node scripts/sync-release-mirror.mjs --check --source /Users/jonathanhaas/Documents/Projects/.codex-study/maestro-internal-fresh --target /Users/jonathanhaas/Documents/Projects/.codex-study/maestro-public-canary-2134`
- `git diff --check`

## Rollback

- Revert this PR to restore the previous hardcoded `workspace-write` sandbox for published replay smoke. If rolled back before the next release, run the canary only on runners with native sandbox support.
