### PR TITLE
Make published replay canary sandbox portable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,7 @@ jobs:
       - name: Verify published package from npm
         env:
           MAESTRO_INSTALL_AUDIT_LEVEL: critical
+          MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: local
           MAESTRO_REGISTRY_POLL_ATTEMPTS: "120"
           MAESTRO_REGISTRY_POLL_DELAY_MS: "5000"
         run: node scripts/smoke-registry-install.js

--- a/scripts/smoke-published-replay-e2e.js
+++ b/scripts/smoke-published-replay-e2e.js
@@ -30,6 +30,18 @@ const timeoutMs = Number.parseInt(
 	process.env.MAESTRO_PUBLISHED_REPLAY_E2E_TIMEOUT_MS ?? "45000",
 	10,
 );
+const replaySandboxModes = [
+	"read-only",
+	"workspace-write",
+	"danger-full-access",
+	"native",
+	"docker",
+	"local",
+	"none",
+];
+// Hosted Linux release runners do not always expose Maestro's native sandbox.
+const replaySandboxMode =
+	process.env.MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE?.trim() || "local";
 
 function fail(message, details) {
 	console.error(message);
@@ -37,6 +49,13 @@ function fail(message, details) {
 		console.error(details);
 	}
 	process.exit(1);
+}
+
+if (!replaySandboxModes.includes(replaySandboxMode)) {
+	fail(
+		`Invalid MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "${replaySandboxMode}"`,
+		`Allowed values: ${replaySandboxModes.join(", ")}`,
+	);
 }
 
 function parseArgs(argv) {
@@ -297,7 +316,7 @@ function runSingleShotMode(binPath, label, mode) {
 				"--approval-mode",
 				"auto",
 				"--sandbox",
-				"workspace-write",
+				replaySandboxMode,
 				"--tools",
 				"read",
 				PROMPT_TEXT,
@@ -413,7 +432,7 @@ function runRpcMode(binPath) {
 				"--approval-mode",
 				"auto",
 				"--sandbox",
-				"workspace-write",
+				replaySandboxMode,
 				"--tools",
 				"read",
 			],

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -829,6 +829,32 @@ describe("ci workflow guardrails", () => {
 		);
 	});
 
+	it("keeps published replay canaries portable on hosted Linux", () => {
+		const script = readFileSync(
+			new URL("../../scripts/smoke-published-replay-e2e.js", import.meta.url),
+			{ encoding: "utf8" },
+		);
+		const releaseWorkflow = parse(
+			readFileSync(
+				new URL("../../.github/workflows/release.yml", import.meta.url),
+				{ encoding: "utf8" },
+			),
+		) as Workflow;
+		const canaryStep = releaseWorkflow.jobs?.[
+			"post-publish-canary"
+		]?.steps?.find((step) => step.name === "Verify published package from npm");
+
+		expect(script).toContain("MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE");
+		expect(script).toContain('"workspace-write"');
+		expect(script).toContain('"local"');
+		expect(script).toContain("replaySandboxModes");
+		expect(script).toContain("replaySandboxMode");
+		expect(canaryStep).toBeDefined();
+		expect(canaryStep?.env).toMatchObject({
+			MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "local",
+		});
+	});
+
 	it("keeps packed CLI smoke enabled independently of package-lock management", () => {
 		const script = readFileSync(
 			new URL("../../scripts/release-readiness.js", import.meta.url),


### PR DESCRIPTION
## Summary
- make the published replay E2E smoke use a portable local sandbox by default on hosted Linux
- set the public post-publish canary replay smoke to MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE=local
- add a guardrail test that keeps the public canary wired to the portable replay sandbox override

Internal PR: https://github.com/evalops/maestro-internal/pull/2135

## Test Plan
- node --check scripts/smoke-published-replay-e2e.js
- public focused vitest was not runnable in this worktree because node_modules/vitest is absent; CI will run the guardrail
- MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE=local node scripts/smoke-published-replay-e2e.js --package @evalops/maestro --version 0.10.22 --cli-command maestro (run from internal worktree against the published package)