### PR TITLE
Sync published replay smoke mirror

### DIFF
--- a/scripts/smoke-published-replay-e2e.js
+++ b/scripts/smoke-published-replay-e2e.js
@@ -30,18 +30,6 @@ const timeoutMs = Number.parseInt(
 	process.env.MAESTRO_PUBLISHED_REPLAY_E2E_TIMEOUT_MS ?? "45000",
 	10,
 );
-const replaySandboxModes = [
-	"read-only",
-	"workspace-write",
-	"danger-full-access",
-	"native",
-	"docker",
-	"local",
-	"none",
-];
-// Hosted Linux release runners do not always expose Maestro's native sandbox.
-const replaySandboxMode =
-	process.env.MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE?.trim() || "local";
 
 function fail(message, details) {
 	console.error(message);
@@ -49,13 +37,6 @@ function fail(message, details) {
 		console.error(details);
 	}
 	process.exit(1);
-}
-
-if (!replaySandboxModes.includes(replaySandboxMode)) {
-	fail(
-		`Invalid MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "${replaySandboxMode}"`,
-		`Allowed values: ${replaySandboxModes.join(", ")}`,
-	);
 }
 
 function parseArgs(argv) {
@@ -316,7 +297,7 @@ function runSingleShotMode(binPath, label, mode) {
 				"--approval-mode",
 				"auto",
 				"--sandbox",
-				replaySandboxMode,
+				"workspace-write",
 				"--tools",
 				"read",
 				PROMPT_TEXT,
@@ -432,7 +413,7 @@ function runRpcMode(binPath) {
 				"--approval-mode",
 				"auto",
 				"--sandbox",
-				replaySandboxMode,
+				"workspace-write",
 				"--tools",
 				"read",
 			],


### PR DESCRIPTION
Summary
- Sync the public release mirror copy of scripts/smoke-published-replay-e2e.js with maestro-internal.
- Keeps the public-release-mirror gate for evalops/maestro-internal#2137 comparing against a matching public branch instead of stale public main.

Source Signal
- evalops/maestro-internal#2137 public-release-mirror failed on scripts/smoke-published-replay-e2e.js drift.

Test Plan
- node /Users/jonathanhaas/Documents/Projects/.codex-worktrees/maestro-internal-status-db-20260523/scripts/sync-release-mirror.mjs --check --source /Users/jonathanhaas/Documents/Projects/.codex-worktrees/maestro-internal-status-db-20260523 --target /tmp/maestro-public-sync-2137.O2ubmL/public-mirror

Rollback
- Revert a76a5fbc to restore the prior public mirror file.