### PR TITLE
Keep published replay default sandbox covered

### DIFF
--- a/.github/workflows/verify-published-package.yml
+++ b/.github/workflows/verify-published-package.yml
@@ -57,6 +57,7 @@ jobs:
           PACKAGE_NAME: ${{ github.event.inputs.package_name || steps.defaults.outputs.package_name }}
           PACKAGE_VERSION: ${{ github.event.inputs.version || steps.defaults.outputs.version }}
           CLI_COMMAND: ${{ github.event.inputs.cli_command || steps.defaults.outputs.cli_command }}
+          MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: local
         run: |
           set -euo pipefail
           node scripts/smoke-registry-install.js \

--- a/scripts/smoke-published-replay-e2e.js
+++ b/scripts/smoke-published-replay-e2e.js
@@ -41,7 +41,8 @@ const replaySandboxModes = [
 ];
 // Hosted Linux release runners do not always expose Maestro's native sandbox.
 const replaySandboxMode =
-	process.env.MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE?.trim() || "local";
+	process.env.MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE?.trim() ||
+	"workspace-write";
 
 function fail(message, details) {
 	console.error(message);

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -840,10 +840,9 @@ describe("ci workflow guardrails", () => {
 				{ encoding: "utf8" },
 			),
 		) as Workflow;
-		const releaseCanaryJob = releaseWorkflow.jobs?.["post-publish-canary"];
-		const canaryStep = releaseWorkflow.jobs?.[
-			"post-publish-canary"
-		]?.steps?.find((step) => step.name === "Verify published package from npm");
+			const canaryStep = releaseWorkflow.jobs?.[
+				"post-publish-canary"
+			]?.steps?.find((step) => step.name === "Verify published package from npm");
 		const verifyWorkflowPath = new URL(
 			"../../.github/workflows/verify-published-package.yml",
 			import.meta.url,
@@ -860,15 +859,11 @@ describe("ci workflow guardrails", () => {
 		expect(script).toContain("replaySandboxMode");
 		expect(sandboxArgs.length).toBeGreaterThanOrEqual(2);
 		expect(script).not.toMatch(/"--sandbox",\s*"workspace-write"/);
-		if (releaseCanaryJob) {
 			expect(canaryStep).toBeDefined();
 			expect(canaryStep?.env).toMatchObject({
 				MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "local",
 			});
-		} else {
-			expect(canaryStep).toBeUndefined();
-		}
-		if (existsSync(verifyWorkflowPath)) {
+			if (existsSync(verifyWorkflowPath)) {
 			const verifyWorkflow = parse(
 				readFileSync(verifyWorkflowPath, { encoding: "utf8" }),
 			) as Workflow;

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -829,10 +829,24 @@ describe("ci workflow guardrails", () => {
 		);
 	});
 
-	it("keeps published replay canaries portable on hosted runners", () => {
+	it("keeps published replay canaries portable on hosted Linux", () => {
 		const script = readFileSync(
 			new URL("../../scripts/smoke-published-replay-e2e.js", import.meta.url),
 			{ encoding: "utf8" },
+		);
+		const releaseWorkflow = parse(
+			readFileSync(
+				new URL("../../.github/workflows/release.yml", import.meta.url),
+				{ encoding: "utf8" },
+			),
+		) as Workflow;
+		const releaseCanaryJob = releaseWorkflow.jobs?.["post-publish-canary"];
+		const canaryStep = releaseWorkflow.jobs?.[
+			"post-publish-canary"
+		]?.steps?.find((step) => step.name === "Verify published package from npm");
+		const verifyWorkflowPath = new URL(
+			"../../.github/workflows/verify-published-package.yml",
+			import.meta.url,
 		);
 
 		const sandboxArgs = [
@@ -840,9 +854,32 @@ describe("ci workflow guardrails", () => {
 		];
 		expect(script).toContain("MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE");
 		expect(script).toContain("Invalid MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE");
-		expect(script).toContain('|| "local"');
+		expect(script).toContain('"workspace-write"');
+		expect(script).toContain('"local"');
+		expect(script).toContain("replaySandboxModes");
+		expect(script).toContain("replaySandboxMode");
 		expect(sandboxArgs.length).toBeGreaterThanOrEqual(2);
 		expect(script).not.toMatch(/"--sandbox",\s*"workspace-write"/);
+		if (releaseCanaryJob) {
+			expect(canaryStep).toBeDefined();
+			expect(canaryStep?.env).toMatchObject({
+				MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "local",
+			});
+		} else {
+			expect(canaryStep).toBeUndefined();
+		}
+		if (existsSync(verifyWorkflowPath)) {
+			const verifyWorkflow = parse(
+				readFileSync(verifyWorkflowPath, { encoding: "utf8" }),
+			) as Workflow;
+			const verifyStep = verifyWorkflow.jobs?.verify?.steps?.find(
+				(step) => step.name === "Verify published package from npm",
+			);
+			expect(verifyStep).toBeDefined();
+			expect(verifyStep?.env).toMatchObject({
+				MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "local",
+			});
+		}
 	});
 
 	it("keeps packed CLI smoke enabled independently of package-lock management", () => {

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -851,10 +851,13 @@ describe("ci workflow guardrails", () => {
 		const sandboxArgs = [
 			...script.matchAll(/"--sandbox",\s*replaySandboxMode/g),
 		];
-		expect(script).toContain("MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE");
-		expect(script).toContain("Invalid MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE");
-		expect(script).toContain('"workspace-write"');
-		expect(script).toContain('"local"');
+			expect(script).toContain("MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE");
+			expect(script).toContain("Invalid MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE");
+			expect(script).toMatch(
+				/const replaySandboxMode =\s*process\.env\.MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE\?\.trim\(\)\s*\|\|\s*"workspace-write";/,
+			);
+			expect(script).toContain('"workspace-write"');
+			expect(script).toContain('"local"');
 		expect(script).toContain("replaySandboxModes");
 		expect(script).toContain("replaySandboxMode");
 		expect(sandboxArgs.length).toBeGreaterThanOrEqual(2);
@@ -863,10 +866,14 @@ describe("ci workflow guardrails", () => {
 			expect(canaryStep?.env).toMatchObject({
 				MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "local",
 			});
-			if (existsSync(verifyWorkflowPath)) {
-			const verifyWorkflow = parse(
-				readFileSync(verifyWorkflowPath, { encoding: "utf8" }),
-			) as Workflow;
+			const requiresVerifyWorkflow =
+				process.env.GITHUB_REPOSITORY === "evalops/maestro" ||
+				existsSync(verifyWorkflowPath);
+			if (requiresVerifyWorkflow) {
+				expect(existsSync(verifyWorkflowPath)).toBe(true);
+				const verifyWorkflow = parse(
+					readFileSync(verifyWorkflowPath, { encoding: "utf8" }),
+				) as Workflow;
 			const verifyStep = verifyWorkflow.jobs?.verify?.steps?.find(
 				(step) => step.name === "Verify published package from npm",
 			);


### PR DESCRIPTION
Summary:
- keep the published replay smoke default on workspace-write/native policy
- leave hosted release and verify-published-package canaries on local via MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE
- mirror the guardrail shape used internally so missing public canary steps fail validation

Internal PR: https://github.com/evalops/maestro-internal/pull/2138

Test Plan:
- node --check scripts/smoke-published-replay-e2e.js
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/verify-published-package.yml"); YAML.load_file(".github/workflows/release.yml"); puts "workflow YAML ok"'
- node scripts/sync-release-mirror.mjs --check --source /Users/jonathanhaas/Documents/Projects/.codex-study/maestro-internal-2138 --target /Users/jonathanhaas/Documents/Projects/.codex-study/maestro-public-2138
- git diff --check

Rollback:
- revert this PR to restore the previous local default for published replay smokes