### PR TITLE
Sync release helper formatting for v0.10.23

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -22,7 +22,7 @@ import {
 	insertChangelogEntry,
 	mergeOrInsertChangelogEntry,
 } from "./release-notes.js";
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -93,6 +93,22 @@ function syncPackageMetadata() {
 	}
 }
 
+function formatPackageJsonFiles(packageJsonPaths) {
+	if (packageJsonPaths.length === 0) {
+		return;
+	}
+
+	try {
+		execFileSync("bunx", ["biome", "format", "--write", ...packageJsonPaths], {
+			stdio: "inherit",
+		});
+		console.log("🧹 Formatted package.json files");
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : "unknown error";
+		throw new Error(`Failed to format package.json files: ${reason}`);
+	}
+}
+
 function hasScript(rootPkg, scriptName) {
 	return typeof rootPkg.scripts?.[scriptName] === "string";
 }
@@ -142,6 +158,10 @@ async function updateVersionedFiles(
 		for (const pkg of workspacePkgs) {
 			writePackageJson(pkg.path, pkg.data);
 		}
+		formatPackageJsonFiles([
+			getRootPackagePath(),
+			...workspacePkgs.map((pkg) => pkg.path),
+		]);
 		console.log("✅ Updated package.json files");
 
 		// Update changelog

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -793,6 +793,27 @@ describe("ci workflow guardrails", () => {
 		expect(releaseReadinessStep?.if).toContain("release_helper_only != 'true'");
 	});
 
+	it("formats version-generated package manifests before release checks", () => {
+		const script = readFileSync(
+			new URL("../../scripts/version.js", import.meta.url),
+			{ encoding: "utf8" },
+		);
+		const formatCall = "formatPackageJsonFiles([";
+
+		expect(script).toContain("execFileSync");
+		expect(script).toContain('"bunx"');
+		expect(script).toContain('"biome"');
+		expect(script).toContain('"format"');
+		expect(script).toContain('"--write"');
+		expect(script).toContain(formatCall);
+		expect(script.indexOf(formatCall)).toBeGreaterThan(
+			script.indexOf("writePackageJson(pkg.path, pkg.data);"),
+		);
+		expect(script.indexOf(formatCall)).toBeLessThan(
+			script.indexOf("updateChangelog(newVersion"),
+		);
+	});
+
 	it("keeps public registry smoke install helper exports", async () => {
 		const helpers = (await import(
 			"../../scripts/install-smoke-utils.js"


### PR DESCRIPTION
## Summary

- mirror the internal release helper update for generated package-manifest formatting
- add the public guardrail that keeps the version script formatting package manifests before release checks
- provide the public ref needed by internal release PR #2139 mirror validation

Internal PR: https://github.com/evalops/maestro-internal/pull/2139

## Test Plan

- node scripts/sync-release-mirror.mjs --check --source /Users/jonathanhaas/Documents/Projects/.codex-study/maestro-release-0.10.23 --target /Users/jonathanhaas/Documents/Projects/.codex-study/maestro-public-mirror-2102
- node --check scripts/version.js
- node ./scripts/run-vitest.js --run test/scripts/ci-guardrails.test.ts
- git diff --check
- commit hook ran staged Guardian, bunx biome check . && bun run lint:evals, prebuild, build, and binary compile

## Rollback

- Revert this PR to restore the previous public version helper behavior; internal release PR #2139 would need a matching mirror update before merge.