### PR TITLE
ci: fix Hopper release auth order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,13 +239,10 @@ jobs:
           workdir=$(mktemp -d)
           trap 'rm -rf "$workdir"' EXIT
 
-          gh auth setup-git
-          gh auth status
-          gh auth refresh --hostname github.com --scopes repo || true
-
+          export GH_TOKEN="$HOPPER_PUSH_TOKEN"
           gh api user >/dev/null || {
-            echo "gh auth not configured; initializing with provided token"
-            export GH_TOKEN="$HOPPER_PUSH_TOKEN"
+            echo "HOPPER_PUSH_TOKEN could not authenticate with GitHub."
+            exit 1
           }
 
           git clone "https://x-access-token:${HOPPER_PUSH_TOKEN}@github.com/${repo}.git" "$workdir"


### PR DESCRIPTION
Summary
- Export HOPPER_PUSH_TOKEN as GH_TOKEN before any gh CLI auth probe in the public release workflow.
- Remove CI gh auth-store mutations so the workflow uses the intended token directly.

Test plan
- node ./scripts/run-vitest.js --run test/scripts/ci-guardrails.test.ts