### PR TITLE
Guard against proof artifact labels

### DIFF
--- a/scripts/check-public-surface-boundary.mjs
+++ b/scripts/check-public-surface-boundary.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const requiredMirrorExcludes = [
@@ -16,8 +17,117 @@ const forbiddenPublicPaths = [
 	"test/scenario-pack.test.ts",
 ];
 
+const openAiProof = ["OpenAI", "Proof"];
+const forbiddenProofArtifactLabels = [
+	["Maestro", ...openAiProof].join(" "),
+	["COMPUTER", "USE", ...openAiProof.map((term) => term.toUpperCase())].join(
+		"_",
+	),
+	["Maestro", ...openAiProof].join(""),
+	["maestro", ...openAiProof.map((term) => term.toLowerCase())].join("-"),
+];
+
+const fallbackScanExcludedDirectories = new Set([
+	".git",
+	".next",
+	".nx",
+	"build",
+	"dist",
+	"node_modules",
+	"target",
+	"tmp",
+]);
+
 function read(path) {
 	return readFileSync(resolve(path), "utf8");
+}
+
+function filesystemFiles(root = ".") {
+	const files = [];
+	function walk(relativeDirectory) {
+		for (const entry of readdirSync(resolve(relativeDirectory), {
+			withFileTypes: true,
+		})) {
+			const relativePath =
+				relativeDirectory === "." ? entry.name : `${relativeDirectory}/${entry.name}`;
+			if (entry.isDirectory()) {
+				if (!fallbackScanExcludedDirectories.has(entry.name)) {
+					walk(relativePath);
+				}
+				continue;
+			}
+			if (entry.isFile()) {
+				files.push(relativePath);
+			}
+		}
+	}
+	walk(root);
+	return files;
+}
+
+function isGitRepository() {
+	try {
+		return (
+			execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "pipe"],
+			}).trim() === "true"
+		);
+	} catch {
+		return false;
+	}
+}
+
+function gitProofArtifactErrors() {
+	if (!isGitRepository()) {
+		return null;
+	}
+	const matches = [];
+	for (const [index, label] of forbiddenProofArtifactLabels.entries()) {
+		try {
+			const output = execFileSync(
+				"git",
+				["grep", "--cached", "-n", "-I", "-i", "-F", "-e", label, "--", "."],
+				{
+					encoding: "utf8",
+					stdio: ["ignore", "pipe", "pipe"],
+				},
+			);
+			for (const line of output.split(/\r?\n/u)) {
+				const path = line.split(":", 1)[0];
+				if (path) {
+					matches.push(
+						`${path} contains forbidden local proof artifact label variant ${index + 1}`,
+					);
+				}
+			}
+		} catch (error) {
+			if (error?.status === 1) {
+				continue;
+			}
+			return null;
+		}
+	}
+	return [...new Set(matches)];
+}
+
+function filesystemProofArtifactErrors() {
+	const matches = [];
+	for (const path of filesystemFiles()) {
+		const bytes = readFileSync(resolve(path));
+		if (bytes.includes(0)) {
+			continue;
+		}
+		const source = bytes.toString("utf8").toLowerCase();
+		for (const [index, label] of forbiddenProofArtifactLabels.entries()) {
+			if (source.includes(label.toLowerCase())) {
+				matches.push(
+					`${path} contains forbidden local proof artifact label variant ${index + 1}`,
+				);
+			}
+		}
+	}
+	return matches;
 }
 
 function fail(errors) {
@@ -56,6 +166,8 @@ for (const path of forbiddenPublicPaths) {
 		errors.push(`${path} must not exist in the mirrored public source tree.`);
 	}
 }
+
+errors.push(...(gitProofArtifactErrors() ?? filesystemProofArtifactErrors()));
 
 if (errors.length > 0) {
 	fail(errors);


### PR DESCRIPTION
## Summary
- Add a public surface boundary guard that scans tracked files for local proof-artifact labels before they can land in source.
- Assemble the denied labels from fragments so the source does not itself contain the bad product-facing text.

## Source Signal
- Local product cleanup after proof artifacts introduced product-shaped labels during validation.
- Source-of-truth internal PR: https://github.com/evalops/maestro-internal/pull/2148

## Test Plan
- `node scripts/check-public-surface-boundary.mjs`
- Commit hook ran Guardian, `bunx biome check .`, `bun run lint:evals`, build, and binary compile.
- `rg --no-messages -n --hidden -S -i "maestro openai proof|computer_use_openai_proof|maestroopenaiproof|maestro-openai-proof|MAESTRO OPENAI PROOF" /Users/jonathanhaas/Documents/Projects/maestro /Users/jonathanhaas/Documents/Projects/maestro-internal --glob "!**/.git/**" --glob "!**/node_modules/**" --glob "!**/.next/**" --glob "!**/dist/**" --glob "!**/build/**" --glob "!**/target/**"` returned no matches.

## Rollback
- Revert this PR to remove the additional public surface boundary scan.