### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/agent/swarm/executor.ts
+++ b/src/agent/swarm/executor.ts
@@ -309,6 +309,20 @@ function hashA2AEndpointUrlForTelemetry(
 	return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
 }
 
+function platformA2APeerRouteName(
+	candidate: PlatformAgentRegistryA2APeerCandidate,
+	endpointHash = hashA2AEndpointUrlForTelemetry(candidate.endpointUrl),
+): string {
+	const configuredName =
+		trimString(candidate.agent.name) ?? trimString(candidate.agent.id);
+	if (configuredName) {
+		return configuredName;
+	}
+	return endpointHash
+		? `endpoint:${endpointHash}`
+		: "platform-agent-registry-peer";
+}
+
 function canonicalizeA2AEndpointUrlForTelemetry(url: string): string {
 	try {
 		const parsed = new URL(url);
@@ -1042,12 +1056,7 @@ export class SwarmExecutor {
 		const config = await this.a2aConfigForPlatformCandidate(candidate, options);
 		const selectedSkillId = ranked.selectedSkill?.id ?? skillId;
 		const endpointHash = hashA2AEndpointUrlForTelemetry(candidate.endpointUrl);
-		const routeName =
-			trimString(candidate.agent.name) ??
-			trimString(candidate.agent.id) ??
-			(endpointHash
-				? `endpoint:${endpointHash}`
-				: "platform-agent-registry-peer");
+		const routeName = platformA2APeerRouteName(candidate, endpointHash);
 		return {
 			name: routeName,
 			displayName: candidate.agent.name,
@@ -1527,6 +1536,7 @@ export class SwarmExecutor {
 				peer: route.name,
 				peerDisplayName: route.displayName,
 				source: route.source,
+				parentTaskId: task.id,
 				taskId: sent.task.id,
 				contextId,
 				messageId,

--- a/src/agent/swarm/types.ts
+++ b/src/agent/swarm/types.ts
@@ -155,6 +155,8 @@ export interface SwarmA2ATeammateExecution {
 	peerDisplayName?: string;
 	/** Peer source used by the router. */
 	source: "registry" | "platform-agent-registry";
+	/** Parent swarm task id used to derive telemetry lane ids. */
+	parentTaskId?: string;
 	/** A2A task id returned by the peer. */
 	taskId: string;
 	/** A2A context id used for resume/reply. */

--- a/src/platform/a2a-completion-audit.ts
+++ b/src/platform/a2a-completion-audit.ts
@@ -123,6 +123,7 @@ function buildRemoteLaneSources(
 			const parentTaskId = parentTaskIdForLane(
 				teammate.completedTasks,
 				ledgerEntry,
+				teammate.a2a,
 			);
 			return {
 				laneId: parentTaskId
@@ -188,7 +189,8 @@ function buildLaneAudit(
 ): A2ACompletionAuditLane {
 	const { a2a, ledgerEntry } = lane;
 	const parentTaskId =
-		lane.parentTaskId ?? parentTaskIdForLane(lane.completedTasks, ledgerEntry);
+		lane.parentTaskId ??
+		parentTaskIdForLane(lane.completedTasks, ledgerEntry, a2a);
 	const status = ledgerEntry?.state;
 	const evidence: Record<A2ACompletionEvidenceKey, boolean> = {
 		status: Boolean(status),
@@ -254,12 +256,14 @@ function parentTaskIdForLedger(
 function parentTaskIdForLane(
 	completedTasks: string[],
 	ledgerEntry: A2ATaskLedgerEntry | undefined,
+	a2a?: A2AAuditA2A,
 ): string | undefined {
 	const ledgerParentTaskId = parentTaskIdForLedger(ledgerEntry);
+	const a2aParentTaskId = a2a?.parentTaskId;
 	if (ledgerEntry?.state && !isCompletedA2AState(ledgerEntry.state)) {
-		return ledgerParentTaskId ?? lastValue(completedTasks);
+		return ledgerParentTaskId ?? a2aParentTaskId ?? lastValue(completedTasks);
 	}
-	return lastValue(completedTasks) ?? ledgerParentTaskId;
+	return lastValue(completedTasks) ?? ledgerParentTaskId ?? a2aParentTaskId;
 }
 
 function isCompletedA2AState(state: string): boolean {

--- a/test/agent/swarm-executor.test.ts
+++ b/test/agent/swarm-executor.test.ts
@@ -816,6 +816,7 @@ describe("SwarmExecutor", () => {
 			.update("https://anonymous.internal/a2a")
 			.digest("hex")}`;
 		const expectedPeer = `endpoint:${expectedHash}`;
+		const expectedLaneId = a2aDelegationLaneId(expectedPeer, "task-1");
 		const [, input] = sendA2AMessageMock.mock.calls[0] as [
 			unknown,
 			{
@@ -839,8 +840,10 @@ describe("SwarmExecutor", () => {
 		expect(recordA2ADelegationTelemetryMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				phase: "peer_selected",
+				laneId: expectedLaneId,
 				peerName: expectedPeer,
 				peerEndpointHash: expectedHash,
+				peerEndpointUrl: undefined,
 			}),
 		);
 	});
@@ -850,6 +853,7 @@ describe("SwarmExecutor", () => {
 			.update("https://anonymous.internal/a2a")
 			.digest("hex")}`;
 		const expectedPeer = `endpoint:${expectedHash}`;
+		const expectedLaneId = a2aDelegationLaneId(expectedPeer, "task-1");
 		listA2APeerCandidatesWithPlatformMock.mockResolvedValue([
 			{
 				agent: {
@@ -920,11 +924,19 @@ describe("SwarmExecutor", () => {
 				relayPeer: expectedPeer,
 			}),
 		);
+		expect(JSON.stringify(sendA2AMessageMock.mock.calls[0]?.[1])).not.toContain(
+			"secret",
+		);
+		expect(JSON.stringify(sendA2AMessageMock.mock.calls[0]?.[1])).not.toContain(
+			"token=one",
+		);
 		expect(recordA2ADelegationTelemetryMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				phase: "peer_selected",
+				laneId: expectedLaneId,
 				peerName: expectedPeer,
 				peerEndpointHash: expectedHash,
+				peerEndpointUrl: undefined,
 			}),
 		);
 	});

--- a/test/platform/a2a-completion-audit.test.ts
+++ b/test/platform/a2a-completion-audit.test.ts
@@ -311,6 +311,67 @@ describe("A2A completion audit", () => {
 		);
 	});
 
+	it("keeps telemetry lane ids when ledger parent metadata is missing", () => {
+		const lane = remoteLane(
+			"lane_alpha",
+			"alpha",
+			"remote-task-1",
+			"old_parent",
+		);
+		lane.completedTasks = [];
+		const a2a = lane.a2a;
+		if (!a2a) {
+			throw new Error("remoteLane test helper must create A2A metadata");
+		}
+		lane.a2a = {
+			...a2a,
+			parentTaskId: "current_parent",
+		};
+		const ledgerEntry = ledgerTask("alpha", "remote-task-1", "missing_parent");
+		ledgerEntry.metadata = {
+			swarmId: "swarm_missing_parent_metadata",
+			transport: "a2a",
+		};
+
+		const audit = buildA2ACompletionAudit({
+			swarm: {
+				id: "swarm_missing_parent_metadata",
+				status: "completed",
+				config: {
+					teammateCount: 1,
+					planFile: "/tmp/plan.md",
+					tasks: [],
+					cwd: "/tmp",
+				},
+				teammates: [lane],
+				pendingTasks: [],
+				activeTasks: new Map(),
+				completedTasks: new Set(),
+				failedTasks: new Set(),
+				startedAt: Date.now(),
+			},
+			ledger: { tasks: [ledgerEntry] },
+			pushEvidenceKeys: new Set([a2aPushEvidenceKey("alpha", "remote-task-1")]),
+		});
+
+		expect(audit.complete).toBe(false);
+		expect(audit.lanes[0]).toEqual(
+			expect.objectContaining({
+				laneId: a2aDelegationLaneId("alpha", "current_parent"),
+				parentTaskId: "current_parent",
+				evidence: expect.objectContaining({
+					status: true,
+					artifact: true,
+					task: true,
+					workGraph: true,
+					push: true,
+					correlation: false,
+				}),
+				missingEvidence: ["correlation"],
+			}),
+		);
+	});
+
 	it("uses the current parent instead of the oldest completed task", () => {
 		const swarm = {
 			id: "swarm_multi_task",


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"529a80e594476a1f09ef9a7c8d906f810221dd02"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `529a80e594476a1f09ef9a7c8d906f810221dd02`
- last generated public sync base: `808121f675cce6d11207c6ac6971f6d40bcec7a4`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (529a80e59447)`
- public projection: `https://github.com/evalops/maestro@main (808121f675cc)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/agent/swarm/executor.ts
- copy/update src/agent/swarm/types.ts
- copy/update src/platform/a2a-completion-audit.ts
- copy/update test/agent/swarm-executor.test.ts
- copy/update test/platform/a2a-completion-audit.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/agent/swarm/executor.ts
- copy/update src/agent/swarm/types.ts
- copy/update src/platform/a2a-completion-audit.ts
- copy/update test/agent/swarm-executor.test.ts
- copy/update test/platform/a2a-completion-audit.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@529a80e594476a1f09ef9a7c8d906f810221dd02`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #548 to internal source `529a80e594476a1f09ef9a7c8d906f810221dd02`