### PR TITLE
Install ripgrep for public flaky canary

### DIFF
--- a/.github/workflows/flaky-canary.yml
+++ b/.github/workflows/flaky-canary.yml
@@ -53,6 +53,8 @@ jobs:
           done
 
       - uses: ./.github/actions/setup-bun-nx
+        with:
+          ensure-ripgrep: "true"
 
       - name: Run flake-prone tests twice
         run: |


### PR DESCRIPTION
## Summary
- enable the shared setup action to install ripgrep before the public flaky canary runs
- match the internal canary fix so schedule jobs can run tests that shell out to `rg`

## Validation
- bunx actionlint .github/workflows/flaky-canary.yml
- git diff --check