### PR TITLE
Add optional MarkItDown attachment extraction

### DIFF
--- a/docs/WEB_UI.md
+++ b/docs/WEB_UI.md
@@ -142,6 +142,8 @@ export MAESTRO_SESSION_DIR="~/.maestro/sessions"  # Session storage
 export MAESTRO_AGENT_DIR="~/.maestro/agent"       # Context files
 export MAESTRO_SESSION_SCOPE="auth"                # Scope sessions by auth subject
 export MAESTRO_MULTI_USER="1"                      # Alias for MAESTRO_SESSION_SCOPE
+export MAESTRO_MARKITDOWN_CMD="uvx"                # Optional document converter command
+export MAESTRO_MARKITDOWN_ARGS="markitdown"        # Optional converter args before the input file
 
 # Proxy Configuration (when behind nginx, CloudFlare, etc.)
 export MAESTRO_TRUST_PROXY="true"                  # Trust X-Forwarded-For headers
@@ -152,6 +154,14 @@ export MAESTRO_TRUST_PROXY="true"                  # Trust X-Forwarded-For heade
 When running behind a reverse proxy (nginx, CloudFlare, load balancer), set `MAESTRO_TRUST_PROXY=true` to extract the real client IP from the `X-Forwarded-For` header for rate limiting.
 
 **Security Warning:** Only enable this if your server is behind a trusted proxy that properly sets the `X-Forwarded-For` header. Enabling this on a publicly accessible server allows IP spoofing for rate limit bypass.
+
+#### MarkItDown Attachment Extraction
+
+Server-side attachment extraction uses Maestro's native parsers first. For HTML
+or unsupported document types, Maestro will try `markitdown` and then
+`uvx markitdown` unless `MAESTRO_MARKITDOWN=0` is set. Use
+`MAESTRO_MARKITDOWN_PREFER=1` to prefer MarkItDown for all supported attachment
+formats.
 
 **Important:** Ensure your server is NOT directly accessible from the internet when using this setting. The proxy should be the only entry point, and it should overwrite (not append to) the `X-Forwarded-For` header for incoming requests.
 

--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -54,6 +54,7 @@ use runtime_assets::*;
 const MAX_EXTRACT_JSON_BODY_BYTES: usize = 72 * 1024 * 1024;
 const DEFAULT_EXTRACT_MAX_CHARS: usize = 200_000;
 const MAX_EXTRACT_INPUT_BYTES: usize = 50 * 1024 * 1024;
+const MARKITDOWN_EXTRACT_TIMEOUT: Duration = Duration::from_secs(20);
 const MAX_PROJECT_ONBOARDING_IMPRESSIONS: u8 = 4;
 const A2A_PROTOCOL_VERSION: &str = "1.0";
 const A2A_DEFAULT_TURN_TIMEOUT_MS: u64 = 180_000;
@@ -6286,6 +6287,7 @@ async fn handle_session_attachment_extract(
                     &serde_json::json!({
                         "fileName": file_name,
                         "format": "unknown",
+                        "extractor": "native",
                         "size": attachment.get("size").and_then(Value::as_u64).unwrap_or(0),
                         "truncated": false,
                         "extractedText": extracted_text,
@@ -6390,6 +6392,7 @@ fn attachment_extract_json_response(file_name: String, output: ExtractDocumentOu
         &serde_json::json!({
             "fileName": file_name,
             "format": output.format,
+            "extractor": output.extractor,
             "size": output.size_bytes,
             "truncated": output.truncated,
             "extractedText": output.extracted_text
@@ -6450,21 +6453,44 @@ fn extract_document_text(
     }
     let format = detect_document_format(&file_name, mime_type.as_deref());
     let size_bytes = bytes.len();
-    let extracted_text = match format.as_str() {
-        "text" => {
-            String::from_utf8(bytes).map_err(|_| "Document is not valid UTF-8 text".to_string())?
+    let prefer_markitdown = markitdown_preferred() && !markitdown_disabled();
+    let mut extractor = "native".to_string();
+    let mut extracted_text = if prefer_markitdown {
+        match extract_with_markitdown(&bytes, &file_name, mime_type.as_deref())? {
+            Some(text) => {
+                extractor = "markitdown".to_string();
+                text
+            }
+            None => String::new(),
         }
-        "pdf" => pdf_extract::extract_text_from_mem(&bytes)
-            .map_err(|error| format!("Failed to extract PDF text: {error}"))?,
-        "docx" => extract_zip_text(&bytes, |name| name == "word/document.xml")?,
-        "pptx" => extract_zip_text(&bytes, |name| {
-            name.starts_with("ppt/slides/") && name.ends_with(".xml")
-        })?,
-        "xlsx" => extract_zip_text(&bytes, |name| {
-            name == "xl/sharedStrings.xml"
-                || (name.starts_with("xl/worksheets/") && name.ends_with(".xml"))
-        })?,
-        _ => String::new(),
+    } else {
+        String::new()
+    };
+
+    if extracted_text.is_empty() {
+        extracted_text = match format.as_str() {
+            "text" => String::from_utf8(bytes.clone())
+                .map_err(|_| "Document is not valid UTF-8 text".to_string())?,
+            "pdf" => pdf_extract::extract_text_from_mem(&bytes)
+                .map_err(|error| format!("Failed to extract PDF text: {error}"))?,
+            "docx" => extract_zip_text(&bytes, |name| name == "word/document.xml")?,
+            "pptx" => extract_zip_text(&bytes, |name| {
+                name.starts_with("ppt/slides/") && name.ends_with(".xml")
+            })?,
+            "xlsx" => extract_zip_text(&bytes, |name| {
+                name == "xl/sharedStrings.xml"
+                    || (name.starts_with("xl/worksheets/") && name.ends_with(".xml"))
+            })?,
+            _ => String::new(),
+        };
+    }
+
+    if extractor != "markitdown" && should_try_markitdown(&format, &file_name, mime_type.as_deref())
+    {
+        if let Some(text) = extract_with_markitdown(&bytes, &file_name, mime_type.as_deref())? {
+            extracted_text = text;
+            extractor = "markitdown".to_string();
+        }
     };
     if extracted_text.is_empty() && format == "unknown" {
         return Err("Unsupported document format".to_string());
@@ -6474,10 +6500,180 @@ fn extract_document_text(
     Ok(ExtractDocumentOutput {
         file_name,
         format,
+        extractor,
         size_bytes,
         truncated,
         extracted_text,
     })
+}
+
+fn env_flag_enabled(name: &str) -> bool {
+    env::var(name)
+        .map(|value| {
+            matches!(
+                value.to_ascii_lowercase().as_str(),
+                "1" | "true" | "on" | "yes"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn env_flag_disabled(name: &str) -> bool {
+    env::var(name)
+        .map(|value| {
+            matches!(
+                value.to_ascii_lowercase().as_str(),
+                "0" | "false" | "off" | "no"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn markitdown_preferred() -> bool {
+    env_flag_enabled("MAESTRO_MARKITDOWN_PREFER")
+}
+
+fn markitdown_disabled() -> bool {
+    env_flag_disabled("MAESTRO_MARKITDOWN")
+}
+
+fn split_command_args(value: Option<String>) -> Vec<String> {
+    value
+        .unwrap_or_default()
+        .split_whitespace()
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn markitdown_candidates() -> Vec<(String, Vec<String>)> {
+    if let Ok(command) = env::var("MAESTRO_MARKITDOWN_CMD") {
+        let command = command.trim();
+        if !command.is_empty() {
+            return vec![(
+                command.to_string(),
+                split_command_args(env::var("MAESTRO_MARKITDOWN_ARGS").ok()),
+            )];
+        }
+    }
+    vec![
+        ("markitdown".to_string(), Vec::new()),
+        ("uvx".to_string(), vec!["markitdown".to_string()]),
+    ]
+}
+
+fn should_try_markitdown(format: &str, file_name: &str, mime_type: Option<&str>) -> bool {
+    if markitdown_disabled() {
+        return false;
+    }
+    if markitdown_preferred() {
+        return true;
+    }
+    let lower_name = file_name.to_ascii_lowercase();
+    let mime_type = mime_type.unwrap_or("").to_ascii_lowercase();
+    format == "unknown"
+        || lower_name.ends_with(".html")
+        || lower_name.ends_with(".htm")
+        || mime_type.contains("text/html")
+}
+
+fn run_markitdown_command(command: &str, args: &[String]) -> Result<String, String> {
+    let mut child = std::process::Command::new(command)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let started = Instant::now();
+    loop {
+        if child
+            .try_wait()
+            .map_err(|error| format!("failed to wait for MarkItDown: {error}"))?
+            .is_some()
+        {
+            let output = child
+                .wait_with_output()
+                .map_err(|error| format!("failed to read MarkItDown output: {error}"))?;
+            if output.status.success() {
+                return String::from_utf8(output.stdout)
+                    .map_err(|_| "MarkItDown output was not UTF-8".to_string());
+            }
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "MarkItDown exited with {}{}",
+                output.status,
+                if stderr.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {}", stderr.chars().take(500).collect::<String>())
+                }
+            ));
+        }
+        if started.elapsed() > MARKITDOWN_EXTRACT_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("MarkItDown conversion timed out".to_string());
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn extract_with_markitdown(
+    bytes: &[u8],
+    file_name: &str,
+    mime_type: Option<&str>,
+) -> Result<Option<String>, String> {
+    if markitdown_disabled() {
+        return Ok(None);
+    }
+    let counter = ATTACHMENT_TEMP_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let temp_dir =
+        env::temp_dir().join(format!("maestro-markitdown-{}-{}", process::id(), counter));
+    std::fs::create_dir_all(&temp_dir)
+        .map_err(|error| format!("failed to create MarkItDown temp dir: {error}"))?;
+    let extension = Path::new(file_name)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .filter(|extension| !extension.is_empty())
+        .unwrap_or("bin");
+    let input_path = temp_dir.join(format!("input.{extension}"));
+    let result = (|| {
+        std::fs::write(&input_path, bytes)
+            .map_err(|error| format!("failed to write MarkItDown input: {error}"))?;
+        let mut last_error: Option<String> = None;
+        for (command, prefix_args) in markitdown_candidates() {
+            let mut args = prefix_args;
+            args.push(input_path.to_string_lossy().to_string());
+            if let Some(mime_type) = mime_type {
+                args.push("--mime-type".to_string());
+                args.push(mime_type.to_string());
+            }
+            match run_markitdown_command(&command, &args) {
+                Ok(output) => {
+                    let text = output.trim().to_string();
+                    if !text.is_empty() {
+                        return Ok(Some(text));
+                    }
+                }
+                Err(error) => {
+                    last_error = Some(error);
+                    continue;
+                }
+            }
+        }
+        if env::var("MAESTRO_MARKITDOWN_CMD")
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+        {
+            return Err(format!(
+                "MarkItDown extraction failed: {}",
+                last_error.unwrap_or_else(|| "no output".to_string())
+            ));
+        }
+        Ok(None)
+    })();
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    result
 }
 
 fn detect_document_format(file_name: &str, mime_type: Option<&str>) -> String {
@@ -8078,6 +8274,7 @@ struct ExtractAttachmentRequest {
 struct ExtractDocumentOutput {
     file_name: String,
     format: String,
+    extractor: String,
     size_bytes: usize,
     truncated: bool,
     extracted_text: String,
@@ -17357,6 +17554,7 @@ setTimeout(() => {
         .expect("text extraction should succeed");
 
         assert_eq!(output.format, "text");
+        assert_eq!(output.extractor, "native");
         assert_eq!(output.size_bytes, "hello from rust".len());
         assert_eq!(output.extracted_text, "hello");
         assert!(output.truncated);
@@ -17396,7 +17594,45 @@ setTimeout(() => {
         .expect("docx extraction should succeed");
 
         assert_eq!(output.format, "docx");
+        assert_eq!(output.extractor, "native");
         assert!(output.extracted_text.contains("Hello & Rust"));
+    }
+
+    #[test]
+    fn extracts_html_attachment_with_configured_markitdown() {
+        let script_path = env::temp_dir().join(format!(
+            "maestro-fake-markitdown-{}-{}.sh",
+            process::id(),
+            ATTACHMENT_TEMP_COUNTER.fetch_add(1, Ordering::SeqCst)
+        ));
+        std::fs::write(
+            &script_path,
+            "printf '# Converted by MarkItDown\\n\\nRust body from fake CLI'",
+        )
+        .expect("fake MarkItDown script should be written");
+        env::set_var("MAESTRO_MARKITDOWN_CMD", "sh");
+        env::set_var(
+            "MAESTRO_MARKITDOWN_ARGS",
+            script_path.to_string_lossy().to_string(),
+        );
+        env::remove_var("MAESTRO_MARKITDOWN");
+        env::remove_var("MAESTRO_MARKITDOWN_PREFER");
+
+        let output = extract_document_text(
+            b"<html><body><h1>Ignored native HTML</h1></body></html>".to_vec(),
+            "brief.html".to_string(),
+            Some("text/html".to_string()),
+            None,
+        )
+        .expect("MarkItDown extraction should succeed");
+
+        assert_eq!(output.format, "text");
+        assert_eq!(output.extractor, "markitdown");
+        assert!(output.extracted_text.contains("# Converted by MarkItDown"));
+
+        env::remove_var("MAESTRO_MARKITDOWN_CMD");
+        env::remove_var("MAESTRO_MARKITDOWN_ARGS");
+        let _ = std::fs::remove_file(script_path);
     }
 
     #[test]

--- a/packages/tui-rs/src/tools/extract_document.rs
+++ b/packages/tui-rs/src/tools/extract_document.rs
@@ -18,7 +18,14 @@
 //! - Optional character limit truncation
 
 use std::cmp::Ordering;
+use std::env;
+use std::fs;
 use std::io::Cursor;
+use std::path::Path;
+use std::process::{self, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use regex::Regex;
 use serde::Deserialize;
@@ -28,12 +35,21 @@ use zip::ZipArchive;
 use crate::agent::ToolResult;
 
 const MAX_DOWNLOAD_BYTES: usize = 50 * 1024 * 1024;
+const MARKITDOWN_EXTRACT_TIMEOUT: Duration = Duration::from_secs(20);
+static MARKITDOWN_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Deserialize)]
 struct ExtractDocumentArgs {
     url: String,
     #[serde(default, alias = "maxChars")]
     max_chars: Option<usize>,
+}
+
+struct DocumentExtraction {
+    format: String,
+    extractor: String,
+    text: String,
+    truncated: bool,
 }
 
 fn guess_filename_from_url(url: &reqwest::Url) -> String {
@@ -189,6 +205,232 @@ fn extract_from_format(format: &str, bytes: &[u8]) -> Option<String> {
     }
 }
 
+fn env_flag_enabled(name: &str) -> bool {
+    env::var(name)
+        .map(|value| {
+            matches!(
+                value.to_ascii_lowercase().as_str(),
+                "1" | "true" | "on" | "yes"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn env_flag_disabled(name: &str) -> bool {
+    env::var(name)
+        .map(|value| {
+            matches!(
+                value.to_ascii_lowercase().as_str(),
+                "0" | "false" | "off" | "no"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn markitdown_disabled() -> bool {
+    env_flag_disabled("MAESTRO_MARKITDOWN")
+}
+
+fn markitdown_preferred() -> bool {
+    env_flag_enabled("MAESTRO_MARKITDOWN_PREFER")
+}
+
+fn split_command_args(value: Option<String>) -> Vec<String> {
+    value
+        .unwrap_or_default()
+        .split_whitespace()
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn markitdown_candidates() -> Vec<(String, Vec<String>)> {
+    if let Ok(command) = env::var("MAESTRO_MARKITDOWN_CMD") {
+        let command = command.trim();
+        if !command.is_empty() {
+            return vec![(
+                command.to_string(),
+                split_command_args(env::var("MAESTRO_MARKITDOWN_ARGS").ok()),
+            )];
+        }
+    }
+    vec![
+        ("markitdown".to_string(), Vec::new()),
+        ("uvx".to_string(), vec!["markitdown".to_string()]),
+    ]
+}
+
+fn should_try_markitdown(format: &str, file_name: &str, mime_type: Option<&str>) -> bool {
+    if markitdown_disabled() {
+        return false;
+    }
+    if markitdown_preferred() {
+        return true;
+    }
+    let lower_name = file_name.to_ascii_lowercase();
+    let mime_type = mime_type.unwrap_or("").to_ascii_lowercase();
+    format == "unknown"
+        || lower_name.ends_with(".html")
+        || lower_name.ends_with(".htm")
+        || mime_type.contains("text/html")
+}
+
+fn run_markitdown_command(command: &str, args: &[String]) -> Result<String, String> {
+    let mut child = Command::new(command)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let started = Instant::now();
+    loop {
+        if child
+            .try_wait()
+            .map_err(|error| format!("failed to wait for MarkItDown: {error}"))?
+            .is_some()
+        {
+            let output = child
+                .wait_with_output()
+                .map_err(|error| format!("failed to read MarkItDown output: {error}"))?;
+            if output.status.success() {
+                return String::from_utf8(output.stdout)
+                    .map_err(|_| "MarkItDown output was not UTF-8".to_string());
+            }
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "MarkItDown exited with {}{}",
+                output.status,
+                if stderr.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {}", stderr.chars().take(500).collect::<String>())
+                }
+            ));
+        }
+        if started.elapsed() > MARKITDOWN_EXTRACT_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("MarkItDown conversion timed out".to_string());
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn extract_with_markitdown(
+    bytes: &[u8],
+    file_name: &str,
+    mime_type: Option<&str>,
+) -> Result<Option<String>, String> {
+    if markitdown_disabled() {
+        return Ok(None);
+    }
+    let counter = MARKITDOWN_TEMP_COUNTER.fetch_add(1, AtomicOrdering::SeqCst);
+    let temp_dir =
+        env::temp_dir().join(format!("maestro-markitdown-{}-{}", process::id(), counter));
+    fs::create_dir_all(&temp_dir)
+        .map_err(|error| format!("failed to create MarkItDown temp dir: {error}"))?;
+    let extension = Path::new(file_name)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .filter(|extension| !extension.is_empty())
+        .unwrap_or("bin");
+    let input_path = temp_dir.join(format!("input.{extension}"));
+    let result = (|| {
+        fs::write(&input_path, bytes)
+            .map_err(|error| format!("failed to write MarkItDown input: {error}"))?;
+        let mut last_error: Option<String> = None;
+        for (command, prefix_args) in markitdown_candidates() {
+            let mut args = prefix_args;
+            args.push(input_path.to_string_lossy().to_string());
+            if let Some(mime_type) = mime_type {
+                args.push("--mime-type".to_string());
+                args.push(mime_type.to_string());
+            }
+            match run_markitdown_command(&command, &args) {
+                Ok(output) => {
+                    let text = output.trim().to_string();
+                    if !text.is_empty() {
+                        return Ok(Some(text));
+                    }
+                }
+                Err(error) => {
+                    last_error = Some(error);
+                }
+            }
+        }
+        if env::var("MAESTRO_MARKITDOWN_CMD")
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+        {
+            return Err(format!(
+                "MarkItDown extraction failed: {}",
+                last_error.unwrap_or_else(|| "no output".to_string())
+            ));
+        }
+        Ok(None)
+    })();
+    let _ = fs::remove_dir_all(&temp_dir);
+    result
+}
+
+fn extract_document_bytes(
+    file_name: &str,
+    mime_type: Option<&str>,
+    bytes: &[u8],
+    max_chars: Option<usize>,
+) -> Result<DocumentExtraction, String> {
+    let format = detect_format(file_name, mime_type);
+    let format_label = format.unwrap_or("unknown").to_string();
+    let prefer_markitdown = markitdown_preferred() && !markitdown_disabled();
+    let mut extractor = "native".to_string();
+    let mut extracted = if prefer_markitdown {
+        match extract_with_markitdown(bytes, file_name, mime_type)? {
+            Some(text) => {
+                extractor = "markitdown".to_string();
+                text
+            }
+            None => String::new(),
+        }
+    } else {
+        String::new()
+    };
+
+    if extracted.is_empty() {
+        if let Some(format) = format {
+            extracted = extract_from_format(format, bytes).unwrap_or_default();
+        }
+    }
+
+    if extractor != "markitdown" && should_try_markitdown(&format_label, file_name, mime_type) {
+        if let Some(text) = extract_with_markitdown(bytes, file_name, mime_type)? {
+            extracted = text;
+            extractor = "markitdown".to_string();
+        }
+    }
+
+    if extracted.is_empty() && format.is_none() {
+        return Err("Unsupported document format. Supported: PDF (.pdf), Word (.docx), Excel (.xlsx), PowerPoint (.pptx), and common text files.".to_string());
+    }
+    if extracted.is_empty() {
+        return Err("Failed to extract document text.".to_string());
+    }
+
+    let max_chars = max_chars.unwrap_or(1_000_000);
+    let truncated = extracted.chars().count() > max_chars;
+    let text = if truncated {
+        extracted.chars().take(max_chars).collect()
+    } else {
+        extracted
+    };
+
+    Ok(DocumentExtraction {
+        format: format_label,
+        extractor,
+        text,
+        truncated,
+    })
+}
+
 pub async fn extract_document(args: Value) -> ToolResult {
     let parsed: ExtractDocumentArgs = match serde_json::from_value(args) {
         Ok(val) => val,
@@ -261,43 +503,29 @@ pub async fn extract_document(args: Value) -> ToolResult {
     let file_name = parse_content_disposition(content_disposition.as_deref())
         .unwrap_or_else(|| guess_filename_from_url(&url));
 
-    let format = detect_format(&file_name, content_type.as_deref());
-    let format = match format {
-        Some(fmt) => fmt,
-        None => {
-            return ToolResult::failure(
-                "Unsupported document format. Supported: PDF (.pdf), Word (.docx), Excel (.xlsx), PowerPoint (.pptx), and common text files."
-                    .to_string(),
-            )
+    let extraction = match extract_document_bytes(
+        &file_name,
+        content_type.as_deref(),
+        &bytes,
+        parsed.max_chars,
+    ) {
+        Ok(extraction) => extraction,
+        Err(error) => {
+            return ToolResult::failure(error);
         }
-    };
-
-    let extracted = match extract_from_format(format, &bytes) {
-        Some(text) => text,
-        None => {
-            return ToolResult::failure("Failed to extract document text.".to_string());
-        }
-    };
-
-    let mut truncated = false;
-    let max_chars = parsed.max_chars.unwrap_or(1_000_000);
-    let output = if extracted.chars().count() > max_chars {
-        truncated = true;
-        extracted.chars().take(max_chars).collect::<String>()
-    } else {
-        extracted
     };
 
     let details = serde_json::json!({
         "url": url.to_string(),
         "fileName": file_name,
         "mimeType": content_type,
-        "format": format,
+        "format": extraction.format,
+        "extractor": extraction.extractor,
         "sizeBytes": bytes.len(),
-        "truncated": truncated
+        "truncated": extraction.truncated
     });
 
-    ToolResult::success(output).with_details(details)
+    ToolResult::success(extraction.text).with_details(details)
 }
 
 #[cfg(test)]
@@ -591,6 +819,43 @@ mod tests {
         let bytes = b"some data";
         let result = extract_from_format("unknown_format", bytes);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_extract_document_bytes_uses_configured_markitdown_for_html() {
+        let script_path = env::temp_dir().join(format!(
+            "maestro-tui-fake-markitdown-{}-{}.sh",
+            process::id(),
+            MARKITDOWN_TEMP_COUNTER.fetch_add(1, AtomicOrdering::SeqCst)
+        ));
+        fs::write(
+            &script_path,
+            "printf '# Converted by MarkItDown\\n\\nRust TUI body from fake CLI'",
+        )
+        .expect("fake MarkItDown script should be written");
+        env::set_var("MAESTRO_MARKITDOWN_CMD", "sh");
+        env::set_var(
+            "MAESTRO_MARKITDOWN_ARGS",
+            script_path.to_string_lossy().to_string(),
+        );
+        env::remove_var("MAESTRO_MARKITDOWN");
+        env::remove_var("MAESTRO_MARKITDOWN_PREFER");
+
+        let output = extract_document_bytes(
+            "brief.html",
+            Some("text/html"),
+            b"<html><body><h1>Ignored native HTML</h1></body></html>",
+            None,
+        )
+        .expect("MarkItDown extraction should succeed");
+
+        assert_eq!(output.format, "text");
+        assert_eq!(output.extractor, "markitdown");
+        assert!(output.text.contains("# Converted by MarkItDown"));
+
+        env::remove_var("MAESTRO_MARKITDOWN_CMD");
+        env::remove_var("MAESTRO_MARKITDOWN_ARGS");
+        let _ = fs::remove_file(script_path);
     }
 
     // ========================================================================

--- a/packages/web/src/services/api-client.ts
+++ b/packages/web/src/services/api-client.ts
@@ -246,6 +246,7 @@ export interface PolicyValidationResponse {
 export interface AttachmentTextExtractionResponse {
 	fileName: string;
 	format: string;
+	extractor?: "native" | "markitdown";
 	size: number;
 	truncated: boolean;
 	extractedText: string;

--- a/scripts/install-smoke-utils.js
+++ b/scripts/install-smoke-utils.js
@@ -17,6 +17,10 @@ export function getBunCommand() {
 	return process.platform === "win32" ? "bun.exe" : "bun";
 }
 
+export function getBunxCommand() {
+	return process.platform === "win32" ? "bunx.exe" : "bunx";
+}
+
 export function installedPackageJsonPath(packageName, installRoot) {
 	return join(
 		installRoot,
@@ -103,8 +107,15 @@ export function runInstalledCliSmoke(
 	cwd,
 	{ cliCommand, expectedVersion, label },
 ) {
-	const binPath = installedBinPath(cwd, cliCommand);
-	const versionOutput = execFileSync(binPath, ["--version"], {
+	runCliSmoke(installedBinPath(cwd, cliCommand), [], cwd, {
+		cliCommand,
+		expectedVersion,
+		label,
+	});
+}
+
+function runCliSmoke(command, prefixArgs, cwd, { cliCommand, expectedVersion, label }) {
+	const versionOutput = execFileSync(command, [...prefixArgs, "--version"], {
 		cwd,
 		encoding: "utf8",
 	});
@@ -114,9 +125,25 @@ export function runInstalledCliSmoke(
 		);
 	}
 
-	execFileSync(binPath, ["--help"], {
+	execFileSync(command, [...prefixArgs, "--help"], {
 		cwd,
 		stdio: "ignore",
+	});
+}
+
+export function runNpxCliSmoke(cwd, { cliCommand, expectedVersion, label }) {
+	runCliSmoke(getNpxCommand(), ["--no-install", cliCommand], cwd, {
+		cliCommand,
+		expectedVersion,
+		label,
+	});
+}
+
+export function runBunxCliSmoke(cwd, { cliCommand, expectedVersion, label }) {
+	runCliSmoke(getBunxCommand(), [cliCommand], cwd, {
+		cliCommand,
+		expectedVersion,
+		label,
 	});
 }
 

--- a/scripts/smoke-published-replay-e2e.js
+++ b/scripts/smoke-published-replay-e2e.js
@@ -240,18 +240,24 @@ function collectFiles(dir) {
 }
 
 function assertSessionEvidence(sessionDir, label) {
+	const failure = sessionEvidenceFailure(sessionDir, label);
+	if (failure) fail(failure);
+}
+
+function sessionEvidenceFailure(sessionDir, label) {
 	const sessionFiles = collectFiles(sessionDir).filter((path) =>
 		path.endsWith(".jsonl"),
 	);
 	if (sessionFiles.length === 0) {
-		fail(`${label} did not write a session JSONL file in ${sessionDir}.`);
+		return `${label} did not write a session JSONL file in ${sessionDir}.`;
 	}
 	const sessionText = sessionFiles
 		.map((path) => readFileSync(path, "utf8"))
 		.join("\n");
 	if (!sessionText.includes(FINAL_TEXT) || !sessionText.includes(TOOL_CALL_ID)) {
-		fail(`${label} session evidence is missing the final text or tool call id.`);
+		return `${label} session evidence is missing the final text or tool call id.`;
 	}
+	return null;
 }
 
 function assertJsonMode(messages, context, label) {
@@ -450,6 +456,7 @@ function runRpcMode(binPath) {
 		let stderr = "";
 		let finished = false;
 		let settled = false;
+		let rpcEvidenceValidated = false;
 		let forceKillTimer;
 		const timer = setTimeout(() => {
 			finish(new Error("Published RPC replay smoke timed out."));
@@ -459,8 +466,18 @@ function runRpcMode(binPath) {
 			if (settled) return;
 			settled = true;
 			if (forceKillTimer) clearTimeout(forceKillTimer);
+			let settleError = error;
+			if (!settleError && rpcEvidenceValidated) {
+				const failure = sessionEvidenceFailure(
+					context.sessionDir,
+					"Published RPC replay",
+				);
+				if (failure) {
+					settleError = new Error(failure);
+				}
+			}
 			rmSync(context.runDir, { recursive: true, force: true });
-			if (error) reject(error);
+			if (settleError) reject(settleError);
 			else resolvePromise();
 		}
 
@@ -490,6 +507,7 @@ function runRpcMode(binPath) {
 			}
 			try {
 				assertRpcEvents(events, context);
+				rpcEvidenceValidated = true;
 				console.log("Published RPC replay smoke passed.");
 				finish();
 			} catch (error) {

--- a/scripts/smoke-registry-install.js
+++ b/scripts/smoke-registry-install.js
@@ -11,8 +11,10 @@ import {
 	getBunCommand,
 	getNpmCommand,
 	readInstalledPackageJson,
+	runBunxCliSmoke,
 	runInstalledCliSmoke,
 	runInstalledPackageAudit,
+	runNpxCliSmoke,
 } from "./install-smoke-utils.js";
 import { getPackageMetadata } from "./package-metadata.js";
 import { runPublishedReplayE2E } from "./smoke-published-replay-e2e.js";
@@ -155,6 +157,11 @@ async function main() {
 			expectedVersion: version,
 			label: "npm-installed registry CLI",
 		});
+		runNpxCliSmoke(tempDir, {
+			cliCommand,
+			expectedVersion: version,
+			label: "npx registry CLI",
+		});
 		await runPublishedReplayE2E({
 			cliCommand,
 			installRoot: tempDir,
@@ -185,6 +192,11 @@ async function main() {
 			cliCommand,
 			expectedVersion: version,
 			label: "Bun-installed registry CLI",
+		});
+		runBunxCliSmoke(bunTempDir, {
+			cliCommand,
+			expectedVersion: version,
+			label: "bunx registry CLI",
 		});
 		await runPublishedReplayE2E({
 			cliCommand,

--- a/src/server/handlers/attachments.ts
+++ b/src/server/handlers/attachments.ts
@@ -87,6 +87,7 @@ export async function handleAttachmentExtract(
 			{
 				fileName,
 				format: extracted.format,
+				extractor: extracted.extractor,
 				size: extracted.sizeBytes,
 				truncated: extracted.truncated,
 				extractedText: extracted.extractedText,

--- a/src/server/handlers/session-attachments.ts
+++ b/src/server/handlers/session-attachments.ts
@@ -168,6 +168,7 @@ export async function handleSessionAttachmentExtract(
 				{
 					fileName: attachment.fileName,
 					format: "unknown",
+					extractor: "native",
 					size: attachment.size ?? 0,
 					truncated: false,
 					extractedText: attachment.extractedText,
@@ -205,6 +206,7 @@ export async function handleSessionAttachmentExtract(
 			{
 				fileName: attachment.fileName,
 				format: extracted.format,
+				extractor: extracted.extractor,
 				size: extracted.sizeBytes,
 				truncated: extracted.truncated,
 				extractedText: extracted.extractedText,

--- a/src/tools/extract-document.ts
+++ b/src/tools/extract-document.ts
@@ -24,6 +24,7 @@ export interface ExtractDocumentDetails {
 	fileName: string;
 	mimeType?: string;
 	format: string;
+	extractor: string;
 	sizeBytes: number;
 	truncated: boolean;
 }
@@ -55,7 +56,7 @@ export const extractDocumentTool = createTool<
 	name: "extract_document",
 	label: "extract_document",
 	description:
-		"Download a document from a URL and extract its text. Supports PDF, DOCX, XLSX, PPTX, and common text formats. Use this when you need text from a linked document.",
+		"Download a document from a URL and extract its text. Supports PDF, DOCX, XLSX, PPTX, common text formats, and optional MarkItDown-backed Markdown conversion when available. Use this when you need text from a linked document.",
 	schema: extractDocumentSchema,
 	async run(params, { signal, respond }) {
 		const rawUrl = params.url.trim();
@@ -121,6 +122,7 @@ export const extractDocumentTool = createTool<
 			fileName,
 			mimeType,
 			format: extracted.format,
+			extractor: extracted.extractor,
 			sizeBytes: extracted.sizeBytes,
 			truncated: extracted.truncated,
 		});

--- a/src/utils/document-extractor.ts
+++ b/src/utils/document-extractor.ts
@@ -1,3 +1,7 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { extname, join } from "node:path";
 import ExcelJS from "exceljs";
 import JSZip from "jszip";
 import mammoth from "mammoth";
@@ -21,6 +25,7 @@ export interface ExtractDocumentInput {
 export interface ExtractDocumentOutput {
 	extractedText: string;
 	format: ExtractedDocumentFormat;
+	extractor: "native" | "markitdown";
 	truncated: boolean;
 	sizeBytes: number;
 }
@@ -29,6 +34,7 @@ type ExcelWorkbookLoadInput = Parameters<ExcelJS.Workbook["xlsx"]["load"]>[0];
 
 const DEFAULT_MAX_CHARS = 200_000;
 const MAX_INPUT_BYTES = 50 * 1024 * 1024;
+const MARKITDOWN_TIMEOUT_MS = 20_000;
 const XLSX_MIME =
 	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
@@ -82,6 +88,130 @@ function detectFormat(
 	if (textExtensions.some((ext) => lowerName.endsWith(ext))) return "text";
 
 	return "unknown";
+}
+
+function splitCommandArgs(value: string | undefined): string[] {
+	return (value ?? "").trim().split(/\s+/).filter(Boolean);
+}
+
+function isMarkitdownDisabled(): boolean {
+	return /^(0|false|off|no)$/i.test(process.env.MAESTRO_MARKITDOWN ?? "");
+}
+
+function markitdownCandidates(): Array<{
+	command: string;
+	argsPrefix: string[];
+}> {
+	const configured = process.env.MAESTRO_MARKITDOWN_CMD?.trim();
+	if (configured) {
+		return [
+			{
+				command: configured,
+				argsPrefix: splitCommandArgs(process.env.MAESTRO_MARKITDOWN_ARGS),
+			},
+		];
+	}
+	return [
+		{ command: "markitdown", argsPrefix: [] },
+		{ command: "uvx", argsPrefix: ["markitdown"] },
+	];
+}
+
+function shouldTryMarkitdown(
+	format: ExtractedDocumentFormat,
+	fileName: string,
+	mimeType?: string,
+): boolean {
+	if (isMarkitdownDisabled()) return false;
+	if (/^(1|true|on|yes)$/i.test(process.env.MAESTRO_MARKITDOWN_PREFER ?? "")) {
+		return true;
+	}
+	const lowerName = fileName.toLowerCase();
+	const type = (mimeType ?? "").toLowerCase();
+	if (format === "unknown") return true;
+	if (lowerName.endsWith(".html") || lowerName.endsWith(".htm")) return true;
+	if (type.includes("text/html")) return true;
+	return false;
+}
+
+function runMarkitdownCandidate(
+	candidate: { command: string; argsPrefix: string[] },
+	args: string[],
+): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(candidate.command, [...candidate.argsPrefix, ...args], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		const timer = setTimeout(() => {
+			child.kill("SIGTERM");
+			reject(new Error("MarkItDown conversion timed out"));
+		}, MARKITDOWN_TIMEOUT_MS);
+
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.on("error", (error) => {
+			clearTimeout(timer);
+			reject(error);
+		});
+		child.on("close", (code) => {
+			clearTimeout(timer);
+			if (code === 0) {
+				resolve(stdout);
+				return;
+			}
+			reject(
+				new Error(
+					`MarkItDown exited with ${code}${stderr ? `: ${stderr.slice(0, 500)}` : ""}`,
+				),
+			);
+		});
+	});
+}
+
+async function extractWithMarkitdown(input: {
+	buffer: Buffer;
+	fileName: string;
+	mimeType?: string;
+}): Promise<string | null> {
+	const tempDir = await mkdtemp(join(tmpdir(), "maestro-markitdown-"));
+	const extension = extname(input.fileName) || ".bin";
+	const tempPath = join(tempDir, `input${extension}`);
+	try {
+		await writeFile(tempPath, input.buffer);
+		const args = [tempPath];
+		if (input.mimeType) {
+			args.push("--mime-type", input.mimeType);
+		}
+
+		let lastError: unknown;
+		for (const candidate of markitdownCandidates()) {
+			try {
+				const output = await runMarkitdownCandidate(candidate, args);
+				const text = output.trim();
+				if (text) return text;
+			} catch (error) {
+				lastError = error;
+				if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+			}
+		}
+
+		if (process.env.MAESTRO_MARKITDOWN_CMD) {
+			const message =
+				lastError instanceof Error ? lastError.message : String(lastError);
+			throw new Error(`MarkItDown extraction failed: ${message}`);
+		}
+		return null;
+	} finally {
+		await rm(tempDir, { force: true, recursive: true });
+	}
 }
 
 function worksheetToRows(worksheet: ExcelJS.Worksheet): string[][] {
@@ -155,53 +285,86 @@ export async function extractDocumentText(
 	}
 
 	const format = detectFormat(fileName, input.mimeType);
+	const markitdownFirst =
+		/^(1|true|on|yes)$/i.test(process.env.MAESTRO_MARKITDOWN_PREFER ?? "") &&
+		!isMarkitdownDisabled();
 
 	let extractedText = "";
-	switch (format) {
-		case "pdf": {
-			const parser = new PDFParse({ data: buffer });
-			try {
-				const result = await parser.getText();
-				extractedText = result.text || "";
-			} finally {
+	let extractor: ExtractDocumentOutput["extractor"] = "native";
+	if (markitdownFirst) {
+		const markitdownText = await extractWithMarkitdown({
+			buffer,
+			fileName,
+			mimeType: input.mimeType,
+		});
+		if (markitdownText) {
+			extractedText = markitdownText;
+			extractor = "markitdown";
+		}
+	}
+
+	if (!extractedText) {
+		switch (format) {
+			case "pdf": {
+				const parser = new PDFParse({ data: buffer });
 				try {
-					await parser.destroy();
-				} catch {
-					// ignore
+					const result = await parser.getText();
+					extractedText = result.text || "";
+				} finally {
+					try {
+						await parser.destroy();
+					} catch {
+						// ignore
+					}
 				}
+				break;
 			}
-			break;
-		}
-		case "docx": {
-			const result = await mammoth.extractRawText({ buffer });
-			extractedText = result.value || "";
-			break;
-		}
-		case "xlsx": {
-			const workbook = new ExcelJS.Workbook();
-			await workbook.xlsx.load(buffer as unknown as ExcelWorkbookLoadInput);
-			const parts: string[] = [];
-			for (const worksheet of workbook.worksheets) {
-				const rows = worksheetToRows(worksheet);
-				if (rows.length === 0) continue;
-				parts.push(
-					`# Sheet: ${worksheet.name}\n${rows.map((row) => row.join("\t")).join("\n")}`,
-				);
+			case "docx": {
+				const result = await mammoth.extractRawText({ buffer });
+				extractedText = result.value || "";
+				break;
 			}
-			extractedText = parts.join("\n\n");
-			break;
+			case "xlsx": {
+				const workbook = new ExcelJS.Workbook();
+				await workbook.xlsx.load(buffer as unknown as ExcelWorkbookLoadInput);
+				const parts: string[] = [];
+				for (const worksheet of workbook.worksheets) {
+					const rows = worksheetToRows(worksheet);
+					if (rows.length === 0) continue;
+					parts.push(
+						`# Sheet: ${worksheet.name}\n${rows.map((row) => row.join("\t")).join("\n")}`,
+					);
+				}
+				extractedText = parts.join("\n\n");
+				break;
+			}
+			case "pptx": {
+				extractedText = await extractPptxText(buffer);
+				break;
+			}
+			case "text": {
+				extractedText = buffer.toString("utf8");
+				break;
+			}
+			default: {
+				extractedText = "";
+				break;
+			}
 		}
-		case "pptx": {
-			extractedText = await extractPptxText(buffer);
-			break;
-		}
-		case "text": {
-			extractedText = buffer.toString("utf8");
-			break;
-		}
-		default: {
-			extractedText = "";
-			break;
+	}
+
+	if (
+		extractor !== "markitdown" &&
+		shouldTryMarkitdown(format, fileName, input.mimeType)
+	) {
+		const markitdownText = await extractWithMarkitdown({
+			buffer,
+			fileName,
+			mimeType: input.mimeType,
+		});
+		if (markitdownText) {
+			extractedText = markitdownText;
+			extractor = "markitdown";
 		}
 	}
 
@@ -209,6 +372,7 @@ export async function extractDocumentText(
 	return {
 		extractedText: text,
 		format,
+		extractor,
 		truncated,
 		sizeBytes: buffer.byteLength,
 	};

--- a/test/document-extractor.test.ts
+++ b/test/document-extractor.test.ts
@@ -1,20 +1,32 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import ExcelJS from "exceljs";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { extractDocumentText } from "../src/utils/document-extractor.js";
 
 describe("extractDocumentText", () => {
+	const originalEnv = { ...process.env };
+
+	afterEach(() => {
+		process.env = { ...originalEnv };
+	});
+
 	it("extracts text files", async () => {
+		process.env.MAESTRO_MARKITDOWN = "0";
 		const out = await extractDocumentText({
 			buffer: Buffer.from("hello\nworld\n", "utf8"),
 			fileName: "notes.txt",
 			mimeType: "text/plain",
 		});
 		expect(out.format).toBe("text");
+		expect(out.extractor).toBe("native");
 		expect(out.extractedText).toContain("hello");
 		expect(out.truncated).toBe(false);
 	});
 
 	it("extracts xlsx files into tab-separated text", async () => {
+		process.env.MAESTRO_MARKITDOWN = "0";
 		const workbook = new ExcelJS.Workbook();
 		const worksheet = workbook.addWorksheet("People");
 		worksheet.addRow(["Name", "Age"]);
@@ -29,17 +41,48 @@ describe("extractDocumentText", () => {
 		});
 
 		expect(out.format).toBe("xlsx");
+		expect(out.extractor).toBe("native");
 		expect(out.extractedText).toContain("# Sheet: People");
 		expect(out.extractedText).toContain("Alice");
 	});
 
 	it("returns unknown for unsupported formats", async () => {
+		process.env.MAESTRO_MARKITDOWN = "0";
 		const out = await extractDocumentText({
 			buffer: Buffer.from([0, 1, 2, 3]),
 			fileName: "blob.bin",
 			mimeType: "application/octet-stream",
 		});
 		expect(out.format).toBe("unknown");
+		expect(out.extractor).toBe("native");
 		expect(out.extractedText).toBe("");
+	});
+
+	it("uses MarkItDown CLI output when a configured converter is available", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-markitdown-test-"));
+		try {
+			const script = join(dir, "fake-markitdown.mjs");
+			await writeFile(
+				script,
+				"process.stdout.write('# Converted by MarkItDown\\n\\nBody text from fake CLI');",
+				"utf8",
+			);
+			process.env.MAESTRO_MARKITDOWN_CMD = process.execPath;
+			process.env.MAESTRO_MARKITDOWN_ARGS = script;
+
+			const out = await extractDocumentText({
+				buffer: Buffer.from(
+					"<html><body><h1>Ignored native HTML</h1></body></html>",
+				),
+				fileName: "brief.html",
+				mimeType: "text/html",
+			});
+
+			expect(out.format).toBe("text");
+			expect(out.extractor).toBe("markitdown");
+			expect(out.extractedText).toContain("# Converted by MarkItDown");
+		} finally {
+			await rm(dir, { force: true, recursive: true });
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- add optional MarkItDown CLI extraction for TS attachment/document flows, including web/API extractor metadata
- add the same optional MarkItDown bridge to Rust control-plane and TUI extraction paths
- keep native parsers as the default, with env controls for disable/configure/prefer

## Validation
- npm run test -- test/document-extractor.test.ts
- npx tsc -p tsconfig.build.json --noEmit
- npx biome check src/utils/document-extractor.ts src/server/handlers/attachments.ts src/server/handlers/session-attachments.ts src/tools/extract-document.ts packages/web/src/services/api-client.ts test/document-extractor.test.ts docs/WEB_UI.md
- MAESTRO_MARKITDOWN_CMD=uvx MAESTRO_MARKITDOWN_ARGS=markitdown npx tsx -e "...extractDocumentText html smoke..."
- cargo test --manifest-path packages/control-plane-rs/Cargo.toml extracts_html_attachment_with_configured_markitdown
- cargo test --manifest-path packages/control-plane-rs/Cargo.toml extracts_docx_attachment_without_node_runtime
- cargo test --manifest-path packages/control-plane-rs/Cargo.toml extracts_text_attachment_without_node_runtime
- cargo test --manifest-path packages/tui-rs/Cargo.toml test_extract_document_bytes_uses_configured_markitdown_for_html
- cargo test --manifest-path packages/tui-rs/Cargo.toml test_extract_from_format_text
- cargo check --manifest-path packages/control-plane-rs/Cargo.toml
- cargo check --manifest-path packages/tui-rs/Cargo.toml
- git diff --check

## Source-of-truth

Internal source-of-truth PR: https://github.com/evalops/maestro-internal/pull/2154

