### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -98,6 +98,20 @@ function expectPublicValidationWorkflow(): void {
 	expect(isPublicValidationWorkflow(workflow)).toBe(true);
 }
 
+function expectRustTuiRunnerLane(runsOn: string): void {
+	expect(runsOn).toContain("ubuntu-latest");
+	if (runsOn.includes("PUBLIC_PR_VALIDATION_RUNNER")) {
+		expect(runsOn).not.toContain("PR_RUST_RUNNER");
+		expect(runsOn).not.toContain("evalops-private-heavy");
+		expect(runsOn).not.toContain("INTERNAL_CONFIRMATION_RUNNER");
+		return;
+	}
+
+	expect(runsOn).toContain("PR_RUST_RUNNER");
+	expect(runsOn).toContain("evalops-private-heavy");
+	expect(runsOn).toContain("INTERNAL_CONFIRMATION_RUNNER");
+}
+
 describe("planCiChecks", () => {
 	it("runs expensive checks on non-PR events", () => {
 		expect(
@@ -1653,6 +1667,24 @@ describe("rust workflow guardrails", () => {
 		expect(steps.find((step) => step.name === "Run all tests")?.run).toContain(
 			'cargo_bin="${CARGO_HOME:-$HOME/.cargo}/bin/cargo"',
 		);
+	});
+
+	it("routes Rust TUI pull-request jobs to the expected runner lane", () => {
+		const workflow = parse(
+			readFileSync(
+				new URL("../../.github/workflows/rust.yml", import.meta.url),
+				{
+					encoding: "utf8",
+				},
+			),
+		) as Workflow;
+		const buildRunsOn = String(workflow.jobs?.build?.["runs-on"] ?? "");
+		const hooksCoverageRunsOn = String(
+			workflow.jobs?.["hooks-coverage"]?.["runs-on"] ?? "",
+		);
+
+		expectRustTuiRunnerLane(buildRunsOn);
+		expectRustTuiRunnerLane(hooksCoverageRunsOn);
 	});
 });
 


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"4b6587d371532d7e336b1140a91048609d244e4a"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `4b6587d371532d7e336b1140a91048609d244e4a`
- last generated public sync base: `618190f96208b40f3eca4645433b865bb0b8d0f3`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `2`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (4b6587d37153)`
- public projection: `https://github.com/evalops/maestro@main (4f07615c4f79)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update test/scripts/ci-guardrails.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update test/scripts/ci-guardrails.test.ts

## Public-only commits since last generated sync

- 4f07615c Harden public flaky canary checkout retry (#550)
- a0f6a79a Install ripgrep for public flaky canary (#549)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@4b6587d371532d7e336b1140a91048609d244e4a`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.