### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/app-server/policy-control-api.ts
+++ b/src/app-server/policy-control-api.ts
@@ -213,6 +213,9 @@ export function createMaestroAppServerPolicyControl(): MaestroAppServerPolicyCon
 		},
 
 		async checkPolicy(params = {}) {
+			if (!isRecord(params)) {
+				throw new MaestroAppServerPolicyControlError(-32602, "Invalid params");
+			}
 			const checks: MaestroAppServerPolicyCheckItem[] = [];
 			const session = parseSession(params.session, false);
 			const action = parseActionContext(params.action, session);

--- a/test/app-server/policy-control-api.test.ts
+++ b/test/app-server/policy-control-api.test.ts
@@ -362,6 +362,22 @@ describe("Maestro app-server managed policy API", () => {
 		});
 	});
 
+	it("rejects null policy check params as invalid params", async () => {
+		const api = createMaestroAppServerSessionApi(manager);
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "null-policy-params",
+			method: "policy/check",
+			params: null,
+		});
+
+		expect(response.error).toMatchObject({
+			code: -32602,
+			message: "Invalid params",
+		});
+	});
+
 	it("reports no active policy as loaded false without blocking checks", async () => {
 		const api = createMaestroAppServerSessionApi(manager);
 


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"7c017d8bde680201f14cea0ff11e21088c213a63"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `7c017d8bde680201f14cea0ff11e21088c213a63`
- last generated public sync base: `96a4d65043d9f2191e1a7ee05af75aba0ca9e1cb`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (7c017d8bde68)`
- public projection: `https://github.com/evalops/maestro@main (96a4d65043d9)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/app-server/policy-control-api.ts
- copy/update test/app-server/policy-control-api.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/app-server/policy-control-api.ts
- copy/update test/app-server/policy-control-api.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@7c017d8bde680201f14cea0ff11e21088c213a63`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.