### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/contracts/src/maestro-app-server.ts
+++ b/packages/contracts/src/maestro-app-server.ts
@@ -19,6 +19,9 @@ export const maestroAppServerClientMethods = [
 	"sandbox/probe",
 	"sandbox/proof/run",
 	"externalAgent/import",
+	"pluginBundle/list",
+	"pluginBundle/install",
+	"pluginBundle/remove",
 	"command/exec",
 	"command/exec/write",
 	"command/exec/terminate",
@@ -102,6 +105,7 @@ export const MaestroAppServerCapabilitiesSchema = Type.Object({
 	sandboxProbe: Type.Boolean(),
 	sandboxProof: Type.Boolean(),
 	externalAgentImport: Type.Boolean(),
+	pluginBundles: Type.Boolean(),
 	commandExec: Type.Boolean(),
 	commandProcessControl: Type.Boolean(),
 	filesystem: Type.Boolean(),
@@ -546,6 +550,68 @@ export type MaestroAppServerExternalAgentImportResult = Static<
 	typeof MaestroAppServerExternalAgentImportResultSchema
 >;
 
+export const maestroAppServerPluginBundleScopes = [
+	"project",
+	"local",
+	"user",
+] as const;
+export const MaestroAppServerPluginBundleScopeSchema = stringLiteralUnion(
+	maestroAppServerPluginBundleScopes,
+);
+export type MaestroAppServerPluginBundleScope =
+	(typeof maestroAppServerPluginBundleScopes)[number];
+
+export const MaestroAppServerPluginBundleSchema = Type.Object({
+	source: Type.String(),
+	scope: MaestroAppServerPluginBundleScopeSchema,
+	configPath: Type.String(),
+});
+export type MaestroAppServerPluginBundle = Static<
+	typeof MaestroAppServerPluginBundleSchema
+>;
+
+export const MaestroAppServerPluginBundleResourcesSchema = Type.Object({
+	extensions: Type.Object({
+		user: Type.Array(Type.String()),
+		project: Type.Array(Type.String()),
+	}),
+	skills: Type.Object({
+		user: Type.Array(Type.String()),
+		project: Type.Array(Type.String()),
+	}),
+	prompts: Type.Object({
+		user: Type.Array(Type.String()),
+		project: Type.Array(Type.String()),
+	}),
+	themes: Type.Object({
+		user: Type.Array(Type.String()),
+		project: Type.Array(Type.String()),
+	}),
+});
+export type MaestroAppServerPluginBundleResources = Static<
+	typeof MaestroAppServerPluginBundleResourcesSchema
+>;
+
+export const MaestroAppServerPluginBundleListResultSchema = Type.Object({
+	bundles: Type.Array(MaestroAppServerPluginBundleSchema),
+	resources: MaestroAppServerPluginBundleResourcesSchema,
+	errors: Type.Array(Type.String()),
+});
+export type MaestroAppServerPluginBundleListResult = Static<
+	typeof MaestroAppServerPluginBundleListResultSchema
+>;
+
+export const MaestroAppServerPluginBundleMutationResultSchema = Type.Object({
+	source: Type.String(),
+	scope: MaestroAppServerPluginBundleScopeSchema,
+	configPath: Type.String(),
+	changed: Type.Boolean(),
+	message: Type.String(),
+});
+export type MaestroAppServerPluginBundleMutationResult = Static<
+	typeof MaestroAppServerPluginBundleMutationResultSchema
+>;
+
 export const MaestroAppServerEmptyResultSchema = Type.Object(
 	{},
 	{ additionalProperties: false },
@@ -729,6 +795,8 @@ export const MaestroAppServerResponseSchema = Type.Object({
 			MaestroAppServerSandboxProbeResultSchema,
 			MaestroAppServerSandboxProofResultSchema,
 			MaestroAppServerExternalAgentImportResultSchema,
+			MaestroAppServerPluginBundleListResultSchema,
+			MaestroAppServerPluginBundleMutationResultSchema,
 			MaestroAppServerCommandExecResultSchema,
 			MaestroAppServerCommandProcessResultSchema,
 			MaestroAppServerFsReadFileResultSchema,

--- a/src/app-server/external-agent-import-api.ts
+++ b/src/app-server/external-agent-import-api.ts
@@ -300,6 +300,12 @@ function hooksConfigPath(
 	if (scope === "user") {
 		return getUserHooksConfigPath();
 	}
+	if (scope === "local") {
+		throw new MaestroAppServerExternalAgentImportError(
+			-32602,
+			"Hooks artifact does not support local scope",
+		);
+	}
 	return getProjectHooksConfigPath(projectRoot);
 }
 

--- a/src/app-server/in-process-client.ts
+++ b/src/app-server/in-process-client.ts
@@ -13,6 +13,8 @@ import type {
 	MaestroAppServerModelProviderCapabilitiesReadResult,
 	MaestroAppServerNetworkAuditListResult,
 	MaestroAppServerNetworkFetchResult,
+	MaestroAppServerPluginBundleListResult,
+	MaestroAppServerPluginBundleMutationResult,
 	MaestroAppServerPolicyCheckResult,
 	MaestroAppServerPolicyReadResult,
 	MaestroAppServerRequirementsListResult,
@@ -73,53 +75,59 @@ type AppServerMethodResult<M extends AppServerRequestMethod> =
 										? MaestroAppServerSandboxProofResult
 										: M extends "externalAgent/import"
 											? MaestroAppServerExternalAgentImportResult
-											: M extends "command/exec"
-												? MaestroAppServerCommandExecResult
+											: M extends "pluginBundle/list"
+												? MaestroAppServerPluginBundleListResult
 												: M extends
-															| "command/exec/write"
-															| "command/exec/terminate"
-													? MaestroAppServerCommandProcessResult
-													: M extends "fs/readFile"
-														? MaestroAppServerFsReadFileResult
-														: M extends "fs/readDirectory"
-															? MaestroAppServerFsReadDirectoryResult
-															: M extends "fs/getMetadata"
-																? MaestroAppServerFsMetadataResult
-																: M extends "fs/watch"
-																	? MaestroAppServerFsWatchResult
-																	: M extends
-																				| "fs/writeFile"
-																				| "fs/createDirectory"
-																				| "fs/remove"
-																				| "fs/copy"
-																				| "fs/unwatch"
-																		? MaestroAppServerEmptyResult
-																		: M extends "thread/list"
-																			? MaestroAppServerThreadListResult
-																			: M extends "thread/read"
-																				? MaestroAppServerThreadReadResult
-																				: M extends "thread/metadata/update"
-																					? MaestroAppServerThreadMetadataUpdateResult
-																					: M extends "thread/name/set"
-																						? MaestroAppServerThreadMetadataUpdateResult
-																						: M extends
-																									| "thread/goal/get"
-																									| "thread/goal/set"
-																									| "thread/goal/clear"
-																							? MaestroAppServerThreadGoalResult
-																							: M extends "thread/start"
-																								? MaestroAppServerThreadStartResult
-																								: M extends "thread/fork"
-																									? MaestroAppServerThreadForkResult
-																									: M extends
-																												| "thread/archive"
-																												| "thread/unarchive"
-																										? MaestroAppServerThreadArchiveResult
-																										: M extends "thread/delete"
-																											? MaestroAppServerThreadDeleteResult
-																											: M extends "thread/turns/list"
-																												? MaestroAppServerTurnsListResult
-																												: never;
+															| "pluginBundle/install"
+															| "pluginBundle/remove"
+													? MaestroAppServerPluginBundleMutationResult
+													: M extends "command/exec"
+														? MaestroAppServerCommandExecResult
+														: M extends
+																	| "command/exec/write"
+																	| "command/exec/terminate"
+															? MaestroAppServerCommandProcessResult
+															: M extends "fs/readFile"
+																? MaestroAppServerFsReadFileResult
+																: M extends "fs/readDirectory"
+																	? MaestroAppServerFsReadDirectoryResult
+																	: M extends "fs/getMetadata"
+																		? MaestroAppServerFsMetadataResult
+																		: M extends "fs/watch"
+																			? MaestroAppServerFsWatchResult
+																			: M extends
+																						| "fs/writeFile"
+																						| "fs/createDirectory"
+																						| "fs/remove"
+																						| "fs/copy"
+																						| "fs/unwatch"
+																				? MaestroAppServerEmptyResult
+																				: M extends "thread/list"
+																					? MaestroAppServerThreadListResult
+																					: M extends "thread/read"
+																						? MaestroAppServerThreadReadResult
+																						: M extends "thread/metadata/update"
+																							? MaestroAppServerThreadMetadataUpdateResult
+																							: M extends "thread/name/set"
+																								? MaestroAppServerThreadMetadataUpdateResult
+																								: M extends
+																											| "thread/goal/get"
+																											| "thread/goal/set"
+																											| "thread/goal/clear"
+																									? MaestroAppServerThreadGoalResult
+																									: M extends "thread/start"
+																										? MaestroAppServerThreadStartResult
+																										: M extends "thread/fork"
+																											? MaestroAppServerThreadForkResult
+																											: M extends
+																														| "thread/archive"
+																														| "thread/unarchive"
+																												? MaestroAppServerThreadArchiveResult
+																												: M extends "thread/delete"
+																													? MaestroAppServerThreadDeleteResult
+																													: M extends "thread/turns/list"
+																														? MaestroAppServerTurnsListResult
+																														: never;
 
 export class InProcessMaestroAppServerClientError extends Error {
 	constructor(

--- a/src/app-server/plugin-bundle-api.ts
+++ b/src/app-server/plugin-bundle-api.ts
@@ -1,0 +1,326 @@
+import { dirname, resolve } from "node:path";
+import type {
+	MaestroAppServerPluginBundleListResult,
+	MaestroAppServerPluginBundleMutationResult,
+	MaestroAppServerPluginBundleScope,
+} from "@evalops/contracts";
+import {
+	type WritablePackageScope,
+	addConfiguredPackageSpecToConfig,
+	getWritablePackageConfigPath,
+	loadConfiguredPackageSpecs,
+	removeConfiguredPackageSpecFromConfig,
+} from "../config/toml-config.js";
+import { parsePackageSpec } from "../packages/loader.js";
+import { loadConfiguredPackageResources } from "../packages/runtime.js";
+import {
+	formatPackageSource,
+	parsePackageSource,
+} from "../packages/sources.js";
+import type { PackageSpec } from "../packages/types.js";
+
+type UnknownRecord = Record<string, unknown>;
+
+export class MaestroAppServerPluginBundleError extends Error {
+	constructor(
+		readonly code: number,
+		message: string,
+	) {
+		super(message);
+		this.name = "MaestroAppServerPluginBundleError";
+	}
+}
+
+export interface MaestroAppServerPluginBundleApi {
+	listBundles(
+		params?: UnknownRecord,
+	): Promise<MaestroAppServerPluginBundleListResult>;
+	installBundle(
+		params?: UnknownRecord,
+	): Promise<MaestroAppServerPluginBundleMutationResult>;
+	removeBundle(
+		params?: UnknownRecord,
+	): Promise<MaestroAppServerPluginBundleMutationResult>;
+}
+
+export interface MaestroAppServerPluginBundleApiOptions {
+	projectRoot?: string;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function booleanValue(value: unknown, fallback: boolean): boolean {
+	return typeof value === "boolean" ? value : fallback;
+}
+
+function paramsRecord(params: unknown): UnknownRecord {
+	if (params === undefined) {
+		return {};
+	}
+	if (isRecord(params)) {
+		return params;
+	}
+	throw new MaestroAppServerPluginBundleError(-32602, "Invalid params");
+}
+
+function projectRootFromParams(
+	params: UnknownRecord,
+	options: MaestroAppServerPluginBundleApiOptions,
+): string {
+	return resolve(
+		stringValue(params.projectRoot) ?? options.projectRoot ?? process.cwd(),
+	);
+}
+
+function scopeFromParams(params: UnknownRecord): WritablePackageScope {
+	const scope = stringValue(params.scope);
+	if (scope === "project" || scope === "local" || scope === "user") {
+		return scope;
+	}
+	if (scope !== undefined) {
+		throw new MaestroAppServerPluginBundleError(
+			-32602,
+			"Invalid plugin bundle scope",
+		);
+	}
+	return "local";
+}
+
+function packageSpecFromParams(params: UnknownRecord): PackageSpec {
+	const spec = params.spec ?? params.source;
+	if (typeof spec === "string" && spec.trim()) {
+		return spec.trim();
+	}
+	if (isRecord(spec) && typeof spec.source === "string" && spec.source.trim()) {
+		return spec as unknown as PackageSpec;
+	}
+	throw new MaestroAppServerPluginBundleError(
+		-32602,
+		"Plugin bundle requires source or spec",
+	);
+}
+
+function sourceString(spec: PackageSpec): string {
+	return typeof spec === "string" ? spec : spec.source;
+}
+
+function resolvePackageSpecIdentity(spec: PackageSpec, cwd: string): string {
+	const [sourceSpec] = parsePackageSpec(spec, cwd);
+	return formatPackageSource(parsePackageSource(sourceSpec, cwd));
+}
+
+function tryResolvePackageSourceIdentity(
+	sourceSpec: string,
+	cwd: string,
+): string | null {
+	try {
+		return formatPackageSource(parsePackageSource(sourceSpec, cwd));
+	} catch {
+		return null;
+	}
+}
+
+function configuredPackageMatches(
+	entry: ReturnType<typeof loadConfiguredPackageSpecs>[number],
+	requestedSpec: string,
+	requestedCwd: string,
+): boolean {
+	const [rawSourceSpec] = parsePackageSpec(entry.spec, entry.cwd);
+	if (rawSourceSpec === requestedSpec) {
+		return true;
+	}
+	const requestedIdentity = tryResolvePackageSourceIdentity(
+		requestedSpec,
+		requestedCwd,
+	);
+	if (!requestedIdentity) {
+		return false;
+	}
+	return (
+		resolvePackageSpecIdentity(entry.spec, entry.cwd) === requestedIdentity
+	);
+}
+
+function validateBundleInstall(
+	projectRoot: string,
+	scope: WritablePackageScope,
+	spec: PackageSpec,
+): { configPath: string } {
+	const configPath = getWritablePackageConfigPath(scope, projectRoot);
+	const configDir = dirname(configPath);
+	const requestedIdentity = resolvePackageSpecIdentity(spec, projectRoot);
+	const duplicate = loadConfiguredPackageSpecs(projectRoot).find(
+		(entry) =>
+			entry.configPath === configPath &&
+			resolvePackageSpecIdentity(entry.spec, configDir) === requestedIdentity,
+	);
+	if (duplicate) {
+		const [sourceSpec] = parsePackageSpec(duplicate.spec, configDir);
+		throw new MaestroAppServerPluginBundleError(
+			-32602,
+			`Package "${sourceSpec}" already exists in ${configPath}.`,
+		);
+	}
+	return { configPath };
+}
+
+function resolveBundleRemoval(
+	projectRoot: string,
+	spec: PackageSpec,
+	scope?: WritablePackageScope,
+): { configPath: string; scope: WritablePackageScope } {
+	const requestedSpec = sourceString(spec);
+	const matches = loadConfiguredPackageSpecs(projectRoot).filter(
+		(entry) =>
+			(scope === undefined || entry.scope === scope) &&
+			configuredPackageMatches(entry, requestedSpec, projectRoot),
+	);
+	const orderedScopes: WritablePackageScope[] =
+		scope === undefined ? ["local", "project", "user"] : [scope];
+	for (const candidateScope of orderedScopes) {
+		const match = matches.find((entry) => entry.scope === candidateScope);
+		if (match) {
+			return { configPath: match.configPath, scope: match.scope };
+		}
+	}
+	const scopeMessage = scope === undefined ? "" : ` in ${scope} config`;
+	throw new MaestroAppServerPluginBundleError(
+		-32602,
+		`Configured package "${requestedSpec}" was not found${scopeMessage}.`,
+	);
+}
+
+function toBundleScope(
+	scope: WritablePackageScope,
+): MaestroAppServerPluginBundleScope {
+	return scope;
+}
+
+function pluginBundleErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function toPluginBundleInvalidParams(
+	error: unknown,
+): MaestroAppServerPluginBundleError {
+	if (error instanceof MaestroAppServerPluginBundleError) {
+		return error;
+	}
+	return new MaestroAppServerPluginBundleError(
+		-32602,
+		pluginBundleErrorMessage(error),
+	);
+}
+
+export function createMaestroAppServerPluginBundleApi(
+	options: MaestroAppServerPluginBundleApiOptions = {},
+): MaestroAppServerPluginBundleApi {
+	return {
+		async listBundles(params = {}) {
+			const normalizedParams = paramsRecord(params);
+			const projectRoot = projectRootFromParams(normalizedParams, options);
+			const resources = loadConfiguredPackageResources(projectRoot);
+			return {
+				bundles: loadConfiguredPackageSpecs(projectRoot).map((entry) => ({
+					source: sourceString(entry.spec),
+					scope: toBundleScope(entry.scope),
+					configPath: entry.configPath,
+				})),
+				resources: {
+					extensions: resources.extensions,
+					skills: resources.skills,
+					prompts: resources.prompts,
+					themes: resources.themes,
+				},
+				errors: resources.errors,
+			};
+		},
+
+		async installBundle(params = {}) {
+			const normalizedParams = paramsRecord(params);
+			const projectRoot = projectRootFromParams(normalizedParams, options);
+			const spec = packageSpecFromParams(normalizedParams);
+			const source = sourceString(spec);
+			const scope = scopeFromParams(normalizedParams);
+			let validation: ReturnType<typeof validateBundleInstall>;
+			try {
+				validation = validateBundleInstall(projectRoot, scope, spec);
+			} catch (error) {
+				throw toPluginBundleInvalidParams(error);
+			}
+			const { configPath } = validation;
+			if (booleanValue(normalizedParams.dryRun, false)) {
+				return {
+					source,
+					scope,
+					configPath,
+					changed: false,
+					message: "Plugin bundle install planned",
+				};
+			}
+			let result: ReturnType<typeof addConfiguredPackageSpecToConfig>;
+			try {
+				result = addConfiguredPackageSpecToConfig({
+					workspaceDir: projectRoot,
+					scope,
+					spec,
+				});
+			} catch (error) {
+				throw toPluginBundleInvalidParams(error);
+			}
+			return {
+				source,
+				scope: result.scope,
+				configPath: result.path,
+				changed: true,
+				message: "Plugin bundle installed",
+			};
+		},
+
+		async removeBundle(params = {}) {
+			const normalizedParams = paramsRecord(params);
+			const projectRoot = projectRootFromParams(normalizedParams, options);
+			const spec = packageSpecFromParams(normalizedParams);
+			const scope =
+				normalizedParams.scope === undefined
+					? undefined
+					: scopeFromParams(normalizedParams);
+			const removal = resolveBundleRemoval(projectRoot, spec, scope);
+			if (booleanValue(normalizedParams.dryRun, false)) {
+				return {
+					source: sourceString(spec),
+					scope: removal.scope,
+					configPath: removal.configPath,
+					changed: false,
+					message: "Plugin bundle removal planned",
+				};
+			}
+			let result: ReturnType<typeof removeConfiguredPackageSpecFromConfig>;
+			try {
+				result = removeConfiguredPackageSpecFromConfig({
+					workspaceDir: projectRoot,
+					scope,
+					spec: sourceString(spec),
+				});
+			} catch (error) {
+				throw new MaestroAppServerPluginBundleError(
+					-32602,
+					pluginBundleErrorMessage(error),
+				);
+			}
+			return {
+				source: sourceString(spec),
+				scope: result.scope,
+				configPath: result.path,
+				changed: result.removedCount > 0,
+				message: `Removed ${result.removedCount} plugin bundle(s)`,
+			};
+		},
+	};
+}

--- a/src/app-server/session-api.ts
+++ b/src/app-server/session-api.ts
@@ -15,6 +15,8 @@ import {
 	type MaestroAppServerModelProviderCapabilitiesReadResult,
 	type MaestroAppServerNetworkAuditListResult,
 	type MaestroAppServerNetworkFetchResult,
+	type MaestroAppServerPluginBundleListResult,
+	type MaestroAppServerPluginBundleMutationResult,
 	type MaestroAppServerPolicyCheckResult,
 	type MaestroAppServerPolicyReadResult,
 	type MaestroAppServerRequirementsListResult,
@@ -73,6 +75,11 @@ import {
 	createMaestroAppServerNetworkGovernance,
 } from "./network-governance-api.js";
 import {
+	type MaestroAppServerPluginBundleApi,
+	MaestroAppServerPluginBundleError,
+	createMaestroAppServerPluginBundleApi,
+} from "./plugin-bundle-api.js";
+import {
 	type MaestroAppServerPolicyControl,
 	MaestroAppServerPolicyControlError,
 	createMaestroAppServerPolicyControl,
@@ -92,6 +99,10 @@ export {
 	type MaestroAppServerExternalAgentImport,
 	createMaestroAppServerExternalAgentImport,
 } from "./external-agent-import-api.js";
+export {
+	type MaestroAppServerPluginBundleApi,
+	createMaestroAppServerPluginBundleApi,
+} from "./plugin-bundle-api.js";
 export {
 	type MaestroAppServerSandboxProof,
 	createMaestroAppServerSandboxProof,
@@ -163,6 +174,7 @@ export interface MaestroAppServerSessionApiOptions {
 	networkGovernance?: MaestroAppServerNetworkGovernance | false;
 	sandboxProof?: MaestroAppServerSandboxProof | false;
 	externalAgentImport?: MaestroAppServerExternalAgentImport | false;
+	pluginBundles?: MaestroAppServerPluginBundleApi | false;
 	onNotification?: (notification: MaestroAppServerServerNotification) => void;
 }
 
@@ -198,6 +210,15 @@ export interface MaestroAppServerSessionApi {
 	importExternalAgent(
 		params?: Record<string, unknown>,
 	): Promise<MaestroAppServerExternalAgentImportResult>;
+	listPluginBundles(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerPluginBundleListResult>;
+	installPluginBundle(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerPluginBundleMutationResult>;
+	removePluginBundle(
+		params?: Record<string, unknown>,
+	): Promise<MaestroAppServerPluginBundleMutationResult>;
 	execCommand(
 		params?: Record<string, unknown>,
 	): Promise<MaestroAppServerCommandExecResult>;
@@ -823,11 +844,10 @@ export function createMaestroAppServerSessionApi(
 		options.sandboxProof === false
 			? undefined
 			: (options.sandboxProof ?? createMaestroAppServerSandboxProof());
-	const externalAgentImport =
-		options.externalAgentImport === false
+	const pluginBundles =
+		options.pluginBundles === false
 			? undefined
-			: (options.externalAgentImport ??
-				createMaestroAppServerExternalAgentImport({ store }));
+			: (options.pluginBundles ?? createMaestroAppServerPluginBundleApi());
 	const canUpdateThreadMetadata = Boolean(
 		store.setSessionTitle &&
 			store.saveSessionSummary &&
@@ -840,6 +860,11 @@ export function createMaestroAppServerSessionApi(
 		store.setSessionAppServerGoal && store.loadEntries,
 	);
 	const canMutateSessionPersistence = store.canCreateSession?.() ?? true;
+	const externalAgentImport =
+		options.externalAgentImport === false || !canMutateSessionPersistence
+			? undefined
+			: (options.externalAgentImport ??
+				createMaestroAppServerExternalAgentImport({ store }));
 	const canStartThreads = Boolean(
 		store.createSession && canMutateSessionPersistence,
 	);
@@ -860,6 +885,7 @@ export function createMaestroAppServerSessionApi(
 	const canUseNetworkGovernance = Boolean(networkGovernance);
 	const canUseSandboxProof = Boolean(sandboxProof);
 	const canUseExternalAgentImport = Boolean(externalAgentImport);
+	const canUsePluginBundles = Boolean(pluginBundles);
 
 	return {
 		initialize() {
@@ -882,6 +908,7 @@ export function createMaestroAppServerSessionApi(
 					sandboxProbe: canUseSandboxProof,
 					sandboxProof: canUseSandboxProof,
 					externalAgentImport: canUseExternalAgentImport,
+					pluginBundles: canUsePluginBundles,
 					commandExec: canUseHostControl,
 					commandProcessControl: canUseHostControl,
 					filesystem: canUseHostControl,
@@ -981,6 +1008,36 @@ export function createMaestroAppServerSessionApi(
 			}
 			const normalizedParams = normalizeExternalAgentImportParams(params);
 			return externalAgentImport.importBundle(normalizedParams);
+		},
+
+		async listPluginBundles(params = {}) {
+			if (!pluginBundles) {
+				throw new MaestroAppServerError(
+					-32601,
+					"Plugin bundle lifecycle is not available",
+				);
+			}
+			return pluginBundles.listBundles(params);
+		},
+
+		async installPluginBundle(params = {}) {
+			if (!pluginBundles) {
+				throw new MaestroAppServerError(
+					-32601,
+					"Plugin bundle lifecycle is not available",
+				);
+			}
+			return pluginBundles.installBundle(params);
+		},
+
+		async removePluginBundle(params = {}) {
+			if (!pluginBundles) {
+				throw new MaestroAppServerError(
+					-32601,
+					"Plugin bundle lifecycle is not available",
+				);
+			}
+			return pluginBundles.removeBundle(params);
 		},
 
 		async execCommand(params = {}) {
@@ -1634,6 +1691,24 @@ export async function handleMaestroAppServerRequest(
 					id,
 					result: await api.importExternalAgent(request.params),
 				};
+			case "pluginBundle/list":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.listPluginBundles(request.params),
+				};
+			case "pluginBundle/install":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.installPluginBundle(request.params),
+				};
+			case "pluginBundle/remove":
+				return {
+					jsonrpc: "2.0",
+					id,
+					result: await api.removePluginBundle(request.params),
+				};
 			case "command/exec":
 				return {
 					jsonrpc: "2.0",
@@ -1796,7 +1871,8 @@ export async function handleMaestroAppServerRequest(
 			error instanceof MaestroAppServerNetworkGovernanceError ||
 			error instanceof MaestroAppServerPolicyControlError ||
 			error instanceof MaestroAppServerSandboxProofError ||
-			error instanceof MaestroAppServerExternalAgentImportError
+			error instanceof MaestroAppServerExternalAgentImportError ||
+			error instanceof MaestroAppServerPluginBundleError
 		) {
 			return {
 				jsonrpc: "2.0",

--- a/test/app-server/external-agent-import-api.test.ts
+++ b/test/app-server/external-agent-import-api.test.ts
@@ -64,6 +64,46 @@ describe("Maestro app-server external agent import API", () => {
 		});
 	});
 
+	it("does not expose external agent imports when session persistence is disabled", async () => {
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "disabled-sessions"),
+		});
+		manager.disable();
+		const api = createMaestroAppServerSessionApi(manager);
+		const projectRoot = join(testDir, "disabled-project");
+
+		expect(api.initialize()).toMatchObject({
+			capabilities: {
+				externalAgentImport: false,
+			},
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "external-agent-import-disabled",
+			method: "externalAgent/import",
+			params: {
+				dryRun: false,
+				projectRoot,
+				artifacts: [
+					{
+						kind: "config",
+						scope: "local",
+						values: { model: "gpt-5.1" },
+					},
+				],
+			},
+		});
+
+		expect(response.error).toEqual({
+			code: -32601,
+			message: "External agent import is not available",
+		});
+		expect(existsSync(join(projectRoot, ".maestro", "config.local.toml"))).toBe(
+			false,
+		);
+	});
+
 	it("imports sessions, config, hooks, MCP servers, and skills from one bundle", async () => {
 		const projectRoot = join(testDir, "project");
 		const sourceManager = new SessionManager(false, undefined, {
@@ -302,6 +342,43 @@ describe("Maestro app-server external agent import API", () => {
 		]);
 		expect(response.result?.warnings).toHaveLength(1);
 		expect(readFileSync(hooksPath, "utf8")).toBe("{not-json");
+	});
+
+	it("rejects local hooks scope instead of writing project hooks", async () => {
+		const projectRoot = join(testDir, "local-hooks-project");
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "local-hooks-sessions"),
+		});
+		const api = createMaestroAppServerSessionApi(manager);
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "external-agent-import-local-hooks",
+			method: "externalAgent/import",
+			params: {
+				dryRun: false,
+				projectRoot,
+				artifacts: [
+					{
+						kind: "hooks",
+						scope: "local",
+						hooks: { SessionStart: [] },
+					},
+				],
+			},
+		});
+
+		expect(response.result?.warnings).toEqual([
+			"Hooks artifact does not support local scope",
+		]);
+		expect(response.result?.imported).toEqual([
+			expect.objectContaining({
+				kind: "hooks",
+				status: "skipped",
+				message: "Hooks artifact does not support local scope",
+			}),
+		]);
+		expect(existsSync(join(projectRoot, ".maestro", "hooks.json"))).toBe(false);
 	});
 
 	it("blocks skill file path traversal", async () => {

--- a/test/app-server/plugin-bundle-api.test.ts
+++ b/test/app-server/plugin-bundle-api.test.ts
@@ -1,0 +1,274 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Value } from "@sinclair/typebox/value";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MaestroAppServerResponseSchema } from "../../packages/contracts/src/maestro-app-server.js";
+import {
+	createMaestroAppServerSessionApi,
+	handleMaestroAppServerRequest,
+} from "../../src/app-server/session-api.js";
+import { SessionManager } from "../../src/session/manager.js";
+import { loadSkills } from "../../src/skills/loader.js";
+
+function writePluginBundle(root: string): string {
+	const packageDir = join(root, "vendor", "review-bundle");
+	const skillDir = join(packageDir, "skills", "reviewing");
+	mkdirSync(skillDir, { recursive: true });
+	writeFileSync(
+		join(packageDir, "package.json"),
+		JSON.stringify(
+			{
+				name: "@test/maestro-review-bundle",
+				version: "1.0.0",
+				keywords: ["maestro-package"],
+				maestro: { skills: ["./skills"] },
+			},
+			null,
+			2,
+		),
+		"utf8",
+	);
+	writeFileSync(
+		join(skillDir, "SKILL.md"),
+		"---\nname: reviewing\ndescription: Review imported through plugin bundle lifecycle.\n---\n\n# Reviewing\n",
+		"utf8",
+	);
+	return packageDir;
+}
+
+describe("Maestro app-server plugin bundle lifecycle API", () => {
+	let testDir: string;
+	let previousMaestroHome: string | undefined;
+
+	beforeEach(() => {
+		testDir = join(tmpdir(), `maestro-app-server-plugin-${Date.now()}`);
+		mkdirSync(testDir, { recursive: true });
+		previousMaestroHome = process.env.MAESTRO_HOME;
+		process.env.MAESTRO_HOME = join(testDir, "home");
+	});
+
+	afterEach(() => {
+		if (previousMaestroHome === undefined) {
+			delete process.env.MAESTRO_HOME;
+		} else {
+			process.env.MAESTRO_HOME = previousMaestroHome;
+		}
+		if (existsSync(testDir)) {
+			rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
+	it("advertises plugin bundle lifecycle capabilities", () => {
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "sessions"),
+		});
+		const api = createMaestroAppServerSessionApi(manager);
+
+		expect(api.initialize()).toMatchObject({
+			capabilities: {
+				pluginBundles: true,
+			},
+		});
+	});
+
+	it("installs, lists, loads, and removes a local plugin bundle", async () => {
+		const projectRoot = join(testDir, "project");
+		const packageDir = writePluginBundle(projectRoot);
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "sessions"),
+		});
+		const api = createMaestroAppServerSessionApi(manager);
+
+		const installed = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-install",
+			method: "pluginBundle/install",
+			params: {
+				projectRoot,
+				scope: "local",
+				source: `local:${packageDir}`,
+			},
+		});
+		expect(installed.result).toMatchObject({
+			changed: true,
+			configPath: join(projectRoot, ".maestro", "config.local.toml"),
+			scope: "local",
+			source: `local:${packageDir}`,
+			message: "Plugin bundle installed",
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, installed)).toBe(true);
+
+		const listed = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-list",
+			method: "pluginBundle/list",
+			params: { projectRoot },
+		});
+		expect(listed.result?.bundles).toEqual([
+			expect.objectContaining({
+				scope: "local",
+				source: "../vendor/review-bundle",
+			}),
+		]);
+		expect(listed.result?.resources.skills.project).toEqual(
+			expect.arrayContaining([join(packageDir, "skills", "reviewing")]),
+		);
+		expect(loadSkills(projectRoot, { includeSystem: false }).skills).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: "reviewing",
+					sourceType: "project",
+				}),
+			]),
+		);
+
+		const duplicatePreview = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-install-duplicate-dry-run",
+			method: "pluginBundle/install",
+			params: {
+				projectRoot,
+				scope: "local",
+				dryRun: true,
+				source: `local:${packageDir}`,
+			},
+		});
+		expect(duplicatePreview.error).toMatchObject({
+			code: -32602,
+			message: expect.stringContaining("already exists"),
+		});
+
+		const removePreview = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-remove-dry-run",
+			method: "pluginBundle/remove",
+			params: {
+				projectRoot,
+				dryRun: true,
+				source: `local:${packageDir}`,
+			},
+		});
+		expect(removePreview.result).toMatchObject({
+			changed: false,
+			configPath: join(projectRoot, ".maestro", "config.local.toml"),
+			scope: "local",
+			message: "Plugin bundle removal planned",
+		});
+
+		const removed = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-remove",
+			method: "pluginBundle/remove",
+			params: {
+				projectRoot,
+				source: `local:${packageDir}`,
+			},
+		});
+		expect(removed.result).toMatchObject({
+			changed: true,
+			scope: "local",
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, removed)).toBe(true);
+
+		const listedAfterRemove = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-list-after-remove",
+			method: "pluginBundle/list",
+			params: { projectRoot },
+		});
+		expect(listedAfterRemove.result?.bundles).toEqual([]);
+	});
+
+	it("previews plugin bundle installs without writing config", async () => {
+		const projectRoot = join(testDir, "dry-run-project");
+		const packageDir = writePluginBundle(projectRoot);
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "dry-run-sessions"),
+		});
+		const api = createMaestroAppServerSessionApi(manager);
+
+		const planned = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-install-dry-run",
+			method: "pluginBundle/install",
+			params: {
+				projectRoot,
+				dryRun: true,
+				source: `local:${packageDir}`,
+			},
+		});
+
+		expect(planned.result).toMatchObject({
+			changed: false,
+			configPath: join(projectRoot, ".maestro", "config.local.toml"),
+			message: "Plugin bundle install planned",
+		});
+		expect(existsSync(join(projectRoot, ".maestro", "config.local.toml"))).toBe(
+			false,
+		);
+	});
+
+	it("returns invalid params for malformed plugin bundle install sources", async () => {
+		const projectRoot = join(testDir, "malformed-source-project");
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "malformed-source-sessions"),
+		});
+		const api = createMaestroAppServerSessionApi(manager);
+
+		const rejected = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-install-malformed-source",
+			method: "pluginBundle/install",
+			params: {
+				projectRoot,
+				source: "not a package source",
+			},
+		});
+
+		expect(rejected.error).toMatchObject({
+			code: -32602,
+			message: "Invalid package source format: not a package source",
+		});
+		expect(Value.Check(MaestroAppServerResponseSchema, rejected)).toBe(true);
+	});
+
+	it("rejects invalid scopes and missing removal previews", async () => {
+		const projectRoot = join(testDir, "invalid-project");
+		const packageDir = writePluginBundle(projectRoot);
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "invalid-sessions"),
+		});
+		const api = createMaestroAppServerSessionApi(manager);
+
+		const invalidScope = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-install-invalid-scope",
+			method: "pluginBundle/install",
+			params: {
+				projectRoot,
+				scope: "workspace",
+				source: `local:${packageDir}`,
+			},
+		});
+		expect(invalidScope.error).toMatchObject({
+			code: -32602,
+			message: "Invalid plugin bundle scope",
+		});
+
+		const missingRemoval = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-remove-missing-dry-run",
+			method: "pluginBundle/remove",
+			params: {
+				projectRoot,
+				dryRun: true,
+				source: `local:${packageDir}`,
+			},
+		});
+		expect(missingRemoval.error).toMatchObject({
+			code: -32602,
+			message: expect.stringContaining("was not found"),
+		});
+	});
+});


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"4ca93cfd51403eea44768c6bedc1ff3e60123fe1"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `4ca93cfd51403eea44768c6bedc1ff3e60123fe1`
- last generated public sync base: `67a52dbe2c3fba404ef4de3ba638d63e1da5f8cb`
- previewed public-tree drift: `7` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (4ca93cfd5140)`
- public projection: `https://github.com/evalops/maestro@main (67a52dbe2c3f)`
- files to copy or update: `7`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/contracts/src/maestro-app-server.ts
- copy/update src/app-server/external-agent-import-api.ts
- copy/update src/app-server/in-process-client.ts
- copy/update src/app-server/plugin-bundle-api.ts
- copy/update src/app-server/session-api.ts
- copy/update test/app-server/external-agent-import-api.test.ts
- copy/update test/app-server/plugin-bundle-api.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/contracts/src/maestro-app-server.ts
- copy/update src/app-server/external-agent-import-api.ts
- copy/update src/app-server/in-process-client.ts
- copy/update src/app-server/plugin-bundle-api.ts
- copy/update src/app-server/session-api.ts
- copy/update test/app-server/external-agent-import-api.test.ts
- copy/update test/app-server/plugin-bundle-api.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@4ca93cfd51403eea44768c6bedc1ff3e60123fe1`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.