### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/agent/transport/tool-execution-bridge.ts
+++ b/src/agent/transport/tool-execution-bridge.ts
@@ -177,6 +177,22 @@ export interface ToolExecutionBridgeInput {
 	actionDescription?: string;
 }
 
+export interface ToolExecutionBridgeRuntimeLinkage {
+	agentRunId?: string;
+	agentId?: string;
+	workspaceId?: string;
+	sessionId?: string;
+	remoteRunnerSessionId?: string;
+}
+
+export type ToolExecutionBridgeRuntimeLinkageProvider =
+	| ToolExecutionBridgeRuntimeLinkage
+	| (() => ToolExecutionBridgeRuntimeLinkage | undefined);
+
+export interface DefaultPlatformToolExecutionBridgeOptions {
+	runtimeLinkage?: ToolExecutionBridgeRuntimeLinkageProvider;
+}
+
 interface ToolExecutionClassification {
 	family: "bash" | "mcp";
 	mode: PlatformBridgeMode;
@@ -456,14 +472,20 @@ function buildLinkage(
 	toolCall: ToolCall,
 	organizationId: string | undefined,
 	workspaceId: string,
+	runtimeLinkage: ToolExecutionBridgeRuntimeLinkage | undefined,
 ): ToolExecutionLinkage {
 	const sessionId =
-		trimString(cfg.session?.id) ?? getEnvValue(["MAESTRO_SESSION_ID"]);
-	const agentRunId = getEnvValue(["MAESTRO_AGENT_RUN_ID"]);
+		trimString(cfg.session?.id) ??
+		trimString(runtimeLinkage?.sessionId) ??
+		getEnvValue(["MAESTRO_SESSION_ID"]);
+	const agentRunId =
+		trimString(runtimeLinkage?.agentRunId) ??
+		getEnvValue(["MAESTRO_AGENT_RUN_ID"]);
 	return {
-		workspaceId,
+		workspaceId: trimString(runtimeLinkage?.workspaceId) ?? workspaceId,
 		...(organizationId ? { organizationId } : {}),
 		agentId:
+			trimString(runtimeLinkage?.agentId) ??
 			getEnvValue(["MAESTRO_AGENT_ID"]) ??
 			trimString(process.env.npm_package_name) ??
 			"maestro",
@@ -535,16 +557,21 @@ function buildMetadata(
 	input: ToolExecutionBridgeInput,
 	classification: ToolExecutionClassification,
 	linkage: ToolExecutionLinkage,
+	runtimeLinkage: ToolExecutionBridgeRuntimeLinkage | undefined,
 ): Record<string, string> {
 	const originalArgs = input.toolCall.arguments as Record<string, unknown>;
 	const redactedArguments =
 		stableStringify(originalArgs) !== stableStringify(input.sanitizedArgs);
 	const sessionId =
-		trimString(input.cfg.session?.id) ?? getEnvValue(["MAESTRO_SESSION_ID"]);
-	const remoteRunnerSessionId = getEnvValue([
-		"MAESTRO_REMOTE_RUNNER_SESSION_ID",
-		"MAESTRO_RUNNER_SESSION_ID",
-	]);
+		trimString(input.cfg.session?.id) ??
+		trimString(runtimeLinkage?.sessionId) ??
+		getEnvValue(["MAESTRO_SESSION_ID"]);
+	const remoteRunnerSessionId =
+		trimString(runtimeLinkage?.remoteRunnerSessionId) ??
+		getEnvValue([
+			"MAESTRO_REMOTE_RUNNER_SESSION_ID",
+			"MAESTRO_RUNNER_SESSION_ID",
+		]);
 	return {
 		maestro_bridge_mode: classification.mode,
 		maestro_tool_call_id: input.toolCall.id,
@@ -572,12 +599,14 @@ function buildExecuteRequest(
 	input: ToolExecutionBridgeInput,
 	config: ToolExecutionServiceConfig,
 	classification: ToolExecutionClassification,
+	runtimeLinkage: ToolExecutionBridgeRuntimeLinkage | undefined,
 ): ExecutePlatformToolRequest {
 	const linkage = buildLinkage(
 		input.cfg,
 		input.toolCall,
 		config.organizationId,
 		config.workspaceId ?? process.cwd(),
+		runtimeLinkage,
 	);
 	return {
 		linkage,
@@ -594,7 +623,7 @@ function buildExecuteRequest(
 			allowNonIdempotentRetry: false,
 		},
 		idempotencyKey: `maestro:${input.toolCall.id}`,
-		metadata: buildMetadata(input, classification, linkage),
+		metadata: buildMetadata(input, classification, linkage, runtimeLinkage),
 	};
 }
 
@@ -678,6 +707,12 @@ export interface PlatformToolExecutionBridge {
 export class DefaultPlatformToolExecutionBridge
 	implements PlatformToolExecutionBridge
 {
+	private readonly runtimeLinkage?: ToolExecutionBridgeRuntimeLinkageProvider;
+
+	constructor(options: DefaultPlatformToolExecutionBridgeOptions = {}) {
+		this.runtimeLinkage = options.runtimeLinkage;
+	}
+
 	async prepare(
 		input: ToolExecutionBridgeInput,
 		signal?: AbortSignal,
@@ -706,7 +741,12 @@ export class DefaultPlatformToolExecutionBridge
 			return { status: "skip" };
 		}
 
-		const request = buildExecuteRequest(input, config, classification);
+		const request = buildExecuteRequest(
+			input,
+			config,
+			classification,
+			resolveRuntimeLinkage(this.runtimeLinkage),
+		);
 		if (classification.mode === "observe") {
 			return {
 				status: "observe",
@@ -919,6 +959,12 @@ export class DefaultPlatformToolExecutionBridge
 			return { metadata: plan.metadata };
 		}
 	}
+}
+
+function resolveRuntimeLinkage(
+	provider: ToolExecutionBridgeRuntimeLinkageProvider | undefined,
+): ToolExecutionBridgeRuntimeLinkage | undefined {
+	return typeof provider === "function" ? provider() : provider;
 }
 
 let defaultBridge: PlatformToolExecutionBridge | null = null;

--- a/src/server/app-context.ts
+++ b/src/server/app-context.ts
@@ -6,6 +6,7 @@ import type {
 import type { Agent } from "../agent/index.js";
 import type { ToolRetryService } from "../agent/tool-retry.js";
 import type { ClientToolExecutionService } from "../agent/transport.js";
+import type { PlatformToolExecutionBridge } from "../agent/transport/tool-execution-bridge.js";
 import type { ThinkingLevel } from "../agent/types.js";
 import type { RegisteredModel } from "../models/registry.js";
 import type { AuthCredential } from "../providers/auth.js";
@@ -77,6 +78,7 @@ export interface WebServerServices {
 			approvalService?: ActionApprovalService;
 			clientToolService?: ClientToolExecutionService;
 			toolRetryService?: ToolRetryService;
+			platformToolExecutionBridge?: PlatformToolExecutionBridge | false;
 		},
 	) => Promise<Agent>;
 	createBackgroundAgent: (

--- a/src/server/headless-runtime-service.ts
+++ b/src/server/headless-runtime-service.ts
@@ -19,6 +19,7 @@ import {
 	subscribeSwarmRuntimeEvents,
 } from "../agent/swarm/runtime-events.js";
 import type { ToolRetryService } from "../agent/tool-retry.js";
+import { DefaultPlatformToolExecutionBridge } from "../agent/transport/tool-execution-bridge.js";
 import type { AgentEvent, Attachment, ThinkingLevel } from "../agent/types.js";
 import { runUserPromptWithRecovery } from "../agent/user-prompt-runtime.js";
 import {
@@ -138,6 +139,25 @@ export function inferFleetModelTier(
 
 function hasMiniModelVariant(normalizedProviderModel: string): boolean {
 	return /(?:^|[/:._-])mini(?:$|[/:._-])/.test(normalizedProviderModel);
+}
+
+function createHostedRunnerToolExecutionBridge(
+	hostedRunner: WebServerContext["hostedRunner"],
+): DefaultPlatformToolExecutionBridge | undefined {
+	if (!hostedRunner) {
+		return undefined;
+	}
+	return new DefaultPlatformToolExecutionBridge({
+		runtimeLinkage: () => ({
+			agentRunId: hostedRunner.agentRunId,
+			agentId: hostedRunner.agentId,
+			workspaceId: hostedRunner.workspaceId,
+			sessionId:
+				hostedRunner.activeMaestroSessionId ??
+				hostedRunner.configuredMaestroSessionId,
+			remoteRunnerSessionId: hostedRunner.runnerSessionId,
+		}),
+	});
 }
 
 export function getFleetPlatformEventBusStatus():
@@ -1012,6 +1032,9 @@ export class HeadlessSessionRuntime {
 				includeVscodeTools: options.client === "vscode",
 				includeJetBrainsTools: options.client === "jetbrains",
 				includeConductorTools: options.client === "conductor",
+				platformToolExecutionBridge: createHostedRunnerToolExecutionBridge(
+					options.context.hostedRunner,
+				),
 			},
 		);
 		const automaticMemoryConsolidation =

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -30,6 +30,7 @@ import {
 import { Agent, ProviderTransport } from "./agent/index.js";
 import type { ToolRetryService } from "./agent/tool-retry.js";
 import type { ClientToolExecutionService } from "./agent/transport.js";
+import type { PlatformToolExecutionBridge } from "./agent/transport/tool-execution-bridge.js";
 import type { AgentTool, ThinkingLevel } from "./agent/types.js";
 import {
 	disposeCheckpointService,
@@ -448,6 +449,7 @@ async function createAgent(
 		approvalService?: ActionApprovalService;
 		clientToolService?: ClientToolExecutionService;
 		toolRetryService?: ToolRetryService;
+		platformToolExecutionBridge?: PlatformToolExecutionBridge | false;
 	},
 ): Promise<Agent> {
 	const cwd = options?.cwd ?? process.cwd();
@@ -500,6 +502,7 @@ async function createAgent(
 			(options?.enableClientTools || options?.useClientAskUser
 				? clientToolService
 				: undefined),
+		platformToolExecutionBridge: options?.platformToolExecutionBridge,
 		sessionTokenCounter,
 		auditLogger,
 	});

--- a/test/agent/tool-execution-bridge.test.ts
+++ b/test/agent/tool-execution-bridge.test.ts
@@ -203,6 +203,76 @@ describe("tool execution bridge", () => {
 		});
 	});
 
+	it("uses hosted AgentRuntime linkage when the run handle is bound after startup", async () => {
+		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
+			MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG,
+		]);
+		vi.stubEnv("MAESTRO_AGENT_RUN_ID", "");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				const parsed = new URL(url);
+				requests.push({
+					body: parseRequestBody(init?.body),
+					headers: headersToRecord(init?.headers),
+					method: init?.method,
+					pathname: parsed.pathname,
+					url,
+				});
+				return new Response(
+					JSON.stringify({
+						execution: {
+							id: "texec_hosted_1",
+							state: "TOOL_EXECUTION_STATE_SUCCEEDED",
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}),
+		);
+
+		const bridge = new DefaultPlatformToolExecutionBridge({
+			runtimeLinkage: () => ({
+				agentRunId: "run_hosted_1",
+				agentId: "agent_hosted",
+				workspaceId: "ws_hosted",
+				remoteRunnerSessionId: "rrs_hosted_1",
+			}),
+		});
+		const prepared = await bridge.prepare({
+			cfg: baseConfig(),
+			toolCall: {
+				type: "toolCall",
+				id: "tc_hosted_1",
+				name: "bash",
+				arguments: { command: "git status" },
+			},
+			sanitizedArgs: { command: "git status" },
+		});
+		if (prepared.status !== "observe") {
+			throw new Error("expected observe plan");
+		}
+
+		await bridge.recordObservation(prepared.plan, {
+			...okResult,
+			toolCallId: "tc_hosted_1",
+		});
+
+		expect(requests[0]?.body).toMatchObject({
+			linkage: expect.objectContaining({
+				runId: "run_hosted_1",
+				agentId: "agent_hosted",
+				workspaceId: "ws_hosted",
+				stepId: "tc_hosted_1",
+			}),
+			metadata: expect.objectContaining({
+				maestro_agent_run_id: "run_hosted_1",
+				maestro_remote_runner_session_id: "rrs_hosted_1",
+			}),
+		});
+	});
+
 	it("truncates metadata without splitting surrogate pairs", async () => {
 		process.env.EVALOPS_FEATURE_FLAGS_PATH = writeFlags([
 			MAESTRO_PLATFORM_RUNTIME_AGENT_RUNTIME_OBSERVE_FLAG,

--- a/test/server/headless-runtime-service.test.ts
+++ b/test/server/headless-runtime-service.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { DefaultPlatformToolExecutionBridge } from "../../src/agent/transport/tool-execution-bridge.js";
 import type {
 	AgentEvent,
 	AppMessage,
@@ -154,13 +155,14 @@ describe("HeadlessRuntimeService restore manifests", () => {
 		);
 
 		const service = new HeadlessRuntimeService();
+		const createAgent = vi.fn().mockResolvedValue(fakeAgent);
 		const runtime = await service.ensureRuntime({
 			scope_key: "anon",
 			registeredModel: TEST_MODEL,
 			thinkingLevel: "off",
 			approvalMode: "prompt",
 			context: {
-				createAgent: vi.fn().mockResolvedValue(fakeAgent),
+				createAgent,
 				createBackgroundAgent: vi.fn().mockResolvedValue(new FakeAgent()),
 				hostedRunner: {
 					enabled: true,
@@ -172,6 +174,16 @@ describe("HeadlessRuntimeService restore manifests", () => {
 			sessionManager,
 		});
 
+		expect(createAgent).toHaveBeenCalledWith(
+			TEST_MODEL,
+			"off",
+			"prompt",
+			expect.objectContaining({
+				platformToolExecutionBridge: expect.any(
+					DefaultPlatformToolExecutionBridge,
+				),
+			}),
+		);
 		expect(runtime.getSnapshot()).toMatchObject({
 			session_id: sessionId,
 			cursor: 7,


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"5affb4637fc88e58742245e5b3bad3a82fefaaf1"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `5affb4637fc88e58742245e5b3bad3a82fefaaf1`
- last generated public sync base: `9f9a76899f2b19bf1660ef1c6e4f1dd944075143`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (5affb4637fc8)`
- public projection: `https://github.com/evalops/maestro@main (9f9a76899f2b)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/agent/transport/tool-execution-bridge.ts
- copy/update src/server/app-context.ts
- copy/update src/server/headless-runtime-service.ts
- copy/update src/web-server.ts
- copy/update test/agent/tool-execution-bridge.test.ts
- copy/update test/server/headless-runtime-service.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/agent/transport/tool-execution-bridge.ts
- copy/update src/server/app-context.ts
- copy/update src/server/headless-runtime-service.ts
- copy/update src/web-server.ts
- copy/update test/agent/tool-execution-bridge.test.ts
- copy/update test/server/headless-runtime-service.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@5affb4637fc88e58742245e5b3bad3a82fefaaf1`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.