### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/server/headless-runtime-service.ts
+++ b/src/server/headless-runtime-service.ts
@@ -342,9 +342,13 @@ export async function loadHostedRunnerRestoreManifest(
 			`Hosted runner restore manifest snapshot is for Maestro session ${restore.snapshot.session_id}, not ${maestroSessionId}`,
 		);
 	}
-	if (restore.snapshot.state.session_id !== maestroSessionId) {
+	const snapshotStateSessionId =
+		typeof restore.snapshot.state.session_id === "string"
+			? restore.snapshot.state.session_id.trim()
+			: "";
+	if (snapshotStateSessionId && snapshotStateSessionId !== maestroSessionId) {
 		throw new Error(
-			`Hosted runner restore manifest snapshot state is for Maestro session ${restore.snapshot.state.session_id}, not ${maestroSessionId}`,
+			`Hosted runner restore manifest snapshot state is for Maestro session ${snapshotStateSessionId}, not ${maestroSessionId}`,
 		);
 	}
 	if (

--- a/test/server/headless-runtime-service.test.ts
+++ b/test/server/headless-runtime-service.test.ts
@@ -254,6 +254,46 @@ describe("HeadlessRuntimeService restore manifests", () => {
 
 	it.each([
 		{
+			field: "missing snapshot.state.session_id",
+			apply: (manifest: ReturnType<typeof buildRestoreManifest>) => {
+				delete manifest.snapshot.state.session_id;
+			},
+		},
+		{
+			field: "null snapshot.state.session_id",
+			apply: (manifest: ReturnType<typeof buildRestoreManifest>) => {
+				manifest.snapshot.state.session_id = null;
+			},
+		},
+	])("accepts restore manifest with $field", async (testCase) => {
+		const workspaceRoot = await mkdtemp(
+			join(tmpdir(), "maestro-headless-restore-compatible-"),
+		);
+		const sessionDir = await mkdtemp(join(tmpdir(), "maestro-sessions-"));
+		tempDirs.push(workspaceRoot, sessionDir);
+		const fakeAgent = new FakeAgent();
+		const sessionManager = new SessionManager(false, undefined, { sessionDir });
+		sessionManager.startSession(fakeAgent.state);
+		const manifest = buildRestoreManifest({
+			sessionId: sessionManager.getSessionId(),
+			sessionFile: sessionManager.getSessionFile(),
+			workspaceRoot,
+		});
+		testCase.apply(manifest);
+		const manifestPath = join(workspaceRoot, "restore-manifest.json");
+		await writeFile(manifestPath, JSON.stringify(manifest), "utf8");
+
+		await expect(
+			loadHostedRunnerRestoreManifest(manifestPath),
+		).resolves.toEqual(
+			expect.objectContaining({
+				maestro_session_id: sessionManager.getSessionId(),
+			}),
+		);
+	});
+
+	it.each([
+		{
 			field: "snapshot.session_id",
 			applyMismatch: (manifest: ReturnType<typeof buildRestoreManifest>) => {
 				manifest.snapshot.session_id = "other-session";


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"803a3c63e52e99c393b242b0a6195de43c1dd09e"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `803a3c63e52e99c393b242b0a6195de43c1dd09e`
- last generated public sync base: `4dccf8cbe302e5e41986e73281bbec0fc1f8f9fb`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (803a3c63e52e)`
- public projection: `https://github.com/evalops/maestro@main (4dccf8cbe302)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/server/headless-runtime-service.ts
- copy/update test/server/headless-runtime-service.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/server/headless-runtime-service.ts
- copy/update test/server/headless-runtime-service.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@803a3c63e52e99c393b242b0a6195de43c1dd09e`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.