### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/codex-operating-layer.json
+++ b/docs/protocols/codex-operating-layer.json
@@ -121,7 +121,7 @@
 		{
 			"area": "approvals-sandbox-policy",
 			"evidenceType": "source",
-			"path": "packages/control-plane-rs/src/main.rs",
+			"path": "packages/control-plane-rs/src/codex_bridge.rs",
 			"anchors": [
 				"server_requests\": [\"approval\"]",
 				"codex_headless_pending_request_id",
@@ -334,7 +334,7 @@
 		{
 			"area": "multi-agent-workgraph",
 			"evidenceType": "source",
-			"path": "packages/control-plane-rs/src/main.rs",
+			"path": "packages/control-plane-rs/src/codex_bridge.rs",
 			"anchors": [
 				"childRunIds",
 				"codexWorkGraph",


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"33ab672b7e98da284b8d35b29b31d40be7e0d3db"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `33ab672b7e98da284b8d35b29b31d40be7e0d3db`
- last generated public sync base: `ea7f336ec788ab7fded5102a7dbb7fcb4a588246`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (33ab672b7e98)`
- public projection: `https://github.com/evalops/maestro@main (ea7f336ec788)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/codex-operating-layer.json

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/codex-operating-layer.json

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@33ab672b7e98da284b8d35b29b31d40be7e0d3db`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.