### PR TITLE
chore: align public evals guardian naming

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -59,7 +59,7 @@ jobs:
             sleep $((attempt * 5))
           done
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - name: Composer Guardian
+      - name: Maestro Guardian
         if: ${{ matrix.chunkIndex == 1 }}
         env:
           MAESTRO_GUARDIAN_TOOL_TIMEOUT_MS: "600000"

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1103,9 +1103,7 @@ describe("ci workflow guardrails", () => {
 			(step) => step.name === "Install Semgrep CLI",
 		);
 		const uvInstall = steps.find((step) => step.name === "Install uv");
-		const guardianStep = steps.find(
-			(step) => step.name === "Composer Guardian",
-		);
+		const guardianStep = steps.find((step) => step.name === "Maestro Guardian");
 
 		expect(checkout?.with).toMatchObject({ "fetch-depth": 0 });
 		expect(uvInstall?.if).toBe("${{ matrix.chunkIndex == 1 }}");


### PR DESCRIPTION
## Summary
- rename the public evals workflow guardian step to Maestro Guardian
- update the public CI guardrail expectation to match the mirrored Maestro branding

## Provenance
- matches evalops/maestro-internal#2211

## Validation
- node ./scripts/run-vitest.js --run test/scripts/ci-guardrails.test.ts
- pre-commit hook: guardian, biome, lint:evals, generated-code/conformance checks, build