### PR TITLE
chore: rename public GitHub agent workflow

### DIFF
--- a/.github/workflows/github-agent.yml
+++ b/.github/workflows/github-agent.yml
@@ -1,4 +1,4 @@
-name: Composer Self-Improvement
+name: Maestro Self-Improvement
 
 on:
   # Trigger on labeled issues


### PR DESCRIPTION
## Summary
- rename the public-owned GitHub agent workflow from Composer Self-Improvement to Maestro Self-Improvement
- keep existing @composer and composer-task triggers unchanged for compatibility

## Validation
- node ./scripts/run-vitest.js --run test/scripts/ci-guardrails.test.ts
- node ./scripts/run-vitest.js --run test/packages/core/naming-consistency.test.ts
- pre-commit hook: guardian, biome, lint:evals, generated-code/conformance checks, build