### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/codex-operating-layer.json
+++ b/docs/protocols/codex-operating-layer.json
@@ -449,7 +449,7 @@
 		{
 			"area": "remote-runner-continuity",
 			"evidenceType": "source",
-			"path": "packages/tui-rs/src/headless/messages.rs",
+			"path": "packages/tui-rs/src/headless/messages/state.rs",
 			"anchors": [
 				"CodexSubagentContinuityEdge",
 				"codex_subagent_edges",


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"0d714eeac195c4e190e0dcbee1b1825b41a83364"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `0d714eeac195c4e190e0dcbee1b1825b41a83364`
- last generated public sync base: `b0c7e03b781f5989099debcd452e3933268ee483`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (0d714eeac195)`
- public projection: `https://github.com/evalops/maestro@main (b0c7e03b781f)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/codex-operating-layer.json

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/codex-operating-layer.json

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@0d714eeac195c4e190e0dcbee1b1825b41a83364`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.