### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -31,6 +31,45 @@ jobs:
           fallback-to-package-version: "true"
           create-tag-if-missing: "true"
 
+      - id: registry-release
+        name: Check npm registry release
+        if: ${{ github.repository == 'evalops/maestro' }}
+        env:
+          PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
+          RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          published_version="$(npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version 2>/dev/null || true)"
+          if [[ "${published_version}" == "${RELEASE_VERSION}" ]]; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "${PACKAGE_NAME}@${RELEASE_VERSION} is published on npm."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "${PACKAGE_NAME}@${RELEASE_VERSION} is not published on npm yet."
+          fi
+
+      - id: active-release
+        name: Check active public release workflow
+        if: ${{ github.repository == 'evalops/maestro' && steps.registry-release.outputs.published != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          active_count="$(
+            gh run list \
+              --workflow release \
+              --json headBranch,status \
+              --limit 50 \
+              --jq "[.[] | select(.headBranch == \"${RELEASE_TAG}\" and .status != \"completed\")] | length"
+          )"
+          echo "active_count=${active_count}" >> "$GITHUB_OUTPUT"
+          if [[ "${active_count}" == "0" ]]; then
+            echo "No active release workflow exists for ${RELEASE_TAG}."
+          else
+            echo "Found ${active_count} active release workflow run(s) for ${RELEASE_TAG}; not dispatching another."
+          fi
+
       - name: Require version bump for existing release tag
         if: ${{ steps.release.outputs.tag_exists == 'true' && steps.release.outputs.tag_matches_head != 'true' && steps.release.outputs.package_changed_since_tag == 'true' }}
         env:
@@ -56,7 +95,7 @@ jobs:
           fi
 
       - name: Dispatch public release workflow
-        if: ${{ github.repository == 'evalops/maestro' && steps.release.outputs.tag_exists != 'true' }}
+        if: ${{ github.repository == 'evalops/maestro' && (steps.release.outputs.tag_exists != 'true' || steps.registry-release.outputs.published != 'true') && (steps.active-release.outputs.active_count == '0' || steps.active-release.outputs.active_count == '') }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.release_tag }}

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -24,9 +24,26 @@ describe("tag-release workflow", () => {
 		const dispatchStep = workflow.jobs["tag-current-version"].steps.find(
 			(step) => step.name === "Dispatch public release workflow",
 		);
+		const registryStep = workflow.jobs["tag-current-version"].steps.find(
+			(step) => step.name === "Check npm registry release",
+		);
+		const activeReleaseStep = workflow.jobs["tag-current-version"].steps.find(
+			(step) => step.name === "Check active public release workflow",
+		);
 
 		expect(dispatchStep?.env?.RELEASE_TAG).toBe(
 			"${{ steps.release.outputs.release_tag }}",
+		);
+		expect(registryStep?.run).toContain("npm view");
+		expect(activeReleaseStep?.run).toContain("gh run list");
+		expect(activeReleaseStep?.run).toContain("--workflow release");
+		expect(activeReleaseStep?.run).toContain(".headBranch");
+		expect(activeReleaseStep?.run).not.toContain("--branch");
+		expect(dispatchStep?.if).toContain(
+			"steps.registry-release.outputs.published != 'true'",
+		);
+		expect(dispatchStep?.if).toContain(
+			"steps.active-release.outputs.active_count == '0'",
 		);
 		expect(dispatchStep?.run).toContain(
 			'gh workflow run release --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"',


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"81c6908f9d999b04d8bd1461648dbd4f419cac17"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `81c6908f9d999b04d8bd1461648dbd4f419cac17`
- last generated public sync base: `3230906276ef7604e0d5e76a599b42e90d735c2c`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (81c6908f9d99)`
- public projection: `https://github.com/evalops/maestro@main (3230906276ef)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update test/workflows/tag-release.test.ts
- copy/update .github/workflows/tag-release.yml

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update test/workflows/tag-release.test.ts
- copy/update .github/workflows/tag-release.yml

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@81c6908f9d999b04d8bd1461648dbd4f419cac17`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.