### PR TITLE
Gate release canary on install metadata evidence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,15 +322,25 @@ jobs:
               exit 1
             fi
             jq -e '
-              .schemaVersion == "evalops.maestro.published-replay-evidence.v1"
-              and (.package.spec | type == "string")
-              and (.package.cliCommand | type == "string")
-              and .replay.provider == "scripted-replay"
-              and ([.modes[].mode] | sort) == ["json", "rpc", "text"]
-              and all(.modes[]; .status == "ok" and .provider == "scripted-replay")
-              and all(.modes[]; .tool.name == "read" and .tool.resultStatus == "success")
-              and all(.modes[]; .final.status == "ok")
-              and all(.modes[] | select(.mode == "text" or .mode == "json"); .session.jsonlFileCount > 0 and .session.bytes > 0 and .session.containsFinalText == true and .session.containsToolCallId == true and (.session.sha256 | type == "string" and length == 64))
+              . as $evidence
+              | $evidence.schemaVersion == "evalops.maestro.published-replay-evidence.v1"
+              and ($evidence.package.spec | type == "string")
+              and ($evidence.package.cliCommand | type == "string")
+              and ($evidence.package.installMetadata | type == "object")
+              and $evidence.package.installMetadata.installable == true
+              and ($evidence.package.installMetadata.name | type == "string")
+              and ($evidence.package.installMetadata.version | type == "string")
+              and ($evidence.package.installMetadata.binCommands | index($evidence.package.cliCommand) != null)
+              and ($evidence.package.installMetadata.forbiddenWorkspaceNames | type == "array")
+              and $evidence.package.installMetadata.forbiddenReferences == []
+              and $evidence.package.installMetadata.workspaceProtocolReferences == []
+              and ($evidence.package.installMetadata.dependencySections | type == "object")
+              and $evidence.replay.provider == "scripted-replay"
+              and ([$evidence.modes[].mode] | sort) == ["json", "rpc", "text"]
+              and all($evidence.modes[]; .status == "ok" and .provider == "scripted-replay")
+              and all($evidence.modes[]; .tool.name == "read" and .tool.resultStatus == "success")
+              and all($evidence.modes[]; .final.status == "ok")
+              and all($evidence.modes[] | select(.mode == "text" or .mode == "json"); .session.jsonlFileCount > 0 and .session.bytes > 0 and .session.containsFinalText == true and .session.containsToolCallId == true and (.session.sha256 | type == "string" and length == 64))
             ' "$evidence" >/dev/null
           done
 

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1004,6 +1004,11 @@ describe("ci workflow guardrails", () => {
 		const canaryStep = releaseWorkflow.jobs?.[
 			"post-publish-canary"
 		]?.steps?.find((step) => step.name === "Verify published package from npm");
+		const evidenceStep = releaseWorkflow.jobs?.[
+			"post-publish-canary"
+		]?.steps?.find(
+			(step) => step.name === "Validate published replay evidence",
+		);
 		const verifyWorkflowPath = new URL(
 			"../../.github/workflows/verify-published-package.yml",
 			import.meta.url,
@@ -1028,6 +1033,22 @@ describe("ci workflow guardrails", () => {
 			expect(canaryStep?.env).toMatchObject({
 				MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "local",
 			});
+			expect(evidenceStep?.run).toContain(
+				"$evidence.package.installMetadata.installable == true",
+			);
+			expect(evidenceStep?.run).toContain(". as $evidence");
+			expect(evidenceStep?.run).toContain(
+				"$evidence.package.installMetadata.binCommands | index($evidence.package.cliCommand) != null",
+			);
+			expect(evidenceStep?.run).not.toContain(
+				".package.installMetadata.binCommands | index(.package.cliCommand) != null",
+			);
+			expect(evidenceStep?.run).toContain(
+				"$evidence.package.installMetadata.forbiddenReferences == []",
+			);
+			expect(evidenceStep?.run).toContain(
+				"$evidence.package.installMetadata.workspaceProtocolReferences == []",
+			);
 			expect(hasPublicVerifyWorkflow).toBe(true);
 			const verifyWorkflow = parse(
 				readFileSync(verifyWorkflowPath, { encoding: "utf8" }),


### PR DESCRIPTION
## Summary
- require post-publish replay evidence to include install metadata
- fail the canary when published package metadata is not installable or still references private/workspace deps
- add a workflow guardrail test for the new evidence checks

## Validation
- node ./scripts/run-vitest.js --run test/scripts/ci-guardrails.test.ts
- node -e "const fs=require('fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/release.yml','utf8')); console.log('release workflow yaml ok')"
- git diff --check
- pre-commit hook: Guardian, Biome, lint/evidence/codegen checks, build, bun compile

Draft until evalops/maestro-internal#2237 lands and the public mirror includes installMetadata in published replay evidence.