### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ versioning when releases are cut.
   and keep scheduled public runs inert so public publishing stays downstream of
   the internal source-of-truth release.
 
+## [0.10.29] - 2026-05-26
+
+### Changed
+
+- Extract native read-only tool batching (#2253). <!-- maestro-release-note:40501a390b70 -->
+- Fix parallel ripgrep error reporting. <!-- maestro-release-note:142d584de5a0 -->
+
 ## [0.10.28] - 2026-05-26
 
 ### Changed

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Maestro Web API",
-    "version": "0.10.28",
+    "version": "0.10.29",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evalops/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
-  "version": "0.10.28",
+  "version": "0.10.29",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/ai",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Shared Maestro AI SDK (models, transport, and agent event stream facade).",
 	"type": "module",
 	"main": "./dist/packages/ai/src/index.js",
@@ -131,8 +131,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.28",
-		"@evalops/tui": "^0.10.28",
+		"@evalops/contracts": "^0.10.29",
+		"@evalops/tui": "^0.10.29",
 		"@google/genai": "^1.29.1",
 		"@sinclair/typebox": "^0.34.0",
 		"nats": "^2.29.3"

--- a/packages/consumer-sdk/package.json
+++ b/packages/consumer-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/consumer",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Unified EvalOps consumer SDK for Maestro service integrations",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -28,7 +28,7 @@
 		"directory": "packages/consumer-sdk"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.28"
+		"@evalops/contracts": "^0.10.29"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/contracts",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Shared Maestro contracts for frontend/backend integration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-core",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Maestro agent loop, transport, types, and sandbox primitives — the engine behind all Maestro interfaces",
 	"type": "module",
 	"main": "./dist/packages/core/src/index.js",
@@ -69,7 +69,7 @@
 		"vscode-jsonrpc": "^8.2.0"
 	},
 	"peerDependencies": {
-		"@evalops/tui": "^0.10.28"
+		"@evalops/tui": "^0.10.29"
 	},
 	"peerDependenciesMeta": {
 		"@evalops/tui": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-desktop",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Maestro Desktop - Beautiful Electron app for AI-assisted development",
 	"type": "module",
 	"main": "dist-electron/main/index.js",
@@ -37,7 +37,7 @@
 		"directory": "packages/desktop"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.28",
+		"@evalops/contracts": "^0.10.29",
 		"electron-store": "^10.0.1",
 		"electron-updater": "^6.3.9"
 	},

--- a/packages/github-agent/package.json
+++ b/packages/github-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/github-agent",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Autonomous GitHub agent - Maestro building Maestro",
 	"type": "module",
 	"bin": {
@@ -36,8 +36,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/ai": "^0.10.28",
-		"@evalops/contracts": "^0.10.28",
+		"@evalops/ai": "^0.10.29",
+		"@evalops/contracts": "^0.10.29",
 		"@octokit/rest": "^21.0.0",
 		"@octokit/webhooks": "^13.0.0",
 		"@sinclair/typebox": "^0.34.0",

--- a/packages/governance-mcp-server/package.json
+++ b/packages/governance-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance-mcp-server",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "MCP server exposing Platform governance proxy tools to any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -43,7 +43,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/governance": "^0.10.28",
+		"@evalops/governance": "^0.10.29",
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"zod": "^4.3.5"
 	},

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Thin Platform governance proxy for MCP-compatible agents.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/memory",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"private": true,
 	"type": "module",
 	"sideEffects": false,

--- a/packages/slack-agent-ui/package.json
+++ b/packages/slack-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent-ui",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Web UI for Slack Agent - Dashboard gallery, connector management, OAuth flows",
 	"type": "module",
 	"private": true,

--- a/packages/slack-agent/package.json
+++ b/packages/slack-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Slack bot agent with Docker sandbox support for Maestro",
 	"type": "module",
 	"bin": {
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@daytonaio/sdk": "^0.139.0",
-		"@evalops/ai": "^0.10.28",
+		"@evalops/ai": "^0.10.29",
 		"@sinclair/typebox": "^0.34.0",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/tui-rs/src/agent/native.rs
+++ b/packages/tui-rs/src/agent/native.rs
@@ -111,13 +111,19 @@ use crate::ai::{
     RequestConfig, Role, StreamEvent, ThinkingConfig, Tool, UnifiedClient,
 };
 use crate::hooks::{HookResult, IntegratedHookSystem};
-use crate::mcp::McpToolAnnotations;
 use crate::safety::{
     apply_workflow_state_hooks, check_model_allowed, ActionFirewall, FirewallContext,
     FirewallVerdict, WorkflowStateTracker,
 };
 use crate::state::QueueMode;
-use crate::tools::{BatchConfig, BatchExecutor, BatchToolCall, ToolExecutor, ToolRegistry};
+use crate::tools::{ToolExecutor, ToolRegistry};
+
+mod read_only_tools;
+
+use self::read_only_tools::{
+    execute_native_read_only_tool_wave, is_explicit_inline_read_only_tool,
+    is_native_parallel_read_only_tool_call, QueuedReadOnlyToolExecution,
+};
 
 fn provider_id(provider: AiProvider) -> &'static str {
     match provider {
@@ -179,125 +185,6 @@ fn emit_compaction_event(
         custom_instructions: None,
         timestamp: Utc::now().to_rfc3339(),
     });
-}
-
-#[derive(Debug)]
-struct QueuedReadOnlyToolExecution {
-    call_id: String,
-    tool_name: String,
-    args: serde_json::Value,
-    safe_args: serde_json::Value,
-    resolved_args: serde_json::Value,
-    extra_context: Option<String>,
-}
-
-fn native_read_only_tool_concurrency_limit() -> usize {
-    std::env::var("MAESTRO_NATIVE_READ_ONLY_TOOL_CONCURRENCY")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .map(|value| value.clamp(1, 16))
-        .unwrap_or(8)
-}
-
-fn native_read_only_batch_config() -> BatchConfig {
-    BatchConfig::default()
-        .with_concurrency(native_read_only_tool_concurrency_limit())
-        .continue_on_error(true)
-        .emit_events(true)
-}
-
-fn is_known_native_read_only_tool(tool_name: &str) -> bool {
-    matches!(
-        tool_name,
-        "read"
-            | "glob"
-            | "grep"
-            | "diff"
-            | "list"
-            | "find"
-            | "search"
-            | "parallel_ripgrep"
-            | "websearch"
-            | "web_fetch"
-            | "webfetch"
-            | "read_image"
-            | "mcp_list_resources"
-            | "mcp_list_prompts"
-            | "mcp_read_resource"
-            | "mcp_get_prompt"
-            | "vscode_get_diagnostics"
-            | "vscode_get_definition"
-            | "vscode_find_references"
-            | "vscode_read_file_range"
-            | "jetbrains_get_diagnostics"
-            | "jetbrains_get_definition"
-            | "jetbrains_find_references"
-            | "jetbrains_read_file_range"
-    )
-}
-
-fn is_native_parallel_read_only_tool_call(
-    tool_name: &str,
-    requires_approval: bool,
-    annotations: Option<&McpToolAnnotations>,
-    explicit_inline_read_only: bool,
-) -> bool {
-    if requires_approval {
-        return false;
-    }
-
-    let tool_key = tool_name.to_lowercase();
-    if is_known_native_read_only_tool(&tool_key) {
-        return true;
-    }
-
-    if tool_key.starts_with("mcp__") {
-        return annotations.is_some_and(|annotation| {
-            annotation.read_only_hint == Some(true) && annotation.destructive_hint != Some(true)
-        });
-    }
-
-    explicit_inline_read_only
-}
-
-fn is_explicit_inline_read_only_tool(tool_name: &str, tool_executor: &ToolExecutor) -> bool {
-    tool_executor.inline_tools().any(|tool| {
-        tool.definition.name.eq_ignore_ascii_case(tool_name)
-            && tool.definition.annotations.read_only
-            && !tool.definition.annotations.destructive
-    })
-}
-
-async fn execute_native_read_only_tool_wave(
-    cwd: &str,
-    event_tx: &mpsc::UnboundedSender<FromAgent>,
-    pending: &[QueuedReadOnlyToolExecution],
-    cancel_token: Option<CancellationToken>,
-) -> HashMap<String, ToolResult> {
-    let calls = pending
-        .iter()
-        .map(|call| {
-            BatchToolCall::new(
-                call.call_id.clone(),
-                call.tool_name.clone(),
-                call.resolved_args.clone(),
-            )
-        })
-        .collect();
-    let batch_executor =
-        BatchExecutor::with_config(cwd.to_string(), native_read_only_batch_config());
-    let results = if let Some(cancel_token) = cancel_token {
-        batch_executor
-            .execute_with_cancel(calls, Some(event_tx.clone()), cancel_token)
-            .await
-    } else {
-        batch_executor.execute(calls, Some(event_tx.clone())).await
-    };
-
-    results
-        .into_iter()
-        .map(|result| (result.call_id, result.result))
-        .collect()
 }
 
 /// Configuration for the native agent
@@ -2810,148 +2697,6 @@ mod tests {
         let err = parse_tool_input("bash", "{invalid").unwrap_err();
         assert!(err.contains("bash"));
         assert!(err.contains("Failed to parse tool input JSON"));
-    }
-
-    #[test]
-    fn test_native_parallel_read_only_classifier_preconditions() {
-        assert!(is_native_parallel_read_only_tool_call(
-            "read", false, None, false
-        ));
-        assert!(!is_native_parallel_read_only_tool_call(
-            "read_probe",
-            false,
-            None,
-            false
-        ));
-        assert!(is_native_parallel_read_only_tool_call(
-            "read_probe",
-            false,
-            None,
-            true
-        ));
-
-        assert!(!is_native_parallel_read_only_tool_call(
-            "write", true, None, true
-        ));
-        assert!(!is_native_parallel_read_only_tool_call(
-            "bash", false, None, false
-        ));
-
-        let read_only_mcp = McpToolAnnotations {
-            read_only_hint: Some(true),
-            destructive_hint: Some(false),
-            ..Default::default()
-        };
-        assert!(is_native_parallel_read_only_tool_call(
-            "mcp__repo__inspect",
-            false,
-            Some(&read_only_mcp),
-            false
-        ));
-
-        let destructive_mcp = McpToolAnnotations {
-            read_only_hint: Some(true),
-            destructive_hint: Some(true),
-            ..Default::default()
-        };
-        assert!(!is_native_parallel_read_only_tool_call(
-            "mcp__repo__mutate",
-            false,
-            Some(&destructive_mcp),
-            true
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_rust_client_read_only_wave_live_pre_post_conditions() {
-        let temp = tempfile::tempdir().unwrap();
-        let composer_dir = temp.path().join(".composer");
-        std::fs::create_dir_all(&composer_dir).unwrap();
-        std::fs::write(
-            composer_dir.join("tools.json"),
-            r#"{
-                "tools": [{
-                    "name": "read_probe",
-                    "description": "Delayed read-only probe for native batching tests",
-                    "command": "sleep 0.08; cat",
-                    "parameters": {
-                        "phase": {"type": "string"},
-                        "index": {"type": "number"}
-                    },
-                    "annotations": {
-                        "readOnly": true
-                    }
-                }]
-            }"#,
-        )
-        .unwrap();
-
-        let pending: Vec<QueuedReadOnlyToolExecution> = (0..4)
-            .map(|index| {
-                let args = serde_json::json!({
-                    "phase": "inspect",
-                    "index": index
-                });
-                QueuedReadOnlyToolExecution {
-                    call_id: format!("inspect-{index}"),
-                    tool_name: "read_probe".to_string(),
-                    args: args.clone(),
-                    safe_args: args.clone(),
-                    resolved_args: args,
-                    extra_context: None,
-                }
-            })
-            .collect();
-
-        let tool_executor = ToolExecutor::new(temp.path().to_str().unwrap());
-        assert_eq!(pending.len(), 4);
-        assert!(pending.iter().all(|call| {
-            is_native_parallel_read_only_tool_call(
-                &call.tool_name,
-                false,
-                None,
-                is_explicit_inline_read_only_tool(&call.tool_name, &tool_executor),
-            )
-        }));
-
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let results =
-            execute_native_read_only_tool_wave(temp.path().to_str().unwrap(), &tx, &pending, None)
-                .await;
-
-        assert_eq!(results.len(), 4);
-        assert!(results.values().all(|result| result.success));
-
-        let mut starts = 0;
-        let mut ends = 0;
-        let mut event_order = Vec::new();
-        while let Ok(event) = rx.try_recv() {
-            match event {
-                FromAgent::ToolStart { .. } => {
-                    starts += 1;
-                    event_order.push("start");
-                }
-                FromAgent::ToolEnd { .. } => {
-                    ends += 1;
-                    event_order.push("end");
-                }
-                _ => {}
-            }
-        }
-        assert_eq!(starts, 4);
-        assert_eq!(ends, 4);
-        let first_end = event_order
-            .iter()
-            .position(|event| *event == "end")
-            .expect("read-only wave should emit a ToolEnd event");
-        let starts_before_first_end = event_order[..first_end]
-            .iter()
-            .filter(|event| **event == "start")
-            .count();
-        assert_eq!(
-            starts_before_first_end, 4,
-            "read-only wave should start every member before the first completion"
-        );
     }
 
     #[tokio::test]

--- a/packages/tui-rs/src/agent/native/read_only_tools.rs
+++ b/packages/tui-rs/src/agent/native/read_only_tools.rs
@@ -1,0 +1,278 @@
+use std::collections::HashMap;
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use super::super::{FromAgent, ToolResult};
+use crate::mcp::McpToolAnnotations;
+use crate::tools::{BatchConfig, BatchExecutor, BatchToolCall, ToolExecutor};
+
+#[derive(Debug)]
+pub(super) struct QueuedReadOnlyToolExecution {
+    pub(super) call_id: String,
+    pub(super) tool_name: String,
+    pub(super) args: serde_json::Value,
+    pub(super) safe_args: serde_json::Value,
+    pub(super) resolved_args: serde_json::Value,
+    pub(super) extra_context: Option<String>,
+}
+
+fn native_read_only_tool_concurrency_limit() -> usize {
+    std::env::var("MAESTRO_NATIVE_READ_ONLY_TOOL_CONCURRENCY")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .map(|value| value.clamp(1, 16))
+        .unwrap_or(8)
+}
+
+fn native_read_only_batch_config() -> BatchConfig {
+    BatchConfig::default()
+        .with_concurrency(native_read_only_tool_concurrency_limit())
+        .continue_on_error(true)
+        .emit_events(true)
+}
+
+fn is_known_native_read_only_tool(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "read"
+            | "glob"
+            | "grep"
+            | "diff"
+            | "list"
+            | "find"
+            | "search"
+            | "parallel_ripgrep"
+            | "websearch"
+            | "web_fetch"
+            | "webfetch"
+            | "read_image"
+            | "mcp_list_resources"
+            | "mcp_list_prompts"
+            | "mcp_read_resource"
+            | "mcp_get_prompt"
+            | "vscode_get_diagnostics"
+            | "vscode_get_definition"
+            | "vscode_find_references"
+            | "vscode_read_file_range"
+            | "jetbrains_get_diagnostics"
+            | "jetbrains_get_definition"
+            | "jetbrains_find_references"
+            | "jetbrains_read_file_range"
+    )
+}
+
+pub(super) fn is_native_parallel_read_only_tool_call(
+    tool_name: &str,
+    requires_approval: bool,
+    annotations: Option<&McpToolAnnotations>,
+    explicit_inline_read_only: bool,
+) -> bool {
+    if requires_approval {
+        return false;
+    }
+
+    let tool_key = tool_name.to_lowercase();
+    if is_known_native_read_only_tool(&tool_key) {
+        return true;
+    }
+
+    if tool_key.starts_with("mcp__") {
+        return annotations.is_some_and(|annotation| {
+            annotation.read_only_hint == Some(true) && annotation.destructive_hint != Some(true)
+        });
+    }
+
+    explicit_inline_read_only
+}
+
+pub(super) fn is_explicit_inline_read_only_tool(
+    tool_name: &str,
+    tool_executor: &ToolExecutor,
+) -> bool {
+    tool_executor.inline_tools().any(|tool| {
+        tool.definition.name.eq_ignore_ascii_case(tool_name)
+            && tool.definition.annotations.read_only
+            && !tool.definition.annotations.destructive
+    })
+}
+
+pub(super) async fn execute_native_read_only_tool_wave(
+    cwd: &str,
+    event_tx: &mpsc::UnboundedSender<FromAgent>,
+    pending: &[QueuedReadOnlyToolExecution],
+    cancel_token: Option<CancellationToken>,
+) -> HashMap<String, ToolResult> {
+    let calls = pending
+        .iter()
+        .map(|call| {
+            BatchToolCall::new(
+                call.call_id.clone(),
+                call.tool_name.clone(),
+                call.resolved_args.clone(),
+            )
+        })
+        .collect();
+    let batch_executor =
+        BatchExecutor::with_config(cwd.to_string(), native_read_only_batch_config());
+    let results = if let Some(cancel_token) = cancel_token {
+        batch_executor
+            .execute_with_cancel(calls, Some(event_tx.clone()), cancel_token)
+            .await
+    } else {
+        batch_executor.execute(calls, Some(event_tx.clone())).await
+    };
+
+    results
+        .into_iter()
+        .map(|result| (result.call_id, result.result))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::McpToolAnnotations;
+
+    #[test]
+    fn test_native_parallel_read_only_classifier_preconditions() {
+        assert!(is_native_parallel_read_only_tool_call(
+            "read", false, None, false
+        ));
+        assert!(!is_native_parallel_read_only_tool_call(
+            "read_probe",
+            false,
+            None,
+            false
+        ));
+        assert!(is_native_parallel_read_only_tool_call(
+            "read_probe",
+            false,
+            None,
+            true
+        ));
+
+        assert!(!is_native_parallel_read_only_tool_call(
+            "write", true, None, true
+        ));
+        assert!(!is_native_parallel_read_only_tool_call(
+            "bash", false, None, false
+        ));
+
+        let read_only_mcp = McpToolAnnotations {
+            read_only_hint: Some(true),
+            destructive_hint: Some(false),
+            ..Default::default()
+        };
+        assert!(is_native_parallel_read_only_tool_call(
+            "mcp__repo__inspect",
+            false,
+            Some(&read_only_mcp),
+            false
+        ));
+
+        let destructive_mcp = McpToolAnnotations {
+            read_only_hint: Some(true),
+            destructive_hint: Some(true),
+            ..Default::default()
+        };
+        assert!(!is_native_parallel_read_only_tool_call(
+            "mcp__repo__mutate",
+            false,
+            Some(&destructive_mcp),
+            true
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_rust_client_read_only_wave_live_pre_post_conditions() {
+        let temp = tempfile::tempdir().unwrap();
+        let composer_dir = temp.path().join(".composer");
+        std::fs::create_dir_all(&composer_dir).unwrap();
+        std::fs::write(
+            composer_dir.join("tools.json"),
+            r#"{
+                "tools": [{
+                    "name": "read_probe",
+                    "description": "Delayed read-only probe for native batching tests",
+                    "command": "sleep 0.08; cat",
+                    "parameters": {
+                        "phase": {"type": "string"},
+                        "index": {"type": "number"}
+                    },
+                    "annotations": {
+                        "readOnly": true
+                    }
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        let pending: Vec<QueuedReadOnlyToolExecution> = (0..4)
+            .map(|index| {
+                let args = serde_json::json!({
+                    "phase": "inspect",
+                    "index": index
+                });
+                QueuedReadOnlyToolExecution {
+                    call_id: format!("inspect-{index}"),
+                    tool_name: "read_probe".to_string(),
+                    args: args.clone(),
+                    safe_args: args.clone(),
+                    resolved_args: args,
+                    extra_context: None,
+                }
+            })
+            .collect();
+
+        let tool_executor = ToolExecutor::new(temp.path().to_str().unwrap());
+        assert_eq!(pending.len(), 4);
+        assert!(pending.iter().all(|call| {
+            is_native_parallel_read_only_tool_call(
+                &call.tool_name,
+                false,
+                None,
+                is_explicit_inline_read_only_tool(&call.tool_name, &tool_executor),
+            )
+        }));
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let results =
+            execute_native_read_only_tool_wave(temp.path().to_str().unwrap(), &tx, &pending, None)
+                .await;
+
+        assert_eq!(results.len(), 4);
+        assert!(results.values().all(|result| result.success));
+
+        let mut starts = 0;
+        let mut ends = 0;
+        let mut event_order = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                FromAgent::ToolStart { .. } => {
+                    starts += 1;
+                    event_order.push("start");
+                }
+                FromAgent::ToolEnd { .. } => {
+                    ends += 1;
+                    event_order.push("end");
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(starts, 4);
+        assert_eq!(ends, 4);
+        let first_end = event_order
+            .iter()
+            .position(|event| *event == "end")
+            .expect("read-only wave should emit a ToolEnd event");
+        let starts_before_first_end = event_order[..first_end]
+            .iter()
+            .filter(|event| **event == "start")
+            .count();
+        assert_eq!(
+            starts_before_first_end, 4,
+            "read-only wave should start every member before the first completion"
+        );
+    }
+}

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/tui",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Terminal UI library with differential rendering for Maestro",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Maestro",
 	"description": "Use Maestro's deterministic AI assistant inside VS Code.",
 	"publisher": "evalops",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"license": "MIT",
 	"type": "commonjs",
 	"main": "./dist/extension.js",
@@ -139,7 +139,7 @@
 		"test": "vitest --run"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.28"
+		"@evalops/contracts": "^0.10.29"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-web",
-	"version": "0.10.28",
+	"version": "0.10.29",
 	"description": "Web UI for Maestro - Browser-based AI coding assistant interface",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,7 +24,7 @@
 		"directory": "packages/web"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.28",
+		"@evalops/contracts": "^0.10.29",
 		"docx-preview": "^0.3.7",
 		"dompurify": "^3.3.0",
 		"exceljs": "^4.4.0",

--- a/src/tools/parallel-ripgrep.ts
+++ b/src/tools/parallel-ripgrep.ts
@@ -37,6 +37,17 @@ const RANGE_DETAIL_LIMIT = 200;
 /** Default max matches per pattern (prevents runaway searches) */
 const DEFAULT_MAX_RESULTS = 500;
 
+function shellQuoteArg(value: string): string {
+	if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
+		return value;
+	}
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function formatRipgrepCommand(args: string[]): string {
+	return ["rg", ...args].map(shellQuoteArg).join(" ");
+}
+
 const parallelRipgrepSchema = Type.Object({
 	patterns: Type.Array(Type.String({ minLength: 1 }), {
 		minItems: 1,
@@ -388,7 +399,7 @@ export const parallelRipgrepTool = createTool<
 		let truncatedByBytes = false;
 		const ripgrepCalls = patterns.map(async (pattern) => {
 			const args = [...baseArgs, "--", pattern, ...pathArgs];
-			commands.push(["rg", ...args].join(" "));
+			commands.push(formatRipgrepCommand(args));
 			const result = await runRipgrep(args, signal, commandCwd);
 			truncatedByBytes ||= result.truncated;
 			return { pattern, result };
@@ -405,7 +416,7 @@ export const parallelRipgrepTool = createTool<
 				error instanceof Error
 					? error.message
 					: `Unknown error: ${String(error)}`;
-			return respond.text(`ripgrep failed\n\n${reason}`).detail({
+			return respond.error(`ripgrep failed\n\n${reason}`).detail({
 				commands,
 				cwd: commandCwd,
 				matchCount: 0,

--- a/test/tools/parallel-ripgrep.test.ts
+++ b/test/tools/parallel-ripgrep.test.ts
@@ -212,6 +212,28 @@ function goodbye() {
 			const output = getTextOutput(result);
 			expect(output).toContain("match");
 		});
+
+		it("quotes shell-sensitive command details", async () => {
+			const spacedDir = join(testDir, "space dir");
+			mkdirSync(spacedDir);
+			writeFileSync(
+				join(spacedDir, "literal.ts"),
+				"const value = 'hello world';",
+			);
+
+			const result = await parallelRipgrepTool.execute("prg-13-quoted", {
+				patterns: ["hello world"],
+				paths: [spacedDir],
+				glob: "*.ts",
+				literal: true,
+			});
+
+			expect(result.isError).toBeFalsy();
+			const command = result.details?.commands.at(0);
+			expect(command).toContain("--glob '*.ts'");
+			expect(command).toContain("-- 'hello world'");
+			expect(command).toContain(`'${spacedDir}'`);
+		});
 	});
 
 	describe("hidden files and gitignore", () => {
@@ -281,6 +303,23 @@ function goodbye() {
 					paths: ["/nonexistent/path/xyz"],
 				}),
 			).rejects.toThrow(/No such file or directory|IO error/);
+		});
+
+		it("marks ripgrep startup failures as tool errors", async () => {
+			const result = await parallelRipgrepTool.execute("prg-20", {
+				patterns: ["hello"],
+				paths: ["."],
+				cwd: join(testDir, "missing-cwd"),
+			});
+
+			expect(result.isError).toBe(true);
+			expect(getTextOutput(result)).toContain("ripgrep failed");
+			expect(result.details).toMatchObject({
+				matchCount: 0,
+				rangeCount: 0,
+				ranges: [],
+				truncated: false,
+			});
 		});
 	});
 });


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"99f18e5a9843fb3188080e1e798348555179661e"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `99f18e5a9843fb3188080e1e798348555179661e`
- last generated public sync base: `5c55b7330975ed271dc5f787ad64e960fc67f618`
- previewed public-tree drift: `21` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `3`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (99f18e5a9843)`
- public projection: `https://github.com/evalops/maestro@main (4ada0ec22b84)`
- files to copy or update: `21`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update CHANGELOG.md
- copy/update openapi.json
- copy/update package.json
- copy/update packages/ai/package.json
- copy/update packages/consumer-sdk/package.json
- copy/update packages/contracts/package.json
- copy/update packages/core/package.json
- copy/update packages/desktop/package.json
- copy/update packages/github-agent/package.json
- copy/update packages/governance-mcp-server/package.json
- copy/update packages/governance/package.json
- copy/update packages/memory/package.json
- copy/update packages/slack-agent-ui/package.json
- copy/update packages/slack-agent/package.json
- copy/update packages/tui-rs/src/agent/native.rs
- copy/update packages/tui-rs/src/agent/native/read_only_tools.rs
- copy/update packages/tui/package.json
- copy/update packages/vscode-extension/package.json
- copy/update packages/web/package.json
- copy/update src/tools/parallel-ripgrep.ts
- copy/update test/tools/parallel-ripgrep.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update CHANGELOG.md
- copy/update openapi.json
- copy/update package.json
- copy/update packages/ai/package.json
- copy/update packages/consumer-sdk/package.json
- copy/update packages/contracts/package.json
- copy/update packages/core/package.json
- copy/update packages/desktop/package.json
- copy/update packages/github-agent/package.json
- copy/update packages/governance-mcp-server/package.json
- copy/update packages/governance/package.json
- copy/update packages/memory/package.json
- copy/update packages/slack-agent-ui/package.json
- copy/update packages/slack-agent/package.json
- copy/update packages/tui-rs/src/agent/native.rs
- copy/update packages/tui-rs/src/agent/native/read_only_tools.rs
- copy/update packages/tui/package.json
- copy/update packages/vscode-extension/package.json
- copy/update packages/web/package.json
- copy/update src/tools/parallel-ripgrep.ts

## Public-only commits since last generated sync

- 4ada0ec2 Merge pull request #622 from evalops/codex/deprecate-message-cutover-fix-20260526
- 2cf44a01 Merge pull request #621 from evalops/codex/deprecate-release-workflow-fix-20260526
- 7f02bd81 Merge pull request #619 from evalops/codex/deprecate-release-workflow-20260526

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@99f18e5a9843fb3188080e1e798348555179661e`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #620 to internal source `99f18e5a9843fb3188080e1e798348555179661e`