### PR TITLE
Fix deprecation workflow package default

### DIFF
--- a/.github/workflows/deprecate-release.yml
+++ b/.github/workflows/deprecate-release.yml
@@ -49,7 +49,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - id: defaults
-        run: echo "package_name=$(node -p 'require(\"./package.json\").name')" >> "$GITHUB_OUTPUT"
+        run: node -e "process.stdout.write('package_name=' + require('./package.json').name + '\n')" >> "$GITHUB_OUTPUT"
 
       - name: Validate deprecation target
         env:


### PR DESCRIPTION
## Summary
- fix the `deprecate-release` workflow default package-name step so Node receives `require('./package.json')` without escaped quotes
- this unblocks the dry-run preflight path that failed after #619 landed

## Validation
- `actionlint .github/workflows/deprecate-release.yml`
- local Node output check for `package_name=@evalops/maestro`
- `git diff --check`
- commit hook: guardian + `bunx biome check . && bun run lint:evals` + build/compile

## Follow-up evidence
- Failed dry-run before this patch: https://github.com/evalops/maestro/actions/runs/26433479133
