### PR TITLE
Fix deprecate workflow cutover check

### DIFF
--- a/.github/workflows/deprecate-release.yml
+++ b/.github/workflows/deprecate-release.yml
@@ -16,7 +16,7 @@ on:
       message:
         description: Deprecation message.
         required: false
-        default: "Broken release: install @evalops/maestro@0.10.26 or newer."
+        default: "Broken release: install version 0.10.26 or newer of this package."
         type: string
       dry_run:
         description: Print the npm deprecate command without changing npm.


### PR DESCRIPTION
## Summary
- remove the hard-coded package alias from the public-only deprecate-release workflow default message
- keep the deprecation package target flowing through the existing package_name input

## Test plan
- npm run cutover:check
- git diff --check