### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/agent/transport.ts
+++ b/src/agent/transport.ts
@@ -108,6 +108,7 @@ import {
 } from "./transport/reusable-tool-results.js";
 import type { PlatformToolExecutionBridge } from "./transport/tool-execution-bridge.js";
 import { createToolExecutionPromise } from "./transport/tool-execution.js";
+import { buildToolPhaseSummaryEvent } from "./transport/tool-phase-summary.js";
 import {
 	type ToolSafetyVerdict,
 	evaluateToolSafety,
@@ -1331,153 +1332,8 @@ export class ProviderTransport implements AgentTransport {
 					toolDef.source.supportsParallelToolCalls === true &&
 					toolDef.annotations?.destructiveHint !== true;
 
-				const buildToolPhaseSummary = ():
-					| Extract<AgentEvent, { type: "tool_phase_summary" }>
-					| undefined => {
-					const rawDecisions = [...toolSchedulingDecisions.values()].sort(
-						(left, right) => left.emittedIndex - right.emittedIndex,
-					);
-					if (rawDecisions.length === 0) {
-						return undefined;
-					}
-					const waveCounts = new Map<number, number>();
-					for (const decision of rawDecisions) {
-						if (decision.waveIndex !== undefined) {
-							waveCounts.set(
-								decision.waveIndex,
-								(waveCounts.get(decision.waveIndex) ?? 0) + 1,
-							);
-						}
-					}
-					const decisions: Extract<
-						AgentEvent,
-						{ type: "tool_phase_summary" }
-					>["decisions"] = rawDecisions.map((decision) => {
-						const isSingleModelToolCall = rawDecisions.length === 1;
-						const waveSize =
-							decision.waveIndex !== undefined
-								? (waveCounts.get(decision.waveIndex) ?? 1)
-								: 1;
-						const outcome =
-							decision.cacheHit === true
-								? "cached"
-								: decision.decision === "skipped"
-									? "skipped"
-									: decision.decision === "delayed" ||
-											decision.blockedByMutation === true
-										? "delayed"
-										: decision.decision === "parallelized" ||
-												(waveSize > 1 && decision.decision === "scheduled")
-											? "parallelized"
-											: "serialized";
-						const reason =
-							outcome === "cached"
-								? "cache_hit"
-								: decision.blockedByMutation === true
-									? decision.reason
-									: decision.reason === "workflow_state_serialized"
-										? "workflow_state_serialized"
-										: decision.mcpOptIn === true
-											? "mcp_parallel_opt_in"
-											: decision.reason.startsWith("read_only")
-												? outcome === "parallelized"
-													? "read_only_parallel_safe"
-													: isSingleModelToolCall
-														? "single_read_only_call"
-														: decision.reason
-												: decision.reason.startsWith("path_scoped_mutation")
-													? "path_scoped_mutation"
-													: decision.reason;
-						return {
-							toolCallId: decision.callId,
-							toolName: decision.toolName,
-							emittedIndex: decision.emittedIndex,
-							outcome,
-							decision: outcome,
-							reason,
-							waveIndex:
-								decision.waveIndex !== undefined
-									? Math.max(0, decision.waveIndex - 1)
-									: undefined,
-							waitMs: Math.max(0, Math.round(decision.schedulerWaitMs ?? 0)),
-							schedulerWaitMs: Math.max(
-								0,
-								Math.round(decision.schedulerWaitMs ?? 0),
-							),
-							mcpOptIn: decision.mcpOptIn,
-							cacheHit: decision.cacheHit,
-							blockedByMutation: decision.blockedByMutation,
-						};
-					});
-					const parallelizedCallCount = decisions.filter(
-						(decision) => decision.outcome === "parallelized",
-					).length;
-					const delayedCallCount = decisions.filter(
-						(decision) => decision.outcome === "delayed",
-					).length;
-					const batchShapingFeedback =
-						decisions.length === 1 &&
-						decisions[0]?.reason === "single_read_only_call"
-							? {
-									avoidableSingleton: true,
-									reason: "single_read_only_call",
-									hint: "When you need several independent reads or searches, emit them together in one assistant message so Maestro can batch them safely.",
-								}
-							: undefined;
-					const serializationReasons = Object.fromEntries(
-						[...decisions]
-							.filter(
-								(decision) =>
-									decision.outcome === "serialized" ||
-									decision.outcome === "delayed",
-							)
-							.reduce((counts, decision) => {
-								counts.set(
-									decision.reason,
-									(counts.get(decision.reason) ?? 0) + 1,
-								);
-								return counts;
-							}, new Map<string, number>()),
-					);
-
-					return {
-						type: "tool_phase_summary",
-						modelToolCallCount: rawDecisions.length,
-						modelEmittedToolCallCount: rawDecisions.length,
-						schedulableWaveCount: waveCounts.size,
-						parallelizedCallCount,
-						actuallyParallelizedCallCount: parallelizedCallCount,
-						serializedCallCount: decisions.filter(
-							(decision) =>
-								decision.outcome === "serialized" ||
-								decision.outcome === "delayed",
-						).length,
-						delayedCallCount,
-						blockedByMutationCount: decisions.filter(
-							(decision) => decision.blockedByMutation === true,
-						).length,
-						mcpOptInCallCount: decisions.filter(
-							(decision) => decision.mcpOptIn === true,
-						).length,
-						mcpOptInUseCount: decisions.filter(
-							(decision) => decision.mcpOptIn === true,
-						).length,
-						cacheHitCount: decisions.filter(
-							(decision) => decision.cacheHit === true,
-						).length,
-						totalToolWaitMs: decisions.reduce(
-							(total, decision) => total + decision.waitMs,
-							0,
-						),
-						toolWaitTimeMs: decisions.reduce(
-							(total, decision) => total + decision.waitMs,
-							0,
-						),
-						serializationReasons,
-						decisions,
-						batchShapingFeedback,
-					};
-				};
+				const buildToolPhaseSummary = () =>
+					buildToolPhaseSummaryEvent(toolSchedulingDecisions.values());
 
 				const getMutationScope = (
 					toolCall: ToolCall,

--- a/src/agent/transport/tool-phase-summary.ts
+++ b/src/agent/transport/tool-phase-summary.ts
@@ -1,0 +1,145 @@
+import type { AgentEvent, ToolSchedulingDecision } from "../types.js";
+
+export type ToolPhaseSummaryEvent = Extract<
+	AgentEvent,
+	{ type: "tool_phase_summary" }
+>;
+
+export function buildToolPhaseSummaryEvent(
+	decisionsByToolCall: Iterable<ToolSchedulingDecision>,
+): ToolPhaseSummaryEvent | undefined {
+	const rawDecisions = [...decisionsByToolCall].sort(
+		(left, right) => left.emittedIndex - right.emittedIndex,
+	);
+	if (rawDecisions.length === 0) {
+		return undefined;
+	}
+
+	const waveCounts = new Map<number, number>();
+	for (const decision of rawDecisions) {
+		if (decision.waveIndex !== undefined) {
+			waveCounts.set(
+				decision.waveIndex,
+				(waveCounts.get(decision.waveIndex) ?? 0) + 1,
+			);
+		}
+	}
+
+	const decisions: ToolPhaseSummaryEvent["decisions"] = rawDecisions.map(
+		(decision) => {
+			const isSingleModelToolCall = rawDecisions.length === 1;
+			const waveSize =
+				decision.waveIndex !== undefined
+					? (waveCounts.get(decision.waveIndex) ?? 1)
+					: 1;
+			const outcome =
+				decision.cacheHit === true
+					? "cached"
+					: decision.decision === "skipped"
+						? "skipped"
+						: decision.decision === "delayed" ||
+								decision.blockedByMutation === true
+							? "delayed"
+							: decision.decision === "parallelized" ||
+									(waveSize > 1 && decision.decision === "scheduled")
+								? "parallelized"
+								: "serialized";
+			const reason =
+				outcome === "cached"
+					? "cache_hit"
+					: decision.blockedByMutation === true
+						? decision.reason
+						: decision.reason === "workflow_state_serialized"
+							? "workflow_state_serialized"
+							: decision.mcpOptIn === true
+								? "mcp_parallel_opt_in"
+								: decision.reason.startsWith("read_only")
+									? outcome === "parallelized"
+										? "read_only_parallel_safe"
+										: isSingleModelToolCall
+											? "single_read_only_call"
+											: decision.reason
+									: decision.reason.startsWith("path_scoped_mutation")
+										? "path_scoped_mutation"
+										: decision.reason;
+			return {
+				toolCallId: decision.callId,
+				toolName: decision.toolName,
+				emittedIndex: decision.emittedIndex,
+				outcome,
+				decision: outcome,
+				reason,
+				waveIndex:
+					decision.waveIndex !== undefined
+						? Math.max(0, decision.waveIndex - 1)
+						: undefined,
+				waitMs: Math.max(0, Math.round(decision.schedulerWaitMs ?? 0)),
+				schedulerWaitMs: Math.max(0, Math.round(decision.schedulerWaitMs ?? 0)),
+				mcpOptIn: decision.mcpOptIn,
+				cacheHit: decision.cacheHit,
+				blockedByMutation: decision.blockedByMutation,
+			};
+		},
+	);
+
+	const parallelizedCallCount = decisions.filter(
+		(decision) => decision.outcome === "parallelized",
+	).length;
+	const delayedCallCount = decisions.filter(
+		(decision) => decision.outcome === "delayed",
+	).length;
+	const batchShapingFeedback =
+		decisions.length === 1 && decisions[0]?.reason === "single_read_only_call"
+			? {
+					avoidableSingleton: true,
+					reason: "single_read_only_call",
+					hint: "When you need several independent reads or searches, emit them together in one assistant message so Maestro can batch them safely.",
+				}
+			: undefined;
+	const serializationReasons = Object.fromEntries(
+		[...decisions]
+			.filter(
+				(decision) =>
+					decision.outcome === "serialized" || decision.outcome === "delayed",
+			)
+			.reduce((counts, decision) => {
+				counts.set(decision.reason, (counts.get(decision.reason) ?? 0) + 1);
+				return counts;
+			}, new Map<string, number>()),
+	);
+
+	return {
+		type: "tool_phase_summary",
+		modelToolCallCount: rawDecisions.length,
+		modelEmittedToolCallCount: rawDecisions.length,
+		schedulableWaveCount: waveCounts.size,
+		parallelizedCallCount,
+		actuallyParallelizedCallCount: parallelizedCallCount,
+		serializedCallCount: decisions.filter(
+			(decision) =>
+				decision.outcome === "serialized" || decision.outcome === "delayed",
+		).length,
+		delayedCallCount,
+		blockedByMutationCount: decisions.filter(
+			(decision) => decision.blockedByMutation === true,
+		).length,
+		mcpOptInCallCount: decisions.filter(
+			(decision) => decision.mcpOptIn === true,
+		).length,
+		mcpOptInUseCount: decisions.filter((decision) => decision.mcpOptIn === true)
+			.length,
+		cacheHitCount: decisions.filter((decision) => decision.cacheHit === true)
+			.length,
+		totalToolWaitMs: decisions.reduce(
+			(total, decision) => total + decision.waitMs,
+			0,
+		),
+		toolWaitTimeMs: decisions.reduce(
+			(total, decision) => total + decision.waitMs,
+			0,
+		),
+		serializationReasons,
+		decisions,
+		batchShapingFeedback,
+	};
+}


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"58824b84397c0b1097ec8e694fa1cd867d09651a"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `58824b84397c0b1097ec8e694fa1cd867d09651a`
- last generated public sync base: `c94b873918efeb89187c73dad187f3fc27d23f49`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (58824b84397c)`
- public projection: `https://github.com/evalops/maestro@main (c94b873918ef)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/agent/transport.ts
- copy/update src/agent/transport/tool-phase-summary.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/agent/transport.ts
- copy/update src/agent/transport/tool-phase-summary.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@58824b84397c0b1097ec8e694fa1cd867d09651a`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.