### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/tui-rs/src/tools/shell_env.rs
+++ b/packages/tui-rs/src/tools/shell_env.rs
@@ -118,7 +118,11 @@ fn platform_trusted_tool_env_policy_allows_key(
                 return false;
             }
         }
-        if let Some(patterns) = policy.include_only.as_ref() {
+        if let Some(patterns) = policy
+            .include_only
+            .as_ref()
+            .filter(|patterns| !patterns.is_empty())
+        {
             if !matches_any(key, patterns) {
                 return false;
             }
@@ -201,7 +205,7 @@ where
         }
     }
 
-    if let Some(patterns) = include_only {
+    if let Some(patterns) = include_only.filter(|patterns| !patterns.is_empty()) {
         let keys: Vec<String> = env.keys().cloned().collect();
         for key in keys {
             if !matches_any(&key, patterns) {
@@ -415,6 +419,26 @@ mod tests {
             Some(&"worker-git-credential".to_string())
         );
         assert!(!env.contains_key("GITHUB_TOKEN"));
+    }
+
+    #[test]
+    fn test_platform_trusted_tool_env_ignores_empty_include_only() {
+        let base = env(&[
+            ("PATH", "/bin"),
+            ("MAESTRO_SURFACE", PLATFORM_WORKER_SURFACE),
+            (PLATFORM_TRUSTED_TOOL_ENV_FLAG, "true"),
+            ("GH_TOKEN", "worker-git-credential"),
+        ]);
+        let policy = ShellEnvironmentPolicy {
+            include_only: Some(vec![]),
+            ..Default::default()
+        };
+        let env = build_shell_environment(base, Some(&policy), None);
+        assert_eq!(env.get("PATH"), Some(&"/bin".to_string()));
+        assert_eq!(
+            env.get("GH_TOKEN"),
+            Some(&"worker-git-credential".to_string())
+        );
     }
 
     #[test]

--- a/test/tools/shell-utils.test.ts
+++ b/test/tools/shell-utils.test.ts
@@ -363,6 +363,20 @@ describe("shell-utils", () => {
 			expect(env.GH_TOKEN).toBeUndefined();
 		});
 
+		it("restores scoped tool credentials when include_only policy is empty", () => {
+			const baseEnv = {
+				PATH: "/usr/bin",
+				MAESTRO_SURFACE: "platform-agent-runtime",
+				MAESTRO_PLATFORM_TRUSTED_TOOL_ENV: "true",
+				GH_TOKEN: SAMPLE_GH_TOKEN,
+			};
+			const env = applyShellEnvironmentPolicy(baseEnv, {
+				include_only: [],
+			});
+			expect(env.PATH).toBe("/usr/bin");
+			expect(env.GH_TOKEN).toBe(baseEnv.GH_TOKEN);
+		});
+
 		it("keeps secret-like variables when ignore_default_excludes is true", () => {
 			const baseEnv = {
 				OPENAI_API_KEY: "sk-test",


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"de6b9af4b25f5a14f16199a6d78ce8d9a4eb4097"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `de6b9af4b25f5a14f16199a6d78ce8d9a4eb4097`
- last generated public sync base: `2f8c9925935e7953fed5a719b0b53afa092a2b39`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (de6b9af4b25f)`
- public projection: `https://github.com/evalops/maestro@main (2f8c9925935e)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/tui-rs/src/tools/shell_env.rs
- copy/update test/tools/shell-utils.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/tui-rs/src/tools/shell_env.rs
- copy/update test/tools/shell-utils.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@de6b9af4b25f5a14f16199a6d78ce8d9a4eb4097`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.