### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/a2a-fleet-delegation.md
+++ b/docs/protocols/a2a-fleet-delegation.md
@@ -41,12 +41,18 @@ present. `MAESTRO_A2A_PLATFORM_REGISTER=0` disables the loop, while
 the same A2A projection as `maestro a2a register`, updates an existing
 `MAESTRO_A2A_AGENT_ID` on conflict, and heartbeats the Agent Card, governed
 child-agent skills, current objective IDs, capacity hint, and endpoint URLs on a
-bounded interval. Hosted default registration requires `MAESTRO_A2A_PUBLIC_URL`
-or `MAESTRO_A2A_PUBLIC_HOST`/`MAESTRO_CONTROL_PUBLIC_HOST` so Platform does not
-publish an unroutable local bind address; explicit opt-in can still use local
-fallbacks for development. When no workspace ID is configured, the loop falls
-back to the organization ID, matching the rest of the Platform client behavior.
-Missing Platform configuration leaves local/offline Maestro unchanged.
+bounded interval. It sends organization, workspace, agent, and optional actor
+headers on every registration and heartbeat request. When `MAESTRO_A2A_TRACEPARENT`
+or `MAESTRO_PLATFORM_TRACEPARENT` is present, the loop also forwards
+`traceparent`/`tracestate` headers and mirrors those values into the A2A
+projection attributes so Platform discovery, heartbeats, and later task
+delegations can join the same trace. Hosted default registration requires
+`MAESTRO_A2A_PUBLIC_URL` or `MAESTRO_A2A_PUBLIC_HOST`/`MAESTRO_CONTROL_PUBLIC_HOST`
+so Platform does not publish an unroutable local bind address; explicit opt-in
+can still use local fallbacks for development. When no workspace ID is configured,
+the loop falls back to the organization ID, matching the rest of the Platform
+client behavior. Missing Platform configuration leaves local/offline Maestro
+unchanged.
 
 `delegate` sends a normal A2A `message:send` request with Maestro delegation
 metadata: origin, peer name, role, and working directory. The resulting task is

--- a/packages/control-plane-rs/src/a2a_platform_registration.rs
+++ b/packages/control-plane-rs/src/a2a_platform_registration.rs
@@ -160,6 +160,7 @@ pub(crate) fn resolve_a2a_platform_registration_config(
         "EVALOPS_AGENT_ID",
     ])
     .unwrap_or_else(|| default_a2a_platform_agent_id(config));
+    let (traceparent, tracestate) = trace_context_from_env();
 
     Ok(Some(A2APlatformRegistrationConfig {
         base_url: normalize_platform_base_url(&base_url.expect("base URL presence checked above")),
@@ -207,8 +208,8 @@ pub(crate) fn resolve_a2a_platform_registration_config(
         surface: trimmed_env("MAESTRO_A2A_PLATFORM_SURFACE").unwrap_or_else(|| "a2a".to_string()),
         surface_type: trimmed_env("MAESTRO_A2A_PLATFORM_SURFACE_TYPE")
             .unwrap_or_else(|| "SURFACE_MAESTRO".to_string()),
-        traceparent: first_trimmed_env(&["TRACEPARENT", "TRACE_PARENT", "MAESTRO_TRACEPARENT"]),
-        tracestate: first_trimmed_env(&["TRACESTATE", "TRACE_STATE", "MAESTRO_TRACESTATE"]),
+        traceparent,
+        tracestate,
         remote_runner_session_id: first_trimmed_env(&[
             "MAESTRO_REMOTE_RUNNER_SESSION_ID",
             "MAESTRO_RUNNER_SESSION_ID",
@@ -287,12 +288,16 @@ fn post_platform_connect_json(
         .header("Content-Type", "application/json")
         .header("Connect-Protocol-Version", "1")
         .header("X-Organization-ID", &registration.organization_id)
-        .header("X-Workspace-ID", &registration.workspace_id);
+        .header("X-Workspace-ID", &registration.workspace_id)
+        .header("X-EvalOps-Agent-ID", &registration.agent_id);
+    if let Some(owner_id) = registration.owner_id.as_deref() {
+        request = request.header("X-EvalOps-Actor-ID", owner_id);
+    }
     if let Some(traceparent) = registration.traceparent.as_deref() {
         request = request.header("traceparent", traceparent);
-    }
-    if let Some(tracestate) = registration.tracestate.as_deref() {
-        request = request.header("tracestate", tracestate);
+        if let Some(tracestate) = registration.tracestate.as_deref() {
+            request = request.header("tracestate", tracestate);
+        }
     }
     let response = request
         .json(body)
@@ -425,6 +430,30 @@ fn a2a_platform_peer_projection(
     insert_string(&mut attributes, "controlPlane", Some("rust-control-plane"));
     insert_string(
         &mut attributes,
+        "organizationId",
+        Some(&registration.organization_id),
+    );
+    insert_string(
+        &mut attributes,
+        "workspaceId",
+        Some(&registration.workspace_id),
+    );
+    insert_string(&mut attributes, "agentId", Some(&registration.agent_id));
+    insert_string(&mut attributes, "actorId", registration.owner_id.as_deref());
+    insert_string(
+        &mut attributes,
+        "traceparent",
+        registration.traceparent.as_deref(),
+    );
+    if registration.traceparent.is_some() {
+        insert_string(
+            &mut attributes,
+            "tracestate",
+            registration.tracestate.as_deref(),
+        );
+    }
+    insert_string(
+        &mut attributes,
         "operatingPlaneExtension",
         Some(EVALOPS_A2A_EXTENSION_URI),
     );
@@ -442,16 +471,6 @@ fn a2a_platform_peer_projection(
         &mut attributes,
         "publishedBy",
         Some("maestro-control-plane-auto-registration"),
-    );
-    insert_string(
-        &mut attributes,
-        "traceparent",
-        registration.traceparent.as_deref(),
-    );
-    insert_string(
-        &mut attributes,
-        "tracestate",
-        registration.tracestate.as_deref(),
     );
     insert_string(
         &mut attributes,
@@ -619,6 +638,27 @@ pub(crate) fn normalize_platform_base_url(base_url: &str) -> String {
 
 fn first_trimmed_env(names: &[&str]) -> Option<String> {
     names.iter().find_map(|name| trimmed_env(name))
+}
+
+fn trace_context_from_env() -> (Option<String>, Option<String>) {
+    const TRACE_CONTEXT_CANDIDATES: &[(&str, &[&str])] = &[
+        ("MAESTRO_A2A_TRACEPARENT", &["MAESTRO_A2A_TRACESTATE"]),
+        (
+            "MAESTRO_PLATFORM_TRACEPARENT",
+            &["MAESTRO_PLATFORM_TRACESTATE"],
+        ),
+        ("TRACEPARENT", &["TRACESTATE", "TRACE_STATE"]),
+        ("TRACE_PARENT", &["TRACESTATE", "TRACE_STATE"]),
+        ("MAESTRO_TRACEPARENT", &["MAESTRO_TRACESTATE"]),
+    ];
+
+    for (traceparent_name, tracestate_names) in TRACE_CONTEXT_CANDIDATES {
+        if let Some(traceparent) = trimmed_env(traceparent_name) {
+            return (Some(traceparent), first_trimmed_env(tracestate_names));
+        }
+    }
+
+    (None, None)
 }
 
 fn env_bool(name: &str) -> Option<bool> {

--- a/packages/control-plane-rs/src/tests.rs
+++ b/packages/control-plane-rs/src/tests.rs
@@ -50,6 +50,12 @@ const A2A_PLATFORM_ENV_NAMES: &[&str] = &[
     "MAESTRO_A2A_AGENT_TYPE",
     "MAESTRO_A2A_OWNER_ID",
     "EVALOPS_USER_ID",
+    "MAESTRO_A2A_TRACEPARENT",
+    "MAESTRO_PLATFORM_TRACEPARENT",
+    "TRACEPARENT",
+    "MAESTRO_A2A_TRACESTATE",
+    "MAESTRO_PLATFORM_TRACESTATE",
+    "TRACESTATE",
     "MAESTRO_A2A_INTERNAL_URL",
     "MAESTRO_CONTROL_INTERNAL_URL",
     "MAESTRO_A2A_AGENT_CARD_URL",
@@ -225,6 +231,11 @@ fn a2a_platform_registration_config_uses_platform_env_and_stable_endpoint() {
     env::set_var("MAESTRO_A2A_PUBLIC_URL", "https://maestro.example/a2a/");
     env::set_var("MAESTRO_A2A_INTERNAL_URL", "http://maestro.mesh/a2a");
     env::set_var("MAESTRO_A2A_AGENT_ID", "maestro-peer-1");
+    env::set_var(
+        "MAESTRO_A2A_TRACEPARENT",
+        "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+    );
+    env::set_var("MAESTRO_A2A_TRACESTATE", "evalops=maestro");
     env::set_var("MAESTRO_A2A_CURRENT_OBJECTIVE_IDS", "obj_1, obj_2");
     env::set_var("MAESTRO_A2A_PLATFORM_HEARTBEAT_INTERVAL_MS", "1234");
     env::set_var(
@@ -257,19 +268,106 @@ fn a2a_platform_registration_config_uses_platform_env_and_stable_endpoint() {
         registration.current_objective_ids,
         vec!["obj_1".to_string(), "obj_2".to_string()]
     );
-    assert_eq!(registration.heartbeat_interval_ms, 1234);
     assert_eq!(
         registration.traceparent.as_deref(),
-        Some("00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01")
+        Some("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01")
     );
-    assert_eq!(
-        registration.tracestate.as_deref(),
-        Some("evalops=maestro-a2a")
-    );
+    assert_eq!(registration.tracestate.as_deref(), Some("evalops=maestro"));
+    assert_eq!(registration.heartbeat_interval_ms, 1234);
     assert_eq!(
         registration.remote_runner_session_id.as_deref(),
         Some("mrs_123")
     );
+
+    restore_env(snapshot);
+}
+
+#[test]
+fn a2a_platform_registration_binds_tracestate_to_traceparent_namespace() {
+    let _guard = ENV_LOCK.blocking_lock();
+    let snapshot = snapshot_env(A2A_PLATFORM_ENV_NAMES);
+    clear_env(A2A_PLATFORM_ENV_NAMES);
+
+    env::set_var("MAESTRO_HOSTED_RUNNER_MODE", "1");
+    env::set_var("AGENT_REGISTRY_SERVICE_URL", "https://platform.test");
+    env::set_var("AGENT_REGISTRY_SERVICE_TOKEN", "registry-token");
+    env::set_var("AGENT_REGISTRY_ORGANIZATION_ID", "org_1");
+    env::set_var("AGENT_REGISTRY_WORKSPACE_ID", "ws_1");
+    env::set_var("MAESTRO_A2A_PUBLIC_URL", "https://maestro.example/a2a");
+    env::set_var(
+        "MAESTRO_PLATFORM_TRACEPARENT",
+        "00-11111111111111111111111111111111-2222222222222222-01",
+    );
+    env::set_var("MAESTRO_A2A_TRACESTATE", "evalops=stale-a2a");
+    env::set_var("MAESTRO_PLATFORM_TRACESTATE", "evalops=platform");
+    env::set_var("TRACESTATE", "evalops=stale-process");
+
+    let config = Config::from_env();
+    let registration = resolve_a2a_platform_registration_config(&config)
+        .expect("registration config should resolve")
+        .expect("hosted mode should enable registration");
+
+    assert_eq!(
+        registration.traceparent.as_deref(),
+        Some("00-11111111111111111111111111111111-2222222222222222-01")
+    );
+    assert_eq!(registration.tracestate.as_deref(), Some("evalops=platform"));
+
+    env::remove_var("MAESTRO_PLATFORM_TRACESTATE");
+    let config = Config::from_env();
+    let registration = resolve_a2a_platform_registration_config(&config)
+        .expect("registration config should resolve")
+        .expect("hosted mode should enable registration");
+
+    assert_eq!(
+        registration.traceparent.as_deref(),
+        Some("00-11111111111111111111111111111111-2222222222222222-01")
+    );
+    assert!(registration.tracestate.is_none());
+
+    env::remove_var("MAESTRO_PLATFORM_TRACEPARENT");
+    env::set_var(
+        "TRACEPARENT",
+        "00-33333333333333333333333333333333-4444444444444444-01",
+    );
+    let config = Config::from_env();
+    let registration = resolve_a2a_platform_registration_config(&config)
+        .expect("registration config should resolve")
+        .expect("hosted mode should enable registration");
+
+    assert_eq!(
+        registration.traceparent.as_deref(),
+        Some("00-33333333333333333333333333333333-4444444444444444-01")
+    );
+    assert_eq!(
+        registration.tracestate.as_deref(),
+        Some("evalops=stale-process")
+    );
+
+    restore_env(snapshot);
+}
+
+#[test]
+fn a2a_platform_registration_ignores_orphan_tracestate_env() {
+    let _guard = ENV_LOCK.blocking_lock();
+    let snapshot = snapshot_env(A2A_PLATFORM_ENV_NAMES);
+    clear_env(A2A_PLATFORM_ENV_NAMES);
+
+    env::set_var("MAESTRO_HOSTED_RUNNER_MODE", "1");
+    env::set_var("AGENT_REGISTRY_SERVICE_URL", "https://platform.test");
+    env::set_var("AGENT_REGISTRY_SERVICE_TOKEN", "registry-token");
+    env::set_var("AGENT_REGISTRY_ORGANIZATION_ID", "org_1");
+    env::set_var("AGENT_REGISTRY_WORKSPACE_ID", "ws_1");
+    env::set_var("MAESTRO_A2A_PUBLIC_URL", "https://maestro.example/a2a");
+    env::set_var("TRACESTATE", "evalops=stale-process-state");
+
+    let config = Config::from_env();
+    let registration = resolve_a2a_platform_registration_config(&config)
+        .expect("registration config should resolve")
+        .expect("hosted mode should enable registration");
+
+    assert!(registration.traceparent.is_none());
+    assert!(registration.tracestate.is_none());
 
     restore_env(snapshot);
 }
@@ -362,6 +460,9 @@ fn a2a_platform_payload_projects_governed_agent_card_without_drift_fields() {
         "https://maestro.example/a2a/.well-known/agent-card.json"
     );
     assert_eq!(payload["a2a"]["attributes"]["maxConcurrentObjectives"], "4");
+    assert_eq!(payload["a2a"]["attributes"]["organizationId"], "org_1");
+    assert_eq!(payload["a2a"]["attributes"]["workspaceId"], "ws_1");
+    assert_eq!(payload["a2a"]["attributes"]["agentId"], "maestro-peer-1");
     assert_eq!(
         payload["a2a"]["attributes"]["traceparent"],
         "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
@@ -482,6 +583,20 @@ fn a2a_platform_registration_posts_update_after_conflict_and_heartbeat() {
             Some("ws_1")
         );
         assert_eq!(
+            request
+                .headers
+                .get("x-evalops-agent-id")
+                .map(String::as_str),
+            Some("maestro-peer-1")
+        );
+        assert_eq!(
+            request
+                .headers
+                .get("x-evalops-actor-id")
+                .map(String::as_str),
+            Some("user_1")
+        );
+        assert_eq!(
             request.headers.get("traceparent").map(String::as_str),
             Some("00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01")
         );
@@ -500,6 +615,69 @@ fn a2a_platform_registration_posts_update_after_conflict_and_heartbeat() {
     assert_eq!(requests[1].body["id"], "maestro-peer-1");
     assert_eq!(requests[2].body["agentId"], "maestro-peer-1");
     assert_eq!(requests[2].body["currentObjectiveIds"][0], "obj_1");
+    for request in &requests {
+        assert_eq!(
+            request.body["a2a"]["attributes"]["traceparent"],
+            "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
+        );
+        assert_eq!(
+            request.body["a2a"]["attributes"]["tracestate"],
+            "evalops=maestro-a2a"
+        );
+        assert_eq!(request.body["a2a"]["attributes"]["workspaceId"], "ws_1");
+    }
+
+    restore_env(snapshot);
+}
+
+#[test]
+fn a2a_platform_registration_does_not_forward_orphan_tracestate() {
+    let _guard = ENV_LOCK.blocking_lock();
+    let snapshot = snapshot_env(A2A_PLATFORM_ENV_NAMES);
+    clear_env(A2A_PLATFORM_ENV_NAMES);
+
+    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind test server");
+    let addr = listener.local_addr().expect("test server addr");
+    let server = thread::spawn(move || {
+        capture_http_request(&listener, "200 OK", r#"{"agent":{"id":"maestro-peer-1"}}"#)
+    });
+
+    let config = Config::from_env();
+    let registration = A2APlatformRegistrationConfig {
+        base_url: format!("http://{addr}"),
+        token: "registry-token".to_string(),
+        organization_id: "org_1".to_string(),
+        workspace_id: "ws_1".to_string(),
+        agent_id: "maestro-peer-1".to_string(),
+        name: "Maestro Peer".to_string(),
+        description: "Peer".to_string(),
+        agent_type: "maestro".to_string(),
+        owner_id: None,
+        traceparent: None,
+        tracestate: Some("evalops=stale-process-state".to_string()),
+        public_endpoint_url: "https://maestro.example/a2a".to_string(),
+        internal_endpoint_url: Some("http://maestro.mesh/a2a".to_string()),
+        agent_card_url: None,
+        heartbeat_interval_ms: 60_000,
+        timeout_ms: 2_500,
+        current_objective_ids: vec!["obj_1".to_string()],
+        max_concurrent_objectives: "4".to_string(),
+        surface: "a2a".to_string(),
+        surface_type: "SURFACE_MAESTRO".to_string(),
+        remote_runner_session_id: None,
+    };
+
+    register_or_update_a2a_platform_agent(&registration, &config)
+        .expect("registration should post");
+
+    let request = server.join().expect("test server should finish");
+    assert!(request.headers.get("traceparent").is_none());
+    assert!(request.headers.get("tracestate").is_none());
+    let attributes = request.body["a2a"]["attributes"]
+        .as_object()
+        .expect("attributes");
+    assert!(!attributes.contains_key("traceparent"));
+    assert!(!attributes.contains_key("tracestate"));
 
     restore_env(snapshot);
 }

--- a/packages/tui-rs/src/tools/registry/tests.rs
+++ b/packages/tui-rs/src/tools/registry/tests.rs
@@ -1434,15 +1434,15 @@ async fn test_executor_cache_not_used_for_bash() {
 async fn test_executor_vaults_credentials_from_bash_result() {
     let dir = tempfile::tempdir().unwrap();
     let executor = ToolExecutor::new(dir.path().to_str().unwrap());
-    let token = "ghs_123456789012345678901234567890123456";
+    let token = ["ghs", "123456789012345678901234567890123456"].join("_");
     let args = serde_json::json!({"command": format!("echo GITHUB_TOKEN={token}")});
 
     let result = executor.execute("bash", &args, None, "call-1").await;
 
     assert!(result.success);
-    assert!(!result.output.contains(token));
+    assert!(!result.output.contains(&token));
     assert!(result.output.contains("{{CRED:"));
-    assert!(!result.details.unwrap().to_string().contains(token));
+    assert!(!result.details.unwrap().to_string().contains(&token));
 }
 
 #[test]


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"c084a2470fae794f0adca9fdd0e623fe5927a8c3"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `c084a2470fae794f0adca9fdd0e623fe5927a8c3`
- last generated public sync base: `bfb44de408c5f93e5f620a9618d7316b86b40be3`
- previewed public-tree drift: `4` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (c084a2470fae)`
- public projection: `https://github.com/evalops/maestro@main (bfb44de408c5)`
- files to copy or update: `4`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update packages/control-plane-rs/src/a2a_platform_registration.rs
- copy/update packages/control-plane-rs/src/tests.rs
- copy/update packages/tui-rs/src/tools/registry/tests.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update packages/control-plane-rs/src/a2a_platform_registration.rs
- copy/update packages/control-plane-rs/src/tests.rs
- copy/update packages/tui-rs/src/tools/registry/tests.rs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@c084a2470fae794f0adca9fdd0e623fe5927a8c3`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #640 to internal source `c084a2470fae794f0adca9fdd0e623fe5927a8c3`