### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/a2a-swarm-stage-gates.json
+++ b/docs/protocols/a2a-swarm-stage-gates.json
@@ -335,9 +335,9 @@
 			]
 		},
 		{
-			"id": "stage-6-fleet-hardening",
-			"title": "Fleet hardening",
-			"purpose": "Turn the proven end-to-end path into a durable fleet service with load, chaos, SLO, quota, retention, and incident evidence.",
+			"id": "stage-6-realtime-delivery",
+			"title": "Realtime delivery",
+			"purpose": "Prove A2A streaming status, artifact delivery, and push notifications are durable, authenticated, trace-correlated, tenant-safe, and visible to operators.",
 			"dependsOn": ["stage-5-production-proof-operations"],
 			"entryEvidence": [
 				{
@@ -346,6 +346,65 @@
 					"description": "Stage 5 proves a complete live repo or deploy-lane workflow with signed, dereferenceable evidence.",
 					"authoritativeSource": "Signed Stage 5 evidence bundle",
 					"verification": "Verify Stage 5 evidence signature, GitHub dereference, deploy-verifier output, and root Platform trace id."
+				},
+				{
+					"id": "stream-push-capabilities-advertised",
+					"proofClass": "environment",
+					"description": "Participating peers advertise A2A streaming and push-notification capabilities before delivery proof starts.",
+					"authoritativeSource": "Platform Agent Registry capability metadata and A2A Agent Cards",
+					"verification": "maestro a2a discover --capability a2a:stream --capability a2a:push --import && maestro a2a peers"
+				}
+			],
+			"exitEvidence": [
+				{
+					"id": "status-stream-terminal-events",
+					"proofClass": "streaming-status-events",
+					"description": "A delegated task emits ordered status and artifact events over the A2A stream until terminal state or an explicitly accepted nonterminal observation.",
+					"authoritativeSource": "Target Maestro A2A stream and subscription endpoints",
+					"verification": "Run npm run platform:a2a-delegation-live with streaming enabled, then verify stream event ids, terminal state, and artifact ids in the signed evidence bundle."
+				},
+				{
+					"id": "push-notifications-delivered",
+					"proofClass": "push-notification-delivery",
+					"description": "The target peer delivers authenticated task push notifications to the configured callback and records accepted, rejected, and terminal notifications.",
+					"authoritativeSource": "Platform callback audit ledger and A2A task notification receiver",
+					"verification": "Inspect callback audit ids, accepted notification count, invalid-token rejection, and terminal notification state in the signed evidence bundle."
+				},
+				{
+					"id": "task-message-ids-durable",
+					"proofClass": "durable-task-message-ids",
+					"description": "Task, context, message, stream event, and push notification ids remain stable across polling, streaming, push, evidence verification, and operator inspection.",
+					"authoritativeSource": "Platform task and message ledger plus target Maestro task endpoint",
+					"verification": "Compare taskId, contextId, messageId, streamEventId, pushNotificationId, and evidence refs across the task endpoint, signed bundle, and Platform ledger."
+				},
+				{
+					"id": "delivery-traces-correlated",
+					"proofClass": "trace-correlated-delivery",
+					"description": "Stream and push delivery events preserve trace headers and link back to the root delegation, target task, callback audit, and operator trace.",
+					"authoritativeSource": "Platform trace store and A2A trace headers",
+					"verification": "Open the root trace id and verify stream, task, callback, and push spans share traceparent or tracestate links without exposing tokens."
+				},
+				{
+					"id": "delivery-metrics-operator-visible",
+					"proofClass": "operator-delivery-metrics",
+					"description": "Operators can see stream terminal rate, push delivery latency, callback rejection rate, retry counts, and stuck-delivery alerts for the participating workspace.",
+					"authoritativeSource": "Platform observability metrics and alert index",
+					"verification": "Query delivery metrics for the evidence window and attach stable dashboard, alert, or metric ids to the release evidence."
+				}
+			]
+		},
+		{
+			"id": "stage-7-fleet-hardening",
+			"title": "Fleet hardening",
+			"purpose": "Turn the proven end-to-end path into a durable fleet service with load, chaos, SLO, quota, retention, and incident evidence.",
+			"dependsOn": ["stage-6-realtime-delivery"],
+			"entryEvidence": [
+				{
+					"id": "realtime-delivery-green",
+					"proofClass": "prior-stage",
+					"description": "Stage 6 proves streaming status, artifact delivery, push notifications, durable ids, and operator delivery metrics for the participating workspace.",
+					"authoritativeSource": "Signed Stage 6 evidence bundle",
+					"verification": "Verify Stage 6 evidence signature, stream event ids, push callback audit ids, Platform trace ids, and operator metric ids."
 				},
 				{
 					"id": "fleet-capacity-targets-declared",

--- a/docs/protocols/a2a-swarm-stage-gates.md
+++ b/docs/protocols/a2a-swarm-stage-gates.md
@@ -21,7 +21,8 @@ evidence, but they cannot satisfy production exit gates.
 | 3 | Subagent federation | Remote subagent lanes are negotiated, authorized, invoked, and traced through Platform. |
 | 4 | Swarm coordination | Multiple Maestro peers split work, hold ownership, recover from failures, and reconcile one outcome. |
 | 5 | Production proof and operations | A real repo or deploy workflow resolves to live GitHub, deploy, signature, and Platform trace evidence. |
-| 6 | Fleet hardening | Load, chaos, SLO, runbook, quota, and retention evidence make the system operable at fleet scale. |
+| 6 | Realtime delivery | Streaming status, artifact delivery, push callbacks, durable ids, traces, and operator metrics are proven from production-authoritative records. |
+| 7 | Fleet hardening | Load, chaos, SLO, runbook, quota, and retention evidence make the system operable at fleet scale. |
 
 ## Usage
 
@@ -47,3 +48,6 @@ npm run platform:a2a-evidence-verify -- \
 
 The stage is not complete until the evidence resolves in the named system of
 record. A pretty bundle with unresolvable identifiers is a failed gate.
+Realtime delivery is its own ordered gate: stream events and push callbacks must
+resolve through Platform ledgers, task endpoints, trace stores, and operator
+metrics before fleet hardening can start.

--- a/scripts/check-evidence-integrity.ts
+++ b/scripts/check-evidence-integrity.ts
@@ -14,7 +14,8 @@ const A2A_SWARM_STAGE_IDS = [
 	"stage-3-subagent-federation",
 	"stage-4-swarm-coordination",
 	"stage-5-production-proof-operations",
-	"stage-6-fleet-hardening",
+	"stage-6-realtime-delivery",
+	"stage-7-fleet-hardening",
 ] as const;
 
 const REQUIRED_A2A_SWARM_STAGE_PROOF_CLASSES: Record<
@@ -59,7 +60,14 @@ const REQUIRED_A2A_SWARM_STAGE_PROOF_CLASSES: Record<
 		"deploy-verifier",
 		"traces",
 	],
-	"stage-6-fleet-hardening": [
+	"stage-6-realtime-delivery": [
+		"streaming-status-events",
+		"push-notification-delivery",
+		"durable-task-message-ids",
+		"trace-correlated-delivery",
+		"operator-delivery-metrics",
+	],
+	"stage-7-fleet-hardening": [
 		"load-soak",
 		"chaos",
 		"slo",

--- a/src/tools/ripgrep-utils.ts
+++ b/src/tools/ripgrep-utils.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import { safeJsonParse } from "../utils/json.js";
+import { ensureTool } from "./tools-manager.js";
 
 export const pathSchema = Type.Optional(
 	Type.Union([
@@ -42,6 +43,50 @@ export function toArray<T>(value: T | T[] | undefined): T[] {
 }
 
 const MAX_RIPGREP_OUTPUT_BYTES = 2_000_000; // ~2MB safeguard
+let ripgrepExecutablePromise: Promise<string | null> | null = null;
+
+function ripgrepAbortError(): Error {
+	return new Error("ripgrep search aborted before start");
+}
+
+async function resolveRipgrepExecutable(): Promise<string> {
+	ripgrepExecutablePromise ??= ensureTool("rg", true);
+	const executable = await ripgrepExecutablePromise;
+	if (!executable) {
+		ripgrepExecutablePromise = null;
+		throw new Error("ripgrep is not available and could not be downloaded");
+	}
+	return executable;
+}
+
+function throwIfRipgrepAborted(signal?: AbortSignal): void {
+	if (signal?.aborted) {
+		throw ripgrepAbortError();
+	}
+}
+
+async function resolveRipgrepExecutableWithAbort(
+	signal?: AbortSignal,
+): Promise<string> {
+	throwIfRipgrepAborted(signal);
+	if (!signal) {
+		return await resolveRipgrepExecutable();
+	}
+
+	return await new Promise<string>((resolve, reject) => {
+		const onAbort = (): void => {
+			signal.removeEventListener("abort", onAbort);
+			reject(ripgrepAbortError());
+		};
+
+		signal.addEventListener("abort", onAbort, { once: true });
+		resolveRipgrepExecutable()
+			.then(resolve, reject)
+			.finally(() => {
+				signal.removeEventListener("abort", onAbort);
+			});
+	});
+}
 
 function shellQuoteArg(value: string): string {
 	if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
@@ -64,7 +109,9 @@ export async function runRipgrep(
 	exitCode: number;
 	truncated: boolean;
 }> {
-	const child = spawn("rg", args, {
+	const executable = await resolveRipgrepExecutableWithAbort(signal);
+	throwIfRipgrepAborted(signal);
+	const child = spawn(executable, args, {
 		cwd: cwd ?? process.cwd(),
 		stdio: ["ignore", "pipe", "pipe"],
 		signal,

--- a/test/tools/ripgrep-utils.test.ts
+++ b/test/tools/ripgrep-utils.test.ts
@@ -1,0 +1,122 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("ripgrep utils", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.resetModules();
+		vi.doUnmock("node:child_process");
+		vi.doUnmock("../../src/tools/tools-manager.js");
+	});
+
+	it("runs the managed ripgrep binary when it is available", async () => {
+		const spawnCalls: Array<{ command: string; args: string[]; cwd?: string }> =
+			[];
+		vi.doMock("node:child_process", async () => {
+			const actual =
+				await vi.importActual<typeof import("node:child_process")>(
+					"node:child_process",
+				);
+			return {
+				...actual,
+				spawn: vi.fn(
+					(command: string, args: string[], options?: { cwd?: string }) => {
+						spawnCalls.push({ command, args, cwd: options?.cwd });
+						const child = new EventEmitter() as EventEmitter & {
+							stdout: PassThrough;
+							stderr: PassThrough;
+							kill: ReturnType<typeof vi.fn>;
+						};
+						child.stdout = new PassThrough();
+						child.stderr = new PassThrough();
+						child.kill = vi.fn();
+						process.nextTick(() => {
+							child.stdout.end("match\n");
+							child.stderr.end("");
+							child.emit("close", 0);
+						});
+						return child;
+					},
+				),
+			};
+		});
+		vi.doMock("../../src/tools/tools-manager.js", () => ({
+			ensureTool: vi.fn(async () => "/managed/bin/rg"),
+		}));
+
+		const { runRipgrep } = await import("../../src/tools/ripgrep-utils.js");
+		const result = await runRipgrep(["--files"], undefined, "/workspace");
+
+		expect(result.stdout).toBe("match\n");
+		expect(spawnCalls).toEqual([
+			{ command: "/managed/bin/rg", args: ["--files"], cwd: "/workspace" },
+		]);
+	});
+
+	it("reports a clear error when ripgrep cannot be resolved", async () => {
+		vi.doMock("../../src/tools/tools-manager.js", () => ({
+			ensureTool: vi.fn(async () => null),
+		}));
+
+		const { runRipgrep } = await import("../../src/tools/ripgrep-utils.js");
+
+		await expect(runRipgrep(["--files"])).rejects.toThrow(
+			"ripgrep is not available and could not be downloaded",
+		);
+	});
+
+	it("does not resolve ripgrep when the call is already aborted", async () => {
+		const ensureTool = vi.fn(async () => "/managed/bin/rg");
+		vi.doMock("../../src/tools/tools-manager.js", () => ({
+			ensureTool,
+		}));
+		const controller = new AbortController();
+		controller.abort();
+
+		const { runRipgrep } = await import("../../src/tools/ripgrep-utils.js");
+
+		await expect(runRipgrep(["--files"], controller.signal)).rejects.toThrow(
+			"ripgrep search aborted before start",
+		);
+		expect(ensureTool).not.toHaveBeenCalled();
+	});
+
+	it("does not wait for ripgrep resolution when aborted during lookup", async () => {
+		let resolveEnsureTool!: (value: string | null) => void;
+		const ensureTool = vi.fn(
+			() =>
+				new Promise<string | null>((resolve) => {
+					resolveEnsureTool = resolve;
+				}),
+		);
+		const spawn = vi.fn();
+		vi.doMock("node:child_process", async () => {
+			const actual =
+				await vi.importActual<typeof import("node:child_process")>(
+					"node:child_process",
+				);
+			return {
+				...actual,
+				spawn,
+			};
+		});
+		vi.doMock("../../src/tools/tools-manager.js", () => ({
+			ensureTool,
+		}));
+		const controller = new AbortController();
+
+		const { runRipgrep } = await import("../../src/tools/ripgrep-utils.js");
+		const pending = runRipgrep(["--files"], controller.signal);
+		expect(ensureTool).toHaveBeenCalledTimes(1);
+
+		controller.abort();
+
+		await expect(pending).rejects.toThrow(
+			"ripgrep search aborted before start",
+		);
+		expect(spawn).not.toHaveBeenCalled();
+
+		resolveEnsureTool("/managed/bin/rg");
+	});
+});


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"143c1b277cf68e66d2d183f0553802e9e930d8e3"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `143c1b277cf68e66d2d183f0553802e9e930d8e3`
- last generated public sync base: `8657d1d396e24e63754a793f393b1a1b0751f77e`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (143c1b277cf6)`
- public projection: `https://github.com/evalops/maestro@main (8657d1d396e2)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/a2a-swarm-stage-gates.json
- copy/update docs/protocols/a2a-swarm-stage-gates.md
- copy/update scripts/check-evidence-integrity.ts
- copy/update src/tools/ripgrep-utils.ts
- copy/update test/tools/ripgrep-utils.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/a2a-swarm-stage-gates.json
- copy/update docs/protocols/a2a-swarm-stage-gates.md
- copy/update scripts/check-evidence-integrity.ts
- copy/update src/tools/ripgrep-utils.ts
- copy/update test/tools/ripgrep-utils.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@143c1b277cf68e66d2d183f0553802e9e930d8e3`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.