### PR TITLE
fix: sync release helpers before public mirror validation

### DIFF
--- a/.github/workflows/public-release-mirror.yml
+++ b/.github/workflows/public-release-mirror.yml
@@ -109,6 +109,13 @@ jobs:
             --target "$GITHUB_WORKSPACE/public-mirror" \
             --package-name "${{ steps.release.outputs.canonical_package_name }}"
 
+      - name: Sync release mirror helper files
+        run: |
+          set -euo pipefail
+          node scripts/sync-release-mirror.mjs \
+            --source "$GITHUB_WORKSPACE" \
+            --target "$GITHUB_WORKSPACE/public-mirror"
+
       - name: Validate mirrored public tree
         working-directory: public-mirror
         run: |


### PR DESCRIPTION
## Summary
- keep the public-owned public-release-mirror workflow aligned with the internal mirror release path
- sync release mirror helper files into the public clone before validation/tagging/fallback publish

## Validation
- bunx biome check .github/workflows/public-release-mirror.yml
- git diff --check