### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/release-surface-conformance.json
+++ b/docs/protocols/release-surface-conformance.json
@@ -117,6 +117,8 @@
 			"evidenceType": "source",
 			"anchors": [
 				"Prepare sanitized public release tree",
+				"Sync release mirror helper files",
+				"scripts/sync-release-mirror.mjs",
 				"Validate mirrored public tree",
 				"Publish public npm package fallback",
 				"npm publish"

--- a/docs/protocols/release-surface-conformance.md
+++ b/docs/protocols/release-surface-conformance.md
@@ -23,7 +23,7 @@ npm run check:release-surface
 | registry install smokes | npm, npx, Bun, and bunx install paths stay connected to published replay evidence. |
 | published replay | text, JSON, and RPC replay modes keep session and AgentRuntime evidence. |
 | release readiness | local release gates continue to build, verify runtime deps, pack-smoke, and replay-smoke. |
-| public mirror | the sanitized public tree, mirror contract, and fallback publish workflow keep their guardrails. |
+| public mirror | the sanitized public tree, release-helper mirror sync, mirror contract, and fallback publish workflow keep their guardrails. |
 
 ## Completion Bar
 

--- a/scripts/prepare-public-release-mirror.mjs
+++ b/scripts/prepare-public-release-mirror.mjs
@@ -40,8 +40,10 @@ const DEFAULT_EXCLUDES = [
 	"test/internal/**",
 	"scripts/configure-npm-trusted-publisher.mjs",
 	"scripts/deprecate-release.js",
+	"scripts/published-replay-evidence-gate.js",
 	"scripts/smoke-published-replay-e2e.js",
 	"scripts/smoke-registry-install.js",
+	"scripts/verify-published-replay-evidence.js",
 	"scripts/validate-public-package-deps.js",
 ];
 

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1578,6 +1578,34 @@ describe("ci workflow guardrails", () => {
 		);
 	});
 
+	it("syncs release mirror helpers before validating public release mirrors", () => {
+		const workflow = parse(
+			readFileSync(
+				new URL(
+					"../../.github/workflows/public-release-mirror.yml",
+					import.meta.url,
+				),
+				{ encoding: "utf8" },
+			),
+		) as Workflow;
+		const steps = workflow.jobs?.["mirror-release"]?.steps ?? [];
+		const stepNames = steps.map((step) => step.name ?? step.id ?? "");
+		const prepareIndex = stepNames.indexOf(
+			"Prepare sanitized public release tree",
+		);
+		const syncIndex = stepNames.indexOf("Sync release mirror helper files");
+		const validateIndex = stepNames.indexOf("Validate mirrored public tree");
+		const syncStep = steps[syncIndex];
+
+		expect(prepareIndex).toBeGreaterThanOrEqual(0);
+		expect(syncIndex).toBeGreaterThan(prepareIndex);
+		expect(validateIndex).toBeGreaterThan(syncIndex);
+		expect(syncStep?.run).toContain("scripts/sync-release-mirror.mjs");
+		expect(syncStep?.run).toContain(
+			'--target "$GITHUB_WORKSPACE/public-mirror"',
+		);
+	});
+
 	it("uses token-backed release PR pushes and formats generated release metadata", () => {
 		const workflowPath = new URL(
 			"../../.github/workflows/version-bump.yml",

--- a/test/scripts/prepare-public-release-mirror.test.ts
+++ b/test/scripts/prepare-public-release-mirror.test.ts
@@ -92,6 +92,14 @@ describe("prepare-public-release-mirror", () => {
 			join(source, "scripts/smoke-published-replay-e2e.js"),
 			"internal replay\n",
 		);
+		write(
+			join(source, "scripts/published-replay-evidence-gate.js"),
+			"internal evidence gate\n",
+		);
+		write(
+			join(source, "scripts/verify-published-replay-evidence.js"),
+			"internal evidence verifier\n",
+		);
 		write(join(source, ".env"), "SECRET=value\n");
 		write(join(source, ".env.local"), "LOCAL_SECRET=value\n");
 		write(
@@ -125,6 +133,14 @@ describe("prepare-public-release-mirror", () => {
 		write(
 			join(target, "scripts/smoke-published-replay-e2e.js"),
 			"public replay\n",
+		);
+		write(
+			join(target, "scripts/published-replay-evidence-gate.js"),
+			"public evidence gate\n",
+		);
+		write(
+			join(target, "scripts/verify-published-replay-evidence.js"),
+			"public evidence verifier\n",
 		);
 		write(join(target, ".git/config"), '[remote "origin"]\n');
 
@@ -212,6 +228,18 @@ describe("prepare-public-release-mirror", () => {
 				"utf8",
 			),
 		).toBe("public replay\n");
+		expect(
+			readFileSync(
+				join(target, "scripts/published-replay-evidence-gate.js"),
+				"utf8",
+			),
+		).toBe("public evidence gate\n");
+		expect(
+			readFileSync(
+				join(target, "scripts/verify-published-replay-evidence.js"),
+				"utf8",
+			),
+		).toBe("public evidence verifier\n");
 		expect(readFileSync(join(target, ".git/config"), "utf8")).toBe(
 			'[remote "origin"]\n',
 		);
@@ -222,6 +250,8 @@ describe("prepare-public-release-mirror", () => {
 			"release:verify:published": "node scripts/smoke-registry-install.js",
 			"release:verify:published:e2e":
 				"node scripts/smoke-published-replay-e2e.js",
+			"release:verify:published:evidence":
+				"node scripts/verify-published-replay-evidence.js",
 			"release:deprecate": "node scripts/deprecate-release.js",
 		});
 		expect(pkg.maestro).toMatchObject({


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"b9e836d9c40cf5e3afd8569f5450858a16de2627"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `b9e836d9c40cf5e3afd8569f5450858a16de2627`
- last generated public sync base: `06cf527e9b9f2b5859808a5ce602ef621adb3cb5`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (b9e836d9c40c)`
- public projection: `https://github.com/evalops/maestro@main (755234aae3cb)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/release-surface-conformance.json
- copy/update docs/protocols/release-surface-conformance.md
- copy/update scripts/prepare-public-release-mirror.mjs
- copy/update test/scripts/ci-guardrails.test.ts
- copy/update test/scripts/prepare-public-release-mirror.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/release-surface-conformance.json
- copy/update docs/protocols/release-surface-conformance.md
- copy/update scripts/prepare-public-release-mirror.mjs
- copy/update test/scripts/ci-guardrails.test.ts
- copy/update test/scripts/prepare-public-release-mirror.test.ts

## Public-only commits since last generated sync

- 755234aa fix: sync release helpers before public mirror validation (#646)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@b9e836d9c40cf5e3afd8569f5450858a16de2627`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.