### PR TITLE
[maestro] Keep deprecation message current

### DIFF
--- a/.github/workflows/deprecate-release.yml
+++ b/.github/workflows/deprecate-release.yml
@@ -16,7 +16,7 @@ on:
       message:
         description: Deprecation message.
         required: false
-        default: "Broken release: install version 0.10.26 or newer of this package."
+        default: "Broken release: install @evalops/maestro@latest."
         type: string
       dry_run:
         description: Print the npm deprecate command without changing npm.

--- a/.github/workflows/deprecate-release.yml
+++ b/.github/workflows/deprecate-release.yml
@@ -14,9 +14,9 @@ on:
         default: "0.10.20"
         type: string
       message:
-        description: Deprecation message.
+        description: Optional deprecation message. Leave blank to use the package-aware script default.
         required: false
-        default: "Broken release: install @evalops/maestro@latest."
+        default: ""
         type: string
       dry_run:
         description: Print the npm deprecate command without changing npm.

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -948,7 +948,7 @@ describe("ci workflow guardrails", () => {
 		);
 	});
 
-	it("keeps the deprecate-release default message package-specific and versionless", () => {
+	it("keeps the deprecate-release default message package-aware and versionless", () => {
 		const workflowPath = new URL(
 			"../../.github/workflows/deprecate-release.yml",
 			import.meta.url,
@@ -972,9 +972,7 @@ describe("ci workflow guardrails", () => {
 		const defaultMessage =
 			workflow.on?.workflow_dispatch?.inputs?.message?.default ?? "";
 
-		expect(defaultMessage).toContain("@evalops/maestro");
-		expect(defaultMessage).toContain("latest");
-		expect(defaultMessage).not.toMatch(/\b\d+\.\d+\.\d+\b/);
+		expect(defaultMessage).toBe("");
 	});
 
 	it("keeps packed CLI smoke aligned with registry install validation", () => {

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -948,6 +948,35 @@ describe("ci workflow guardrails", () => {
 		);
 	});
 
+	it("keeps the deprecate-release default message package-specific and versionless", () => {
+		const workflowPath = new URL(
+			"../../.github/workflows/deprecate-release.yml",
+			import.meta.url,
+		);
+		if (!existsSync(workflowPath)) {
+			return;
+		}
+		const workflow = parse(
+			readFileSync(workflowPath, { encoding: "utf8" }),
+		) as {
+			on?: {
+				workflow_dispatch?: {
+					inputs?: {
+						message?: {
+							default?: string;
+						};
+					};
+				};
+			};
+		};
+		const defaultMessage =
+			workflow.on?.workflow_dispatch?.inputs?.message?.default ?? "";
+
+		expect(defaultMessage).toContain("@evalops/maestro");
+		expect(defaultMessage).toContain("latest");
+		expect(defaultMessage).not.toMatch(/\b\d+\.\d+\.\d+\b/);
+	});
+
 	it("keeps packed CLI smoke aligned with registry install validation", () => {
 		const script = readFileSync(
 			new URL("../../scripts/smoke-packed-cli.js", import.meta.url),

--- a/test/scripts/deprecate-release.test.ts
+++ b/test/scripts/deprecate-release.test.ts
@@ -52,6 +52,42 @@ describe("deprecate-release", () => {
 		);
 	});
 
+	it("derives package-aware default messages when no message is supplied", () => {
+		const canonicalResult = spawnSync(
+			process.execPath,
+			[
+				scriptPath.pathname,
+				"--range",
+				"0.10.20",
+				"--package",
+				"@evalops/maestro",
+				"--dry-run",
+			],
+			{ encoding: "utf8" },
+		);
+		const aliasResult = spawnSync(
+			process.execPath,
+			[
+				scriptPath.pathname,
+				"--range",
+				"0.10.20",
+				"--package",
+				"@evalops/contracts",
+				"--dry-run",
+			],
+			{ encoding: "utf8" },
+		);
+
+		expect(canonicalResult.status).toBe(0);
+		expect(canonicalResult.stdout).toContain(
+			"Deprecated release. Upgrade to a supported Maestro version.",
+		);
+		expect(aliasResult.status).toBe(0);
+		expect(aliasResult.stdout).toContain(
+			"Deprecated package path. Install @evalops/maestro instead.",
+		);
+	});
+
 	it("explains npm E404 permission failures for existing package releases", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "maestro-deprecate-test-"));
 		const fakeNpm = join(tempDir, "npm");


### PR DESCRIPTION
## Summary

- update the public deprecate-release default message to point users at @evalops/maestro@latest
- add a CI guardrail so the default remains package-specific and does not hard-code a semver that goes stale

Internal source PR: https://github.com/evalops/maestro-internal/pull/2299

## Test Plan

- node ./scripts/run-vitest.js --run test/scripts/ci-guardrails.test.ts -t "keeps the deprecate-release default message"
- node ./scripts/run-vitest.js --run test/scripts/ci-guardrails.test.ts test/scripts/deprecate-release.test.ts
- bunx biome check .github/workflows/deprecate-release.yml test/scripts/ci-guardrails.test.ts
- npm run check:release-surface
- git diff --check
- pre-commit hook: guardian, bun:lint, lint:evals, build, bun compile