### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/a2a-fleet-delegation.md
+++ b/docs/protocols/a2a-fleet-delegation.md
@@ -309,6 +309,11 @@ The task ledger defaults to:
 `MAESTRO_A2A_TASKS_FILE` overrides the ledger path. `CODEX_A2A_TASKS_FILE` is
 accepted as a migration alias.
 
+A2A `message:stream` and task subscription responses emit deterministic SSE
+`id:` fields derived from the context id, task id, event kind, status timestamp,
+and artifact id. Platform evidence can compare those stream ids against the task
+ledger without depending on process-local counters.
+
 ## Operator Verification
 
 Use bounded one-shot checks against a local control-plane peer:

--- a/packages/control-plane-rs/src/a2a/tasks.rs
+++ b/packages/control-plane-rs/src/a2a/tasks.rs
@@ -693,9 +693,12 @@ async fn send_a2a_stream_response(stream: &mut TcpStream, value: &Value) -> Resu
     let Some(event_name) = a2a_stream_event_name(value) else {
         return send_sse(stream, value).await;
     };
+    let event_id = a2a_stream_event_id(value)
+        .map(|id| format!("id: {id}\n"))
+        .unwrap_or_default();
     let body = serde_json::to_string(value).map_err(|error| error.to_string())?;
     stream
-        .write_all(format!("event: {event_name}\ndata: {body}\n\n").as_bytes())
+        .write_all(format!("{event_id}event: {event_name}\ndata: {body}\n\n").as_bytes())
         .await
         .map_err(|error| error.to_string())
 }
@@ -710,6 +713,79 @@ fn a2a_stream_event_name(value: &Value) -> Option<&'static str> {
     } else {
         None
     }
+}
+
+fn a2a_stream_event_id(value: &Value) -> Option<String> {
+    if let Some(task) = value.get("task") {
+        let context_id = a2a_stream_id_value(task.get("contextId"), "unknown-context");
+        let task_id = a2a_stream_id_value(task.get("id"), "unknown-task");
+        let state = a2a_stream_id_value(
+            task.get("status").and_then(|status| status.get("state")),
+            "snapshot",
+        );
+        let timestamp = a2a_stream_id_value(
+            task.get("status")
+                .and_then(|status| status.get("timestamp")),
+            "latest",
+        );
+        return Some(format!(
+            "a2a:{context_id}:{task_id}:task:{state}:{timestamp}"
+        ));
+    }
+
+    if let Some(update) = value.get("statusUpdate") {
+        let context_id = a2a_stream_id_value(update.get("contextId"), "unknown-context");
+        let task_id = a2a_stream_id_value(update.get("taskId"), "unknown-task");
+        let state = a2a_stream_id_value(
+            update.get("status").and_then(|status| status.get("state")),
+            "snapshot",
+        );
+        let timestamp = a2a_stream_id_value(
+            update
+                .get("status")
+                .and_then(|status| status.get("timestamp")),
+            "latest",
+        );
+        return Some(format!(
+            "a2a:{context_id}:{task_id}:status:{state}:{timestamp}"
+        ));
+    }
+
+    if let Some(update) = value.get("artifactUpdate") {
+        let context_id = a2a_stream_id_value(update.get("contextId"), "unknown-context");
+        let task_id = a2a_stream_id_value(update.get("taskId"), "unknown-task");
+        let artifact_id = a2a_stream_id_value(
+            update
+                .get("artifact")
+                .and_then(|artifact| artifact.get("artifactId").or_else(|| artifact.get("id"))),
+            "latest",
+        );
+        return Some(format!("a2a:{context_id}:{task_id}:artifact:{artifact_id}"));
+    }
+
+    None
+}
+
+fn a2a_stream_id_value(value: Option<&Value>, fallback: &str) -> String {
+    let segment = value
+        .and_then(Value::as_str)
+        .map(a2a_stream_id_segment)
+        .filter(|segment| !segment.is_empty());
+    segment.unwrap_or_else(|| fallback.to_string())
+}
+
+fn a2a_stream_id_segment(value: &str) -> String {
+    value
+        .trim()
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '~') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 pub(super) fn a2a_status_update_event(task: &Value) -> Value {

--- a/packages/control-plane-rs/src/tests.rs
+++ b/packages/control-plane-rs/src/tests.rs
@@ -4296,6 +4296,11 @@ async fn a2a_message_stream_emits_task_status_and_artifact_events() {
     let response = String::from_utf8(bytes).expect("response should be utf-8");
 
     assert!(response.contains("Content-Type: text/event-stream"));
+    assert!(response.contains("id: a2a:ctx-stream:maestro-task-"));
+    assert!(response.contains(":task:TASK_STATE_WORKING:"));
+    assert!(response.contains(":status:TASK_STATE_COMPLETED:"));
+    assert!(response.contains(":artifact:maestro-task-"));
+    assert!(response.contains("-assistant-response"));
     assert!(response.contains("event: task"));
     assert!(response.contains("event: statusUpdate"));
     assert!(response.contains("event: artifactUpdate"));
@@ -4427,6 +4432,12 @@ async fn a2a_task_subscribe_streams_active_task_until_terminal_update() {
     let response = String::from_utf8(response_bytes).expect("response should be utf-8");
 
     assert!(response.contains("Content-Type: text/event-stream"));
+    assert!(
+        response.contains("id: a2a:ctx-1:maestro-task-active-subscribe:task:TASK_STATE_WORKING:")
+    );
+    assert!(response
+        .contains("id: a2a:ctx-1:maestro-task-active-subscribe:status:TASK_STATE_COMPLETED:"));
+    assert!(response.contains("id: a2a:ctx-1:maestro-task-active-subscribe:artifact:artifact-1"));
     assert!(response.contains("event: task"));
     assert!(response.contains("event: statusUpdate"));
     assert!(response.contains("event: artifactUpdate"));

--- a/src/tools/find.ts
+++ b/src/tools/find.ts
@@ -408,7 +408,7 @@ export const findTool = createTool<typeof findSchema, FindToolDetails>({
 
 		const { pattern, path: searchDir, limit, includeHidden = true } = params;
 
-		const fdPath = await ensureTool("fd", true);
+		const fdPath = await ensureTool("fd", true, signal);
 		if (!fdPath) {
 			return respond
 				.error("fd is not available and could not be downloaded")

--- a/src/tools/ripgrep-utils.ts
+++ b/src/tools/ripgrep-utils.ts
@@ -44,19 +44,88 @@ export function toArray<T>(value: T | T[] | undefined): T[] {
 
 const MAX_RIPGREP_OUTPUT_BYTES = 2_000_000; // ~2MB safeguard
 let ripgrepExecutablePromise: Promise<string | null> | null = null;
+let ripgrepInstallController: AbortController | null = null;
+let ripgrepExecutableWaiters = 0;
 
 function ripgrepAbortError(): Error {
 	return new Error("ripgrep search aborted before start");
 }
 
-async function resolveRipgrepExecutable(): Promise<string> {
-	ripgrepExecutablePromise ??= ensureTool("rg", true);
-	const executable = await ripgrepExecutablePromise;
-	if (!executable) {
-		ripgrepExecutablePromise = null;
-		throw new Error("ripgrep is not available and could not be downloaded");
+function resetRipgrepExecutablePromise(): void {
+	ripgrepExecutablePromise = null;
+	ripgrepInstallController = null;
+}
+
+function getRipgrepExecutablePromise(): Promise<string | null> {
+	if (!ripgrepExecutablePromise) {
+		const controller = new AbortController();
+		ripgrepInstallController = controller;
+		const promise = ensureTool("rg", true, controller.signal).then(
+			(executable) => {
+				if (ripgrepInstallController === controller) {
+					ripgrepInstallController = null;
+				}
+				if (ripgrepExecutablePromise === promise && !executable) {
+					ripgrepExecutablePromise = null;
+				}
+				return executable;
+			},
+			(error) => {
+				if (ripgrepInstallController === controller) {
+					ripgrepInstallController = null;
+				}
+				if (ripgrepExecutablePromise === promise) {
+					ripgrepExecutablePromise = null;
+				}
+				throw error;
+			},
+		);
+		ripgrepExecutablePromise = promise;
 	}
-	return executable;
+	return ripgrepExecutablePromise;
+}
+
+function releaseRipgrepExecutableWaiter(signal?: AbortSignal): void {
+	ripgrepExecutableWaiters = Math.max(0, ripgrepExecutableWaiters - 1);
+	if (signal?.aborted && ripgrepExecutableWaiters === 0) {
+		const controller = ripgrepInstallController;
+		resetRipgrepExecutablePromise();
+		controller?.abort(signal.reason);
+	}
+}
+
+async function waitForRipgrepExecutableWithAbort(
+	promise: Promise<string | null>,
+	signal: AbortSignal,
+): Promise<string | null> {
+	throwIfRipgrepAborted(signal);
+	return await new Promise<string | null>((resolve, reject) => {
+		const onAbort = (): void => {
+			signal.removeEventListener("abort", onAbort);
+			reject(ripgrepAbortError());
+		};
+
+		signal.addEventListener("abort", onAbort, { once: true });
+		promise.then(resolve, reject).finally(() => {
+			signal.removeEventListener("abort", onAbort);
+		});
+	});
+}
+
+async function resolveRipgrepExecutable(signal?: AbortSignal): Promise<string> {
+	ripgrepExecutableWaiters += 1;
+	try {
+		const promise = getRipgrepExecutablePromise();
+		const executable = signal
+			? await waitForRipgrepExecutableWithAbort(promise, signal)
+			: await promise;
+		if (!executable) {
+			throw new Error("ripgrep is not available and could not be downloaded");
+		}
+		return executable;
+	} finally {
+		releaseRipgrepExecutableWaiter(signal);
+	}
 }
 
 function throwIfRipgrepAborted(signal?: AbortSignal): void {
@@ -73,19 +142,7 @@ async function resolveRipgrepExecutableWithAbort(
 		return await resolveRipgrepExecutable();
 	}
 
-	return await new Promise<string>((resolve, reject) => {
-		const onAbort = (): void => {
-			signal.removeEventListener("abort", onAbort);
-			reject(ripgrepAbortError());
-		};
-
-		signal.addEventListener("abort", onAbort, { once: true });
-		resolveRipgrepExecutable()
-			.then(resolve, reject)
-			.finally(() => {
-				signal.removeEventListener("abort", onAbort);
-			});
-	});
+	return await resolveRipgrepExecutable(signal);
 }
 
 function shellQuoteArg(value: string): string {

--- a/src/tools/tools-manager.ts
+++ b/src/tools/tools-manager.ts
@@ -61,6 +61,19 @@ interface ToolConfig {
 	) => string | null;
 }
 
+function toolInstallAbortError(config: ToolConfig): Error {
+	return new Error(`${config.name} installation aborted`);
+}
+
+function throwIfToolInstallAborted(
+	config: ToolConfig,
+	signal?: AbortSignal,
+): void {
+	if (signal?.aborted) {
+		throw toolInstallAbortError(config);
+	}
+}
+
 /**
  * Registry of supported external tools and their configurations.
  * Each tool defines platform-specific asset name patterns for GitHub releases.
@@ -170,27 +183,50 @@ export function getToolPath(tool: "fd" | "rg"): string | null {
 async function fetchWithTimeout(
 	url: string,
 	init?: RequestInit,
-): Promise<{ response: Response; clearTimeout: () => void }> {
+	signal?: AbortSignal,
+): Promise<{
+	response: Response;
+	clearTimeout: () => void;
+	cleanup: () => void;
+}> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+	const onAbort = (): void => {
+		controller.abort(signal?.reason);
+	};
+	if (signal?.aborted) {
+		onAbort();
+	} else {
+		signal?.addEventListener("abort", onAbort, { once: true });
+	}
+	const clearFetchTimeout = (): void => clearTimeout(timeout);
+	const cleanup = (): void => {
+		clearFetchTimeout();
+		signal?.removeEventListener("abort", onAbort);
+	};
 	try {
 		const response = await fetch(url, { ...init, signal: controller.signal });
 		return {
 			response,
-			clearTimeout: () => clearTimeout(timeout),
+			clearTimeout: clearFetchTimeout,
+			cleanup,
 		};
 	} catch (error) {
-		clearTimeout(timeout);
+		cleanup();
 		throw error;
 	}
 }
 
-async function getLatestVersion(repo: string): Promise<string> {
-	const { response, clearTimeout: clearFetchTimeout } = await fetchWithTimeout(
+async function getLatestVersion(
+	repo: string,
+	signal?: AbortSignal,
+): Promise<string> {
+	const { response, cleanup: cleanupFetch } = await fetchWithTimeout(
 		`https://api.github.com/repos/${repo}/releases/latest`,
 		{
 			headers: { "User-Agent": "composer-coding-agent" },
 		},
+		signal,
 	);
 	try {
 		if (!response.ok) {
@@ -201,7 +237,7 @@ async function getLatestVersion(repo: string): Promise<string> {
 		// Strip "v" prefix if present for consistent version handling
 		return data.tag_name.replace(/^v/, "");
 	} finally {
-		clearFetchTimeout();
+		cleanupFetch();
 	}
 }
 
@@ -209,9 +245,16 @@ async function getLatestVersion(repo: string): Promise<string> {
  * Download a file from a URL to a local path.
  * Uses streaming to handle large files efficiently.
  */
-async function downloadFile(url: string, dest: string): Promise<void> {
-	const { response, clearTimeout: clearFetchTimeout } =
-		await fetchWithTimeout(url);
+async function downloadFile(
+	url: string,
+	dest: string,
+	signal?: AbortSignal,
+): Promise<void> {
+	const {
+		response,
+		clearTimeout: clearFetchTimeout,
+		cleanup: cleanupFetch,
+	} = await fetchWithTimeout(url, undefined, signal);
 	try {
 		if (!response.ok) {
 			throw new Error(`Failed to download: ${response.status}`);
@@ -229,6 +272,11 @@ async function downloadFile(url: string, dest: string): Promise<void> {
 		);
 		const fileStream = createWriteStream(dest);
 		let idleTimeoutId: ReturnType<typeof setTimeout> | null = null;
+		const onAbort = (): void => {
+			const error = new Error("Tool download aborted");
+			stream.destroy(error);
+			fileStream.destroy(error);
+		};
 
 		const clearIdleTimeout = (): void => {
 			if (idleTimeoutId) {
@@ -254,6 +302,11 @@ async function downloadFile(url: string, dest: string): Promise<void> {
 		};
 
 		resetIdleTimeout();
+		if (signal?.aborted) {
+			onAbort();
+		} else {
+			signal?.addEventListener("abort", onAbort, { once: true });
+		}
 		stream.on("data", resetIdleTimeout);
 		stream.on("end", onStreamEnd);
 		stream.on("close", onStreamEnd);
@@ -266,10 +319,11 @@ async function downloadFile(url: string, dest: string): Promise<void> {
 			stream.off("end", onStreamEnd);
 			stream.off("close", onStreamEnd);
 			stream.off("error", onStreamEnd);
+			signal?.removeEventListener("abort", onAbort);
 			clearIdleTimeout();
 		}
 	} finally {
-		clearFetchTimeout();
+		cleanupFetch();
 	}
 }
 
@@ -328,15 +382,20 @@ function findBinary(root: string, binaryName: string): string | null {
  * @param tool - The tool identifier ("fd" or "rg")
  * @returns Path to the installed binary
  */
-async function downloadTool(tool: "fd" | "rg"): Promise<string> {
+async function downloadTool(
+	tool: "fd" | "rg",
+	signal?: AbortSignal,
+): Promise<string> {
 	const config = TOOLS[tool];
 	if (!config) throw new Error(`Unknown tool: ${tool}`);
+	throwIfToolInstallAborted(config, signal);
 
 	const plat = platform();
 	const architecture = arch();
 
 	// Get the latest version from GitHub
-	const version = await getLatestVersion(config.repo);
+	const version = await getLatestVersion(config.repo, signal);
+	throwIfToolInstallAborted(config, signal);
 
 	// Determine the correct asset for this platform
 	const assetName = config.getAssetName(version, plat, architecture);
@@ -354,7 +413,8 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
 	const binaryPath = join(TOOLS_DIR, config.binaryName + binaryExt);
 
 	// Download the release archive
-	await downloadFile(downloadUrl, archivePath);
+	await downloadFile(downloadUrl, archivePath, signal);
+	throwIfToolInstallAborted(config, signal);
 
 	// Create temp directory for extraction
 	const extractDir = mkdtempSync(join(TOOLS_DIR, "extract-"));
@@ -417,15 +477,17 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
 export async function ensureTool(
 	tool: "fd" | "rg",
 	silent = false,
+	signal?: AbortSignal,
 ): Promise<string | null> {
+	const config = TOOLS[tool];
+	if (!config) return null;
+	throwIfToolInstallAborted(config, signal);
+
 	// Check if already installed
 	const existingPath = getToolPath(tool);
 	if (existingPath) {
 		return existingPath;
 	}
-
-	const config = TOOLS[tool];
-	if (!config) return null;
 
 	// Notify user about download (unless silent)
 	if (!silent) {
@@ -433,12 +495,15 @@ export async function ensureTool(
 	}
 
 	try {
-		const path = await downloadTool(tool);
+		const path = await downloadTool(tool, signal);
 		if (!silent) {
 			console.log(chalk.dim(`${config.name} installed to ${path}`));
 		}
 		return path;
 	} catch (e) {
+		if (signal?.aborted) {
+			throw toolInstallAbortError(config);
+		}
 		// Download failed - log and return null (tool is optional)
 		if (!silent) {
 			console.log(

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1119,8 +1119,13 @@ describe("ci workflow guardrails", () => {
 		expect(script).not.toMatch(/"--sandbox",\s*"workspace-write"/);
 		if (isPublicValidationWorkflow(releaseWorkflow)) {
 			expect(canaryStep).toBeDefined();
+			expect(canaryStep?.run).toBe("node scripts/smoke-registry-install.js");
 			expect(canaryStep?.env).toMatchObject({
+				MAESTRO_INSTALL_AUDIT_LEVEL: "critical",
 				MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "local",
+				MAESTRO_REGISTRY_POLL_ATTEMPTS: "120",
+				MAESTRO_REGISTRY_POLL_DELAY_MS: "5000",
+				MAESTRO_REGISTRY_SMOKE_EVIDENCE_DIR: "published-replay-evidence",
 			});
 			expect(evidenceStep?.run).toBe(
 				"node scripts/verify-published-replay-evidence.js --evidence-dir published-replay-evidence",
@@ -1133,8 +1138,15 @@ describe("ci workflow guardrails", () => {
 				(step) => step.name === "Verify published package from npm",
 			);
 			expect(verifyStep).toBeDefined();
+			expect(verifyStep?.run).toContain(
+				"node scripts/smoke-registry-install.js",
+			);
 			expect(verifyStep?.env).toMatchObject({
+				MAESTRO_INSTALL_AUDIT_LEVEL: "critical",
 				MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "local",
+				MAESTRO_REGISTRY_POLL_ATTEMPTS: "120",
+				MAESTRO_REGISTRY_POLL_DELAY_MS: "5000",
+				MAESTRO_REGISTRY_SMOKE_EVIDENCE_DIR: "published-replay-evidence",
 			});
 		} else {
 			expect(canaryStep).toBeUndefined();

--- a/test/tools/ripgrep-utils.test.ts
+++ b/test/tools/ripgrep-utils.test.ts
@@ -119,4 +119,187 @@ describe("ripgrep utils", () => {
 
 		resolveEnsureTool("/managed/bin/rg");
 	});
+
+	it("aborts shared managed ripgrep resolution when the last waiter aborts", async () => {
+		let installSignal: AbortSignal | undefined;
+		const spawn = vi.fn();
+		const ensureTool = vi.fn(
+			(_tool: string, _silent: boolean, signal?: AbortSignal) =>
+				new Promise<string | null>((_resolve, reject) => {
+					installSignal = signal;
+					signal?.addEventListener(
+						"abort",
+						() => reject(new Error("managed ripgrep resolution aborted")),
+						{ once: true },
+					);
+				}),
+		);
+		vi.doMock("node:child_process", async () => {
+			const actual =
+				await vi.importActual<typeof import("node:child_process")>(
+					"node:child_process",
+				);
+			return {
+				...actual,
+				spawn,
+			};
+		});
+		vi.doMock("../../src/tools/tools-manager.js", () => ({
+			ensureTool,
+		}));
+		const controller = new AbortController();
+
+		const { runRipgrep } = await import("../../src/tools/ripgrep-utils.js");
+		const pending = runRipgrep(["--files"], controller.signal);
+
+		expect(ensureTool).toHaveBeenCalledTimes(1);
+		expect(installSignal).toBeDefined();
+		expect(installSignal?.aborted).toBe(false);
+		controller.abort();
+
+		await expect(pending).rejects.toThrow(/aborted/);
+		expect(installSignal?.aborted).toBe(true);
+		expect(spawn).not.toHaveBeenCalled();
+	});
+
+	it("starts a fresh managed ripgrep resolution after an aborted install retry window", async () => {
+		let installCallCount = 0;
+		let firstInstallSignal: AbortSignal | undefined;
+		let resolveFirstInstall!: (value: string | null) => void;
+		const spawnCalls: Array<{ command: string; args: string[] }> = [];
+		vi.doMock("node:child_process", async () => {
+			const actual =
+				await vi.importActual<typeof import("node:child_process")>(
+					"node:child_process",
+				);
+			return {
+				...actual,
+				spawn: vi.fn((command: string, args: string[]) => {
+					spawnCalls.push({ command, args });
+					const child = new EventEmitter() as EventEmitter & {
+						stdout: PassThrough;
+						stderr: PassThrough;
+						kill: ReturnType<typeof vi.fn>;
+					};
+					child.stdout = new PassThrough();
+					child.stderr = new PassThrough();
+					child.kill = vi.fn();
+					process.nextTick(() => {
+						child.stdout.end("retry match\n");
+						child.stderr.end("");
+						child.emit("close", 0);
+					});
+					return child;
+				}),
+			};
+		});
+		const ensureTool = vi.fn(
+			(_tool: string, _silent: boolean, signal?: AbortSignal) => {
+				installCallCount += 1;
+				if (installCallCount === 1) {
+					firstInstallSignal = signal;
+					return new Promise<string | null>((resolve) => {
+						resolveFirstInstall = resolve;
+					});
+				}
+				return Promise.resolve("/managed/bin/rg");
+			},
+		);
+		vi.doMock("../../src/tools/tools-manager.js", () => ({
+			ensureTool,
+		}));
+		const controller = new AbortController();
+
+		const { runRipgrep } = await import("../../src/tools/ripgrep-utils.js");
+		const abortedSearch = runRipgrep(["--files"], controller.signal);
+		expect(ensureTool).toHaveBeenCalledTimes(1);
+		expect(firstInstallSignal?.aborted).toBe(false);
+
+		controller.abort();
+
+		await expect(abortedSearch).rejects.toThrow(
+			"ripgrep search aborted before start",
+		);
+		expect(firstInstallSignal?.aborted).toBe(true);
+
+		const retrySearch = runRipgrep(["--files"]);
+		expect(ensureTool).toHaveBeenCalledTimes(2);
+		await expect(retrySearch).resolves.toEqual({
+			stdout: "retry match\n",
+			stderr: "",
+			exitCode: 0,
+			truncated: false,
+		});
+		expect(spawnCalls).toEqual([
+			{ command: "/managed/bin/rg", args: ["--files"] },
+		]);
+
+		resolveFirstInstall("/managed/bin/rg");
+		await Promise.resolve();
+	});
+
+	it("dedupes managed ripgrep resolution for concurrent signaled searches", async () => {
+		let resolveEnsureTool!: (value: string | null) => void;
+		let installSignal: AbortSignal | undefined;
+		const ensureTool = vi.fn(
+			(_tool: string, _silent: boolean, signal?: AbortSignal) =>
+				new Promise<string | null>((resolve) => {
+					installSignal = signal;
+					resolveEnsureTool = resolve;
+				}),
+		);
+		const spawnCalls: Array<{ command: string; args: string[] }> = [];
+		vi.doMock("node:child_process", async () => {
+			const actual =
+				await vi.importActual<typeof import("node:child_process")>(
+					"node:child_process",
+				);
+			return {
+				...actual,
+				spawn: vi.fn((command: string, args: string[]) => {
+					spawnCalls.push({ command, args });
+					const child = new EventEmitter() as EventEmitter & {
+						stdout: PassThrough;
+						stderr: PassThrough;
+						kill: ReturnType<typeof vi.fn>;
+					};
+					child.stdout = new PassThrough();
+					child.stderr = new PassThrough();
+					child.kill = vi.fn();
+					process.nextTick(() => {
+						child.stdout.end("match\n");
+						child.stderr.end("");
+						child.emit("close", 0);
+					});
+					return child;
+				}),
+			};
+		});
+		vi.doMock("../../src/tools/tools-manager.js", () => ({
+			ensureTool,
+		}));
+		const firstController = new AbortController();
+		const secondController = new AbortController();
+
+		const { runRipgrep } = await import("../../src/tools/ripgrep-utils.js");
+		const first = runRipgrep(["--files"], firstController.signal);
+		const second = runRipgrep(
+			["--json", "needle", "."],
+			secondController.signal,
+		);
+
+		expect(ensureTool).toHaveBeenCalledTimes(1);
+		expect(installSignal).toBeDefined();
+		resolveEnsureTool("/managed/bin/rg");
+
+		await expect(Promise.all([first, second])).resolves.toEqual([
+			{ stdout: "match\n", stderr: "", exitCode: 0, truncated: false },
+			{ stdout: "match\n", stderr: "", exitCode: 0, truncated: false },
+		]);
+		expect(spawnCalls).toEqual([
+			{ command: "/managed/bin/rg", args: ["--files"] },
+			{ command: "/managed/bin/rg", args: ["--json", "needle", "."] },
+		]);
+		expect(installSignal?.aborted).toBe(false);
+	});
 });


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"bc438188011809953e30c120255bf88f9799f032"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `bc438188011809953e30c120255bf88f9799f032`
- last generated public sync base: `e48d11ea2953f2ef6370c0710177ab072a3c7eff`
- previewed public-tree drift: `8` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `2`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (bc4381880118)`
- public projection: `https://github.com/evalops/maestro@main (242933c38737)`
- files to copy or update: `8`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update packages/control-plane-rs/src/a2a/tasks.rs
- copy/update packages/control-plane-rs/src/tests.rs
- copy/update src/tools/find.ts
- copy/update src/tools/ripgrep-utils.ts
- copy/update src/tools/tools-manager.ts
- copy/update test/scripts/ci-guardrails.test.ts
- copy/update test/tools/ripgrep-utils.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/a2a-fleet-delegation.md
- copy/update packages/control-plane-rs/src/a2a/tasks.rs
- copy/update packages/control-plane-rs/src/tests.rs
- copy/update src/tools/find.ts
- copy/update src/tools/ripgrep-utils.ts
- copy/update src/tools/tools-manager.ts
- copy/update test/scripts/ci-guardrails.test.ts
- copy/update test/tools/ripgrep-utils.test.ts

## Public-only commits since last generated sync

- 242933c3 Merge pull request #651 from evalops/codex/verify-published-canary-env-20260527
- a48c6448 [maestro] Keep deprecation message current (#649)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@bc438188011809953e30c120255bf88f9799f032`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #650 to internal source `bc438188011809953e30c120255bf88f9799f032`