### PR TITLE
[maestro] Make published package canary explicit

### DIFF
--- a/.github/workflows/verify-published-package.yml
+++ b/.github/workflows/verify-published-package.yml
@@ -63,8 +63,11 @@ jobs:
           PACKAGE_NAME: ${{ github.event.inputs.package_name || steps.defaults.outputs.package_name }}
           PACKAGE_VERSION: ${{ github.event.inputs.version || steps.defaults.outputs.version }}
           CLI_COMMAND: ${{ github.event.inputs.cli_command || steps.defaults.outputs.cli_command }}
+          MAESTRO_INSTALL_AUDIT_LEVEL: critical
           MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: local
           MAESTRO_REGISTRY_SMOKE_EVIDENCE_DIR: published-replay-evidence
+          MAESTRO_REGISTRY_POLL_ATTEMPTS: "120"
+          MAESTRO_REGISTRY_POLL_DELAY_MS: "5000"
         run: |
           set -euo pipefail
           node scripts/smoke-registry-install.js \


### PR DESCRIPTION
## Summary
- Make the public verify-published-package workflow explicitly run the published registry canary at critical audit level.
- Pin the same registry polling and evidence-directory settings used by the release post-publish canary.

## Tests
- node ./scripts/run-vitest.js --run test/scripts/ci-guardrails.test.ts -t "keeps published replay canaries portable on hosted Linux"
- node --input-type=module -e '<parsed verify-published-package.yml and asserted canary env>'
- pre-commit hook: biome, lint:evals/conformance checks, generated-surface checks, build/compile