### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ versioning when releases are cut.
   and keep scheduled public runs inert so public publishing stays downstream of
   the internal source-of-truth release.
 
+## [0.10.40] - 2026-05-27
+
+### Changed
+
+- Harden release surface gate scripts. <!-- maestro-release-note:52e5b469a427 -->
+- Verify published replay provider config mirrors. <!-- maestro-release-note:db33aac1117f -->
+- Require deterministic published replay provider config. <!-- maestro-release-note:20ccb579d520 -->
+- Gate published replay provider transcript evidence. <!-- maestro-release-note:85d27c1a856b -->
+
+### Fixed
+
+- Harden ripgrep path errors and replay error evidence (#2307). <!-- maestro-release-note:2d2352fdcfa1 -->
+
 ## [0.10.39] - 2026-05-27
 
 ### Changed

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Maestro Web API",
-    "version": "0.10.39",
+    "version": "0.10.40",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evalops/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
-  "version": "0.10.39",
+  "version": "0.10.40",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/ai",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Shared Maestro AI SDK (models, transport, and agent event stream facade).",
 	"type": "module",
 	"main": "./dist/packages/ai/src/index.js",
@@ -131,8 +131,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.39",
-		"@evalops/tui": "^0.10.39",
+		"@evalops/contracts": "^0.10.40",
+		"@evalops/tui": "^0.10.40",
 		"@google/genai": "^1.29.1",
 		"@sinclair/typebox": "^0.34.0",
 		"nats": "^2.29.3"

--- a/packages/consumer-sdk/package.json
+++ b/packages/consumer-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/consumer",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Unified EvalOps consumer SDK for Maestro service integrations",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -28,7 +28,7 @@
 		"directory": "packages/consumer-sdk"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.39"
+		"@evalops/contracts": "^0.10.40"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/contracts",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Shared Maestro contracts for frontend/backend integration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-core",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Maestro agent loop, transport, types, and sandbox primitives — the engine behind all Maestro interfaces",
 	"type": "module",
 	"main": "./dist/packages/core/src/index.js",
@@ -69,7 +69,7 @@
 		"vscode-jsonrpc": "^8.2.0"
 	},
 	"peerDependencies": {
-		"@evalops/tui": "^0.10.39"
+		"@evalops/tui": "^0.10.40"
 	},
 	"peerDependenciesMeta": {
 		"@evalops/tui": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-desktop",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Maestro Desktop - Beautiful Electron app for AI-assisted development",
 	"type": "module",
 	"main": "dist-electron/main/index.js",
@@ -37,7 +37,7 @@
 		"directory": "packages/desktop"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.39",
+		"@evalops/contracts": "^0.10.40",
 		"electron-store": "^10.0.1",
 		"electron-updater": "^6.3.9"
 	},

--- a/packages/github-agent/package.json
+++ b/packages/github-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/github-agent",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Autonomous GitHub agent - Maestro building Maestro",
 	"type": "module",
 	"bin": {
@@ -36,8 +36,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/ai": "^0.10.39",
-		"@evalops/contracts": "^0.10.39",
+		"@evalops/ai": "^0.10.40",
+		"@evalops/contracts": "^0.10.40",
 		"@octokit/rest": "^21.0.0",
 		"@octokit/webhooks": "^13.0.0",
 		"@sinclair/typebox": "^0.34.0",

--- a/packages/governance-mcp-server/package.json
+++ b/packages/governance-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance-mcp-server",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "MCP server exposing Platform governance proxy tools to any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -43,7 +43,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/governance": "^0.10.39",
+		"@evalops/governance": "^0.10.40",
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"zod": "^4.3.5"
 	},

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Thin Platform governance proxy for MCP-compatible agents.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/memory",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"private": true,
 	"type": "module",
 	"sideEffects": false,

--- a/packages/slack-agent-ui/package.json
+++ b/packages/slack-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent-ui",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Web UI for Slack Agent - Dashboard gallery, connector management, OAuth flows",
 	"type": "module",
 	"private": true,

--- a/packages/slack-agent/package.json
+++ b/packages/slack-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Slack bot agent with Docker sandbox support for Maestro",
 	"type": "module",
 	"bin": {
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@daytonaio/sdk": "^0.139.0",
-		"@evalops/ai": "^0.10.39",
+		"@evalops/ai": "^0.10.40",
 		"@sinclair/typebox": "^0.34.0",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/tui",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Terminal UI library with differential rendering for Maestro",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Maestro",
 	"description": "Use Maestro's deterministic AI assistant inside VS Code.",
 	"publisher": "evalops",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"license": "MIT",
 	"type": "commonjs",
 	"main": "./dist/extension.js",
@@ -139,7 +139,7 @@
 		"test": "vitest --run"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.39"
+		"@evalops/contracts": "^0.10.40"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-web",
-	"version": "0.10.39",
+	"version": "0.10.40",
 	"description": "Web UI for Maestro - Browser-based AI coding assistant interface",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,7 +24,7 @@
 		"directory": "packages/web"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.39",
+		"@evalops/contracts": "^0.10.40",
 		"docx-preview": "^0.3.7",
 		"dompurify": "^3.3.0",
 		"exceljs": "^4.4.0",


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"739307ef8425e434fd9ff5080e99d330a7d9bf87"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `739307ef8425e434fd9ff5080e99d330a7d9bf87`
- last generated public sync base: `3801659a4db4ad89e43efa75eb5acc0828343c25`
- previewed public-tree drift: `17` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (739307ef8425)`
- public projection: `https://github.com/evalops/maestro@main (3801659a4db4)`
- files to copy or update: `17`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update CHANGELOG.md
- copy/update openapi.json
- copy/update package.json
- copy/update packages/ai/package.json
- copy/update packages/consumer-sdk/package.json
- copy/update packages/contracts/package.json
- copy/update packages/core/package.json
- copy/update packages/desktop/package.json
- copy/update packages/github-agent/package.json
- copy/update packages/governance-mcp-server/package.json
- copy/update packages/governance/package.json
- copy/update packages/memory/package.json
- copy/update packages/slack-agent-ui/package.json
- copy/update packages/slack-agent/package.json
- copy/update packages/tui/package.json
- copy/update packages/vscode-extension/package.json
- copy/update packages/web/package.json

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update CHANGELOG.md
- copy/update openapi.json
- copy/update package.json
- copy/update packages/ai/package.json
- copy/update packages/consumer-sdk/package.json
- copy/update packages/contracts/package.json
- copy/update packages/core/package.json
- copy/update packages/desktop/package.json
- copy/update packages/github-agent/package.json
- copy/update packages/governance-mcp-server/package.json
- copy/update packages/governance/package.json
- copy/update packages/memory/package.json
- copy/update packages/slack-agent-ui/package.json
- copy/update packages/slack-agent/package.json
- copy/update packages/tui/package.json
- copy/update packages/vscode-extension/package.json
- copy/update packages/web/package.json

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@739307ef8425e434fd9ff5080e99d330a7d9bf87`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.