### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ versioning when releases are cut.
   and keep scheduled public runs inert so public publishing stays downstream of
   the internal source-of-truth release.
 
+## [0.10.44] - 2026-05-28
+
+### Changed
+
+- Harden hosted runner continuity evidence. <!-- maestro-release-note:a0e4b937ee8e -->
+- Require public release tag mismatches with package-impacting changes to use a
+  new package version.
+
+### Fixed
+
+- Release post-v0.10.43 package changes under v0.10.44 instead of silently
+  skipping the public tag guard.
+
 ## [0.10.43] - 2026-05-28
 
 ### Changed

--- a/docs/protocols/codex-operating-layer.json
+++ b/docs/protocols/codex-operating-layer.json
@@ -381,12 +381,15 @@
 			"path": "src/server/handlers/hosted-runner-drain.ts",
 			"anchors": [
 				"evalops.remote-runner.work-continuity.v1",
+				"evalops.remote-runner.runtime-continuity.v1",
 				"collectHostedRunnerWorkContinuity",
+				"buildHostedRunnerRuntimeContinuity",
 				"codex_subagent_child_run_ids",
 				"codex_subagent_thread_ids",
 				"codex_subagent_edges",
 				"collectCodexSubagentEdgesFromSource",
-				"codexSubagentOperation"
+				"codexSubagentOperation",
+				"source_owner_instance_id"
 			]
 		},
 		{
@@ -406,13 +409,17 @@
 			"area": "remote-runner-continuity",
 			"evidenceType": "source",
 			"path": "packages/tui-rs/src/hosted_runner.rs",
-			"anchors": ["evalops.remote-runner.work-continuity.v1"]
+			"anchors": [
+				"evalops.remote-runner.work-continuity.v1",
+				"evalops.remote-runner.runtime-continuity.v1"
+			]
 		},
 		{
 			"area": "remote-runner-continuity",
 			"evidenceType": "source",
 			"path": "packages/tui-rs/src/hosted_runner/manifests.rs",
 			"anchors": [
+				"RuntimeContinuityManifest",
 				"CodexSubagentContinuityEdge",
 				"codex_subagent_edges",
 				"collect_codex_subagent_edges_from_source"
@@ -481,6 +488,7 @@
 				"records Codex subagent continuity without copying prompt payloads into manifest metadata",
 				"records Codex subagent edge lifecycle from restored runtime state",
 				"HOSTED_RUNNER_WORK_CONTINUITY_VERSION",
+				"HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION",
 				"codex_subagent_child_run_ids",
 				"codex_subagent_edges",
 				"close_agent"
@@ -490,7 +498,11 @@
 			"area": "remote-runner-continuity",
 			"evidenceType": "doc",
 			"path": "docs/protocols/hosted-runner-contract.md",
-			"anchors": ["work_continuity", "Codex subagent child runs"]
+			"anchors": [
+				"runtime_continuity",
+				"work_continuity",
+				"Codex subagent child runs"
+			]
 		},
 		{
 			"area": "realtime-streaming",

--- a/docs/protocols/headless-conformance.md
+++ b/docs/protocols/headless-conformance.md
@@ -57,8 +57,9 @@ The first conformance tranche covers:
 - approval server request emission and protocol response resolution
 - hosted workspace-root enforcement for file reads
 - hosted utility command/search/watch lifecycle
-- hosted drain/snapshot handoff, including manifest export paths and post-drain
-  mutation rejection
+- hosted drain/snapshot handoff, including manifest export paths,
+  runtime-continuity evidence for drain/restore handoff, and post-drain mutation
+  rejection
 - hosted restore from a drain manifest for adapters with hosted lifecycle hooks,
   including reset replay and post-restore controller mutation
 - hosted incomplete restore semantics for Rust unit coverage: failed or skipped

--- a/docs/protocols/headless.md
+++ b/docs/protocols/headless.md
@@ -238,6 +238,14 @@ The runtime flush status is the field that controls restore readiness:
 means no runtime activity was persisted. Older local manifests that used
 `interrupted` for the runtime flush status are treated as `failed`.
 
+New drain manifests also include `runtime_continuity`, a compact handoff record
+for Platform and operators. It names the source runner session, owner instance,
+source process id, restore manifest path, restore environment key, and the
+cursor-scoped evidence refs that prove which headless snapshot should be
+restored after process shutdown or replica replacement. `platform_evidence`
+mirrors a redacted summary of the same block so AgentRuntime progress records
+can be queried without reading the full runtime snapshot.
+
 ## Hosted Remote-Runner Restore
 
 When Platform has already restored workspace artifacts and a prior snapshot

--- a/docs/protocols/hosted-runner-contract.md
+++ b/docs/protocols/hosted-runner-contract.md
@@ -215,6 +215,8 @@ The manifest protocol is
 `evalops.remote-runner.snapshot-manifest.v1`. Both Rust-hosted and
 TypeScript-hosted drain paths write this same local manifest envelope, including
 the runtime flush status, workspace export contract, headless runtime snapshot,
+schema-versioned `runtime_continuity` evidence for the source runner session,
+source owner instance, source process, restore manifest path, and replay cursor,
 schema-versioned `work_continuity` metadata for active/pending
 Codex subagent child runs, and
 `retention_policy` metadata describing visibility and redaction classes. Managed

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Maestro Web API",
-    "version": "0.10.43",
+    "version": "0.10.44",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evalops/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
-  "version": "0.10.43",
+  "version": "0.10.44",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/ai",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Shared Maestro AI SDK (models, transport, and agent event stream facade).",
 	"type": "module",
 	"main": "./dist/packages/ai/src/index.js",
@@ -131,8 +131,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.43",
-		"@evalops/tui": "^0.10.43",
+		"@evalops/contracts": "^0.10.44",
+		"@evalops/tui": "^0.10.44",
 		"@google/genai": "^1.29.1",
 		"@sinclair/typebox": "^0.34.0",
 		"nats": "^2.29.3"

--- a/packages/consumer-sdk/package.json
+++ b/packages/consumer-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/consumer",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Unified EvalOps consumer SDK for Maestro service integrations",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -28,7 +28,7 @@
 		"directory": "packages/consumer-sdk"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.43"
+		"@evalops/contracts": "^0.10.44"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/contracts",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Shared Maestro contracts for frontend/backend integration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-core",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Maestro agent loop, transport, types, and sandbox primitives — the engine behind all Maestro interfaces",
 	"type": "module",
 	"main": "./dist/packages/core/src/index.js",
@@ -69,7 +69,7 @@
 		"vscode-jsonrpc": "^8.2.0"
 	},
 	"peerDependencies": {
-		"@evalops/tui": "^0.10.43"
+		"@evalops/tui": "^0.10.44"
 	},
 	"peerDependenciesMeta": {
 		"@evalops/tui": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-desktop",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Maestro Desktop - Beautiful Electron app for AI-assisted development",
 	"type": "module",
 	"main": "dist-electron/main/index.js",
@@ -37,7 +37,7 @@
 		"directory": "packages/desktop"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.43",
+		"@evalops/contracts": "^0.10.44",
 		"electron-store": "^10.0.1",
 		"electron-updater": "^6.3.9"
 	},

--- a/packages/github-agent/package.json
+++ b/packages/github-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/github-agent",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Autonomous GitHub agent - Maestro building Maestro",
 	"type": "module",
 	"bin": {
@@ -36,8 +36,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/ai": "^0.10.43",
-		"@evalops/contracts": "^0.10.43",
+		"@evalops/ai": "^0.10.44",
+		"@evalops/contracts": "^0.10.44",
 		"@octokit/rest": "^21.0.0",
 		"@octokit/webhooks": "^13.0.0",
 		"@sinclair/typebox": "^0.34.0",

--- a/packages/governance-mcp-server/package.json
+++ b/packages/governance-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance-mcp-server",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "MCP server exposing Platform governance proxy tools to any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -43,7 +43,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/governance": "^0.10.43",
+		"@evalops/governance": "^0.10.44",
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"zod": "^4.3.5"
 	},

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Thin Platform governance proxy for MCP-compatible agents.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/memory",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"private": true,
 	"type": "module",
 	"sideEffects": false,

--- a/packages/slack-agent-ui/package.json
+++ b/packages/slack-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent-ui",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Web UI for Slack Agent - Dashboard gallery, connector management, OAuth flows",
 	"type": "module",
 	"private": true,

--- a/packages/slack-agent/package.json
+++ b/packages/slack-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Slack bot agent with Docker sandbox support for Maestro",
 	"type": "module",
 	"bin": {
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@daytonaio/sdk": "^0.139.0",
-		"@evalops/ai": "^0.10.43",
+		"@evalops/ai": "^0.10.44",
 		"@sinclair/typebox": "^0.34.0",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -51,6 +51,8 @@ pub const HOSTED_RUNNER_RETENTION_POLICY_VERSION: &str = "evalops.remote-runner.
 pub const HOSTED_RUNNER_WORK_CONTINUITY_VERSION: &str = "evalops.remote-runner.work-continuity.v1";
 pub const HOSTED_RUNNER_PLATFORM_EVIDENCE_VERSION: &str =
     "evalops.remote-runner.platform-evidence.v1";
+pub const HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION: &str =
+    "evalops.remote-runner.runtime-continuity.v1";
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS: u64 = 15_000;
 const CONNECTION_IDLE_MS: i64 = (DEFAULT_HEARTBEAT_INTERVAL_MS as i64) * 3;

--- a/packages/tui-rs/src/hosted_runner/manifests.rs
+++ b/packages/tui-rs/src/hosted_runner/manifests.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 use super::{
     resolve_workspace_path, HostedError, HostedResult, HostedRunnerConfig, HostedRunnerErrorCode,
     HOSTED_RUNNER_PLATFORM_EVIDENCE_VERSION, HOSTED_RUNNER_RETENTION_POLICY_VERSION,
-    HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION, HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
+    HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION, HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
+    HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
 };
 use crate::headless::messages::{
     active_codex_subagent_status, codex_subagent_child_runs, codex_subagent_edge_key,
@@ -133,6 +134,8 @@ pub(super) struct SnapshotManifest {
     pub(super) runtime: RuntimeFlushManifest,
     pub(super) workspace_export: WorkspaceExportManifest,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) runtime_continuity: Option<RuntimeContinuityManifest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) work_continuity: Option<WorkContinuityManifest>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) platform_evidence: Option<PlatformEvidenceManifest>,
@@ -170,6 +173,31 @@ impl SnapshotManifest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct RuntimeContinuityManifest {
+    pub(super) protocol_version: String,
+    pub(super) handoff: String,
+    pub(super) source_runner_session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) source_owner_instance_id: Option<String>,
+    pub(super) source_process_id: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) source_runtime_lease: Option<RuntimeContinuityLeaseManifest>,
+    pub(super) restore_environment_key: String,
+    pub(super) restore_manifest_path: String,
+    pub(super) evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct RuntimeContinuityLeaseManifest {
+    pub(super) protocol_version: String,
+    pub(super) state: String,
+    pub(super) generation: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) maestro_session_id: Option<String>,
+    pub(super) updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(super) struct WorkContinuityManifest {
     pub(super) protocol_version: String,
     pub(super) active_tool_count: usize,
@@ -202,6 +230,8 @@ pub(super) struct PlatformEvidenceManifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) requested_by: Option<String>,
     pub(super) work_continuity: PlatformEvidenceWorkContinuityManifest,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) runtime_continuity: Option<PlatformEvidenceRuntimeContinuityManifest>,
     pub(super) retention: PlatformEvidenceRetentionManifest,
     pub(super) evidence_refs: Vec<String>,
 }
@@ -221,6 +251,18 @@ pub(super) struct PlatformEvidenceWorkContinuityManifest {
     pub(super) codex_subagent_thread_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(super) codex_subagent_edges: Vec<CodexSubagentContinuityEdge>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct PlatformEvidenceRuntimeContinuityManifest {
+    pub(super) protocol_version: String,
+    pub(super) handoff: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) source_owner_instance_id: Option<String>,
+    pub(super) source_process_id: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) source_runtime_lease_generation: Option<u64>,
+    pub(super) restore_manifest_path: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -287,12 +329,46 @@ pub(super) fn runtime_flush_status_label(status: RuntimeFlushStatus) -> &'static
     }
 }
 
+pub(super) struct RuntimeContinuityManifestInput<'a> {
+    pub(super) config: &'a HostedRunnerConfig,
+    pub(super) maestro_session_id: &'a str,
+    pub(super) manifest_path: &'a Path,
+    pub(super) runtime: &'a RuntimeFlushManifest,
+}
+
+pub(super) fn default_runtime_continuity_manifest(
+    input: RuntimeContinuityManifestInput<'_>,
+) -> RuntimeContinuityManifest {
+    RuntimeContinuityManifest {
+        protocol_version: HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION.to_string(),
+        handoff: "drain_restore".to_string(),
+        source_runner_session_id: input.config.runner_session_id.clone(),
+        source_owner_instance_id: input.config.owner_instance_id.clone(),
+        source_process_id: std::process::id(),
+        source_runtime_lease: None,
+        restore_environment_key: "MAESTRO_REMOTE_RUNNER_RESTORE_MANIFEST".to_string(),
+        restore_manifest_path: input.manifest_path.to_string_lossy().to_string(),
+        evidence_refs: vec![
+            format!(
+                "remote-runner://sessions/{}/drain#snapshot",
+                input.config.runner_session_id
+            ),
+            format!(
+                "maestro://headless/sessions/{}#cursor:{}",
+                input.maestro_session_id,
+                input.runtime.cursor.unwrap_or(0)
+            ),
+        ],
+    }
+}
+
 pub(super) struct PlatformEvidenceManifestInput<'a> {
     pub(super) config: &'a HostedRunnerConfig,
     pub(super) maestro_session_id: &'a str,
     pub(super) created_at: &'a str,
     pub(super) manifest_path: &'a Path,
     pub(super) runtime: &'a RuntimeFlushManifest,
+    pub(super) runtime_continuity: &'a RuntimeContinuityManifest,
     pub(super) work_continuity: &'a WorkContinuityManifest,
     pub(super) retention_policy: &'a RetentionPolicyManifest,
     pub(super) reason: Option<&'a str>,
@@ -342,6 +418,18 @@ pub(super) fn default_platform_evidence_manifest(
             codex_subagent_thread_ids: input.work_continuity.codex_subagent_thread_ids.clone(),
             codex_subagent_edges: input.work_continuity.codex_subagent_edges.clone(),
         },
+        runtime_continuity: Some(PlatformEvidenceRuntimeContinuityManifest {
+            protocol_version: input.runtime_continuity.protocol_version.clone(),
+            handoff: input.runtime_continuity.handoff.clone(),
+            source_owner_instance_id: input.runtime_continuity.source_owner_instance_id.clone(),
+            source_process_id: input.runtime_continuity.source_process_id,
+            source_runtime_lease_generation: input
+                .runtime_continuity
+                .source_runtime_lease
+                .as_ref()
+                .map(|lease| lease.generation),
+            restore_manifest_path: input.runtime_continuity.restore_manifest_path.clone(),
+        }),
         retention: PlatformEvidenceRetentionManifest {
             policy_version: input.retention_policy.policy_version.clone(),
             control_plane_metadata_visibility: input

--- a/packages/tui-rs/src/hosted_runner/snapshots.rs
+++ b/packages/tui-rs/src/hosted_runner/snapshots.rs
@@ -82,12 +82,19 @@ pub(super) async fn write_snapshot_manifest(
     };
     let work_continuity = default_work_continuity_manifest(&snapshot);
     let retention_policy = default_retention_policy_manifest();
+    let runtime_continuity = default_runtime_continuity_manifest(RuntimeContinuityManifestInput {
+        config: &shared.config,
+        maestro_session_id: &maestro_session_id,
+        manifest_path: &path,
+        runtime: &runtime,
+    });
     let platform_evidence = default_platform_evidence_manifest(PlatformEvidenceManifestInput {
         config: &shared.config,
         maestro_session_id: &maestro_session_id,
         created_at: &created_at,
         manifest_path: &path,
         runtime: &runtime,
+        runtime_continuity: &runtime_continuity,
         work_continuity: &work_continuity,
         retention_policy: &retention_policy,
         reason: input.reason.as_deref(),
@@ -108,6 +115,7 @@ pub(super) async fn write_snapshot_manifest(
             mode: "local_path_contract".to_string(),
             paths: workspace_export_paths,
         },
+        runtime_continuity: Some(runtime_continuity),
         work_continuity: Some(work_continuity),
         platform_evidence: Some(platform_evidence),
         snapshot,

--- a/packages/tui-rs/src/hosted_runner/tests.rs
+++ b/packages/tui-rs/src/hosted_runner/tests.rs
@@ -399,6 +399,29 @@ async fn identity_and_drain_follow_runner_contract() {
         manifest["work_continuity"]["protocol_version"],
         HOSTED_RUNNER_WORK_CONTINUITY_VERSION
     );
+    assert_eq!(
+        manifest["runtime_continuity"]["protocol_version"],
+        HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION
+    );
+    assert_eq!(manifest["runtime_continuity"]["handoff"], "drain_restore");
+    assert_eq!(
+        manifest["runtime_continuity"]["source_runner_session_id"],
+        "mrs_test"
+    );
+    assert_eq!(
+        manifest["runtime_continuity"]["source_owner_instance_id"],
+        "owner_test"
+    );
+    assert!(
+        manifest["runtime_continuity"]["source_process_id"]
+            .as_u64()
+            .unwrap_or_default()
+            > 0
+    );
+    assert_eq!(
+        manifest["runtime_continuity"]["restore_environment_key"],
+        "MAESTRO_REMOTE_RUNNER_RESTORE_MANIFEST"
+    );
     assert_eq!(manifest["work_continuity"]["active_tool_count"], 0);
     assert_eq!(manifest["work_continuity"]["tracked_tool_count"], 0);
     assert_eq!(
@@ -420,6 +443,10 @@ async fn identity_and_drain_follow_runner_contract() {
     assert_eq!(
         manifest["platform_evidence"]["runtime_flush_status"],
         "skipped"
+    );
+    assert_eq!(
+        manifest["platform_evidence"]["runtime_continuity"]["protocol_version"],
+        HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION
     );
     assert_eq!(
         manifest["platform_evidence"]["manifest_path"],
@@ -700,24 +727,14 @@ fn snapshot_manifest_parser_accepts_typescript_hosted_shape() {
     let workspace = tempdir().expect("workspace");
     let readme_path = workspace.path().join("README.md");
     std::fs::write(&readme_path, "# workspace\n").expect("workspace file");
-    let manifest = json!({
-        "protocol_version": HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
-        "runner_session_id": "mrs_ts",
-        "workspace_id": "ws_ts",
-        "agent_run_id": "run_ts",
-        "maestro_session_id": "session_ts",
-        "reason": "ttl_expired",
-        "requested_by": "platform",
-        "created_at": "2026-04-23T00:00:00.000Z",
-        "workspace_root": workspace.path(),
-        "runtime": {
+    let runtime = json!({
             "flush_status": "completed",
             "session_id": "session_ts",
             "session_file": workspace.path().join(".maestro/sessions/session.jsonl"),
             "protocol_version": HEADLESS_PROTOCOL_VERSION,
             "cursor": 7
-        },
-        "workspace_export": {
+    });
+    let workspace_export = json!({
             "mode": "local_path_contract",
             "paths": [{
                 "input": "README.md",
@@ -725,8 +742,8 @@ fn snapshot_manifest_parser_accepts_typescript_hosted_shape() {
                 "relative_path": "README.md",
                 "type": "file"
             }]
-        },
-        "work_continuity": {
+    });
+    let work_continuity = json!({
             "protocol_version": HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
             "active_tool_count": 1,
             "tracked_tool_count": 1,
@@ -734,8 +751,30 @@ fn snapshot_manifest_parser_accepts_typescript_hosted_shape() {
             "codex_subagent_tool_call_ids": ["collab-spawn-ts"],
             "codex_subagent_child_run_ids": ["agent-run-child-ts"],
             "codex_subagent_thread_ids": ["child-thread-ts"]
-        },
-        "platform_evidence": {
+    });
+    let platform_work_continuity = json!({
+            "protocol_version": HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
+            "active_tool_count": 1,
+            "tracked_tool_count": 1,
+            "pending_request_count": 0,
+            "codex_subagent_tool_call_count": 1,
+            "codex_subagent_child_run_count": 1,
+            "codex_subagent_thread_count": 1,
+            "codex_subagent_edge_count": 0,
+            "codex_subagent_tool_call_ids": ["collab-spawn-ts"],
+            "codex_subagent_child_run_ids": ["agent-run-child-ts"],
+            "codex_subagent_thread_ids": ["child-thread-ts"]
+    });
+    let retention = json!({
+            "policy_version": HOSTED_RUNNER_RETENTION_POLICY_VERSION,
+            "control_plane_metadata_visibility": "operator",
+            "runtime_snapshot_visibility": "internal",
+            "redaction_required_before_external_persistence": [
+                "runtime_snapshot",
+                "runtime_logs"
+            ]
+    });
+    let platform_evidence = json!({
             "protocol_version": HOSTED_RUNNER_PLATFORM_EVIDENCE_VERSION,
             "event_type": "hosted_runner_drain_manifest_recorded",
             "runner_session_id": "mrs_ts",
@@ -749,35 +788,15 @@ fn snapshot_manifest_parser_accepts_typescript_hosted_shape() {
             "created_at": "2026-04-23T00:00:00.000Z",
             "reason": "ttl_expired",
             "requested_by": "platform",
-            "work_continuity": {
-                "protocol_version": HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
-                "active_tool_count": 1,
-                "tracked_tool_count": 1,
-                "pending_request_count": 0,
-                "codex_subagent_tool_call_count": 1,
-                "codex_subagent_child_run_count": 1,
-                "codex_subagent_thread_count": 1,
-                "codex_subagent_edge_count": 0,
-                "codex_subagent_tool_call_ids": ["collab-spawn-ts"],
-                "codex_subagent_child_run_ids": ["agent-run-child-ts"],
-                "codex_subagent_thread_ids": ["child-thread-ts"]
-            },
-            "retention": {
-                "policy_version": HOSTED_RUNNER_RETENTION_POLICY_VERSION,
-                "control_plane_metadata_visibility": "operator",
-                "runtime_snapshot_visibility": "internal",
-                "redaction_required_before_external_persistence": [
-                    "runtime_snapshot",
-                    "runtime_logs"
-                ]
-            },
+            "work_continuity": platform_work_continuity,
+            "retention": retention,
             "evidence_refs": [
                 "remote-runner://sessions/mrs_ts/drain#manifest",
                 "maestro://headless/sessions/session_ts#drain",
                 "platform-agent-run:run_ts"
             ]
-        },
-        "retention_policy": {
+    });
+    let retention_policy = json!({
             "policy_version": HOSTED_RUNNER_RETENTION_POLICY_VERSION,
             "managed_by": "platform",
             "visibility": {
@@ -799,8 +818,8 @@ fn snapshot_manifest_parser_accepts_typescript_hosted_shape() {
                     "raw_environment"
                 ]
             }
-        },
-        "snapshot": {
+    });
+    let snapshot = json!({
             "protocolVersion": HEADLESS_PROTOCOL_VERSION,
             "session_id": "session_ts",
             "cursor": 7,
@@ -827,7 +846,23 @@ fn snapshot_manifest_parser_accepts_typescript_hosted_shape() {
                 "is_ready": true,
                 "is_responding": false
             }
-        }
+    });
+    let manifest = json!({
+        "protocol_version": HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
+        "runner_session_id": "mrs_ts",
+        "workspace_id": "ws_ts",
+        "agent_run_id": "run_ts",
+        "maestro_session_id": "session_ts",
+        "reason": "ttl_expired",
+        "requested_by": "platform",
+        "created_at": "2026-04-23T00:00:00.000Z",
+        "workspace_root": workspace.path(),
+        "runtime": runtime,
+        "workspace_export": workspace_export,
+        "work_continuity": work_continuity,
+        "platform_evidence": platform_evidence,
+        "retention_policy": retention_policy,
+        "snapshot": snapshot
     });
     let bytes = serde_json::to_vec(&manifest).expect("manifest json");
     let parsed = parse_snapshot_manifest_bytes(&bytes, workspace.path()).expect("typed manifest");

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/tui",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Terminal UI library with differential rendering for Maestro",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Maestro",
 	"description": "Use Maestro's deterministic AI assistant inside VS Code.",
 	"publisher": "evalops",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"license": "MIT",
 	"type": "commonjs",
 	"main": "./dist/extension.js",
@@ -139,7 +139,7 @@
 		"test": "vitest --run"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.43"
+		"@evalops/contracts": "^0.10.44"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-web",
-	"version": "0.10.43",
+	"version": "0.10.44",
 	"description": "Web UI for Maestro - Browser-based AI coding assistant interface",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,7 +24,7 @@
 		"directory": "packages/web"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.43",
+		"@evalops/contracts": "^0.10.44",
 		"docx-preview": "^0.3.7",
 		"dompurify": "^3.3.0",
 		"exceljs": "^4.4.0",

--- a/src/server/handlers/hosted-runner-drain.ts
+++ b/src/server/handlers/hosted-runner-drain.ts
@@ -18,7 +18,11 @@ import {
 } from "../../cli/headless-protocol.js";
 import type { HostedRunnerContext, WebServerContext } from "../app-context.js";
 import type { HeadlessRuntimeSnapshot } from "../headless-runtime-service.js";
-import { markHostedRunnerLeaseDraining } from "../hosted-runner-lease.js";
+import {
+	HOSTED_RUNNER_LEASE_PROTOCOL_VERSION,
+	type HostedRunnerLeaseSnapshot,
+	markHostedRunnerLeaseDraining,
+} from "../hosted-runner-lease.js";
 import { ApiError, readJsonBody, sendJson } from "../server-utils.js";
 
 const execFileAsync = promisify(execFile);
@@ -40,6 +44,9 @@ export const HOSTED_RUNNER_WORK_CONTINUITY_VERSION =
 
 export const HOSTED_RUNNER_PLATFORM_EVIDENCE_VERSION =
 	"evalops.remote-runner.platform-evidence.v1";
+
+export const HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION =
+	"evalops.remote-runner.runtime-continuity.v1";
 
 export enum HostedRunnerDrainStatusValue {
 	Drained = "drained",
@@ -175,6 +182,7 @@ export interface HostedRunnerSnapshotManifest {
 		mode: HostedRunnerWorkspaceExportMode;
 		paths: HostedRunnerWorkspaceExportPath[];
 	};
+	runtime_continuity: HostedRunnerRuntimeContinuity;
 	work_continuity: HostedRunnerWorkContinuity;
 	platform_evidence: HostedRunnerPlatformEvidence;
 	snapshot: HeadlessRuntimeSnapshot;
@@ -184,6 +192,24 @@ export interface HostedRunnerSnapshotManifest {
 		branch?: string;
 		dirty?: boolean;
 	};
+}
+
+export interface HostedRunnerRuntimeContinuity {
+	protocol_version: typeof HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION;
+	handoff: "drain_restore";
+	source_runner_session_id: string;
+	source_owner_instance_id?: string;
+	source_process_id: number;
+	source_runtime_lease?: {
+		protocol_version: typeof HOSTED_RUNNER_LEASE_PROTOCOL_VERSION;
+		state: HostedRunnerLeaseSnapshot["state"];
+		generation: number;
+		maestro_session_id?: string;
+		updated_at: string;
+	};
+	restore_environment_key: "MAESTRO_REMOTE_RUNNER_RESTORE_MANIFEST";
+	restore_manifest_path: string;
+	evidence_refs: string[];
 }
 
 export interface HostedRunnerWorkContinuity {
@@ -226,6 +252,14 @@ export interface HostedRunnerPlatformEvidence {
 		codex_subagent_child_run_ids: string[];
 		codex_subagent_thread_ids: string[];
 		codex_subagent_edges?: HeadlessCodexSubagentContinuityEdge[];
+	};
+	runtime_continuity: {
+		protocol_version: typeof HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION;
+		handoff: "drain_restore";
+		source_owner_instance_id?: string;
+		source_process_id: number;
+		source_runtime_lease_generation?: number;
+		restore_manifest_path: string;
 	};
 	retention: {
 		policy_version: typeof HOSTED_RUNNER_RETENTION_POLICY_VERSION;
@@ -518,6 +552,41 @@ function buildHostedRunnerRetentionPolicy(): HostedRunnerRetentionPolicy {
 	};
 }
 
+function buildHostedRunnerRuntimeContinuity(input: {
+	hostedRunner: HostedRunnerContext;
+	maestroSessionId: string;
+	manifestPath: string;
+	runtime: HostedRunnerSnapshotManifest["runtime"];
+	leaseSnapshot: HostedRunnerLeaseSnapshot;
+}): HostedRunnerRuntimeContinuity {
+	return {
+		protocol_version: HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION,
+		handoff: "drain_restore",
+		source_runner_session_id: input.hostedRunner.runnerSessionId,
+		...(input.hostedRunner.ownerInstanceId
+			? { source_owner_instance_id: input.hostedRunner.ownerInstanceId }
+			: {}),
+		source_process_id: process.pid,
+		source_runtime_lease: {
+			protocol_version: HOSTED_RUNNER_LEASE_PROTOCOL_VERSION,
+			state: input.leaseSnapshot.state,
+			generation: input.leaseSnapshot.generation,
+			...(input.leaseSnapshot.maestroSessionId
+				? { maestro_session_id: input.leaseSnapshot.maestroSessionId }
+				: {}),
+			updated_at: input.leaseSnapshot.updatedAt,
+		},
+		restore_environment_key: "MAESTRO_REMOTE_RUNNER_RESTORE_MANIFEST",
+		restore_manifest_path: input.manifestPath,
+		evidence_refs: [
+			`remote-runner://sessions/${input.hostedRunner.runnerSessionId}/drain#snapshot`,
+			`maestro://headless/sessions/${input.maestroSessionId}#cursor:${
+				input.runtime.cursor ?? 0
+			}`,
+		],
+	};
+}
+
 function buildHostedRunnerPlatformEvidence(input: {
 	hostedRunner: HostedRunnerContext;
 	status: HostedRunnerDrainStatus;
@@ -525,6 +594,7 @@ function buildHostedRunnerPlatformEvidence(input: {
 	createdAt: string;
 	manifestPath: string;
 	runtime: HostedRunnerSnapshotManifest["runtime"];
+	runtimeContinuity: HostedRunnerRuntimeContinuity;
 	workContinuity: HostedRunnerWorkContinuity;
 	retentionPolicy: HostedRunnerRetentionPolicy;
 	reason?: string;
@@ -569,6 +639,24 @@ function buildHostedRunnerPlatformEvidence(input: {
 				input.workContinuity.codex_subagent_child_run_ids,
 			codex_subagent_thread_ids: input.workContinuity.codex_subagent_thread_ids,
 			...(edges.length > 0 ? { codex_subagent_edges: edges } : {}),
+		},
+		runtime_continuity: {
+			protocol_version: input.runtimeContinuity.protocol_version,
+			handoff: input.runtimeContinuity.handoff,
+			...(input.runtimeContinuity.source_owner_instance_id
+				? {
+						source_owner_instance_id:
+							input.runtimeContinuity.source_owner_instance_id,
+					}
+				: {}),
+			source_process_id: input.runtimeContinuity.source_process_id,
+			...(input.runtimeContinuity.source_runtime_lease
+				? {
+						source_runtime_lease_generation:
+							input.runtimeContinuity.source_runtime_lease.generation,
+					}
+				: {}),
+			restore_manifest_path: input.runtimeContinuity.restore_manifest_path,
 		},
 		retention: {
 			policy_version: input.retentionPolicy.policy_version,
@@ -778,7 +866,10 @@ export async function drainHostedRunner(
 	}
 
 	const requestedAtDate = options.now?.() ?? new Date();
-	markHostedRunnerLeaseDraining(hostedRunner, requestedAtDate);
+	const leaseSnapshot = markHostedRunnerLeaseDraining(
+		hostedRunner,
+		requestedAtDate,
+	);
 	const requestedAt = requestedAtDate.toISOString();
 	const workspaceRoot = await resolveWorkspaceRoot(hostedRunner);
 	const snapshotRoot = resolve(
@@ -868,6 +959,13 @@ export async function drainHostedRunner(
 		buildHostedRunnerSnapshot(maestroSessionId, workspaceRoot, runtime);
 	const workContinuity = collectHostedRunnerWorkContinuity(snapshot);
 	const retentionPolicy = buildHostedRunnerRetentionPolicy();
+	const runtimeContinuity = buildHostedRunnerRuntimeContinuity({
+		hostedRunner,
+		maestroSessionId,
+		manifestPath: snapshotPath,
+		runtime,
+		leaseSnapshot,
+	});
 	const platformEvidence = buildHostedRunnerPlatformEvidence({
 		hostedRunner,
 		status,
@@ -875,6 +973,7 @@ export async function drainHostedRunner(
 		createdAt: requestedAt,
 		manifestPath: snapshotPath,
 		runtime,
+		runtimeContinuity,
 		workContinuity,
 		retentionPolicy,
 		reason: input.reason,
@@ -899,6 +998,7 @@ export async function drainHostedRunner(
 			mode: HostedRunnerWorkspaceExportModeValue.LocalPathContract,
 			paths: exportPaths,
 		},
+		runtime_continuity: runtimeContinuity,
 		work_continuity: workContinuity,
 		platform_evidence: platformEvidence,
 		snapshot,
@@ -936,6 +1036,7 @@ export async function drainHostedRunner(
 				createdAt: requestedAt,
 				manifestPath: snapshotPath,
 				runtime,
+				runtimeContinuity,
 				workContinuity,
 				retentionPolicy,
 				reason: input.reason,

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1099,6 +1099,12 @@ describe("ci workflow guardrails", () => {
 		expect(releaseImpactFilter).toContain('"scripts/codegen-utils.mjs"');
 		expect(releaseImpactFilter).toContain('"scripts/runtime-workspaces.mjs"');
 		expect(releaseImpactFilter).toContain('"scripts/workspace-utils.js"');
+		expect(mismatchGuard?.if).toContain(
+			"github.repository == 'evalops/maestro'",
+		);
+		expect(mismatchGuard?.if).not.toContain(
+			"steps.registry-release.outputs.published != 'true'",
+		);
 		expect(mismatchGuard?.if).toContain("steps.release.outputs.tag_exists");
 		expect(mismatchGuard?.if).toContain(
 			"steps.release.outputs.tag_matches_head != 'true'",

--- a/test/scripts/deprecate-release.test.ts
+++ b/test/scripts/deprecate-release.test.ts
@@ -119,6 +119,34 @@ describe("deprecate-release", () => {
 		}
 	});
 
+	it("explains npm auth failures from stale release tokens", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "maestro-deprecate-auth-test-"));
+		const fakeNpm = join(tempDir, "npm");
+		writeFileSync(
+			fakeNpm,
+			[
+				"#!/usr/bin/env bash",
+				"echo 'npm error code E401' >&2",
+				"echo 'npm error 401 Unauthorized - PUT https://registry.npmjs.org/@evalops%2fmaestro' >&2",
+				"exit 1",
+				"",
+			].join("\n"),
+		);
+		chmodSync(fakeNpm, 0o755);
+
+		try {
+			const result = runDeprecate({ MAESTRO_NPM_COMMAND: fakeNpm });
+
+			expect(result.status).toBe(1);
+			expect(result.stderr).toContain(
+				"npm could not authenticate while deprecating @evalops/maestro@0.10.20.",
+			);
+			expect(result.stderr).toContain("Refresh the npm-release NPM_TOKEN");
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("forwards stdin to npm so local OTP prompts can be answered", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "maestro-deprecate-otp-test-"));
 		const fakeNpm = join(tempDir, "npm");

--- a/test/server/hosted-runner-drain.test.ts
+++ b/test/server/hosted-runner-drain.test.ts
@@ -18,6 +18,7 @@ import type { HostedRunnerContext } from "../../src/server/app-context.js";
 import {
 	HOSTED_RUNNER_PLATFORM_EVIDENCE_VERSION,
 	HOSTED_RUNNER_RETENTION_POLICY_VERSION,
+	HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION,
 	HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION,
 	HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
 	HostedRunnerDrainReasonValue,
@@ -145,6 +146,26 @@ describe("hosted runner drain", () => {
 				protocol_version: HEADLESS_PROTOCOL_VERSION,
 				cursor: 7,
 			},
+			runtime_continuity: {
+				protocol_version: HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION,
+				handoff: "drain_restore",
+				source_runner_session_id: "mrs_123",
+				source_owner_instance_id: "pod_123",
+				source_process_id: process.pid,
+				source_runtime_lease: {
+					protocol_version: "evalops.maestro.hosted-runner-lease.v1",
+					state: "draining",
+					generation: 1,
+					maestro_session_id: "session_123",
+					updated_at: "2026-04-23T00:00:00.000Z",
+				},
+				restore_environment_key: "MAESTRO_REMOTE_RUNNER_RESTORE_MANIFEST",
+				restore_manifest_path: result?.manifest_path,
+				evidence_refs: [
+					"remote-runner://sessions/mrs_123/drain#snapshot",
+					"maestro://headless/sessions/session_123#cursor:7",
+				],
+			},
 			work_continuity: {
 				protocol_version: HOSTED_RUNNER_WORK_CONTINUITY_VERSION,
 				codex_subagent_schema_version: CODEX_SUBAGENT_WORK_GRAPH_SCHEMA,
@@ -182,6 +203,14 @@ describe("hosted runner drain", () => {
 					codex_subagent_tool_call_ids: [],
 					codex_subagent_child_run_ids: [],
 					codex_subagent_thread_ids: [],
+				},
+				runtime_continuity: {
+					protocol_version: HOSTED_RUNNER_RUNTIME_CONTINUITY_VERSION,
+					handoff: "drain_restore",
+					source_owner_instance_id: "pod_123",
+					source_process_id: process.pid,
+					source_runtime_lease_generation: 1,
+					restore_manifest_path: result?.manifest_path,
 				},
 				retention: {
 					policy_version: HOSTED_RUNNER_RETENTION_POLICY_VERSION,

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -15,6 +15,7 @@ describe("tag-release workflow", () => {
 				"tag-current-version": {
 					steps: Array<{
 						env?: Record<string, string>;
+						if?: string;
 						name?: string;
 						run?: string;
 					}>;
@@ -30,6 +31,12 @@ describe("tag-release workflow", () => {
 		const activeReleaseStep = workflow.jobs["tag-current-version"].steps.find(
 			(step) => step.name === "Check active public release workflow",
 		);
+		const mismatchGuard = workflow.jobs["tag-current-version"].steps.find(
+			(step) => step.name === "Require version bump for existing release tag",
+		);
+		const summaryStep = workflow.jobs["tag-current-version"].steps.find(
+			(step) => step.name === "Summarize tag status",
+		);
 
 		expect(dispatchStep?.env?.RELEASE_TAG).toBe(
 			"${{ steps.release.outputs.release_tag }}",
@@ -42,11 +49,18 @@ describe("tag-release workflow", () => {
 		expect(dispatchStep?.if).toContain(
 			"steps.registry-release.outputs.published != 'true'",
 		);
+		expect(mismatchGuard?.if).toContain(
+			"github.repository == 'evalops/maestro'",
+		);
+		expect(mismatchGuard?.if).not.toContain(
+			"steps.registry-release.outputs.published != 'true'",
+		);
 		expect(dispatchStep?.if).toContain(
 			"steps.active-release.outputs.active_count == '0'",
 		);
 		expect(dispatchStep?.run).toContain(
 			'gh workflow run release --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"',
 		);
+		expect(summaryStep?.run).toContain("is already published on npm");
 	});
 });


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"450933cda2933c9f7d0b3af106c1c0e76fa42349"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `450933cda2933c9f7d0b3af106c1c0e76fa42349`
- last generated public sync base: `fc677d9951ca880fd3f65b0e79a9a5561343ded1`
- previewed public-tree drift: `30` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `3`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (450933cda293)`
- public projection: `https://github.com/evalops/maestro@main (e4cf307429bf)`
- files to copy or update: `30`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update CHANGELOG.md
- copy/update docs/protocols/codex-operating-layer.json
- copy/update docs/protocols/headless-conformance.md
- copy/update docs/protocols/headless.md
- copy/update docs/protocols/hosted-runner-contract.md
- copy/update openapi.json
- copy/update package.json
- copy/update packages/ai/package.json
- copy/update packages/consumer-sdk/package.json
- copy/update packages/contracts/package.json
- copy/update packages/core/package.json
- copy/update packages/desktop/package.json
- copy/update packages/github-agent/package.json
- copy/update packages/governance-mcp-server/package.json
- copy/update packages/governance/package.json
- copy/update packages/memory/package.json
- copy/update packages/slack-agent-ui/package.json
- copy/update packages/slack-agent/package.json
- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update packages/tui-rs/src/hosted_runner/manifests.rs
- copy/update packages/tui-rs/src/hosted_runner/snapshots.rs
- copy/update packages/tui-rs/src/hosted_runner/tests.rs
- copy/update packages/tui/package.json
- copy/update packages/vscode-extension/package.json
- copy/update packages/web/package.json
- ... 5 more

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update CHANGELOG.md
- copy/update docs/protocols/codex-operating-layer.json
- copy/update docs/protocols/headless-conformance.md
- copy/update docs/protocols/headless.md
- copy/update docs/protocols/hosted-runner-contract.md
- copy/update openapi.json
- copy/update package.json
- copy/update packages/ai/package.json
- copy/update packages/consumer-sdk/package.json
- copy/update packages/contracts/package.json
- copy/update packages/core/package.json
- copy/update packages/desktop/package.json
- copy/update packages/github-agent/package.json
- copy/update packages/governance-mcp-server/package.json
- copy/update packages/governance/package.json
- copy/update packages/memory/package.json
- copy/update packages/slack-agent-ui/package.json
- copy/update packages/slack-agent/package.json
- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update packages/tui-rs/src/hosted_runner/manifests.rs

## Public-only commits since last generated sync

- e4cf3074 chore: sync release mirror for main
- 29367b78 chore: sync release mirror for main
- 4d15857e chore: sync release mirror for main

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@450933cda2933c9f7d0b3af106c1c0e76fa42349`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #667 to internal source `450933cda2933c9f7d0b3af106c1c0e76fa42349`