### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - name: Require version bump for existing release tag
-        if: ${{ github.repository == 'evalops/maestro' && steps.release.outputs.tag_exists == 'true' && steps.release.outputs.tag_matches_head != 'true' && steps.release.outputs.package_changed_since_tag == 'true' }}
+        if: ${{ github.repository == 'evalops/maestro' && steps.release.outputs.tag_exists == 'true' && steps.release.outputs.tag_matches_head != 'true' && steps.release.outputs.package_changed_since_tag == 'true' && steps.registry-release.outputs.published != 'true' }}
         env:
           RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
           RELEASE_VERSION: ${{ steps.release.outputs.release_version }}

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1053,7 +1053,7 @@ describe("ci workflow guardrails", () => {
 		);
 	});
 
-	it("blocks tag-release when the package version tag points at another commit", () => {
+	it("blocks tag-release when an unpublished package version tag points at another commit", () => {
 		const action = parse(
 			readFileSync(
 				new URL(
@@ -1102,7 +1102,7 @@ describe("ci workflow guardrails", () => {
 		expect(mismatchGuard?.if).toContain(
 			"github.repository == 'evalops/maestro'",
 		);
-		expect(mismatchGuard?.if).not.toContain(
+		expect(mismatchGuard?.if).toContain(
 			"steps.registry-release.outputs.published != 'true'",
 		);
 		expect(mismatchGuard?.if).toContain("steps.release.outputs.tag_exists");

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -52,7 +52,7 @@ describe("tag-release workflow", () => {
 		expect(mismatchGuard?.if).toContain(
 			"github.repository == 'evalops/maestro'",
 		);
-		expect(mismatchGuard?.if).not.toContain(
+		expect(mismatchGuard?.if).toContain(
 			"steps.registry-release.outputs.published != 'true'",
 		);
 		expect(dispatchStep?.if).toContain(


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"636ed32f9ccdd432310f5795342d4bfcd417bc07"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `636ed32f9ccdd432310f5795342d4bfcd417bc07`
- last generated public sync base: `f3c39c7546277b695aa4aac3fa08305e6642b48f`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (636ed32f9ccd)`
- public projection: `https://github.com/evalops/maestro@main (f3c39c754627)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update test/scripts/ci-guardrails.test.ts
- copy/update test/workflows/tag-release.test.ts
- copy/update .github/workflows/tag-release.yml

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update test/scripts/ci-guardrails.test.ts
- copy/update test/workflows/tag-release.test.ts
- copy/update .github/workflows/tag-release.yml

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@636ed32f9ccdd432310f5795342d4bfcd417bc07`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.