### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/scripts/smoke-published-replay-e2e.js
+++ b/scripts/smoke-published-replay-e2e.js
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+	getBunCommand,
 	getNpmCommand,
 	installedBinPath,
 	readInstalledPackageJson,
@@ -228,6 +229,33 @@ function installLabelForInstaller({ packageSpec, installer }) {
 				? "via npm"
 				: "published replay install";
 	return `${packageSpec} ${suffix}`;
+}
+
+export function registryInstallPlanForInstaller({ installer, packageSpec }) {
+	const normalizedInstaller =
+		typeof installer === "string" ? installer.trim().toLowerCase() : "";
+	switch (normalizedInstaller || "npm") {
+		case "npm":
+			return {
+				installer: "npm",
+				command: getNpmCommand(),
+				initArgs: ["init", "-y"],
+				installArgs: ["install", packageSpec],
+				tempPrefix: "maestro-published-replay-install-",
+			};
+		case "bun":
+			return {
+				installer: "bun",
+				command: getBunCommand(),
+				initArgs: ["init", "-y"],
+				installArgs: ["add", packageSpec],
+				tempPrefix: "maestro-bun-published-replay-install-",
+			};
+		default:
+			throw new Error(
+				`Unsupported published replay installer "${installer}". Use npm or bun, or pass --install-root for a preinstalled package.`,
+			);
+	}
 }
 
 function finiteNumber(value) {
@@ -2764,7 +2792,6 @@ async function main() {
 	const version = overrides.version || defaults.version;
 	const packageSpec = `${name}@${version}`;
 	const installer = overrides.installer || "npm";
-	const npmCommand = getNpmCommand();
 	const evidencePath = resolvePublishedReplayEvidencePath({
 		evidencePath: overrides.evidencePath,
 		evidenceDir: overrides.evidenceDir,
@@ -2775,13 +2802,17 @@ async function main() {
 	const shouldCleanup = !installRoot;
 
 	if (!installRoot) {
-		installRoot = mkdtempSync(join(tmpdir(), "maestro-published-replay-install-"));
+		const installPlan = registryInstallPlanForInstaller({
+			installer,
+			packageSpec,
+		});
+		installRoot = mkdtempSync(join(tmpdir(), installPlan.tempPrefix));
 		try {
-			spawnSync(npmCommand, ["init", "-y"], {
+			spawnSync(installPlan.command, installPlan.initArgs, {
 				cwd: installRoot,
 				stdio: "ignore",
 			});
-			const install = spawnSync(npmCommand, ["install", packageSpec], {
+			const install = spawnSync(installPlan.command, installPlan.installArgs, {
 				cwd: installRoot,
 				encoding: "utf8",
 				stdio: "inherit",
@@ -2790,7 +2821,9 @@ async function main() {
 				throw install.error;
 			}
 			if (install.status !== 0) {
-				throw new Error(`npm install ${packageSpec} exited with ${install.status}`);
+				throw new Error(
+					`${installPlan.command} ${installPlan.installArgs.join(" ")} exited with ${install.status}`,
+				);
 			}
 		} catch (error) {
 			if (shouldCleanup) {

--- a/test/scripts/smoke-published-replay-e2e.test.ts
+++ b/test/scripts/smoke-published-replay-e2e.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	buildPublishedReplayEvidence,
 	filterPublishedReplayEvidenceRefs,
+	registryInstallPlanForInstaller,
 	resolvePublishedReplayEvidencePath,
 } from "../../scripts/smoke-published-replay-e2e.js";
 
@@ -201,6 +202,42 @@ function makeAgentRuntimeLifecycle() {
 }
 
 describe("resolvePublishedReplayEvidencePath", () => {
+	it("uses the requested package manager for standalone registry installs", () => {
+		expect(
+			registryInstallPlanForInstaller({
+				installer: "npm",
+				packageSpec: `${rootPackageName}@9.9.9`,
+			}),
+		).toMatchObject({
+			installer: "npm",
+			command: process.platform === "win32" ? "npm.cmd" : "npm",
+			initArgs: ["init", "-y"],
+			installArgs: ["install", `${rootPackageName}@9.9.9`],
+			tempPrefix: "maestro-published-replay-install-",
+		});
+		expect(
+			registryInstallPlanForInstaller({
+				installer: "bun",
+				packageSpec: `${rootPackageName}@9.9.9`,
+			}),
+		).toMatchObject({
+			installer: "bun",
+			command: process.platform === "win32" ? "bun.exe" : "bun",
+			initArgs: ["init", "-y"],
+			installArgs: ["add", `${rootPackageName}@9.9.9`],
+			tempPrefix: "maestro-bun-published-replay-install-",
+		});
+	});
+
+	it("rejects unsupported standalone registry installers", () => {
+		expect(() =>
+			registryInstallPlanForInstaller({
+				installer: "pnpm",
+				packageSpec: `${rootPackageName}@9.9.9`,
+			}),
+		).toThrow(/Unsupported published replay installer "pnpm"/);
+	});
+
 	it("prefers the explicit evidence path", () => {
 		expect(
 			resolvePublishedReplayEvidencePath({


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"3c2644680e3f1f50781d12b1814371c4c037afab"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `3c2644680e3f1f50781d12b1814371c4c037afab`
- last generated public sync base: `678491b76c04d7f88f809986e54ae153a274d8a2`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (3c2644680e3f)`
- public projection: `https://github.com/evalops/maestro@main (678491b76c04)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update test/scripts/smoke-published-replay-e2e.test.ts
- copy/update scripts/smoke-published-replay-e2e.js

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update test/scripts/smoke-published-replay-e2e.test.ts
- copy/update scripts/smoke-published-replay-e2e.js

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@3c2644680e3f1f50781d12b1814371c4c037afab`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.