### PR TITLE
fix: skip public tag-release guard for published versions

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - name: Require version bump for existing release tag
-        if: ${{ github.repository == 'evalops/maestro' && steps.release.outputs.tag_exists == 'true' && steps.release.outputs.tag_matches_head != 'true' && steps.release.outputs.package_changed_since_tag == 'true' }}
+        if: ${{ github.repository == 'evalops/maestro' && steps.release.outputs.tag_exists == 'true' && steps.release.outputs.tag_matches_head != 'true' && steps.release.outputs.package_changed_since_tag == 'true' && steps.registry-release.outputs.published != 'true' }}
         env:
           RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
           RELEASE_VERSION: ${{ steps.release.outputs.release_version }}

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1053,7 +1053,7 @@ describe("ci workflow guardrails", () => {
 		);
 	});
 
-	it("blocks tag-release when the package version tag points at another commit", () => {
+	it("blocks tag-release when an unpublished package version tag points at another commit", () => {
 		const action = parse(
 			readFileSync(
 				new URL(
@@ -1102,7 +1102,7 @@ describe("ci workflow guardrails", () => {
 		expect(mismatchGuard?.if).toContain(
 			"github.repository == 'evalops/maestro'",
 		);
-		expect(mismatchGuard?.if).not.toContain(
+		expect(mismatchGuard?.if).toContain(
 			"steps.registry-release.outputs.published != 'true'",
 		);
 		expect(mismatchGuard?.if).toContain("steps.release.outputs.tag_exists");

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -52,7 +52,7 @@ describe("tag-release workflow", () => {
 		expect(mismatchGuard?.if).toContain(
 			"github.repository == 'evalops/maestro'",
 		);
-		expect(mismatchGuard?.if).not.toContain(
+		expect(mismatchGuard?.if).toContain(
 			"steps.registry-release.outputs.published != 'true'",
 		);
 		expect(dispatchStep?.if).toContain(


### PR DESCRIPTION
## Summary
- let the public tag-release workflow no-op when the package version is already published on npm
- keep the version-tag mismatch failure for unpublished package-impacting changes
- update workflow guardrail tests for the published-version exemption

## Source-of-truth
- mirrored guardrail test expectations match evalops/maestro-internal#2326

## Failure addressed
Public main run https://github.com/evalops/maestro/actions/runs/26597488393 failed after mirror commit dbfa030b6973051037e3be7c86570c2883425cbc because v0.10.46 already points at the original published release commit while @evalops/maestro@0.10.46 is already on npm. Follow-up public commits for an already-published package version should summarize and exit cleanly instead of requiring another version bump.

## Validation
- node ./scripts/run-vitest.js --run test/workflows/tag-release.test.ts test/scripts/ci-guardrails.test.ts
- bunx biome check .github/workflows/tag-release.yml test/workflows/tag-release.test.ts test/scripts/ci-guardrails.test.ts
- npm run check:release-surface
- git diff --check
- commit hook full lint/codegen/build checks passed