### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/scripts/ci-nx-tests.sh
+++ b/scripts/ci-nx-tests.sh
@@ -34,7 +34,7 @@ git diff --name-only "$NX_BASE" "$NX_HEAD" | tee "$changed_files_log"
 
 changed_files_match() {
 	local pattern="$1"
-	grep -qE "$pattern" "$changed_files_log"
+	rg -q --regexp "$pattern" "$changed_files_log"
 }
 
 run_ci_guardrail_tests() {
@@ -51,7 +51,7 @@ run_smoke_script_static_checks() {
 	while IFS= read -r file; do
 		[[ -f "$file" ]] || continue
 		smoke_scripts+=("$file")
-	done < <(grep -E '^scripts/smoke-[^/]+\.[cm]?[jt]sx?$' "$changed_files_log" || true)
+	done < <(rg --regexp '^scripts/smoke-[^/]+\.[cm]?[jt]sx?$' "$changed_files_log" || true)
 	if [[ "${#smoke_scripts[@]}" -eq 0 ]]; then
 		return 0
 	fi
@@ -82,14 +82,14 @@ run_runtime_package_validators() {
 }
 
 run_shared_memory_tests() {
-	if git diff --name-only "$NX_BASE" "$NX_HEAD" | grep -qE '^(src/shared-memory/|test/shared-memory/|src/config/env-vars\.ts|src/cli/commands/memory\.ts|src/cli/help\.ts|src/session/manager\.ts)'; then
+	if git diff --name-only "$NX_BASE" "$NX_HEAD" | rg -q --regexp '^(src/shared-memory/|test/shared-memory/|src/config/env-vars\.ts|src/cli/commands/memory\.ts|src/cli/help\.ts|src/session/manager\.ts)'; then
 		echo "Running shared memory tests..."
 		bunx vitest --run test/shared-memory/ --reporter=verbose
 	fi
 }
 
 direct_vitest_files=()
-release_helper_script_tests_only() {
+direct_vitest_tests_only() {
 	local mode="$1"
 	local files_csv="$2"
 	if [[ "$mode" != "affected-files" || -z "$files_csv" ]]; then
@@ -104,7 +104,7 @@ release_helper_script_tests_only() {
 	local file
 	for file in "${direct_vitest_files[@]}"; do
 		case "$file" in
-			test/scripts/deprecate-release.test.ts | test/scripts/install-smoke-utils.test.ts | test/scripts/release-context-deps.test.ts | test/scripts/release-impact-filter.test.ts | test/scripts/release-surface-conformance.test.ts | test/scripts/smoke-published-replay-e2e.test.ts | test/scripts/verify-published-replay-evidence.test.ts | test/scripts/workspace-utils.test.ts)
+			test/scripts/deprecate-release.test.ts | test/scripts/install-smoke-utils.test.ts | test/scripts/release-context-deps.test.ts | test/scripts/release-impact-filter.test.ts | test/scripts/release-surface-conformance.test.ts | test/scripts/smoke-published-replay-e2e.test.ts | test/scripts/verify-published-replay-evidence.test.ts | test/scripts/workspace-utils.test.ts | test/workflows/*.test.ts)
 				;;
 			*)
 				return 1
@@ -134,8 +134,8 @@ case "$nx_mode" in
 		cmd=(npx nx run-many -t test --all --parallel=3)
 		;;
 	affected-files)
-		if release_helper_script_tests_only "$nx_mode" "$nx_files"; then
-			echo "Release helper script tests are handled directly by Vitest."
+		if direct_vitest_tests_only "$nx_mode" "$nx_files"; then
+			echo "Selected infrastructure test files are handled directly by Vitest."
 			cmd=(node ./scripts/run-vitest.js --run "${direct_vitest_files[@]}")
 		else
 			cmd=(npx nx affected -t test --files="$nx_files" --parallel=3)
@@ -194,6 +194,11 @@ fi
 summarize_attempt_profile() {
 	local profile_file="$1"
 	local timing_file="$2"
+
+	if [[ "${cmd[0]}" == "node" && "${cmd[1]}" == "./scripts/run-vitest.js" ]]; then
+		echo "Skipping Nx profile summary for direct Vitest run." | tee "$timing_file"
+		return 0
+	fi
 
 	if [[ ! -s "$profile_file" ]]; then
 		echo "::warning::Nx profile ${profile_file} was not written" | tee "$timing_file"
@@ -358,7 +363,7 @@ append_unhandled_error_summary() {
 	fi
 
 	local start
-	start="$(grep -n "Unhandled Error" "$logfile" | head -n1 | cut -d: -f1 || true)"
+	start="$(rg -n --fixed-strings "Unhandled Error" "$logfile" | head -n1 | cut -d: -f1 || true)"
 	if [[ -z "$start" ]]; then
 		return 0
 	fi

--- a/scripts/plan-ci-checks.mjs
+++ b/scripts/plan-ci-checks.mjs
@@ -143,6 +143,10 @@ function isSmokeScript(path) {
 	return /^scripts\/smoke-[^/]+\.[cm]?[jt]sx?$/.test(path);
 }
 
+function isWorkflowUnitTest(path) {
+	return /^test\/workflows\/[^/]+\.test\.[cm]?[jt]sx?$/.test(path);
+}
+
 function isLeafIdeExtensionPath(path) {
 	return path.startsWith("packages/vscode-extension/") && !isPackageManifest(path);
 }
@@ -220,6 +224,7 @@ function isProofHarnessPath(path) {
 	return (
 		CI_GUARDRAIL_FILES.has(path) ||
 		isFastPrChecksInfrastructurePath(path) ||
+		isWorkflowUnitTest(path) ||
 		(path.startsWith("docs/") && path.endsWith(".md")) ||
 		isSmokeScript(path)
 	);
@@ -247,6 +252,7 @@ function isLightPrChecksPath(path) {
 		RELEASE_SURFACE_CONFORMANCE_FILES.has(path) ||
 		RUNTIME_PACKAGE_VALIDATOR_FILES.has(path) ||
 		RELEASE_HELPER_TEST_FILES.has(path) ||
+		isWorkflowUnitTest(path) ||
 		isSmokeScript(path)
 	);
 }

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -209,6 +209,27 @@ describe("planCiChecks", () => {
 		});
 	});
 
+	it("keeps workflow unit-test changes on the light proof lane", () => {
+		expect(
+			planCiChecks({
+				eventName: "pull_request",
+				changedFiles: [
+					".github/workflows/tag-release.yml",
+					"test/scripts/ci-guardrails.test.ts",
+					"test/workflows/tag-release.test.ts",
+				],
+			}),
+		).toMatchObject({
+			ciInfrastructureOnly: false,
+			coverage: false,
+			lightPrChecks: true,
+			proofHarnessOnly: true,
+			prChecks: true,
+			publicMirror: true,
+			rustHostedConformance: false,
+		});
+	});
+
 	it("skips TS/Nx checks for Rust-only pull requests", () => {
 		expect(
 			planCiChecks({
@@ -637,15 +658,15 @@ describe("ci workflow guardrails", () => {
 		expect(regex.test("scripts/summarize-nx-profile.mjs")).toBe(true);
 	});
 
-	it("runs release helper script tests directly instead of the root Nx target", () => {
+	it("runs selected infrastructure tests directly instead of the root Nx target", () => {
 		const script = readFileSync(
 			new URL("../../scripts/ci-nx-tests.sh", import.meta.url),
 			{ encoding: "utf8" },
 		);
 
-		expect(script).toContain("release_helper_script_tests_only");
+		expect(script).toContain("direct_vitest_tests_only");
 		expect(script).toContain(
-			"Release helper script tests are handled directly by Vitest.",
+			"Selected infrastructure test files are handled directly by Vitest.",
 		);
 		expect(script).toContain("node ./scripts/run-vitest.js --run");
 		expect(script).toContain("test/scripts/deprecate-release.test.ts");
@@ -655,6 +676,11 @@ describe("ci workflow guardrails", () => {
 		);
 		expect(script).toContain("test/scripts/smoke-published-replay-e2e.test.ts");
 		expect(script).toContain("test/scripts/workspace-utils.test.ts");
+		expect(script).toContain("test/workflows/*.test.ts");
+		expect(script).toContain("rg -q --regexp");
+		expect(script).toContain(
+			"Skipping Nx profile summary for direct Vitest run.",
+		);
 	});
 
 	it("builds dist before the runtime dependency validator", () => {
@@ -2228,6 +2254,23 @@ describe("planNxTestCommand", () => {
 			}),
 		).toEqual({
 			files: ["test/scripts/release-surface-conformance.test.ts"],
+			mode: "affected-files",
+		});
+	});
+
+	it("keeps workflow unit tests as explicit affected files", () => {
+		expect(
+			planNxTestCommand({
+				basePackage,
+				changedFiles: [
+					".github/workflows/tag-release.yml",
+					"test/scripts/ci-guardrails.test.ts",
+					"test/workflows/tag-release.test.ts",
+				],
+				headPackage: basePackage,
+			}),
+		).toEqual({
+			files: ["test/workflows/tag-release.test.ts"],
 			mode: "affected-files",
 		});
 	});


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"5bc15acfe5ef8e6172b861b2c47e7d88943c8baa"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `5bc15acfe5ef8e6172b861b2c47e7d88943c8baa`
- last generated public sync base: `dbfa030b6973051037e3be7c86570c2883425cbc`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `1`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (5bc15acfe5ef)`
- public projection: `https://github.com/evalops/maestro@main (f0f3039eed6b)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update scripts/ci-nx-tests.sh
- copy/update scripts/plan-ci-checks.mjs
- copy/update test/scripts/ci-guardrails.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update scripts/ci-nx-tests.sh
- copy/update scripts/plan-ci-checks.mjs
- copy/update test/scripts/ci-guardrails.test.ts

## Public-only commits since last generated sync

- f0f3039e fix: skip public tag guard for published versions (#676)

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@5bc15acfe5ef8e6172b861b2c47e7d88943c8baa`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.