### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/scripts/deprecate-release.js
+++ b/scripts/deprecate-release.js
@@ -72,8 +72,17 @@ if (options.otp) {
 	npmArgs.push("--otp", options.otp);
 }
 
+function shellQuote(value) {
+	if (/^[A-Za-z0-9_/:=-]+$/.test(value)) {
+		return value;
+	}
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 if (options.dryRun) {
-	console.log(`[dry-run] ${npmCommand} ${npmArgs.join(" ")}`);
+	console.log(
+		`[dry-run] ${[npmCommand, ...npmArgs].map(shellQuote).join(" ")}`,
+	);
 	process.exit(0);
 }
 

--- a/test/scripts/deprecate-release.test.ts
+++ b/test/scripts/deprecate-release.test.ts
@@ -19,11 +19,11 @@ function runDeprecate(
 		[
 			scriptPath.pathname,
 			"--range",
-			"0.10.20",
+			">=0.10.8 <=0.10.20",
 			"--package",
 			"@evalops/maestro",
 			"--message",
-			"Broken release: install @evalops/maestro@0.10.21 or newer.",
+			"Broken release metadata references private workspace packages; install @evalops/maestro@latest.",
 			...extraArgs,
 		],
 		{
@@ -45,10 +45,10 @@ describe("deprecate-release", () => {
 
 		expect(result.status).toBe(0);
 		expect(result.stdout).toContain(
-			"[dry-run] /tmp/fake-npm deprecate @evalops/maestro@0.10.20",
+			"[dry-run] /tmp/fake-npm deprecate '@evalops/maestro@>=0.10.8 <=0.10.20'",
 		);
 		expect(result.stdout).toContain(
-			"Broken release: install @evalops/maestro@0.10.21 or newer.",
+			"'Broken release metadata references private workspace packages; install @evalops/maestro@latest.'",
 		);
 	});
 
@@ -96,7 +96,7 @@ describe("deprecate-release", () => {
 			[
 				"#!/usr/bin/env bash",
 				"echo 'npm error code E404' >&2",
-				"echo \"npm error 404  The requested resource '@evalops/maestro@0.10.20' could not be found or you do not have permission to access it.\" >&2",
+				"echo \"npm error 404  The requested resource '@evalops/maestro@>=0.10.8 <=0.10.20' could not be found or you do not have permission to access it.\" >&2",
 				"exit 1",
 				"",
 			].join("\n"),
@@ -108,7 +108,7 @@ describe("deprecate-release", () => {
 
 			expect(result.status).toBe(1);
 			expect(result.stderr).toContain(
-				"npm could not deprecate @evalops/maestro@0.10.20.",
+				"npm could not deprecate @evalops/maestro@>=0.10.8 <=0.10.20.",
 			);
 			expect(result.stderr).toContain(
 				"configured npm token does not have publish/deprecate permission",
@@ -139,7 +139,7 @@ describe("deprecate-release", () => {
 
 			expect(result.status).toBe(1);
 			expect(result.stderr).toContain(
-				"npm could not authenticate while deprecating @evalops/maestro@0.10.20.",
+				"npm could not authenticate while deprecating @evalops/maestro@>=0.10.8 <=0.10.20.",
 			);
 			expect(result.stderr).toContain("Refresh the npm-release NPM_TOKEN");
 		} finally {


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"ca0d009ae6617ea241530f7e79fc130d607a6cf6"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `ca0d009ae6617ea241530f7e79fc130d607a6cf6`
- last generated public sync base: `8ea23f5cb9300cefb61fc7c64e490ef743eab533`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (ca0d009ae661)`
- public projection: `https://github.com/evalops/maestro@main (8ea23f5cb930)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update test/scripts/deprecate-release.test.ts
- copy/update scripts/deprecate-release.js

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update test/scripts/deprecate-release.test.ts
- copy/update scripts/deprecate-release.js

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@ca0d009ae6617ea241530f7e79fc130d607a6cf6`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.