### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/protocols/release-surface-conformance.json
+++ b/docs/protocols/release-surface-conformance.json
@@ -127,6 +127,19 @@
 			]
 		},
 		{
+			"area": "tag-release-workflow",
+			"path": ".github/workflows/tag-release.yml",
+			"evidenceType": "source",
+			"anchors": [
+				"Check npm registry release",
+				"Verify already-published package from registry",
+				"node scripts/smoke-registry-install.js",
+				"node scripts/verify-published-replay-evidence.js --evidence-dir tag-release-published-replay-evidence",
+				"MAESTRO_REGISTRY_POLL_ATTEMPTS: \"1\"",
+				"tag-release-published-replay-evidence"
+			]
+		},
+		{
 			"area": "public-mirror-workflow",
 			"path": ".github/workflows/public-release-mirror.yml",
 			"evidenceType": "source",

--- a/docs/protocols/release-surface-conformance.md
+++ b/docs/protocols/release-surface-conformance.md
@@ -23,6 +23,7 @@ npm run check:release-surface
 | registry install smokes | npm, npx, Bun, bunx, and `bunx --bun` runtime paths stay connected to published replay evidence. |
 | published replay | text, JSON, and RPC replay modes keep session, tool, ToolExecution, approval, search/ripgrep, error, artifact, final-status, query-index, and AgentRuntime evidence. |
 | release readiness | local release gates continue to build, verify runtime deps, pack-smoke, and replay-smoke. |
+| tag release | the already-published package path cannot pass on `npm view` alone; it must run npm and Bun registry install smokes plus published replay evidence validation. |
 | public mirror | the sanitized public tree, release-helper mirror sync, mirror contract, and fallback publish workflow keep their guardrails. |
 
 ## Completion Bar

--- a/scripts/check-release-surface-conformance.mjs
+++ b/scripts/check-release-surface-conformance.mjs
@@ -20,6 +20,7 @@ const requiredAreas = [
 	"published-replay-e2e",
 	"release-readiness",
 	"release-workflow",
+	"tag-release-workflow",
 	"public-mirror-workflow",
 	"public-mirror-contract",
 	"prepared-public-mirror",

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1017,6 +1017,9 @@ describe("ci workflow guardrails", () => {
 			on?: {
 				workflow_dispatch?: {
 					inputs?: {
+						range?: {
+							default?: string;
+						};
 						message?: {
 							default?: string;
 						};
@@ -1024,9 +1027,12 @@ describe("ci workflow guardrails", () => {
 				};
 			};
 		};
+		const defaultRange =
+			workflow.on?.workflow_dispatch?.inputs?.range?.default ?? "";
 		const defaultMessage =
 			workflow.on?.workflow_dispatch?.inputs?.message?.default ?? "";
 
+		expect(defaultRange).toBe(">=0.10.8 <=0.10.20");
 		expect(defaultMessage).toBe("");
 	});
 

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1017,9 +1017,6 @@ describe("ci workflow guardrails", () => {
 			on?: {
 				workflow_dispatch?: {
 					inputs?: {
-						range?: {
-							default?: string;
-						};
 						message?: {
 							default?: string;
 						};
@@ -1027,12 +1024,9 @@ describe("ci workflow guardrails", () => {
 				};
 			};
 		};
-		const defaultRange =
-			workflow.on?.workflow_dispatch?.inputs?.range?.default ?? "";
 		const defaultMessage =
 			workflow.on?.workflow_dispatch?.inputs?.message?.default ?? "";
 
-		expect(defaultRange).toBe(">=0.10.8 <=0.10.20");
 		expect(defaultMessage).toBe("");
 	});
 

--- a/test/scripts/release-surface-conformance.test.ts
+++ b/test/scripts/release-surface-conformance.test.ts
@@ -57,6 +57,9 @@ describe("release-surface conformance", () => {
 		expect(failures).toContain(
 			"manifest is missing required area public-mirror-workflow",
 		);
+		expect(failures).toContain(
+			"manifest is missing required area tag-release-workflow",
+		);
 	});
 
 	it("rejects entries without evidence types or anchors", () => {

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -18,7 +18,10 @@ describe("tag-release workflow", () => {
 						if?: string;
 						name?: string;
 						run?: string;
+						uses?: string;
+						with?: Record<string, string>;
 					}>;
+					"timeout-minutes"?: number;
 				};
 			};
 		};
@@ -37,11 +40,68 @@ describe("tag-release workflow", () => {
 		const summaryStep = workflow.jobs["tag-current-version"].steps.find(
 			(step) => step.name === "Summarize tag status",
 		);
+		const setupPublishedSmokeStep = workflow.jobs[
+			"tag-current-version"
+		].steps.find((step) => step.name === "Setup registry install smoke tools");
+		const verifyPublishedSmokeStep = workflow.jobs[
+			"tag-current-version"
+		].steps.find(
+			(step) => step.name === "Verify already-published package from registry",
+		);
+		const uploadEvidenceStep = workflow.jobs["tag-current-version"].steps.find(
+			(step) => step.name === "Upload already-published replay evidence",
+		);
 
+		expect(workflow.jobs["tag-current-version"]["timeout-minutes"]).toBe(45);
 		expect(dispatchStep?.env?.RELEASE_TAG).toBe(
 			"${{ steps.release.outputs.release_tag }}",
 		);
 		expect(registryStep?.run).toContain("npm view");
+		expect(setupPublishedSmokeStep?.if).toContain(
+			"steps.registry-release.outputs.published == 'true'",
+		);
+		expect(setupPublishedSmokeStep?.uses).toBe(
+			"./.github/actions/setup-bun-nx",
+		);
+		expect(setupPublishedSmokeStep?.with).toMatchObject({
+			install: "false",
+			"cache-nx": "false",
+			"ensure-rustfmt": "false",
+		});
+		expect(verifyPublishedSmokeStep?.if).toContain(
+			"github.repository == 'evalops/maestro'",
+		);
+		expect(verifyPublishedSmokeStep?.if).toContain(
+			"steps.registry-release.outputs.published == 'true'",
+		);
+		expect(verifyPublishedSmokeStep?.env).toMatchObject({
+			PACKAGE_NAME: "${{ steps.release.outputs.package_name }}",
+			RELEASE_VERSION: "${{ steps.release.outputs.release_version }}",
+			MAESTRO_INSTALL_AUDIT_LEVEL: "critical",
+			MAESTRO_PUBLISHED_REPLAY_SANDBOX_MODE: "local",
+			MAESTRO_REGISTRY_SMOKE_EVIDENCE_DIR:
+				"tag-release-published-replay-evidence",
+			MAESTRO_REGISTRY_POLL_ATTEMPTS: "1",
+			MAESTRO_REGISTRY_POLL_DELAY_MS: "1000",
+		});
+		expect(verifyPublishedSmokeStep?.run).toContain(
+			"node scripts/smoke-registry-install.js",
+		);
+		expect(verifyPublishedSmokeStep?.run).toContain(
+			'--package "$PACKAGE_NAME"',
+		);
+		expect(verifyPublishedSmokeStep?.run).toContain(
+			'--version "$RELEASE_VERSION"',
+		);
+		expect(verifyPublishedSmokeStep?.run).toContain(
+			"node scripts/verify-published-replay-evidence.js --evidence-dir tag-release-published-replay-evidence",
+		);
+		expect(uploadEvidenceStep?.uses).toBe(
+			"actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+		);
+		expect(uploadEvidenceStep?.with?.path).toBe(
+			"tag-release-published-replay-evidence/*.json",
+		);
 		expect(activeReleaseStep?.run).toContain("gh run list");
 		expect(activeReleaseStep?.run).toContain("--workflow release");
 		expect(activeReleaseStep?.run).toContain(".headBranch");


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"805bbdaded5fa2251a07e296347b92c7dcbf0f82"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `805bbdaded5fa2251a07e296347b92c7dcbf0f82`
- last generated public sync base: `95c83f7641bb4da7e91a6662fde2163d8b56de9f`
- previewed public-tree drift: `6` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `2`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (805bbdaded5f)`
- public projection: `https://github.com/evalops/maestro@main (472dc690eec5)`
- files to copy or update: `6`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/protocols/release-surface-conformance.json
- copy/update docs/protocols/release-surface-conformance.md
- copy/update scripts/check-release-surface-conformance.mjs
- copy/update test/scripts/ci-guardrails.test.ts
- copy/update test/scripts/release-surface-conformance.test.ts
- copy/update test/workflows/tag-release.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/protocols/release-surface-conformance.json
- copy/update docs/protocols/release-surface-conformance.md
- copy/update scripts/check-release-surface-conformance.mjs
- copy/update test/scripts/ci-guardrails.test.ts
- copy/update test/scripts/release-surface-conformance.test.ts
- copy/update test/workflows/tag-release.test.ts

## Public-only commits since last generated sync

- 472dc690 chore: sync release mirror for main
- df5db527 Merge pull request #678 from evalops/codex/deprecate-legacy-range-20260528

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@805bbdaded5fa2251a07e296347b92c7dcbf0f82`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.