### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -124,23 +124,7 @@ runs:
 
     - name: Ensure ripgrep
       if: ${{ inputs.ensure-ripgrep == 'true' }}
-      shell: bash
-      run: |
-        set -euo pipefail
-        if command -v rg >/dev/null 2>&1; then
-          exit 0
-        fi
-        if ! command -v apt-get >/dev/null 2>&1; then
-          echo "::error::ripgrep is required but apt-get is unavailable"
-          exit 1
-        fi
-        if command -v sudo >/dev/null 2>&1; then
-          sudo apt-get update
-          sudo apt-get install -y ripgrep
-        else
-          apt-get update
-          apt-get install -y ripgrep
-        fi
+      uses: ./.github/actions/ensure-ripgrep
 
     - name: Cache Cargo
       uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2

--- a/.github/release-mirror-manifest.json
+++ b/.github/release-mirror-manifest.json
@@ -2,6 +2,7 @@
   "files": [
     ".github/actions/release-context/action.yml",
     ".github/actions/release-notify/action.yml",
+    ".github/actions/ensure-ripgrep/action.yml",
     ".github/actions/setup-bun-nx/action.yml",
     ".github/workflows/tag-release.yml",
     ".github/workflows/version-bump.yml",

--- a/scripts/check-release-mirror-contract.mjs
+++ b/scripts/check-release-mirror-contract.mjs
@@ -71,6 +71,39 @@ function isRepoRelativePath(path) {
 	);
 }
 
+function isMirroredYamlPath(path) {
+	return (
+		(path.startsWith(".github/actions/") ||
+			path.startsWith(".github/workflows/")) &&
+		/\.ya?ml$/u.test(path)
+	);
+}
+
+function localActionDependencyPath(usesValue) {
+	const match = /^\.\/\.github\/actions\/([^/\s'"]+)$/u.exec(usesValue);
+	return match ? `.github/actions/${match[1]}/action.yml` : null;
+}
+
+function collectLocalActionDependencies(path) {
+	if (!isMirroredYamlPath(path) || !existsSync(resolve(path))) {
+		return [];
+	}
+
+	const content = readFileSync(resolve(path), "utf8");
+	const dependencies = new Set();
+	const usesPattern =
+		/^\s*-?\s*uses:\s*["']?(\.\/\.github\/actions\/[^"'\s#]+)["']?\s*(?:#.*)?$/gmu;
+
+	for (const match of content.matchAll(usesPattern)) {
+		const dependency = localActionDependencyPath(match[1]);
+		if (dependency) {
+			dependencies.add(dependency);
+		}
+	}
+
+	return [...dependencies];
+}
+
 const errors = [];
 
 if (!existsSync(resolve(contractPath))) {
@@ -127,6 +160,16 @@ for (const file of seen) {
 		if (file.startsWith(prefix)) {
 			errors.push(
 				`${file} is under an internal-only grouped-command surface.`,
+			);
+		}
+	}
+}
+
+for (const file of seen) {
+	for (const dependency of collectLocalActionDependencies(file)) {
+		if (!seen.has(dependency)) {
+			errors.push(
+				`Missing local action dependency for ${file}: ${dependency}`,
 			);
 		}
 	}

--- a/src/tools/background/task-runtime.ts
+++ b/src/tools/background/task-runtime.ts
@@ -411,7 +411,7 @@ export class BackgroundTaskRuntime {
 		attach(child.stdout);
 		attach(child.stderr);
 
-		child.once("exit", closeStream);
+		child.once("close", closeStream);
 		child.once("error", closeStream);
 	}
 }

--- a/test/scripts/check-release-mirror-contract.test.ts
+++ b/test/scripts/check-release-mirror-contract.test.ts
@@ -84,4 +84,35 @@ describe("check-release-mirror-contract", () => {
 			"Missing command-suite mirror file: src/cli-tui/commands/command-catalog.ts",
 		);
 	});
+
+	it("keeps mirrored local action dependencies together", () => {
+		const root = makeFixture();
+		write(
+			join(root, ".github/release-mirror-manifest.json"),
+			`${JSON.stringify(
+				{ files: [".github/actions/setup-bun-nx/action.yml"] },
+				null,
+				2,
+			)}\n`,
+		);
+		write(
+			join(root, ".github/actions/setup-bun-nx/action.yml"),
+			[
+				"name: setup-bun-nx",
+				"runs:",
+				"  using: composite",
+				"  steps:",
+				"    - name: Ensure ripgrep",
+				"      uses: ./.github/actions/ensure-ripgrep",
+				"",
+			].join("\n"),
+		);
+
+		const result = runCheck(root);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain(
+			"Missing local action dependency for .github/actions/setup-bun-nx/action.yml: .github/actions/ensure-ripgrep/action.yml",
+		);
+	});
 });

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1821,6 +1821,49 @@ describe("ci workflow guardrails", () => {
 		}
 	});
 
+	it("shares CI ripgrep installation through the composite helper", () => {
+		const setupBunNx = parse(
+			readFileSync(
+				new URL(
+					"../../.github/actions/setup-bun-nx/action.yml",
+					import.meta.url,
+				),
+				{ encoding: "utf8" },
+			),
+		) as { runs?: { steps?: WorkflowStep[] } };
+		const setupRust = parse(
+			readFileSync(
+				new URL("../../.github/actions/setup-rust/action.yml", import.meta.url),
+				{ encoding: "utf8" },
+			),
+		) as { runs?: { steps?: WorkflowStep[] } };
+		const ensureRipgrep = parse(
+			readFileSync(
+				new URL(
+					"../../.github/actions/ensure-ripgrep/action.yml",
+					import.meta.url,
+				),
+				{ encoding: "utf8" },
+			),
+		) as { runs?: { steps?: WorkflowStep[] } };
+		const setupBunStep = setupBunNx.runs?.steps?.find(
+			(step) => step.name === "Ensure ripgrep",
+		);
+		const setupRustStep = setupRust.runs?.steps?.find(
+			(step) => step.name === "Ensure ripgrep",
+		);
+		const ensureScript =
+			ensureRipgrep.runs?.steps?.find((step) => step.name === "Ensure ripgrep")
+				?.run ?? "";
+
+		expect(setupBunStep?.uses).toBe("./.github/actions/ensure-ripgrep");
+		expect(setupRustStep?.uses).toBe("./.github/actions/ensure-ripgrep");
+		expect(ensureScript).toContain("rg --version");
+		expect(ensureScript).toContain("sudo apt-get update");
+		expect(ensureScript).toContain("brew install ripgrep");
+		expect(ensureScript).toContain("neither rg, apt-get, nor Homebrew");
+	});
+
 	it("uses dynamic host ports for integration service containers", () => {
 		const workflowText = readFileSync(
 			new URL("../../.github/workflows/integration.yml", import.meta.url),


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"74109cad5252e1743b8830a0cc74b725637d4913"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `74109cad5252e1743b8830a0cc74b725637d4913`
- last generated public sync base: `589347d18b94ed6b62f858013efdc0640647644a`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `2`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (74109cad5252)`
- public projection: `https://github.com/evalops/maestro@main (c02939ca87c0)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update .github/actions/setup-rust/action.yml
- copy/update scripts/check-release-mirror-contract.mjs
- copy/update src/tools/background/task-runtime.ts
- copy/update test/scripts/check-release-mirror-contract.test.ts
- copy/update test/scripts/ci-guardrails.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update .github/actions/setup-rust/action.yml
- copy/update scripts/check-release-mirror-contract.mjs
- copy/update src/tools/background/task-runtime.ts
- copy/update test/scripts/check-release-mirror-contract.test.ts
- copy/update test/scripts/ci-guardrails.test.ts

## Public-only commits since last generated sync

- c02939ca chore: sync release mirror for main
- b84825f0 chore: sync release mirror for main

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@74109cad5252e1743b8830a0cc74b725637d4913`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #682 to internal source `74109cad5252e1743b8830a0cc74b725637d4913`