### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/scripts/check-evidence-integrity.ts
+++ b/scripts/check-evidence-integrity.ts
@@ -1,13 +1,14 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { DEFAULT_EXCLUDES } from "../src/guardian/types.js";
 import { detectEvidenceIntegrityFindings } from "../src/guardian/runner.js";
 
-const A2A_SWARM_STAGE_GATE_MANIFEST =
+export const A2A_SWARM_STAGE_GATE_MANIFEST =
 	"docs/protocols/a2a-swarm-stage-gates.json";
 
-const A2A_SWARM_STAGE_IDS = [
+export const A2A_SWARM_STAGE_IDS = [
 	"stage-0-integrity-foundation",
 	"stage-1-platform-identity-topology",
 	"stage-2-remote-delegation-task-control",
@@ -16,6 +17,13 @@ const A2A_SWARM_STAGE_IDS = [
 	"stage-5-production-proof-operations",
 	"stage-6-realtime-delivery",
 	"stage-7-fleet-hardening",
+] as const;
+
+const REQUIRED_A2A_SWARM_GLOBAL_INVARIANTS = [
+	"Replay fixtures prove schema compatibility only and cannot satisfy exit evidence for production stages.",
+	"Every production claim must name the authoritative system of record and the command, query, or verifier that resolves it.",
+	"Live evidence must redact raw tokens and payloads while preserving enough stable identifiers for independent verification.",
+	"Stages advance in order; later stages may add evidence but cannot weaken prior-stage gates.",
 ] as const;
 
 const REQUIRED_A2A_SWARM_STAGE_PROOF_CLASSES: Record<
@@ -76,6 +84,64 @@ const REQUIRED_A2A_SWARM_STAGE_PROOF_CLASSES: Record<
 	],
 };
 
+const REQUIRED_A2A_SWARM_STAGE_EXIT_EVIDENCE_IDS: Record<
+	(typeof A2A_SWARM_STAGE_IDS)[number],
+	string[]
+> = {
+	"stage-0-integrity-foundation": [
+		"guardian-blocks-synthetic-production-ids",
+		"github-identifiers-dereference",
+		"evidence-bundle-signature",
+		"invalid-token-rejection",
+	],
+	"stage-1-platform-identity-topology": [
+		"durable-agent-identities",
+		"eligible-peer-discovery",
+		"fresh-heartbeats",
+		"topology-audit-visible",
+	],
+	"stage-2-remote-delegation-task-control": [
+		"platform-delegation-created",
+		"task-lifecycle-observed",
+		"control-command-recorded",
+		"platform-only-routing",
+	],
+	"stage-3-subagent-federation": [
+		"remote-subagent-invoked",
+		"capabilities-negotiated",
+		"subagent-authorization-enforced",
+		"subagent-provenance-preserved",
+	],
+	"stage-4-swarm-coordination": [
+		"work-split-recorded",
+		"exclusive-ownership-enforced",
+		"worker-failure-recovered",
+		"final-outcome-reconciled",
+	],
+	"stage-5-production-proof-operations": [
+		"real-commit-sha",
+		"real-github-pr",
+		"real-actions-run",
+		"signed-production-evidence",
+		"deploy-verifier-outcome",
+		"operator-visible-traces",
+	],
+	"stage-6-realtime-delivery": [
+		"status-stream-terminal-events",
+		"push-notifications-delivered",
+		"task-message-ids-durable",
+		"delivery-traces-correlated",
+		"delivery-metrics-operator-visible",
+	],
+	"stage-7-fleet-hardening": [
+		"load-soak-passes",
+		"chaos-cases-pass",
+		"slos-alerts-dashboards",
+		"operator-playbook-ready",
+		"quota-retention-enforced",
+	],
+};
+
 const FIXTURE_SELF_TEST_PATHS = [
 	/test\/guardian\/evidence-integrity\.test\.ts$/,
 	/test\/platform\/a2a-platform-delegation-live\.test\.ts$/,
@@ -124,11 +190,14 @@ function readTextFile(path: string): string | null {
 	}
 }
 
-function validateA2ASwarmStageGateManifest(root: string): string[] {
-	const manifestPath = resolve(root, A2A_SWARM_STAGE_GATE_MANIFEST);
+export function validateA2ASwarmStageGateManifest(
+	root: string,
+	manifestRelativePath = A2A_SWARM_STAGE_GATE_MANIFEST,
+): string[] {
+	const manifestPath = resolve(root, manifestRelativePath);
 	if (!existsSync(manifestPath)) {
 		return [
-			`Missing A2A swarm stage-gate manifest: ${A2A_SWARM_STAGE_GATE_MANIFEST}`,
+			`Missing A2A swarm stage-gate manifest: ${manifestRelativePath}`,
 		];
 	}
 	const contents = readFileSync(manifestPath, "utf8");
@@ -142,6 +211,24 @@ function validateA2ASwarmStageGateManifest(root: string): string[] {
 		failures.push(
 			`${A2A_SWARM_STAGE_GATE_MANIFEST} has unexpected protocolVersion ${protocolVersion}`,
 		);
+	}
+	const globalInvariants = arrayField(manifest, "globalInvariants");
+	const globalInvariantTexts = new Set<string>();
+	globalInvariants.forEach((invariant, index) => {
+		if (typeof invariant !== "string" || invariant.trim().length === 0) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} globalInvariants[${index}] must be a non-empty string`,
+			);
+			return;
+		}
+		globalInvariantTexts.add(invariant.trim());
+	});
+	for (const requiredInvariant of REQUIRED_A2A_SWARM_GLOBAL_INVARIANTS) {
+		if (!globalInvariantTexts.has(requiredInvariant)) {
+			failures.push(
+				`${A2A_SWARM_STAGE_GATE_MANIFEST} globalInvariants missing ${requiredInvariant}`,
+			);
+		}
 	}
 	const stages = arrayField(manifest, "stages");
 	if (stages.length !== A2A_SWARM_STAGE_IDS.length) {
@@ -196,12 +283,13 @@ function validateA2ASwarmStageGateManifest(root: string): string[] {
 			);
 		}
 		validateEvidenceList(stageId, "entryEvidence", entryEvidence, failures);
-		const exitProofClasses = validateEvidenceList(
+		const exitEvidenceValidation = validateEvidenceList(
 			stageId,
 			"exitEvidence",
 			exitEvidence,
 			failures,
 		);
+		const exitProofClasses = exitEvidenceValidation.proofClasses;
 		for (const proofClass of REQUIRED_A2A_SWARM_STAGE_PROOF_CLASSES[stageId] ??
 			[]) {
 			if (!exitProofClasses.has(proofClass)) {
@@ -210,9 +298,23 @@ function validateA2ASwarmStageGateManifest(root: string): string[] {
 				);
 			}
 		}
+		for (const evidenceId of REQUIRED_A2A_SWARM_STAGE_EXIT_EVIDENCE_IDS[
+			stageId
+		] ?? []) {
+			if (!exitEvidenceValidation.evidenceIds.has(evidenceId)) {
+				failures.push(
+					`${A2A_SWARM_STAGE_GATE_MANIFEST} ${stageId} exitEvidence missing evidence id ${evidenceId}`,
+				);
+			}
+		}
 		previousStageId = stageId;
 	});
 	return failures;
+}
+
+interface EvidenceListValidation {
+	evidenceIds: Set<string>;
+	proofClasses: Set<string>;
 }
 
 function validateEvidenceList(
@@ -220,7 +322,7 @@ function validateEvidenceList(
 	fieldName: "entryEvidence" | "exitEvidence",
 	evidence: unknown[],
 	failures: string[],
-): Set<string> {
+): EvidenceListValidation {
 	const proofClasses = new Set<string>();
 	const evidenceIds = new Set<string>();
 	evidence.forEach((evidenceValue, index) => {
@@ -254,7 +356,7 @@ function validateEvidenceList(
 			);
 		}
 	});
-	return proofClasses;
+	return { evidenceIds, proofClasses };
 }
 
 function requireRecord(value: unknown, name: string): Record<string, unknown> {
@@ -329,4 +431,6 @@ function main(): void {
 	console.log("Evidence integrity check passed.");
 }
 
-main();
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	main();
+}

--- a/test/scripts/evidence-integrity.test.ts
+++ b/test/scripts/evidence-integrity.test.ts
@@ -1,0 +1,84 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	A2A_SWARM_STAGE_GATE_MANIFEST,
+	validateA2ASwarmStageGateManifest,
+} from "../../scripts/check-evidence-integrity.ts";
+
+let tempDir = "";
+
+describe("evidence integrity stage-gate manifest", () => {
+	afterEach(() => {
+		if (tempDir) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	it("passes against the checked-in A2A swarm stage-gate manifest", () => {
+		expect(validateA2ASwarmStageGateManifest(process.cwd())).toEqual([]);
+	});
+
+	it("requires realtime delivery to keep push notification evidence", () => {
+		const manifest = readManifest();
+		const realtime = manifest.stages.find(
+			(stage) => stage.id === "stage-6-realtime-delivery",
+		);
+		expect(realtime).toBeDefined();
+		const pushGate = realtime!.exitEvidence.find(
+			(evidence) => evidence.id === "push-notifications-delivered",
+		);
+		expect(pushGate).toBeDefined();
+		pushGate!.id = "push-notification-proof";
+
+		const failures = validateManifestFixture(manifest);
+
+		expect(failures).toContain(
+			"docs/protocols/a2a-swarm-stage-gates.json stage-6-realtime-delivery exitEvidence missing evidence id push-notifications-delivered",
+		);
+	});
+
+	it("requires stage gates to preserve production-proof invariants", () => {
+		const manifest = readManifest();
+		manifest.globalInvariants = manifest.globalInvariants.filter(
+			(invariant) =>
+				invariant !==
+				"Live evidence must redact raw tokens and payloads while preserving enough stable identifiers for independent verification.",
+		);
+
+		const failures = validateManifestFixture(manifest);
+
+		expect(failures).toContain(
+			"docs/protocols/a2a-swarm-stage-gates.json globalInvariants missing Live evidence must redact raw tokens and payloads while preserving enough stable identifiers for independent verification.",
+		);
+	});
+});
+
+interface StageGateManifestFixture {
+	globalInvariants: string[];
+	stages: Array<{
+		id: string;
+		exitEvidence: Array<{ id: string }>;
+	}>;
+}
+
+function readManifest(): StageGateManifestFixture {
+	return JSON.parse(
+		readFileSync(A2A_SWARM_STAGE_GATE_MANIFEST, "utf8"),
+	) as StageGateManifestFixture;
+}
+
+function validateManifestFixture(manifest: StageGateManifestFixture): string[] {
+	tempDir = join(
+		tmpdir(),
+		`a2a-stage-gates-${process.pid}-${Date.now()}-${Math.random()
+			.toString(16)
+			.slice(2)}`,
+	);
+	const manifestPath = join(tempDir, A2A_SWARM_STAGE_GATE_MANIFEST);
+	mkdirSync(join(tempDir, "docs/protocols"), { recursive: true });
+	writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
+	return validateA2ASwarmStageGateManifest(tempDir);
+}


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"60ff40a2ec907cfa378d5c3cc7e2cbae5964f1e1"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `60ff40a2ec907cfa378d5c3cc7e2cbae5964f1e1`
- last generated public sync base: `2f88b2b57f31ef778aba0f231e3f6d86ab443032`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (60ff40a2ec90)`
- public projection: `https://github.com/evalops/maestro@main (2f88b2b57f31)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update scripts/check-evidence-integrity.ts
- copy/update test/scripts/evidence-integrity.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update scripts/check-evidence-integrity.ts
- copy/update test/scripts/evidence-integrity.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@60ff40a2ec907cfa378d5c3cc7e2cbae5964f1e1`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.