### PR TITLE
fix: refresh maestro from release metadata on startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,33 +222,6 @@ jobs:
               ;;
           esac
 
-      - name: Authenticate to Google Cloud for release metadata
-        if: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT != '' }}
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          workload_identity_provider: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT }}
-
-      - name: Setup Google Cloud SDK
-        if: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT != '' }}
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-
-      - name: Sync GCS version metadata
-        if: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT != '' }}
-        env:
-          MAESTRO_RELEASES_BUCKET: ${{ vars.MAESTRO_RELEASES_BUCKET || 'evalops-prod-maestro-releases' }}
-          MAESTRO_RELEASES_PREFIX: ${{ vars.MAESTRO_RELEASES_PREFIX || 'maestro' }}
-        run: |
-          set -euo pipefail
-          prefix="${MAESTRO_RELEASES_PREFIX#/}"
-          prefix="${prefix%/}"
-          target="gs://${MAESTRO_RELEASES_BUCKET%/}/${prefix}/version.json"
-          gcloud storage cp "$GITHUB_WORKSPACE/dist/version.json" "$target"
-          gcloud storage objects update "$target" \
-            --cache-control="public, max-age=60" \
-            --content-type="application/json"
-          echo "Synced Maestro version metadata to ${target}."
-
       - name: Sync Hopper version metadata
         env:
           HOPPER_PUSH_TOKEN: ${{ secrets.HOPPER_PUSH_TOKEN }}
@@ -311,6 +284,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -340,6 +314,36 @@ jobs:
 
       - name: Validate published replay evidence
         run: node scripts/verify-published-replay-evidence.js --evidence-dir published-replay-evidence
+
+      - name: Generate version metadata
+        run: node scripts/create-version-json.js
+
+      - name: Authenticate to Google Cloud for release metadata
+        if: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT != '' }}
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup Google Cloud SDK
+        if: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT != '' }}
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Sync GCS version metadata
+        if: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT != '' }}
+        env:
+          MAESTRO_RELEASES_BUCKET: ${{ vars.MAESTRO_RELEASES_BUCKET || 'evalops-prod-maestro-releases' }}
+          MAESTRO_RELEASES_PREFIX: ${{ vars.MAESTRO_RELEASES_PREFIX || 'maestro' }}
+        run: |
+          set -euo pipefail
+          prefix="${MAESTRO_RELEASES_PREFIX#/}"
+          prefix="${prefix%/}"
+          target="gs://${MAESTRO_RELEASES_BUCKET%/}/${prefix}/version.json"
+          gcloud storage cp "$GITHUB_WORKSPACE/dist/version.json" "$target"
+          gcloud storage objects update "$target" \
+            --cache-control="public, max-age=60" \
+            --content-type="application/json"
+          echo "Synced Maestro version metadata to ${target}."
 
       - name: Upload published replay evidence
         if: ${{ always() && hashFiles('published-replay-evidence/*.json') != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,33 @@ jobs:
               ;;
           esac
 
+      - name: Authenticate to Google Cloud for release metadata
+        if: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT != '' }}
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup Google Cloud SDK
+        if: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT != '' }}
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Sync GCS version metadata
+        if: ${{ vars.MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER != '' && vars.MAESTRO_RELEASE_GCP_SERVICE_ACCOUNT != '' }}
+        env:
+          MAESTRO_RELEASES_BUCKET: ${{ vars.MAESTRO_RELEASES_BUCKET || 'evalops-prod-maestro-releases' }}
+          MAESTRO_RELEASES_PREFIX: ${{ vars.MAESTRO_RELEASES_PREFIX || 'maestro' }}
+        run: |
+          set -euo pipefail
+          prefix="${MAESTRO_RELEASES_PREFIX#/}"
+          prefix="${prefix%/}"
+          target="gs://${MAESTRO_RELEASES_BUCKET%/}/${prefix}/version.json"
+          gcloud storage cp "$GITHUB_WORKSPACE/dist/version.json" "$target"
+          gcloud storage objects update "$target" \
+            --cache-control="public, max-age=60" \
+            --content-type="application/json"
+          echo "Synced Maestro version metadata to ${target}."
+
       - name: Sync Hopper version metadata
         env:
           HOPPER_PUSH_TOKEN: ${{ secrets.HOPPER_PUSH_TOKEN }}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,8 +74,27 @@ async function reportFatalCliError(error: unknown): Promise<void> {
 	}
 }
 
+async function refreshInstalledCliOnStartup(args: string[]): Promise<void> {
+	try {
+		const [{ getPackageVersion }, { attemptStartupUpdate }] = await Promise.all(
+			[import("./package-metadata.js"), import("./update/startup-refresh.js")],
+		);
+		const outcome = await attemptStartupUpdate({
+			args,
+			currentVersion: getPackageVersion(),
+		});
+		if (outcome.status === "restarted") {
+			process.exit(outcome.exitCode);
+		}
+	} catch {
+		// Startup refresh is best-effort and must never prevent the CLI from booting.
+	}
+}
+
 const run = async () => {
 	try {
+		await refreshInstalledCliOnStartup(process.argv.slice(2));
+
 		if (process.argv[2] === "a2a") {
 			const { loadEnv } = await import("./load-env.js");
 			loadEnv();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,11 +93,11 @@ async function refreshInstalledCliOnStartup(args: string[]): Promise<void> {
 
 const run = async () => {
 	try {
+		const { loadEnv } = await import("./load-env.js");
+		loadEnv();
 		await refreshInstalledCliOnStartup(process.argv.slice(2));
 
 		if (process.argv[2] === "a2a") {
-			const { loadEnv } = await import("./load-env.js");
-			loadEnv();
 			const { handleA2ACommand } = await import("./cli/commands/a2a.js");
 			await handleA2ACommand(process.argv.slice(3));
 			return;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -68,6 +68,7 @@ const COMMANDS = new Set([
 	"cost",
 	"stats",
 	"status",
+	"update",
 	"run",
 	"agents",
 	"a2a",
@@ -389,6 +390,7 @@ export function parseArgs(args: string[]): Args {
 					arg === "hosted-runner" ||
 					arg === "init" ||
 					arg === "evalops" ||
+					arg === "update" ||
 					arg === "skill"
 				) {
 					result.commandArgs = args.slice(i + 1);

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,0 +1,195 @@
+import chalk from "chalk";
+import { getPackageVersion } from "../../package-metadata.js";
+import { type UpdateCheckResult, checkForUpdate } from "../../update/check.js";
+import {
+	type StartupUpdateOutcome,
+	attemptStartupUpdate,
+} from "../../update/startup-refresh.js";
+
+interface ParsedUpdateArgs {
+	check: boolean;
+	help: boolean;
+	json: boolean;
+}
+
+interface UpdateCommandDeps {
+	attemptStartupUpdateImpl?: typeof attemptStartupUpdate;
+	checkForUpdateImpl?: typeof checkForUpdate;
+	currentVersion?: string;
+	env?: NodeJS.ProcessEnv;
+	isTty?: boolean;
+}
+
+const STARTUP_UPDATE_SKIP_ENV = "MAESTRO_SKIP_STARTUP_UPDATE";
+const STARTUP_UPDATE_MODE_ENV = "MAESTRO_STARTUP_UPDATE";
+const STARTUP_UPDATE_RETRY_ENV = "MAESTRO_STARTUP_UPDATE_RETRY_MS";
+
+function parseUpdateArgs(args: string[]): ParsedUpdateArgs | { error: string } {
+	const parsed: ParsedUpdateArgs = {
+		check: false,
+		help: false,
+		json: false,
+	};
+
+	for (const arg of args) {
+		switch (arg) {
+			case "--check":
+				parsed.check = true;
+				break;
+			case "--json":
+				parsed.json = true;
+				break;
+			case "--help":
+			case "-h":
+				parsed.help = true;
+				break;
+			default:
+				return { error: `Unknown maestro update option: ${arg}` };
+		}
+	}
+
+	return parsed;
+}
+
+function printUpdateHelp(): void {
+	console.log(`Usage: maestro update [--check] [--json]
+
+Options:
+  --check   Check for the newest Maestro version without installing it
+  --json    Print machine-readable update status
+  --help    Show this help`);
+}
+
+function printJson(value: unknown): void {
+	console.log(JSON.stringify(value, null, 2));
+}
+
+function formatCheckMessage(check: UpdateCheckResult): string {
+	if (check.error) {
+		return `Maestro update check failed: ${check.error}`;
+	}
+	if (check.isUpdateAvailable && check.latestVersion) {
+		return `Maestro ${check.latestVersion} is available (current ${check.currentVersion}).`;
+	}
+	return `Maestro is up to date (${check.currentVersion}).`;
+}
+
+function installEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const nextEnv = { ...env };
+	delete nextEnv[STARTUP_UPDATE_SKIP_ENV];
+	delete nextEnv[STARTUP_UPDATE_MODE_ENV];
+	delete nextEnv.CI;
+	delete nextEnv.NODE_ENV;
+	nextEnv[STARTUP_UPDATE_RETRY_ENV] = "0";
+	return nextEnv;
+}
+
+function jsonForOutcome(outcome: StartupUpdateOutcome) {
+	const check = "check" in outcome ? outcome.check : undefined;
+	return {
+		status: outcome.status,
+		reason: "reason" in outcome ? outcome.reason : undefined,
+		error: "error" in outcome ? outcome.error : undefined,
+		exitCode: "exitCode" in outcome ? outcome.exitCode : undefined,
+		currentVersion: check?.currentVersion,
+		latestVersion: check?.latestVersion,
+		sourceUrl: check?.sourceUrl,
+	};
+}
+
+export async function handleUpdateCommand(
+	commandArgs: string[] = [],
+	deps: UpdateCommandDeps = {},
+): Promise<void> {
+	const parsed = parseUpdateArgs(commandArgs);
+	if ("error" in parsed) {
+		console.error(chalk.red(parsed.error));
+		process.exitCode = 1;
+		return;
+	}
+	if (parsed.help) {
+		printUpdateHelp();
+		return;
+	}
+
+	const currentVersion = deps.currentVersion ?? getPackageVersion();
+	const env = deps.env ?? process.env;
+
+	if (parsed.check) {
+		const check = await (deps.checkForUpdateImpl ?? checkForUpdate)(
+			currentVersion,
+		);
+		if (parsed.json) {
+			printJson({
+				status: check.error
+					? "failed"
+					: check.isUpdateAvailable
+						? "available"
+						: "current",
+				currentVersion: check.currentVersion,
+				latestVersion: check.latestVersion,
+				sourceUrl: check.sourceUrl,
+				error: check.error,
+			});
+		} else if (check.error) {
+			console.error(chalk.red(formatCheckMessage(check)));
+		} else {
+			console.log(formatCheckMessage(check));
+		}
+		if (check.error) {
+			process.exitCode = 1;
+		}
+		return;
+	}
+
+	const outcome = await (deps.attemptStartupUpdateImpl ?? attemptStartupUpdate)(
+		{
+			args: [],
+			currentVersion,
+			env: installEnv(env),
+			isTty: deps.isTty ?? true,
+			restart: false,
+		},
+	);
+
+	if (parsed.json) {
+		printJson(jsonForOutcome(outcome));
+	} else {
+		switch (outcome.status) {
+			case "updated":
+				console.log(
+					chalk.green(
+						`Updated Maestro to ${outcome.check.latestVersion ?? "the latest version"}.`,
+					),
+				);
+				break;
+			case "current":
+				console.log(formatCheckMessage(outcome.check));
+				break;
+			case "available":
+				console.log(
+					`Maestro ${outcome.check.latestVersion ?? "update"} is available, but automatic install was not attempted.`,
+				);
+				break;
+			case "skipped":
+				console.error(
+					chalk.yellow(`Maestro update skipped: ${outcome.reason}.`),
+				);
+				break;
+			case "failed":
+				console.error(chalk.red(`Maestro update failed: ${outcome.error}`));
+				break;
+			case "restarted":
+				console.log(
+					chalk.green(
+						`Updated Maestro to ${outcome.check.latestVersion ?? "the latest version"}.`,
+					),
+				);
+				break;
+		}
+	}
+
+	if (outcome.status === "failed" || outcome.status === "skipped") {
+		process.exitCode = 1;
+	}
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -156,6 +156,10 @@ export function printHelp(
   # Confirm managed mode sinks and EvalOps org identity
   maestro status
 
+  # Check or install the newest published Maestro CLI
+  maestro update --check
+  maestro update
+
   # Inspect mode-level subagent model dispatch before running a swarm
   maestro modes describe smart
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -669,6 +669,12 @@ export async function main(args: string[]) {
 		return;
 	}
 
+	if (parsed.command === "update") {
+		const { handleUpdateCommand } = await import("./cli/commands/update.js");
+		await handleUpdateCommand(parsed.commandArgs ?? []);
+		return;
+	}
+
 	if (parsed.command === "context") {
 		const { handleContextCommand } = await import("./cli/commands/context.js");
 		await handleContextCommand(parsed.subcommand, parsed.messages, {

--- a/src/update/check.ts
+++ b/src/update/check.ts
@@ -1,7 +1,9 @@
+import { getPackageName } from "../package-metadata.js";
 import { withTimeout } from "../utils/async.js";
 
-const DEFAULT_UPDATE_URL =
-	"https://raw.githubusercontent.com/evalops/hopper/main/public/composer/version.json";
+const DEFAULT_GCS_UPDATE_URL =
+	"https://storage.googleapis.com/evalops-prod-maestro-releases/maestro/version.json";
+const NPM_REGISTRY_BASE_URL = "https://registry.npmjs.org";
 const DEFAULT_TIMEOUT_MS = 5_000;
 
 interface VersionMetadata {
@@ -22,7 +24,43 @@ interface CheckForUpdateOptions {
 	fetch?: typeof fetch;
 	timeoutMs?: number;
 	url?: string;
+	urls?: string[];
 }
+
+const splitUrlList = (value: string | undefined): string[] => {
+	if (!value) {
+		return [];
+	}
+	return value
+		.split(/[\n,]/u)
+		.map((url) => url.trim())
+		.filter(Boolean);
+};
+
+const npmLatestUrl = (packageName = getPackageName()): string => {
+	return `${NPM_REGISTRY_BASE_URL}/${encodeURIComponent(packageName)}/latest`;
+};
+
+export const resolveUpdateUrls = (
+	options: Pick<CheckForUpdateOptions, "url" | "urls"> = {},
+	env: NodeJS.ProcessEnv = process.env,
+): string[] => {
+	const explicitUrls = options.urls?.map((url) => url.trim()).filter(Boolean);
+	if (explicitUrls && explicitUrls.length > 0) {
+		return explicitUrls;
+	}
+	if (options.url?.trim()) {
+		return [options.url.trim()];
+	}
+	const envUrls = splitUrlList(env.MAESTRO_UPDATE_URLS);
+	if (envUrls.length > 0) {
+		return envUrls;
+	}
+	if (env.MAESTRO_UPDATE_URL?.trim()) {
+		return [env.MAESTRO_UPDATE_URL.trim()];
+	}
+	return [DEFAULT_GCS_UPDATE_URL, npmLatestUrl()];
+};
 
 const toErrorMessage = (error: unknown): string => {
 	if (error instanceof Error) {
@@ -139,63 +177,77 @@ export async function checkForUpdate(
 	currentVersion: string,
 	options: CheckForUpdateOptions = {},
 ): Promise<UpdateCheckResult> {
-	const url =
-		options.url ?? process.env.MAESTRO_UPDATE_URL ?? DEFAULT_UPDATE_URL;
+	const urls = resolveUpdateUrls(options);
 	const fetchImpl = options.fetch ?? fetch;
 	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	let lastResult: UpdateCheckResult | null = null;
 
-	try {
-		const response = await withTimeout(
-			fetchImpl(url, {
-				headers: { Accept: "application/json" },
-			}),
-			timeoutMs,
-			`Update check timed out after ${timeoutMs}ms`,
-		);
-
-		if (!response.ok) {
-			return {
-				currentVersion,
-				isUpdateAvailable: false,
-				sourceUrl: url,
-				error:
-					`Update check failed (${response.status} ${response.statusText || ""})`.trim(),
-			};
-		}
-		let payload: VersionMetadata;
+	for (const url of urls) {
 		try {
-			payload = (await response.json()) as VersionMetadata;
+			const response = await withTimeout(
+				fetchImpl(url, {
+					headers: { Accept: "application/json" },
+				}),
+				timeoutMs,
+				`Update check timed out after ${timeoutMs}ms`,
+			);
+
+			if (!response.ok) {
+				lastResult = {
+					currentVersion,
+					isUpdateAvailable: false,
+					sourceUrl: url,
+					error:
+						`Update check failed (${response.status} ${response.statusText || ""})`.trim(),
+				};
+				continue;
+			}
+			let payload: VersionMetadata;
+			try {
+				payload = (await response.json()) as VersionMetadata;
+			} catch (error) {
+				lastResult = {
+					currentVersion,
+					isUpdateAvailable: false,
+					sourceUrl: url,
+					error: `Invalid update metadata: ${toErrorMessage(error)}`,
+				};
+				continue;
+			}
+			if (!payload || typeof payload.version !== "string") {
+				lastResult = {
+					currentVersion,
+					isUpdateAvailable: false,
+					sourceUrl: url,
+					error: "Update metadata missing version field",
+				};
+				continue;
+			}
+			const latestVersion = payload.version.trim();
+			const comparison = compareVersions(currentVersion.trim(), latestVersion);
+			return {
+				currentVersion,
+				latestVersion,
+				notes: normalizeNotes(payload.notes),
+				isUpdateAvailable: comparison < 0,
+				sourceUrl: url,
+			};
 		} catch (error) {
-			return {
+			lastResult = {
 				currentVersion,
 				isUpdateAvailable: false,
 				sourceUrl: url,
-				error: `Invalid update metadata: ${toErrorMessage(error)}`,
+				error: toErrorMessage(error),
 			};
 		}
-		if (!payload || typeof payload.version !== "string") {
-			return {
-				currentVersion,
-				isUpdateAvailable: false,
-				sourceUrl: url,
-				error: "Update metadata missing version field",
-			};
-		}
-		const latestVersion = payload.version.trim();
-		const comparison = compareVersions(currentVersion.trim(), latestVersion);
-		return {
-			currentVersion,
-			latestVersion,
-			notes: normalizeNotes(payload.notes),
-			isUpdateAvailable: comparison < 0,
-			sourceUrl: url,
-		};
-	} catch (error) {
-		return {
+	}
+
+	return (
+		lastResult ?? {
 			currentVersion,
 			isUpdateAvailable: false,
-			sourceUrl: url,
-			error: toErrorMessage(error),
-		};
-	}
+			sourceUrl: urls[0] ?? "",
+			error: "No update metadata sources configured",
+		}
+	);
 }

--- a/src/update/check.ts
+++ b/src/update/check.ts
@@ -181,6 +181,7 @@ export async function checkForUpdate(
 	const fetchImpl = options.fetch ?? fetch;
 	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	let lastResult: UpdateCheckResult | null = null;
+	let bestUpdateResult: UpdateCheckResult | null = null;
 	let bestCurrentResult: UpdateCheckResult | null = null;
 
 	for (const url of urls) {
@@ -235,7 +236,16 @@ export async function checkForUpdate(
 			};
 			lastResult = result;
 			if (result.isUpdateAvailable) {
-				return result;
+				if (
+					!bestUpdateResult ||
+					compareVersions(
+						bestUpdateResult.latestVersion ?? currentVersion,
+						latestVersion,
+					) < 0
+				) {
+					bestUpdateResult = result;
+				}
+				continue;
 			}
 			if (
 				!bestCurrentResult ||
@@ -257,6 +267,7 @@ export async function checkForUpdate(
 	}
 
 	return (
+		bestUpdateResult ??
 		bestCurrentResult ??
 		lastResult ?? {
 			currentVersion,

--- a/src/update/check.ts
+++ b/src/update/check.ts
@@ -181,6 +181,7 @@ export async function checkForUpdate(
 	const fetchImpl = options.fetch ?? fetch;
 	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	let lastResult: UpdateCheckResult | null = null;
+	let bestCurrentResult: UpdateCheckResult | null = null;
 
 	for (const url of urls) {
 		try {
@@ -225,13 +226,26 @@ export async function checkForUpdate(
 			}
 			const latestVersion = payload.version.trim();
 			const comparison = compareVersions(currentVersion.trim(), latestVersion);
-			return {
+			const result = {
 				currentVersion,
 				latestVersion,
 				notes: normalizeNotes(payload.notes),
 				isUpdateAvailable: comparison < 0,
 				sourceUrl: url,
 			};
+			lastResult = result;
+			if (result.isUpdateAvailable) {
+				return result;
+			}
+			if (
+				!bestCurrentResult ||
+				compareVersions(
+					bestCurrentResult.latestVersion ?? currentVersion,
+					latestVersion,
+				) < 0
+			) {
+				bestCurrentResult = result;
+			}
 		} catch (error) {
 			lastResult = {
 				currentVersion,
@@ -243,6 +257,7 @@ export async function checkForUpdate(
 	}
 
 	return (
+		bestCurrentResult ??
 		lastResult ?? {
 			currentVersion,
 			isUpdateAvailable: false,

--- a/src/update/startup-refresh.ts
+++ b/src/update/startup-refresh.ts
@@ -13,7 +13,11 @@ import {
 	getPackageName,
 } from "../package-metadata.js";
 import { withTimeout } from "../utils/async.js";
-import { type UpdateCheckResult, checkForUpdate } from "./check.js";
+import {
+	type UpdateCheckResult,
+	checkForUpdate,
+	resolveUpdateUrls,
+} from "./check.js";
 
 const SKIP_ENV = "MAESTRO_SKIP_STARTUP_UPDATE";
 const STARTUP_UPDATE_ENV = "MAESTRO_STARTUP_UPDATE";
@@ -49,7 +53,7 @@ type StartupUpdateOptions = {
 	packageName?: string;
 	checkForUpdateImpl?: (
 		currentVersion: string,
-		options?: { timeoutMs?: number },
+		options?: { timeoutMs?: number; urls?: string[] },
 	) => Promise<UpdateCheckResult>;
 	checkTimeoutMs?: number;
 	globalPrefix?: string | null;
@@ -218,6 +222,11 @@ const startupCheckTimeoutMsFromEnv = (env: NodeJS.ProcessEnv): number => {
 	return DEFAULT_STARTUP_UPDATE_TIMEOUT_MS;
 };
 
+const startupSourceTimeoutMs = (
+	totalTimeoutMs: number,
+	sourceCount: number,
+): number => Math.max(1, Math.floor(totalTimeoutMs / Math.max(1, sourceCount)));
+
 const shouldThrottleAttempt = (
 	state: StartupUpdateState | null,
 	version: string,
@@ -308,10 +317,16 @@ export async function attemptStartupUpdate(
 
 	const checkTimeoutMs =
 		options.checkTimeoutMs ?? startupCheckTimeoutMsFromEnv(env);
+	const updateUrls = resolveUpdateUrls({}, env);
+	const checkOptions = {
+		timeoutMs: startupSourceTimeoutMs(checkTimeoutMs, updateUrls.length),
+		urls: updateUrls,
+	};
 	const check = await withTimeout(
-		(options.checkForUpdateImpl ?? checkForUpdate)(options.currentVersion, {
-			timeoutMs: checkTimeoutMs,
-		}),
+		(options.checkForUpdateImpl ?? checkForUpdate)(
+			options.currentVersion,
+			checkOptions,
+		),
 		checkTimeoutMs,
 		`Startup update check timed out after ${checkTimeoutMs}ms`,
 	).catch(

--- a/src/update/startup-refresh.ts
+++ b/src/update/startup-refresh.ts
@@ -1,5 +1,11 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	realpathSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname, resolve } from "node:path";
 import { getAgentDir } from "../config/constants.js";
 import {
@@ -98,6 +104,20 @@ export const isInstalledPackageEntrypoint = (
 	if (!entrypoint) {
 		return false;
 	}
+	if (isPackageEntrypointPath(entrypoint, packageName)) {
+		return true;
+	}
+	try {
+		return isPackageEntrypointPath(realpathSync(entrypoint), packageName);
+	} catch {
+		return false;
+	}
+};
+
+const isPackageEntrypointPath = (
+	entrypoint: string,
+	packageName: string,
+): boolean => {
 	const normalized = entrypoint.replace(/\\/g, "/");
 	return normalized.includes(`/node_modules/${packageName}/dist/cli.js`);
 };

--- a/src/update/startup-refresh.ts
+++ b/src/update/startup-refresh.ts
@@ -7,6 +7,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
+import { parseArgs } from "../cli/args.js";
 import { getAgentDir } from "../config/constants.js";
 import {
 	getGlobalInstallCommand,
@@ -99,6 +100,9 @@ const shouldSkipForArgs = (args: string[]): string | null => {
 	if (args[0] === "a2a") {
 		return "a2a command";
 	}
+	if (args[0] === "exec") {
+		return "non-interactive command";
+	}
 	if (args[0] === "update") {
 		return "manual update command";
 	}
@@ -129,6 +133,9 @@ const shouldSkipForArgs = (args: string[]): string | null => {
 		) {
 			return "headless command";
 		}
+	}
+	if (parseArgs(args).messages.length > 0) {
+		return "single-shot prompt";
 	}
 	return null;
 };

--- a/src/update/startup-refresh.ts
+++ b/src/update/startup-refresh.ts
@@ -6,7 +6,7 @@ import {
 	realpathSync,
 	writeFileSync,
 } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { getAgentDir } from "../config/constants.js";
 import {
 	getGlobalInstallCommand,
@@ -28,6 +28,14 @@ const DEFAULT_INSTALL_TIMEOUT_MS = 60_000;
 const DEFAULT_RETRY_MS = 24 * 60 * 60 * 1_000;
 const DEFAULT_STARTUP_UPDATE_TIMEOUT_MS = 1_500;
 const NPM_PREFIX_TIMEOUT_MS = 2_000;
+const BUN_PREFIX_TIMEOUT_MS = 2_000;
+
+type PackageManager = "npm" | "bun";
+
+type GlobalInstallContext = {
+	packageManager: PackageManager;
+	prefix: string;
+};
 
 type StartupUpdateState = {
 	version?: string;
@@ -56,8 +64,10 @@ type StartupUpdateOptions = {
 		options?: { timeoutMs?: number; urls?: string[] },
 	) => Promise<UpdateCheckResult>;
 	checkTimeoutMs?: number;
+	globalInstallContexts?: GlobalInstallContext[] | null;
 	globalPrefix?: string | null;
 	installPackage?: (
+		packageManager: PackageManager,
 		packageName: string,
 		version: string,
 	) => {
@@ -250,9 +260,13 @@ const shouldThrottleAttempt = (
 const isInstallableVersion = (version: string): boolean =>
 	INSTALLABLE_VERSION.test(version);
 
-const defaultInstallPackage = (packageName: string, version: string) => {
+const defaultInstallPackage = (
+	packageManager: PackageManager,
+	packageName: string,
+	version: string,
+) => {
 	const result = spawnSync(
-		"npm",
+		packageManager,
 		["install", "-g", `${packageName}@${version}`],
 		{
 			encoding: "utf-8",
@@ -277,6 +291,41 @@ const resolveNpmGlobalPrefix = (
 	}
 	const prefix = result.stdout.trim();
 	return prefix.length > 0 ? prefix : null;
+};
+
+const resolveBunGlobalPrefix = (
+	env: NodeJS.ProcessEnv = process.env,
+): string | null => {
+	const result = spawnSync("bun", ["pm", "bin", "-g"], {
+		encoding: "utf-8",
+		env,
+		stdio: ["ignore", "pipe", "ignore"],
+		timeout: BUN_PREFIX_TIMEOUT_MS,
+	});
+	if (result.error || result.status !== 0) {
+		return null;
+	}
+	const binDir = result.stdout.trim();
+	if (!binDir) {
+		return null;
+	}
+	const bunHome = basename(binDir) === "bin" ? dirname(binDir) : binDir;
+	return join(bunHome, "install", "global");
+};
+
+const resolveGlobalInstallContexts = (
+	env: NodeJS.ProcessEnv = process.env,
+): GlobalInstallContext[] => {
+	const contexts: GlobalInstallContext[] = [];
+	const npmPrefix = resolveNpmGlobalPrefix(env);
+	if (npmPrefix) {
+		contexts.push({ packageManager: "npm", prefix: npmPrefix });
+	}
+	const bunPrefix = resolveBunGlobalPrefix(env);
+	if (bunPrefix) {
+		contexts.push({ packageManager: "bun", prefix: bunPrefix });
+	}
+	return contexts;
 };
 
 export async function attemptStartupUpdate(
@@ -307,15 +356,30 @@ export async function attemptStartupUpdate(
 	if (argsSkipReason) {
 		return { status: "skipped", reason: argsSkipReason };
 	}
-	const globalPrefix =
-		options.globalPrefix === undefined
-			? resolveNpmGlobalPrefix(env)
-			: options.globalPrefix;
-	if (!globalPrefix) {
-		return { status: "skipped", reason: "npm global prefix unavailable" };
+	const globalInstallContexts =
+		options.globalInstallContexts ??
+		(options.globalPrefix === undefined
+			? resolveGlobalInstallContexts(env)
+			: options.globalPrefix
+				? [{ packageManager: "npm" as const, prefix: options.globalPrefix }]
+				: []);
+	if (globalInstallContexts.length === 0) {
+		return {
+			status: "skipped",
+			reason:
+				options.globalPrefix === null
+					? "npm global prefix unavailable"
+					: "global package prefix unavailable",
+		};
 	}
-	if (!isInstalledPackageEntrypoint(argv[1], packageName, globalPrefix)) {
-		return { status: "skipped", reason: "not running installed npm package" };
+	const installContext = globalInstallContexts.find((context) =>
+		isInstalledPackageEntrypoint(argv[1], packageName, context.prefix),
+	);
+	if (!installContext) {
+		return {
+			status: "skipped",
+			reason: "not running installed global package",
+		};
 	}
 
 	const checkTimeoutMs =
@@ -375,6 +439,7 @@ export async function attemptStartupUpdate(
 		lastStatus: "failed",
 	});
 	const install = (options.installPackage ?? defaultInstallPackage)(
+		installContext.packageManager,
 		packageName,
 		check.latestVersion,
 	);
@@ -384,7 +449,7 @@ export async function attemptStartupUpdate(
 			check,
 			error:
 				install.error?.message ??
-				`${getGlobalInstallCommand("npm", `${packageName}@${check.latestVersion}`)} exited ${install.status}`,
+				`${getGlobalInstallCommand(installContext.packageManager, `${packageName}@${check.latestVersion}`)} exited ${install.status}`,
 		};
 	}
 

--- a/src/update/startup-refresh.ts
+++ b/src/update/startup-refresh.ts
@@ -1,0 +1,278 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { getAgentDir } from "../config/constants.js";
+import {
+	getGlobalInstallCommand,
+	getPackageName,
+} from "../package-metadata.js";
+import { type UpdateCheckResult, checkForUpdate } from "./check.js";
+
+const SKIP_ENV = "MAESTRO_SKIP_STARTUP_UPDATE";
+const STARTUP_UPDATE_ENV = "MAESTRO_STARTUP_UPDATE";
+const STARTUP_UPDATE_STATE_ENV = "MAESTRO_STARTUP_UPDATE_STATE";
+const STARTUP_UPDATE_TTL_ENV = "MAESTRO_STARTUP_UPDATE_RETRY_MS";
+const DEFAULT_INSTALL_TIMEOUT_MS = 60_000;
+const DEFAULT_RETRY_MS = 24 * 60 * 60 * 1_000;
+
+type StartupUpdateState = {
+	version?: string;
+	lastAttemptAt?: number;
+	lastStatus?: "failed" | "updated";
+};
+
+export type StartupUpdateOutcome =
+	| { status: "skipped"; reason: string }
+	| { status: "current"; check: UpdateCheckResult }
+	| { status: "available"; check: UpdateCheckResult }
+	| { status: "failed"; check?: UpdateCheckResult; error: string }
+	| { status: "updated"; check: UpdateCheckResult }
+	| { status: "restarted"; check: UpdateCheckResult; exitCode: number };
+
+type StartupUpdateOptions = {
+	args?: string[];
+	argv?: string[];
+	currentVersion: string;
+	env?: NodeJS.ProcessEnv;
+	isTty?: boolean;
+	now?: number;
+	packageName?: string;
+	checkForUpdateImpl?: (currentVersion: string) => Promise<UpdateCheckResult>;
+	installPackage?: (
+		packageName: string,
+		version: string,
+	) => {
+		status: number | null;
+		error?: Error;
+	};
+	restart?: () => { status: number | null; error?: Error };
+	statePath?: string;
+};
+
+const OFF_VALUES = new Set(["0", "false", "off", "skip", "disabled"]);
+const CHECK_ONLY_VALUES = new Set(["check", "notice", "notify"]);
+const INSTALLABLE_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
+
+const envValue = (env: NodeJS.ProcessEnv, key: string): string =>
+	env[key]?.trim().toLowerCase() ?? "";
+
+const shouldSkipForArgs = (args: string[]): string | null => {
+	if (args[0] === "a2a") {
+		return "a2a command";
+	}
+	if (
+		args.includes("--version") ||
+		args.includes("-v") ||
+		args.includes("--help") ||
+		args.includes("-h")
+	) {
+		return "immediate-exit command";
+	}
+	if (
+		args.includes("--headless") ||
+		args.includes("--json") ||
+		args.includes("--rpc") ||
+		args.includes("rpc")
+	) {
+		return "non-interactive command";
+	}
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === "--mode" && args[i + 1] === "headless") {
+			return "headless command";
+		}
+		if (
+			arg?.startsWith("--mode=") &&
+			arg.slice("--mode=".length) === "headless"
+		) {
+			return "headless command";
+		}
+	}
+	return null;
+};
+
+export const isInstalledPackageEntrypoint = (
+	entrypoint: string | undefined,
+	packageName = getPackageName(),
+): boolean => {
+	if (!entrypoint) {
+		return false;
+	}
+	const normalized = entrypoint.replace(/\\/g, "/");
+	return normalized.includes(`/node_modules/${packageName}/dist/cli.js`);
+};
+
+const resolveStatePath = (
+	env: NodeJS.ProcessEnv = process.env,
+	override?: string,
+): string => {
+	if (override) {
+		return override;
+	}
+	if (env[STARTUP_UPDATE_STATE_ENV]) {
+		return resolve(env[STARTUP_UPDATE_STATE_ENV]);
+	}
+	return resolve(getAgentDir(), "startup-update-state.json");
+};
+
+const readState = (path: string): StartupUpdateState | null => {
+	if (!existsSync(path)) {
+		return null;
+	}
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as StartupUpdateState;
+	} catch {
+		return null;
+	}
+};
+
+const writeState = (path: string, state: StartupUpdateState): void => {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(state, null, 2), "utf-8");
+};
+
+const retryMsFromEnv = (env: NodeJS.ProcessEnv): number => {
+	const parsed = Number.parseInt(env[STARTUP_UPDATE_TTL_ENV] ?? "", 10);
+	if (Number.isFinite(parsed) && parsed >= 0) {
+		return parsed;
+	}
+	return DEFAULT_RETRY_MS;
+};
+
+const shouldThrottleAttempt = (
+	state: StartupUpdateState | null,
+	version: string,
+	now: number,
+	retryMs: number,
+): boolean => {
+	if (
+		!state ||
+		state.version !== version ||
+		typeof state.lastAttemptAt !== "number" ||
+		state.lastStatus !== "failed"
+	) {
+		return false;
+	}
+	return now - state.lastAttemptAt < retryMs;
+};
+
+const isInstallableVersion = (version: string): boolean =>
+	INSTALLABLE_VERSION.test(version);
+
+const defaultInstallPackage = (packageName: string, version: string) => {
+	const result = spawnSync(
+		"npm",
+		["install", "-g", `${packageName}@${version}`],
+		{
+			encoding: "utf-8",
+			stdio: "pipe",
+			timeout: DEFAULT_INSTALL_TIMEOUT_MS,
+		},
+	);
+	return { status: result.status, error: result.error };
+};
+
+export async function attemptStartupUpdate(
+	options: StartupUpdateOptions,
+): Promise<StartupUpdateOutcome> {
+	const env = options.env ?? process.env;
+	const args = options.args ?? process.argv.slice(2);
+	const argv = options.argv ?? process.argv;
+	const packageName = options.packageName ?? getPackageName();
+	const updateMode = envValue(env, STARTUP_UPDATE_ENV);
+	const now = options.now ?? Date.now();
+
+	if (env[SKIP_ENV]) {
+		return { status: "skipped", reason: `${SKIP_ENV} is set` };
+	}
+	if (env.CI || env.NODE_ENV === "test") {
+		return { status: "skipped", reason: "test or CI environment" };
+	}
+	if (OFF_VALUES.has(updateMode)) {
+		return { status: "skipped", reason: `${STARTUP_UPDATE_ENV} is disabled` };
+	}
+	if (
+		!(options.isTty ?? Boolean(process.stdin.isTTY && process.stdout.isTTY))
+	) {
+		return { status: "skipped", reason: "non-TTY startup" };
+	}
+	const argsSkipReason = shouldSkipForArgs(args);
+	if (argsSkipReason) {
+		return { status: "skipped", reason: argsSkipReason };
+	}
+	if (!isInstalledPackageEntrypoint(argv[1], packageName)) {
+		return { status: "skipped", reason: "not running installed npm package" };
+	}
+
+	const check = await (options.checkForUpdateImpl ?? checkForUpdate)(
+		options.currentVersion,
+	);
+	if (check.error) {
+		return { status: "failed", check, error: check.error };
+	}
+	if (!check.isUpdateAvailable || !check.latestVersion) {
+		return { status: "current", check };
+	}
+	if (CHECK_ONLY_VALUES.has(updateMode)) {
+		return { status: "available", check };
+	}
+	if (!isInstallableVersion(check.latestVersion)) {
+		return {
+			status: "failed",
+			check,
+			error: `Refusing to install unsupported version ${check.latestVersion}`,
+		};
+	}
+
+	const statePath = resolveStatePath(env, options.statePath);
+	if (
+		shouldThrottleAttempt(
+			readState(statePath),
+			check.latestVersion,
+			now,
+			retryMsFromEnv(env),
+		)
+	) {
+		return { status: "available", check };
+	}
+
+	writeState(statePath, {
+		version: check.latestVersion,
+		lastAttemptAt: now,
+		lastStatus: "failed",
+	});
+	const install = (options.installPackage ?? defaultInstallPackage)(
+		packageName,
+		check.latestVersion,
+	);
+	if (install.error || install.status !== 0) {
+		return {
+			status: "failed",
+			check,
+			error:
+				install.error?.message ??
+				`${getGlobalInstallCommand("npm", `${packageName}@${check.latestVersion}`)} exited ${install.status}`,
+		};
+	}
+
+	writeState(statePath, {
+		version: check.latestVersion,
+		lastAttemptAt: now,
+		lastStatus: "updated",
+	});
+
+	const restart =
+		options.restart ??
+		(() => {
+			const result = spawnSync(process.execPath, argv.slice(1), {
+				stdio: "inherit",
+				env: { ...env, [SKIP_ENV]: "1" },
+			});
+			return { status: result.status, error: result.error };
+		});
+	const restarted = restart();
+	if (restarted.error) {
+		return { status: "updated", check };
+	}
+	return { status: "restarted", check, exitCode: restarted.status ?? 0 };
+}

--- a/src/update/startup-refresh.ts
+++ b/src/update/startup-refresh.ts
@@ -64,7 +64,7 @@ type StartupUpdateOptions = {
 		status: number | null;
 		error?: Error;
 	};
-	restart?: () => { status: number | null; error?: Error };
+	restart?: false | (() => { status: number | null; error?: Error });
 	statePath?: string;
 };
 
@@ -88,6 +88,9 @@ const toErrorMessage = (error: unknown): string => {
 const shouldSkipForArgs = (args: string[]): string | null => {
 	if (args[0] === "a2a") {
 		return "a2a command";
+	}
+	if (args[0] === "update") {
+		return "manual update command";
 	}
 	if (
 		args.includes("--version") ||
@@ -390,6 +393,10 @@ export async function attemptStartupUpdate(
 		lastAttemptAt: now,
 		lastStatus: "updated",
 	});
+
+	if (options.restart === false) {
+		return { status: "updated", check };
+	}
 
 	const restart =
 		options.restart ??

--- a/src/update/startup-refresh.ts
+++ b/src/update/startup-refresh.ts
@@ -7,6 +7,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
 import { getAgentDir } from "../config/constants.js";
 import {
 	getGlobalInstallCommand,
@@ -51,11 +52,16 @@ type StartupUpdateOptions = {
 		status: number | null;
 		error?: Error;
 	};
+	confirmUpdate?: (
+		check: UpdateCheckResult,
+		packageName: string,
+	) => Promise<boolean>;
 	restart?: () => { status: number | null; error?: Error };
 	statePath?: string;
 };
 
 const OFF_VALUES = new Set(["0", "false", "off", "skip", "disabled"]);
+const AUTO_VALUES = new Set(["1", "true", "on", "auto", "install", "yes"]);
 const CHECK_ONLY_VALUES = new Set(["check", "notice", "notify"]);
 const INSTALLABLE_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
 
@@ -192,6 +198,25 @@ const defaultInstallPackage = (packageName: string, version: string) => {
 	return { status: result.status, error: result.error };
 };
 
+const defaultConfirmUpdate = async (
+	check: UpdateCheckResult,
+	packageName: string,
+): Promise<boolean> => {
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stderr,
+	});
+	try {
+		const answer = await rl.question(
+			`${packageName} ${check.latestVersion} is available (current ${check.currentVersion}). Install and restart now? [Y/n] `,
+		);
+		const normalized = answer.trim().toLowerCase();
+		return normalized === "" || normalized === "y" || normalized === "yes";
+	} finally {
+		rl.close();
+	}
+};
+
 export async function attemptStartupUpdate(
 	options: StartupUpdateOptions,
 ): Promise<StartupUpdateOutcome> {
@@ -254,6 +279,15 @@ export async function attemptStartupUpdate(
 		)
 	) {
 		return { status: "available", check };
+	}
+	if (!AUTO_VALUES.has(updateMode)) {
+		const accepted = await (options.confirmUpdate ?? defaultConfirmUpdate)(
+			check,
+			packageName,
+		);
+		if (!accepted) {
+			return { status: "available", check };
+		}
 	}
 
 	writeState(statePath, {

--- a/src/update/startup-refresh.ts
+++ b/src/update/startup-refresh.ts
@@ -12,14 +12,18 @@ import {
 	getGlobalInstallCommand,
 	getPackageName,
 } from "../package-metadata.js";
+import { withTimeout } from "../utils/async.js";
 import { type UpdateCheckResult, checkForUpdate } from "./check.js";
 
 const SKIP_ENV = "MAESTRO_SKIP_STARTUP_UPDATE";
 const STARTUP_UPDATE_ENV = "MAESTRO_STARTUP_UPDATE";
 const STARTUP_UPDATE_STATE_ENV = "MAESTRO_STARTUP_UPDATE_STATE";
+const STARTUP_UPDATE_TIMEOUT_ENV = "MAESTRO_STARTUP_UPDATE_TIMEOUT_MS";
 const STARTUP_UPDATE_TTL_ENV = "MAESTRO_STARTUP_UPDATE_RETRY_MS";
 const DEFAULT_INSTALL_TIMEOUT_MS = 60_000;
 const DEFAULT_RETRY_MS = 24 * 60 * 60 * 1_000;
+const DEFAULT_STARTUP_UPDATE_TIMEOUT_MS = 1_500;
+const NPM_PREFIX_TIMEOUT_MS = 2_000;
 
 type StartupUpdateState = {
 	version?: string;
@@ -43,7 +47,12 @@ type StartupUpdateOptions = {
 	isTty?: boolean;
 	now?: number;
 	packageName?: string;
-	checkForUpdateImpl?: (currentVersion: string) => Promise<UpdateCheckResult>;
+	checkForUpdateImpl?: (
+		currentVersion: string,
+		options?: { timeoutMs?: number },
+	) => Promise<UpdateCheckResult>;
+	checkTimeoutMs?: number;
+	globalPrefix?: string | null;
 	installPackage?: (
 		packageName: string,
 		version: string,
@@ -61,6 +70,16 @@ const INSTALLABLE_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
 
 const envValue = (env: NodeJS.ProcessEnv, key: string): string =>
 	env[key]?.trim().toLowerCase() ?? "";
+
+const toErrorMessage = (error: unknown): string => {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	if (typeof error === "string") {
+		return error;
+	}
+	return "Unknown error";
+};
 
 const shouldSkipForArgs = (args: string[]): string | null => {
 	if (args[0] === "a2a") {
@@ -100,15 +119,20 @@ const shouldSkipForArgs = (args: string[]): string | null => {
 export const isInstalledPackageEntrypoint = (
 	entrypoint: string | undefined,
 	packageName = getPackageName(),
+	globalPrefix?: string | null,
 ): boolean => {
 	if (!entrypoint) {
 		return false;
 	}
-	if (isPackageEntrypointPath(entrypoint, packageName)) {
+	if (isPackageEntrypointPath(entrypoint, packageName, globalPrefix)) {
 		return true;
 	}
 	try {
-		return isPackageEntrypointPath(realpathSync(entrypoint), packageName);
+		return isPackageEntrypointPath(
+			realpathSync(entrypoint),
+			packageName,
+			globalPrefix,
+		);
 	} catch {
 		return false;
 	}
@@ -117,9 +141,36 @@ export const isInstalledPackageEntrypoint = (
 const isPackageEntrypointPath = (
 	entrypoint: string,
 	packageName: string,
+	globalPrefix?: string | null,
 ): boolean => {
 	const normalized = entrypoint.replace(/\\/g, "/");
-	return normalized.includes(`/node_modules/${packageName}/dist/cli.js`);
+	const packageEntrypoint = `/node_modules/${packageName}/dist/cli.js`;
+	if (!normalized.endsWith(packageEntrypoint)) {
+		return false;
+	}
+	if (!globalPrefix) {
+		return true;
+	}
+	const normalizedPrefix = globalPrefix
+		.replace(/\\/g, "/")
+		.replace(/\/+$/u, "");
+	const normalizedPrefixes = new Set([normalizedPrefix]);
+	try {
+		normalizedPrefixes.add(
+			realpathSync(globalPrefix).replace(/\\/g, "/").replace(/\/+$/u, ""),
+		);
+	} catch {
+		// A missing prefix will fail the exact path checks below.
+	}
+	for (const prefix of normalizedPrefixes) {
+		if (
+			normalized === `${prefix}/lib/node_modules/${packageName}/dist/cli.js` ||
+			normalized === `${prefix}/node_modules/${packageName}/dist/cli.js`
+		) {
+			return true;
+		}
+	}
+	return false;
 };
 
 const resolveStatePath = (
@@ -159,6 +210,14 @@ const retryMsFromEnv = (env: NodeJS.ProcessEnv): number => {
 	return DEFAULT_RETRY_MS;
 };
 
+const startupCheckTimeoutMsFromEnv = (env: NodeJS.ProcessEnv): number => {
+	const parsed = Number.parseInt(env[STARTUP_UPDATE_TIMEOUT_ENV] ?? "", 10);
+	if (Number.isFinite(parsed) && parsed > 0) {
+		return parsed;
+	}
+	return DEFAULT_STARTUP_UPDATE_TIMEOUT_MS;
+};
+
 const shouldThrottleAttempt = (
 	state: StartupUpdateState | null,
 	version: string,
@@ -192,6 +251,22 @@ const defaultInstallPackage = (packageName: string, version: string) => {
 	return { status: result.status, error: result.error };
 };
 
+const resolveNpmGlobalPrefix = (
+	env: NodeJS.ProcessEnv = process.env,
+): string | null => {
+	const result = spawnSync("npm", ["prefix", "-g"], {
+		encoding: "utf-8",
+		env,
+		stdio: ["ignore", "pipe", "ignore"],
+		timeout: NPM_PREFIX_TIMEOUT_MS,
+	});
+	if (result.error || result.status !== 0) {
+		return null;
+	}
+	const prefix = result.stdout.trim();
+	return prefix.length > 0 ? prefix : null;
+};
+
 export async function attemptStartupUpdate(
 	options: StartupUpdateOptions,
 ): Promise<StartupUpdateOutcome> {
@@ -220,12 +295,32 @@ export async function attemptStartupUpdate(
 	if (argsSkipReason) {
 		return { status: "skipped", reason: argsSkipReason };
 	}
-	if (!isInstalledPackageEntrypoint(argv[1], packageName)) {
+	const globalPrefix =
+		options.globalPrefix === undefined
+			? resolveNpmGlobalPrefix(env)
+			: options.globalPrefix;
+	if (!globalPrefix) {
+		return { status: "skipped", reason: "npm global prefix unavailable" };
+	}
+	if (!isInstalledPackageEntrypoint(argv[1], packageName, globalPrefix)) {
 		return { status: "skipped", reason: "not running installed npm package" };
 	}
 
-	const check = await (options.checkForUpdateImpl ?? checkForUpdate)(
-		options.currentVersion,
+	const checkTimeoutMs =
+		options.checkTimeoutMs ?? startupCheckTimeoutMsFromEnv(env);
+	const check = await withTimeout(
+		(options.checkForUpdateImpl ?? checkForUpdate)(options.currentVersion, {
+			timeoutMs: checkTimeoutMs,
+		}),
+		checkTimeoutMs,
+		`Startup update check timed out after ${checkTimeoutMs}ms`,
+	).catch(
+		(error): UpdateCheckResult => ({
+			currentVersion: options.currentVersion,
+			isUpdateAvailable: false,
+			sourceUrl: "",
+			error: toErrorMessage(error),
+		}),
 	);
 	if (check.error) {
 		return { status: "failed", check, error: check.error };

--- a/src/update/startup-refresh.ts
+++ b/src/update/startup-refresh.ts
@@ -7,7 +7,6 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { createInterface } from "node:readline/promises";
 import { getAgentDir } from "../config/constants.js";
 import {
 	getGlobalInstallCommand,
@@ -52,16 +51,11 @@ type StartupUpdateOptions = {
 		status: number | null;
 		error?: Error;
 	};
-	confirmUpdate?: (
-		check: UpdateCheckResult,
-		packageName: string,
-	) => Promise<boolean>;
 	restart?: () => { status: number | null; error?: Error };
 	statePath?: string;
 };
 
 const OFF_VALUES = new Set(["0", "false", "off", "skip", "disabled"]);
-const AUTO_VALUES = new Set(["1", "true", "on", "auto", "install", "yes"]);
 const CHECK_ONLY_VALUES = new Set(["check", "notice", "notify"]);
 const INSTALLABLE_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
 
@@ -198,25 +192,6 @@ const defaultInstallPackage = (packageName: string, version: string) => {
 	return { status: result.status, error: result.error };
 };
 
-const defaultConfirmUpdate = async (
-	check: UpdateCheckResult,
-	packageName: string,
-): Promise<boolean> => {
-	const rl = createInterface({
-		input: process.stdin,
-		output: process.stderr,
-	});
-	try {
-		const answer = await rl.question(
-			`${packageName} ${check.latestVersion} is available (current ${check.currentVersion}). Install and restart now? [Y/n] `,
-		);
-		const normalized = answer.trim().toLowerCase();
-		return normalized === "" || normalized === "y" || normalized === "yes";
-	} finally {
-		rl.close();
-	}
-};
-
 export async function attemptStartupUpdate(
 	options: StartupUpdateOptions,
 ): Promise<StartupUpdateOutcome> {
@@ -279,15 +254,6 @@ export async function attemptStartupUpdate(
 		)
 	) {
 		return { status: "available", check };
-	}
-	if (!AUTO_VALUES.has(updateMode)) {
-		const accepted = await (options.confirmUpdate ?? defaultConfirmUpdate)(
-			check,
-			packageName,
-		);
-		if (!accepted) {
-			return { status: "available", check };
-		}
 	}
 
 	writeState(statePath, {

--- a/test/cli/args.test.ts
+++ b/test/cli/args.test.ts
@@ -240,6 +240,14 @@ describe("parseArgs", () => {
 		});
 	});
 
+	it("preserves update command arguments for the update handler", () => {
+		expect(parseArgs(["update", "--check", "--json"])).toMatchObject({
+			command: "update",
+			commandArgs: ["--check", "--json"],
+			messages: [],
+		});
+	});
+
 	it("parses stats commands", () => {
 		expect(parseArgs(["stats"])).toMatchObject({
 			command: "stats",

--- a/test/cli/startup-refresh.test.ts
+++ b/test/cli/startup-refresh.test.ts
@@ -56,6 +56,16 @@ describe("isInstalledPackageEntrypoint", () => {
 		).toBe(false);
 	});
 
+	it("recognizes Bun global package entrypoints", () => {
+		expect(
+			isInstalledPackageEntrypoint(
+				`/Users/me/.bun/install/global/node_modules/${packageName}/dist/cli.js`,
+				packageName,
+				"/Users/me/.bun/install/global",
+			),
+		).toBe(true);
+	});
+
 	it("recognizes npm bin shims that resolve to installed package entrypoints", () => {
 		const dir = mkdtempSync(join(tmpdir(), "maestro-entrypoint-"));
 		try {
@@ -209,9 +219,40 @@ describe("attemptStartupUpdate", () => {
 			installPackage,
 			restart,
 		});
-		expect(installPackage).toHaveBeenCalledWith(packageName, "0.10.1");
+		expect(installPackage).toHaveBeenCalledWith("npm", packageName, "0.10.1");
 		expect(restart).toHaveBeenCalled();
 		expect(outcome).toMatchObject({ status: "restarted", exitCode: 7 });
+	});
+
+	it("uses Bun to update Bun global installs", async () => {
+		const installPackage = vi.fn().mockReturnValue({ status: 0 });
+		const outcome = await attemptStartupUpdate({
+			argv: [
+				"/usr/local/bin/node",
+				`/Users/me/.bun/install/global/node_modules/${packageName}/dist/cli.js`,
+			],
+			currentVersion: "0.10.0",
+			env: {},
+			globalInstallContexts: [
+				{
+					packageManager: "bun",
+					prefix: "/Users/me/.bun/install/global",
+				},
+			],
+			isTty: true,
+			statePath: statePath(),
+			checkForUpdateImpl: async () => ({
+				currentVersion: "0.10.0",
+				latestVersion: "0.10.1",
+				isUpdateAvailable: true,
+				sourceUrl:
+					"https://storage.googleapis.com/example/maestro/version.json",
+			}),
+			installPackage,
+			restart: false,
+		});
+		expect(installPackage).toHaveBeenCalledWith("bun", packageName, "0.10.1");
+		expect(outcome).toMatchObject({ status: "updated" });
 	});
 
 	it("can install without restarting for manual update commands", async () => {
@@ -234,7 +275,7 @@ describe("attemptStartupUpdate", () => {
 			installPackage,
 			restart: false,
 		});
-		expect(installPackage).toHaveBeenCalledWith(packageName, "0.10.1");
+		expect(installPackage).toHaveBeenCalledWith("npm", packageName, "0.10.1");
 		expect(restart).not.toHaveBeenCalled();
 		expect(outcome).toMatchObject({ status: "updated" });
 	});

--- a/test/cli/startup-refresh.test.ts
+++ b/test/cli/startup-refresh.test.ts
@@ -146,7 +146,7 @@ describe("attemptStartupUpdate", () => {
 		expect(checkForUpdateImpl).not.toHaveBeenCalled();
 	});
 
-	it("uses a bounded startup update check timeout", async () => {
+	it("uses a bounded startup update check timeout while preserving fallback sources", async () => {
 		const checkForUpdateImpl = vi.fn().mockResolvedValue({
 			currentVersion: "0.10.0",
 			latestVersion: "0.10.0",
@@ -155,16 +155,19 @@ describe("attemptStartupUpdate", () => {
 		});
 		const outcome = await attemptStartupUpdate({
 			argv: installedArgv,
-			checkTimeoutMs: 123,
+			checkTimeoutMs: 120,
 			currentVersion: "0.10.0",
-			env: {},
+			env: {
+				MAESTRO_UPDATE_URLS: "https://example.com/a,https://example.com/b",
+			},
 			globalPrefix,
 			isTty: true,
 			checkForUpdateImpl,
 		});
 		expect(outcome.status).toBe("current");
 		expect(checkForUpdateImpl).toHaveBeenCalledWith("0.10.0", {
-			timeoutMs: 123,
+			timeoutMs: 60,
+			urls: ["https://example.com/a", "https://example.com/b"],
 		});
 	});
 

--- a/test/cli/startup-refresh.test.ts
+++ b/test/cli/startup-refresh.test.ts
@@ -140,6 +140,42 @@ describe("attemptStartupUpdate", () => {
 		expect(checkForUpdateImpl).not.toHaveBeenCalled();
 	});
 
+	it("skips single-shot prompt invocations before checking the network", async () => {
+		const checkForUpdateImpl = vi.fn();
+		const outcome = await attemptStartupUpdate({
+			args: ["audit this repo"],
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			globalPrefix,
+			isTty: true,
+			checkForUpdateImpl,
+		});
+		expect(outcome).toMatchObject({
+			status: "skipped",
+			reason: "single-shot prompt",
+		});
+		expect(checkForUpdateImpl).not.toHaveBeenCalled();
+	});
+
+	it("skips exec invocations before checking the network", async () => {
+		const checkForUpdateImpl = vi.fn();
+		const outcome = await attemptStartupUpdate({
+			args: ["exec", "audit this repo"],
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			globalPrefix,
+			isTty: true,
+			checkForUpdateImpl,
+		});
+		expect(outcome).toMatchObject({
+			status: "skipped",
+			reason: "non-interactive command",
+		});
+		expect(checkForUpdateImpl).not.toHaveBeenCalled();
+	});
+
 	it("skips when the running package is outside the npm global prefix", async () => {
 		const checkForUpdateImpl = vi.fn();
 		const outcome = await attemptStartupUpdate({

--- a/test/cli/startup-refresh.test.ts
+++ b/test/cli/startup-refresh.test.ts
@@ -8,28 +8,30 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getPackageName } from "../../src/package-metadata.js";
 import {
 	attemptStartupUpdate,
 	isInstalledPackageEntrypoint,
 } from "../../src/update/startup-refresh.js";
 
+const packageName = getPackageName();
 const installedArgv = [
 	"/usr/local/bin/node",
-	"/usr/local/lib/node_modules/@evalops/maestro/dist/cli.js",
+	`/usr/local/lib/node_modules/${packageName}/dist/cli.js`,
 ];
 
 describe("isInstalledPackageEntrypoint", () => {
 	it("recognizes npm-installed package entrypoints", () => {
 		expect(
 			isInstalledPackageEntrypoint(
-				"/usr/local/lib/node_modules/@evalops/maestro/dist/cli.js",
-				"@evalops/maestro",
+				`/usr/local/lib/node_modules/${packageName}/dist/cli.js`,
+				packageName,
 			),
 		).toBe(true);
 		expect(
 			isInstalledPackageEntrypoint(
 				"/Users/me/Projects/maestro/dist/cli.js",
-				"@evalops/maestro",
+				packageName,
 			),
 		).toBe(false);
 	});
@@ -41,8 +43,7 @@ describe("isInstalledPackageEntrypoint", () => {
 				dir,
 				"lib",
 				"node_modules",
-				"@evalops",
-				"maestro",
+				...packageName.split("/"),
 				"dist",
 				"cli.js",
 			);
@@ -53,9 +54,7 @@ describe("isInstalledPackageEntrypoint", () => {
 			mkdirSync(dirname(shimPath), { recursive: true });
 			symlinkSync(cliPath, shimPath);
 
-			expect(isInstalledPackageEntrypoint(shimPath, "@evalops/maestro")).toBe(
-				true,
-			);
+			expect(isInstalledPackageEntrypoint(shimPath, packageName)).toBe(true);
 		} finally {
 			rmSync(dir, { force: true, recursive: true });
 		}
@@ -96,7 +95,7 @@ describe("attemptStartupUpdate", () => {
 		const outcome = await attemptStartupUpdate({
 			argv: installedArgv,
 			currentVersion: "0.10.0",
-			env: { MAESTRO_STARTUP_UPDATE: "auto" },
+			env: {},
 			isTty: true,
 			statePath: statePath(),
 			checkForUpdateImpl: async () => ({
@@ -109,60 +108,9 @@ describe("attemptStartupUpdate", () => {
 			installPackage,
 			restart,
 		});
-		expect(installPackage).toHaveBeenCalledWith("@evalops/maestro", "0.10.1");
+		expect(installPackage).toHaveBeenCalledWith(packageName, "0.10.1");
 		expect(restart).toHaveBeenCalled();
 		expect(outcome).toMatchObject({ status: "restarted", exitCode: 7 });
-	});
-
-	it("prompts before installing by default", async () => {
-		const confirmUpdate = vi.fn().mockResolvedValue(true);
-		const installPackage = vi.fn().mockReturnValue({ status: 0 });
-		const restart = vi.fn().mockReturnValue({ status: 0 });
-		const outcome = await attemptStartupUpdate({
-			argv: installedArgv,
-			currentVersion: "0.10.0",
-			env: {},
-			isTty: true,
-			statePath: statePath(),
-			checkForUpdateImpl: async () => ({
-				currentVersion: "0.10.0",
-				latestVersion: "0.10.1",
-				isUpdateAvailable: true,
-				sourceUrl:
-					"https://storage.googleapis.com/example/maestro/version.json",
-			}),
-			confirmUpdate,
-			installPackage,
-			restart,
-		});
-		expect(confirmUpdate).toHaveBeenCalledWith(
-			expect.objectContaining({ latestVersion: "0.10.1" }),
-			"@evalops/maestro",
-		);
-		expect(installPackage).toHaveBeenCalledWith("@evalops/maestro", "0.10.1");
-		expect(outcome.status).toBe("restarted");
-	});
-
-	it("does not install when the update prompt is declined", async () => {
-		const installPackage = vi.fn();
-		const outcome = await attemptStartupUpdate({
-			argv: installedArgv,
-			currentVersion: "0.10.0",
-			env: {},
-			isTty: true,
-			statePath: statePath(),
-			checkForUpdateImpl: async () => ({
-				currentVersion: "0.10.0",
-				latestVersion: "0.10.1",
-				isUpdateAvailable: true,
-				sourceUrl:
-					"https://storage.googleapis.com/example/maestro/version.json",
-			}),
-			confirmUpdate: async () => false,
-			installPackage,
-		});
-		expect(outcome.status).toBe("available");
-		expect(installPackage).not.toHaveBeenCalled();
 	});
 
 	it("does not install in check-only mode", async () => {
@@ -218,7 +166,7 @@ describe("attemptStartupUpdate", () => {
 		const first = await attemptStartupUpdate({
 			argv: installedArgv,
 			currentVersion: "0.10.0",
-			env: { MAESTRO_STARTUP_UPDATE: "auto" },
+			env: {},
 			isTty: true,
 			now: 1000,
 			statePath: path,
@@ -228,7 +176,7 @@ describe("attemptStartupUpdate", () => {
 		const second = await attemptStartupUpdate({
 			argv: installedArgv,
 			currentVersion: "0.10.0",
-			env: { MAESTRO_STARTUP_UPDATE: "auto" },
+			env: {},
 			isTty: true,
 			now: 2000,
 			statePath: path,

--- a/test/cli/startup-refresh.test.ts
+++ b/test/cli/startup-refresh.test.ts
@@ -112,6 +112,24 @@ describe("attemptStartupUpdate", () => {
 		expect(checkForUpdateImpl).not.toHaveBeenCalled();
 	});
 
+	it("skips the manual update command before checking the network", async () => {
+		const checkForUpdateImpl = vi.fn();
+		const outcome = await attemptStartupUpdate({
+			args: ["update"],
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			globalPrefix,
+			isTty: true,
+			checkForUpdateImpl,
+		});
+		expect(outcome).toMatchObject({
+			status: "skipped",
+			reason: "manual update command",
+		});
+		expect(checkForUpdateImpl).not.toHaveBeenCalled();
+	});
+
 	it("skips when the running package is outside the npm global prefix", async () => {
 		const checkForUpdateImpl = vi.fn();
 		const outcome = await attemptStartupUpdate({
@@ -194,6 +212,31 @@ describe("attemptStartupUpdate", () => {
 		expect(installPackage).toHaveBeenCalledWith(packageName, "0.10.1");
 		expect(restart).toHaveBeenCalled();
 		expect(outcome).toMatchObject({ status: "restarted", exitCode: 7 });
+	});
+
+	it("can install without restarting for manual update commands", async () => {
+		const installPackage = vi.fn().mockReturnValue({ status: 0 });
+		const restart = vi.fn();
+		const outcome = await attemptStartupUpdate({
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			globalPrefix,
+			isTty: true,
+			statePath: statePath(),
+			checkForUpdateImpl: async () => ({
+				currentVersion: "0.10.0",
+				latestVersion: "0.10.1",
+				isUpdateAvailable: true,
+				sourceUrl:
+					"https://storage.googleapis.com/example/maestro/version.json",
+			}),
+			installPackage,
+			restart: false,
+		});
+		expect(installPackage).toHaveBeenCalledWith(packageName, "0.10.1");
+		expect(restart).not.toHaveBeenCalled();
+		expect(outcome).toMatchObject({ status: "updated" });
 	});
 
 	it("does not install in check-only mode", async () => {

--- a/test/cli/startup-refresh.test.ts
+++ b/test/cli/startup-refresh.test.ts
@@ -96,7 +96,7 @@ describe("attemptStartupUpdate", () => {
 		const outcome = await attemptStartupUpdate({
 			argv: installedArgv,
 			currentVersion: "0.10.0",
-			env: {},
+			env: { MAESTRO_STARTUP_UPDATE: "auto" },
 			isTty: true,
 			statePath: statePath(),
 			checkForUpdateImpl: async () => ({
@@ -112,6 +112,57 @@ describe("attemptStartupUpdate", () => {
 		expect(installPackage).toHaveBeenCalledWith("@evalops/maestro", "0.10.1");
 		expect(restart).toHaveBeenCalled();
 		expect(outcome).toMatchObject({ status: "restarted", exitCode: 7 });
+	});
+
+	it("prompts before installing by default", async () => {
+		const confirmUpdate = vi.fn().mockResolvedValue(true);
+		const installPackage = vi.fn().mockReturnValue({ status: 0 });
+		const restart = vi.fn().mockReturnValue({ status: 0 });
+		const outcome = await attemptStartupUpdate({
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			isTty: true,
+			statePath: statePath(),
+			checkForUpdateImpl: async () => ({
+				currentVersion: "0.10.0",
+				latestVersion: "0.10.1",
+				isUpdateAvailable: true,
+				sourceUrl:
+					"https://storage.googleapis.com/example/maestro/version.json",
+			}),
+			confirmUpdate,
+			installPackage,
+			restart,
+		});
+		expect(confirmUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({ latestVersion: "0.10.1" }),
+			"@evalops/maestro",
+		);
+		expect(installPackage).toHaveBeenCalledWith("@evalops/maestro", "0.10.1");
+		expect(outcome.status).toBe("restarted");
+	});
+
+	it("does not install when the update prompt is declined", async () => {
+		const installPackage = vi.fn();
+		const outcome = await attemptStartupUpdate({
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			isTty: true,
+			statePath: statePath(),
+			checkForUpdateImpl: async () => ({
+				currentVersion: "0.10.0",
+				latestVersion: "0.10.1",
+				isUpdateAvailable: true,
+				sourceUrl:
+					"https://storage.googleapis.com/example/maestro/version.json",
+			}),
+			confirmUpdate: async () => false,
+			installPackage,
+		});
+		expect(outcome.status).toBe("available");
+		expect(installPackage).not.toHaveBeenCalled();
 	});
 
 	it("does not install in check-only mode", async () => {
@@ -167,7 +218,7 @@ describe("attemptStartupUpdate", () => {
 		const first = await attemptStartupUpdate({
 			argv: installedArgv,
 			currentVersion: "0.10.0",
-			env: {},
+			env: { MAESTRO_STARTUP_UPDATE: "auto" },
 			isTty: true,
 			now: 1000,
 			statePath: path,
@@ -177,7 +228,7 @@ describe("attemptStartupUpdate", () => {
 		const second = await attemptStartupUpdate({
 			argv: installedArgv,
 			currentVersion: "0.10.0",
-			env: {},
+			env: { MAESTRO_STARTUP_UPDATE: "auto" },
 			isTty: true,
 			now: 2000,
 			statePath: path,

--- a/test/cli/startup-refresh.test.ts
+++ b/test/cli/startup-refresh.test.ts
@@ -19,6 +19,7 @@ const installedArgv = [
 	"/usr/local/bin/node",
 	`/usr/local/lib/node_modules/${packageName}/dist/cli.js`,
 ];
+const globalPrefix = "/usr/local";
 
 describe("isInstalledPackageEntrypoint", () => {
 	it("recognizes npm-installed package entrypoints", () => {
@@ -26,12 +27,31 @@ describe("isInstalledPackageEntrypoint", () => {
 			isInstalledPackageEntrypoint(
 				`/usr/local/lib/node_modules/${packageName}/dist/cli.js`,
 				packageName,
+				globalPrefix,
 			),
 		).toBe(true);
 		expect(
 			isInstalledPackageEntrypoint(
 				"/Users/me/Projects/maestro/dist/cli.js",
 				packageName,
+				globalPrefix,
+			),
+		).toBe(false);
+	});
+
+	it("rejects project and npx package entrypoints outside the npm global prefix", () => {
+		expect(
+			isInstalledPackageEntrypoint(
+				`/Users/me/Projects/app/node_modules/${packageName}/dist/cli.js`,
+				packageName,
+				globalPrefix,
+			),
+		).toBe(false);
+		expect(
+			isInstalledPackageEntrypoint(
+				`/Users/me/.npm/_npx/abc/node_modules/${packageName}/dist/cli.js`,
+				packageName,
+				globalPrefix,
 			),
 		).toBe(false);
 	});
@@ -54,7 +74,9 @@ describe("isInstalledPackageEntrypoint", () => {
 			mkdirSync(dirname(shimPath), { recursive: true });
 			symlinkSync(cliPath, shimPath);
 
-			expect(isInstalledPackageEntrypoint(shimPath, packageName)).toBe(true);
+			expect(isInstalledPackageEntrypoint(shimPath, packageName, dir)).toBe(
+				true,
+			);
 		} finally {
 			rmSync(dir, { force: true, recursive: true });
 		}
@@ -82,11 +104,68 @@ describe("attemptStartupUpdate", () => {
 			argv: ["/usr/local/bin/node", "/Users/me/Projects/maestro/dist/cli.js"],
 			currentVersion: "0.10.0",
 			env: {},
+			globalPrefix,
 			isTty: true,
 			checkForUpdateImpl,
 		});
 		expect(outcome.status).toBe("skipped");
 		expect(checkForUpdateImpl).not.toHaveBeenCalled();
+	});
+
+	it("skips when the running package is outside the npm global prefix", async () => {
+		const checkForUpdateImpl = vi.fn();
+		const outcome = await attemptStartupUpdate({
+			argv: [
+				"/usr/local/bin/node",
+				`/Users/me/app/node_modules/${packageName}/dist/cli.js`,
+			],
+			currentVersion: "0.10.0",
+			env: {},
+			globalPrefix,
+			isTty: true,
+			checkForUpdateImpl,
+		});
+		expect(outcome.status).toBe("skipped");
+		expect(checkForUpdateImpl).not.toHaveBeenCalled();
+	});
+
+	it("skips when the npm global prefix cannot be resolved", async () => {
+		const checkForUpdateImpl = vi.fn();
+		const outcome = await attemptStartupUpdate({
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			globalPrefix: null,
+			isTty: true,
+			checkForUpdateImpl,
+		});
+		expect(outcome).toMatchObject({
+			status: "skipped",
+			reason: "npm global prefix unavailable",
+		});
+		expect(checkForUpdateImpl).not.toHaveBeenCalled();
+	});
+
+	it("uses a bounded startup update check timeout", async () => {
+		const checkForUpdateImpl = vi.fn().mockResolvedValue({
+			currentVersion: "0.10.0",
+			latestVersion: "0.10.0",
+			isUpdateAvailable: false,
+			sourceUrl: "https://storage.googleapis.com/example/maestro/version.json",
+		});
+		const outcome = await attemptStartupUpdate({
+			argv: installedArgv,
+			checkTimeoutMs: 123,
+			currentVersion: "0.10.0",
+			env: {},
+			globalPrefix,
+			isTty: true,
+			checkForUpdateImpl,
+		});
+		expect(outcome.status).toBe("current");
+		expect(checkForUpdateImpl).toHaveBeenCalledWith("0.10.0", {
+			timeoutMs: 123,
+		});
 	});
 
 	it("installs and restarts when a newer version is available", async () => {
@@ -96,6 +175,7 @@ describe("attemptStartupUpdate", () => {
 			argv: installedArgv,
 			currentVersion: "0.10.0",
 			env: {},
+			globalPrefix,
 			isTty: true,
 			statePath: statePath(),
 			checkForUpdateImpl: async () => ({
@@ -119,6 +199,7 @@ describe("attemptStartupUpdate", () => {
 			argv: installedArgv,
 			currentVersion: "0.10.0",
 			env: { MAESTRO_STARTUP_UPDATE: "check" },
+			globalPrefix,
 			isTty: true,
 			checkForUpdateImpl: async () => ({
 				currentVersion: "0.10.0",
@@ -139,6 +220,7 @@ describe("attemptStartupUpdate", () => {
 			argv: installedArgv,
 			currentVersion: "0.10.0",
 			env: {},
+			globalPrefix,
 			isTty: true,
 			checkForUpdateImpl: async () => ({
 				currentVersion: "0.10.0",
@@ -167,6 +249,7 @@ describe("attemptStartupUpdate", () => {
 			argv: installedArgv,
 			currentVersion: "0.10.0",
 			env: {},
+			globalPrefix,
 			isTty: true,
 			now: 1000,
 			statePath: path,
@@ -177,6 +260,7 @@ describe("attemptStartupUpdate", () => {
 			argv: installedArgv,
 			currentVersion: "0.10.0",
 			env: {},
+			globalPrefix,
 			isTty: true,
 			now: 2000,
 			statePath: path,

--- a/test/cli/startup-refresh.test.ts
+++ b/test/cli/startup-refresh.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	attemptStartupUpdate,
+	isInstalledPackageEntrypoint,
+} from "../../src/update/startup-refresh.js";
+
+const installedArgv = [
+	"/usr/local/bin/node",
+	"/usr/local/lib/node_modules/@evalops/maestro/dist/cli.js",
+];
+
+describe("isInstalledPackageEntrypoint", () => {
+	it("recognizes npm-installed package entrypoints", () => {
+		expect(
+			isInstalledPackageEntrypoint(
+				"/usr/local/lib/node_modules/@evalops/maestro/dist/cli.js",
+				"@evalops/maestro",
+			),
+		).toBe(true);
+		expect(
+			isInstalledPackageEntrypoint(
+				"/Users/me/Projects/maestro/dist/cli.js",
+				"@evalops/maestro",
+			),
+		).toBe(false);
+	});
+});
+
+describe("attemptStartupUpdate", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	const statePath = (): string => {
+		const dir = mkdtempSync(join(tmpdir(), "maestro-startup-update-"));
+		tempDirs.push(dir);
+		return join(dir, "state.json");
+	};
+
+	it("skips non-installed entrypoints before checking the network", async () => {
+		const checkForUpdateImpl = vi.fn();
+		const outcome = await attemptStartupUpdate({
+			argv: ["/usr/local/bin/node", "/Users/me/Projects/maestro/dist/cli.js"],
+			currentVersion: "0.10.0",
+			env: {},
+			isTty: true,
+			checkForUpdateImpl,
+		});
+		expect(outcome.status).toBe("skipped");
+		expect(checkForUpdateImpl).not.toHaveBeenCalled();
+	});
+
+	it("installs and restarts when a newer version is available", async () => {
+		const installPackage = vi.fn().mockReturnValue({ status: 0 });
+		const restart = vi.fn().mockReturnValue({ status: 7 });
+		const outcome = await attemptStartupUpdate({
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			isTty: true,
+			statePath: statePath(),
+			checkForUpdateImpl: async () => ({
+				currentVersion: "0.10.0",
+				latestVersion: "0.10.1",
+				isUpdateAvailable: true,
+				sourceUrl:
+					"https://storage.googleapis.com/example/maestro/version.json",
+			}),
+			installPackage,
+			restart,
+		});
+		expect(installPackage).toHaveBeenCalledWith("@evalops/maestro", "0.10.1");
+		expect(restart).toHaveBeenCalled();
+		expect(outcome).toMatchObject({ status: "restarted", exitCode: 7 });
+	});
+
+	it("does not install in check-only mode", async () => {
+		const installPackage = vi.fn();
+		const outcome = await attemptStartupUpdate({
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: { MAESTRO_STARTUP_UPDATE: "check" },
+			isTty: true,
+			checkForUpdateImpl: async () => ({
+				currentVersion: "0.10.0",
+				latestVersion: "0.10.1",
+				isUpdateAvailable: true,
+				sourceUrl:
+					"https://storage.googleapis.com/example/maestro/version.json",
+			}),
+			installPackage,
+		});
+		expect(outcome.status).toBe("available");
+		expect(installPackage).not.toHaveBeenCalled();
+	});
+
+	it("refuses non-semver install metadata", async () => {
+		const installPackage = vi.fn();
+		const outcome = await attemptStartupUpdate({
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			isTty: true,
+			checkForUpdateImpl: async () => ({
+				currentVersion: "0.10.0",
+				latestVersion: "latest",
+				isUpdateAvailable: true,
+				sourceUrl:
+					"https://storage.googleapis.com/example/maestro/version.json",
+			}),
+			installPackage,
+		});
+		expect(outcome.status).toBe("failed");
+		expect(installPackage).not.toHaveBeenCalled();
+	});
+
+	it("throttles repeated failed install attempts for the same version", async () => {
+		const path = statePath();
+		const checkForUpdateImpl = vi.fn().mockResolvedValue({
+			currentVersion: "0.10.0",
+			latestVersion: "0.10.1",
+			isUpdateAvailable: true,
+			sourceUrl: "https://storage.googleapis.com/example/maestro/version.json",
+		});
+		const installPackage = vi.fn().mockReturnValue({ status: 1 });
+
+		const first = await attemptStartupUpdate({
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			isTty: true,
+			now: 1000,
+			statePath: path,
+			checkForUpdateImpl,
+			installPackage,
+		});
+		const second = await attemptStartupUpdate({
+			argv: installedArgv,
+			currentVersion: "0.10.0",
+			env: {},
+			isTty: true,
+			now: 2000,
+			statePath: path,
+			checkForUpdateImpl,
+			installPackage,
+		});
+
+		expect(first.status).toBe("failed");
+		expect(second.status).toBe("available");
+		expect(installPackage).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/cli/startup-refresh.test.ts
+++ b/test/cli/startup-refresh.test.ts
@@ -1,6 +1,12 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	attemptStartupUpdate,
@@ -26,6 +32,33 @@ describe("isInstalledPackageEntrypoint", () => {
 				"@evalops/maestro",
 			),
 		).toBe(false);
+	});
+
+	it("recognizes npm bin shims that resolve to installed package entrypoints", () => {
+		const dir = mkdtempSync(join(tmpdir(), "maestro-entrypoint-"));
+		try {
+			const cliPath = join(
+				dir,
+				"lib",
+				"node_modules",
+				"@evalops",
+				"maestro",
+				"dist",
+				"cli.js",
+			);
+			mkdirSync(dirname(cliPath), { recursive: true });
+			writeFileSync(cliPath, "#!/usr/bin/env node\n", "utf8");
+
+			const shimPath = join(dir, "bin", "maestro");
+			mkdirSync(dirname(shimPath), { recursive: true });
+			symlinkSync(cliPath, shimPath);
+
+			expect(isInstalledPackageEntrypoint(shimPath, "@evalops/maestro")).toBe(
+				true,
+			);
+		} finally {
+			rmSync(dir, { force: true, recursive: true });
+		}
 	});
 });
 

--- a/test/cli/update-check.test.ts
+++ b/test/cli/update-check.test.ts
@@ -138,6 +138,25 @@ describe("checkForUpdate", () => {
 		expect(result.sourceUrl).toContain("registry.npmjs.org");
 	});
 
+	it("selects the highest update version across metadata sources", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(createResponse({ version: "0.9.0" }))
+			.mockResolvedValueOnce(createResponse({ version: "1.0.0" }));
+		const result = await checkForUpdate("0.8.0", {
+			urls: [
+				"https://storage.googleapis.com/example/maestro/version.json",
+				"https://registry.npmjs.org/@evalops%2Fmaestro/latest",
+			],
+			timeoutMs: 0,
+			fetch: fetchMock,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result.isUpdateAvailable).toBe(true);
+		expect(result.latestVersion).toBe("1.0.0");
+		expect(result.sourceUrl).toContain("registry.npmjs.org");
+	});
+
 	it("keeps valid current metadata when later fallback sources fail", async () => {
 		const fetchMock = vi
 			.fn()

--- a/test/cli/update-check.test.ts
+++ b/test/cli/update-check.test.ts
@@ -118,6 +118,51 @@ describe("checkForUpdate", () => {
 		expect(result.latestVersion).toBe("0.9.0");
 		expect(result.sourceUrl).toContain("registry.npmjs.org");
 	});
+
+	it("continues past stale metadata to find a newer fallback source", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(createResponse({ version: "0.8.0" }))
+			.mockResolvedValueOnce(createResponse({ version: "0.9.0" }));
+		const result = await checkForUpdate("0.8.0", {
+			urls: [
+				"https://storage.googleapis.com/example/maestro/version.json",
+				"https://registry.npmjs.org/@evalops%2Fmaestro/latest",
+			],
+			timeoutMs: 0,
+			fetch: fetchMock,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result.isUpdateAvailable).toBe(true);
+		expect(result.latestVersion).toBe("0.9.0");
+		expect(result.sourceUrl).toContain("registry.npmjs.org");
+	});
+
+	it("keeps valid current metadata when later fallback sources fail", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(createResponse({ version: "0.8.0" }))
+			.mockResolvedValueOnce(
+				createResponse(null, {
+					ok: false,
+					status: 500,
+					statusText: "Server Error",
+				}),
+			);
+		const result = await checkForUpdate("0.8.0", {
+			urls: [
+				"https://storage.googleapis.com/example/maestro/version.json",
+				"https://registry.npmjs.org/@evalops%2Fmaestro/latest",
+			],
+			timeoutMs: 0,
+			fetch: fetchMock,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result.isUpdateAvailable).toBe(false);
+		expect(result.latestVersion).toBe("0.8.0");
+		expect(result.error).toBeUndefined();
+		expect(result.sourceUrl).toContain("storage.googleapis.com");
+	});
 });
 
 describe("resolveUpdateUrls", () => {

--- a/test/cli/update-check.test.ts
+++ b/test/cli/update-check.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { checkForUpdate, compareVersions } from "../../src/update/check.js";
+import {
+	checkForUpdate,
+	compareVersions,
+	resolveUpdateUrls,
+} from "../../src/update/check.js";
 
 type ResponseFields = {
 	ok: boolean;
@@ -88,5 +92,58 @@ describe("checkForUpdate", () => {
 		});
 		expect(result.isUpdateAvailable).toBe(false);
 		expect(result.error).toContain("missing version");
+	});
+
+	it("falls back to the next metadata source", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				createResponse(null, {
+					ok: false,
+					status: 403,
+					statusText: "Forbidden",
+				}),
+			)
+			.mockResolvedValueOnce(createResponse({ version: "0.9.0" }));
+		const result = await checkForUpdate("0.8.0", {
+			urls: [
+				"https://storage.googleapis.com/example/maestro/version.json",
+				"https://registry.npmjs.org/@evalops%2Fmaestro/latest",
+			],
+			timeoutMs: 0,
+			fetch: fetchMock,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result.isUpdateAvailable).toBe(true);
+		expect(result.latestVersion).toBe("0.9.0");
+		expect(result.sourceUrl).toContain("registry.npmjs.org");
+	});
+});
+
+describe("resolveUpdateUrls", () => {
+	it("prefers explicit source lists", () => {
+		expect(
+			resolveUpdateUrls({
+				urls: [" https://example.com/a.json ", "https://example.com/b.json"],
+			}),
+		).toEqual(["https://example.com/a.json", "https://example.com/b.json"]);
+	});
+
+	it("supports comma-separated env source lists", () => {
+		expect(
+			resolveUpdateUrls(
+				{},
+				{
+					MAESTRO_UPDATE_URLS:
+						"https://example.com/a.json, https://example.com/b.json",
+				},
+			),
+		).toEqual(["https://example.com/a.json", "https://example.com/b.json"]);
+	});
+
+	it("defaults to GCS metadata before the npm registry", () => {
+		const urls = resolveUpdateUrls({}, {});
+		expect(urls[0]).toContain("storage.googleapis.com");
+		expect(urls[1]).toContain("registry.npmjs.org");
 	});
 });

--- a/test/cli/update-command.test.ts
+++ b/test/cli/update-command.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleUpdateCommand } from "../../src/cli/commands/update.js";
+
+describe("handleUpdateCommand", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		process.exitCode = undefined;
+	});
+
+	it("checks for updates without installing", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+		const attemptStartupUpdateImpl = vi.fn();
+
+		await handleUpdateCommand(["--check", "--json"], {
+			attemptStartupUpdateImpl,
+			checkForUpdateImpl: async () => ({
+				currentVersion: "0.10.0",
+				latestVersion: "0.10.1",
+				isUpdateAvailable: true,
+				sourceUrl:
+					"https://storage.googleapis.com/example/maestro/version.json",
+			}),
+			currentVersion: "0.10.0",
+		});
+
+		expect(attemptStartupUpdateImpl).not.toHaveBeenCalled();
+		expect(JSON.parse(log.mock.calls[0]?.[0] as string)).toMatchObject({
+			status: "available",
+			currentVersion: "0.10.0",
+			latestVersion: "0.10.1",
+		});
+	});
+
+	it("uses the startup updater without restarting for manual installs", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+		const attemptStartupUpdateImpl = vi.fn().mockResolvedValue({
+			status: "updated",
+			check: {
+				currentVersion: "0.10.0",
+				latestVersion: "0.10.1",
+				isUpdateAvailable: true,
+				sourceUrl:
+					"https://storage.googleapis.com/example/maestro/version.json",
+			},
+		});
+
+		await handleUpdateCommand([], {
+			attemptStartupUpdateImpl,
+			currentVersion: "0.10.0",
+			env: {
+				CI: "true",
+				MAESTRO_SKIP_STARTUP_UPDATE: "1",
+				MAESTRO_STARTUP_UPDATE: "off",
+			},
+		});
+
+		expect(attemptStartupUpdateImpl).toHaveBeenCalledWith(
+			expect.objectContaining({
+				args: [],
+				currentVersion: "0.10.0",
+				isTty: true,
+				restart: false,
+			}),
+		);
+		expect(attemptStartupUpdateImpl.mock.calls[0]?.[0].env).toMatchObject({
+			MAESTRO_STARTUP_UPDATE_RETRY_MS: "0",
+		});
+		expect(attemptStartupUpdateImpl.mock.calls[0]?.[0].env).not.toHaveProperty(
+			"CI",
+		);
+		expect(attemptStartupUpdateImpl.mock.calls[0]?.[0].env).not.toHaveProperty(
+			"MAESTRO_SKIP_STARTUP_UPDATE",
+		);
+		expect(log.mock.calls[0]?.[0]).toContain("Updated Maestro to 0.10.1");
+	});
+});

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1283,6 +1283,19 @@ describe("ci workflow guardrails", () => {
 		expect(run).toContain("/version.json");
 	});
 
+	it("loads dotenv configuration before startup refresh", () => {
+		const source = readFileSync(new URL("../../src/cli.ts", import.meta.url), {
+			encoding: "utf8",
+		});
+		const loadEnvImportIndex = source.indexOf('await import("./load-env.js")');
+		const loadEnvIndex = source.indexOf("loadEnv();", loadEnvImportIndex);
+		const refreshIndex = source.indexOf("await refreshInstalledCliOnStartup");
+
+		expect(loadEnvImportIndex).toBeGreaterThan(-1);
+		expect(loadEnvIndex).toBeGreaterThan(loadEnvImportIndex);
+		expect(refreshIndex).toBeGreaterThan(loadEnvIndex);
+	});
+
 	it("keeps packed CLI smoke enabled independently of package-lock management", () => {
 		const script = readFileSync(
 			new URL("../../scripts/release-readiness.js", import.meta.url),

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1248,16 +1248,30 @@ describe("ci workflow guardrails", () => {
 				{ encoding: "utf8" },
 			),
 		) as Workflow;
-		const steps = workflow.jobs?.publish?.steps ?? [];
+		const canaryJob = workflow.jobs?.["post-publish-canary"];
+		const steps = canaryJob?.steps ?? [];
+		const validateIndex = steps.findIndex(
+			(step) => step.name === "Validate published replay evidence",
+		);
+		const metadataIndex = steps.findIndex(
+			(step) => step.name === "Generate version metadata",
+		);
 		const authStep = steps.find(
 			(step) =>
 				step.name === "Authenticate to Google Cloud for release metadata",
 		);
-		const gcsStep = steps.find(
+		const gcsIndex = steps.findIndex(
 			(step) => step.name === "Sync GCS version metadata",
 		);
+		const gcsStep = steps[gcsIndex];
 		const run = gcsStep?.run ?? "";
 
+		expect(canaryJob).toBeDefined();
+		expect(canaryJob?.needs).toContain("publish");
+		expect(canaryJob?.permissions?.["id-token"]).toBe("write");
+		expect(validateIndex).toBeGreaterThan(-1);
+		expect(metadataIndex).toBeGreaterThan(validateIndex);
+		expect(gcsIndex).toBeGreaterThan(metadataIndex);
 		expect(authStep).toBeDefined();
 		expect(authStep?.uses).toContain("google-github-actions/auth@");
 		expect(gcsStep).toBeDefined();

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1241,6 +1241,34 @@ describe("ci workflow guardrails", () => {
 		expect(run).not.toContain("gh auth refresh");
 	});
 
+	it("publishes release version metadata to GCS through workload identity", () => {
+		const workflow = parse(
+			readFileSync(
+				new URL("../../.github/workflows/release.yml", import.meta.url),
+				{ encoding: "utf8" },
+			),
+		) as Workflow;
+		const steps = workflow.jobs?.publish?.steps ?? [];
+		const authStep = steps.find(
+			(step) =>
+				step.name === "Authenticate to Google Cloud for release metadata",
+		);
+		const gcsStep = steps.find(
+			(step) => step.name === "Sync GCS version metadata",
+		);
+		const run = gcsStep?.run ?? "";
+
+		expect(authStep).toBeDefined();
+		expect(authStep?.uses).toContain("google-github-actions/auth@");
+		expect(gcsStep).toBeDefined();
+		expect(gcsStep?.if).toContain(
+			"MAESTRO_RELEASE_GCP_WORKLOAD_IDENTITY_PROVIDER",
+		);
+		expect(run).toContain("gcloud storage cp");
+		expect(run).toContain("dist/version.json");
+		expect(run).toContain("/version.json");
+	});
+
 	it("keeps packed CLI smoke enabled independently of package-lock management", () => {
 		const script = readFileSync(
 			new URL("../../scripts/release-readiness.js", import.meta.url),


### PR DESCRIPTION
## Summary
- add startup release refresh for globally installed Maestro CLIs
- check GCS release metadata first, then fall back to npm registry metadata
- auto-install and restart on interactive startup when a newer semver release exists
- add `maestro update` / `maestro update --check` so users can manually pull the newest published CLI, Amp/Droid-style
- keep opt-outs for CI/non-TTY/headless/version/help/update and MAESTRO_STARTUP_UPDATE=off/check
- sync GCS version metadata only after public npm publish succeeds

## Related
- Internal PR: https://github.com/evalops/maestro-internal/pull/2360
- Deploy PR: https://github.com/evalops/deploy/pull/4944

## Rollout
- [x] If this PR adds or promotes user-visible behavior, explain the staged-rollout choice (or why staging is unnecessary).

Staging is unnecessary for the CLI parser/help/manual update surface because it only runs when the user explicitly invokes `maestro update` or `maestro update --check`. Startup auto-update remains gated to npm-global interactive installs, skips CI/non-TTY/headless/version/help/update invocations, and keeps the existing `MAESTRO_STARTUP_UPDATE` and `MAESTRO_SKIP_STARTUP_UPDATE` controls.

## Test Plan
- node scripts/run-vitest.js --run test/cli/startup-refresh.test.ts test/cli/update-command.test.ts test/cli/args.test.ts test/cli/help.test.ts test/cli/update-check.test.ts
- npx tsc -p tsconfig.build.json --noEmit --pretty false
- node scripts/release-readiness.js ci
