### PR TITLE
[maestro] harden version-bump workflow against native git-hook token exfiltration

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -164,6 +164,9 @@ jobs:
           HUSKY: "0"
         run: |
           set -euo pipefail
+          hooks_dir="${RUNNER_TEMP}/git-hooks-empty"
+          mkdir -p "$hooks_dir"
+          git config --local core.hooksPath "$hooks_dir"
           git remote set-url origin "https://x-access-token:${RELEASE_PR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           if [[ -z "$(git status --porcelain)" ]]; then
             if [[ "$BRANCH_EXISTS" == "true" ]] && [[ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$RELEASE_BRANCH")" ]]; then

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -164,8 +164,8 @@ jobs:
           HUSKY: "0"
         run: |
           set -euo pipefail
-          hooks_dir="${RUNNER_TEMP}/git-hooks-empty"
-          mkdir -p "$hooks_dir"
+          hooks_dir="$(mktemp -d "${RUNNER_TEMP%/}/git-hooks-empty.XXXXXX")"
+          chmod 700 "$hooks_dir"
           git config --local core.hooksPath "$hooks_dir"
           git remote set-url origin "https://x-access-token:${RELEASE_PR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           if [[ -z "$(git status --porcelain)" ]]; then


### PR DESCRIPTION
### Motivation
- Prevent a credential-exposure attack where a caller-selected `base_ref` can plant native git hooks or modify repo scripts after checkout and then exfiltrate a release automation token when later `git commit`/`git push` run with that token in the environment. 
- Apply a minimal, local mitigation that blocks execution of repository-controlled native hooks during the token-bearing commit/push step while preserving the existing release flow.

### Description
- Modified `.github/workflows/version-bump.yml` to harden the `Commit release branch` step by setting `core.hooksPath` to an empty directory under `RUNNER_TEMP` before any token-bearing git operations. 
- The workflow now creates an empty `git-hooks-empty` directory and runs `git config --local core.hooksPath "$hooks_dir"` so native `.git/hooks/*` cannot execute during the commit/push that uses the release token. 
- No other workflow behavior or token usage was changed; the change is intentionally minimal to close the native-hook exfiltration vector while preserving release branch creation, commit, and PR steps.

### Testing
- Ran `bun run bun:lint`, which completed successfully. 
- Ran `npx nx run maestro:test --skip-nx-cache`; the test run reported unrelated test failures in the local environment (`test/tui/bash-mode.test.ts` and `test/tools/apply-patch.test.ts`) that pre-existed this change and are unrelated to the workflow hardening. 
- Pre-commit/guardian checks executed during the change verification passed (guardian evidence/heuristic checks and lint/build/compile steps completed) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a120de40a808326be2a856dedbc808b)