### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,14 +82,25 @@ async function reportFatalCliError(error: unknown): Promise<void> {
 	}
 }
 
-async function refreshInstalledCliOnStartup(args: string[]): Promise<void> {
+async function refreshInstalledCliOnStartup(
+	args: string[],
+	ignoredEnvKeys: string[] = [],
+): Promise<void> {
 	try {
-		const [{ getPackageVersion }, { attemptStartupUpdate }] = await Promise.all(
-			[import("./package-metadata.js"), import("./update/startup-refresh.js")],
-		);
+		const [{ getPackageName, getPackageVersion }, { attemptStartupUpdate }] =
+			await Promise.all([
+				import("./package-metadata.js"),
+				import("./update/startup-refresh.js"),
+			]);
+		const env = { ...process.env };
+		for (const key of ignoredEnvKeys) {
+			delete env[key];
+		}
 		const outcome = await attemptStartupUpdate({
 			args,
-			currentVersion: getPackageVersion(),
+			currentVersion: getPackageVersion(env),
+			env,
+			packageName: getPackageName(env),
 		});
 		if (outcome.status === "restarted") {
 			process.exit(outcome.exitCode);
@@ -156,9 +167,10 @@ const run = async () => {
 		const args = process.argv.slice(2);
 		const immediateExit = getImmediateCliExit(args);
 		let envLoaded = false;
+		let loadedEnvKeys: string[] = [];
 		if (immediateExit !== null) {
 			const { loadEnv } = await import("./load-env.js");
-			loadEnv();
+			loadedEnvKeys = loadEnv();
 			envLoaded = true;
 		}
 		if (shouldUseInstantCliExit(immediateExit, process.env)) {
@@ -168,9 +180,9 @@ const run = async () => {
 
 		if (!envLoaded) {
 			const { loadEnv } = await import("./load-env.js");
-			loadEnv();
+			loadedEnvKeys = loadEnv();
 		}
-		await refreshInstalledCliOnStartup(args);
+		await refreshInstalledCliOnStartup(args, loadedEnvKeys);
 		if (await runCliCommandRuntime(args)) {
 			return;
 		}

--- a/src/load-env.ts
+++ b/src/load-env.ts
@@ -4,11 +4,19 @@ import { config } from "dotenv";
 
 const ENV_FILES = [".env.local", ".env"];
 
-export function loadEnv(): void {
+export function loadEnv(): string[] {
+	const loadedKeys = new Set<string>();
 	for (const file of ENV_FILES) {
 		const resolved = join(process.cwd(), file);
 		if (existsSync(resolved)) {
-			config({ path: resolved, override: false });
+			const before = new Set(Object.keys(process.env));
+			const result = config({ path: resolved, override: false });
+			for (const key of Object.keys(result.parsed ?? {})) {
+				if (!before.has(key)) {
+					loadedKeys.add(key);
+				}
+			}
 		}
 	}
+	return [...loadedKeys];
 }

--- a/src/package-metadata.ts
+++ b/src/package-metadata.ts
@@ -29,16 +29,16 @@ function loadPackageMetadata(): RootPackageMetadata {
 	}
 }
 
-export function getPackageVersion(): string {
-	return (
-		process.env.MAESTRO_VERSION ?? loadPackageMetadata().version ?? "unknown"
-	);
+export function getPackageVersion(
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	return env.MAESTRO_VERSION ?? loadPackageMetadata().version ?? "unknown";
 }
 
-export function getPackageName(): string {
+export function getPackageName(env: NodeJS.ProcessEnv = process.env): string {
 	const metadata = loadPackageMetadata();
 	return (
-		process.env.MAESTRO_PACKAGE_NAME ??
+		env.MAESTRO_PACKAGE_NAME ??
 		metadata.name ??
 		metadata.maestro?.canonicalPackageName ??
 		"@evalops/maestro"

--- a/src/update/check.ts
+++ b/src/update/check.ts
@@ -44,6 +44,7 @@ const npmLatestUrl = (packageName = getPackageName()): string => {
 export const resolveUpdateUrls = (
 	options: Pick<CheckForUpdateOptions, "url" | "urls"> = {},
 	env: NodeJS.ProcessEnv = process.env,
+	packageName = getPackageName(env),
 ): string[] => {
 	const explicitUrls = options.urls?.map((url) => url.trim()).filter(Boolean);
 	if (explicitUrls && explicitUrls.length > 0) {
@@ -59,7 +60,7 @@ export const resolveUpdateUrls = (
 	if (env.MAESTRO_UPDATE_URL?.trim()) {
 		return [env.MAESTRO_UPDATE_URL.trim()];
 	}
-	return [DEFAULT_GCS_UPDATE_URL, npmLatestUrl()];
+	return [DEFAULT_GCS_UPDATE_URL, npmLatestUrl(packageName)];
 };
 
 const toErrorMessage = (error: unknown): string => {

--- a/src/update/startup-refresh.ts
+++ b/src/update/startup-refresh.ts
@@ -31,8 +31,6 @@ const DEFAULT_STARTUP_UPDATE_TIMEOUT_MS = 350;
 const NPM_PREFIX_TIMEOUT_MS = 350;
 const BUN_PREFIX_TIMEOUT_MS = 350;
 
-type PackageManager = "npm" | "bun";
-
 const PACKAGE_MANAGER_ENV_PATTERN =
 	/^(?:npm_config_|NPM_CONFIG_|BUN_CONFIG_|bun_config_|YARN_|yarn_|PNPM_|pnpm_)/u;
 const PACKAGE_MANAGER_ENV_BLOCKLIST = new Set([
@@ -47,6 +45,17 @@ const PACKAGE_MANAGER_ENV_ALLOWLIST = new Set([
 	"NPM_CONFIG_PREFIX",
 	"npm_config_prefix",
 ]);
+
+const bunInstallHomeFromGlobalPrefix = (prefix: string): string | undefined => {
+	const normalized = prefix.replace(/\/+$/u, "");
+	if (
+		basename(normalized) !== "global" ||
+		basename(dirname(normalized)) !== "install"
+	) {
+		return undefined;
+	}
+	return dirname(dirname(normalized));
+};
 
 const packageManagerEnv = (
 	env: NodeJS.ProcessEnv,
@@ -72,8 +81,16 @@ const packageManagerEnv = (
 		sanitized.NPM_CONFIG_PREFIX = options.prefix;
 		delete sanitized.npm_config_prefix;
 	}
+	if (options.packageManager === "bun" && options.prefix) {
+		const bunInstall = bunInstallHomeFromGlobalPrefix(options.prefix);
+		if (bunInstall) {
+			sanitized.BUN_INSTALL = bunInstall;
+		}
+	}
 	return sanitized;
 };
+
+type PackageManager = "npm" | "bun";
 
 type GlobalInstallContext = {
 	packageManager: PackageManager;
@@ -456,7 +473,7 @@ export async function attemptStartupUpdate(
 	const env = options.env ?? process.env;
 	const args = options.args ?? process.argv.slice(2);
 	const argv = options.argv ?? process.argv;
-	const packageName = options.packageName ?? getPackageName();
+	const packageName = options.packageName ?? getPackageName(env);
 	const updateMode = envValue(env, STARTUP_UPDATE_ENV);
 	const now = options.now ?? Date.now();
 
@@ -506,7 +523,7 @@ export async function attemptStartupUpdate(
 
 	const checkTimeoutMs =
 		options.checkTimeoutMs ?? startupCheckTimeoutMsFromEnv(env);
-	const updateUrls = resolveUpdateUrls({}, env);
+	const updateUrls = resolveUpdateUrls({}, env, packageName);
 	const checkOptions = {
 		timeoutMs: startupSourceTimeoutMs(checkTimeoutMs, updateUrls.length),
 		urls: updateUrls,

--- a/test/cli/load-env.test.ts
+++ b/test/cli/load-env.test.ts
@@ -1,0 +1,43 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadEnv } from "../../src/load-env.js";
+
+describe("loadEnv", () => {
+	const originalCwd = process.cwd();
+	const tempDirs: string[] = [];
+	const touchedKeys = new Set<string>();
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		for (const key of touchedKeys) {
+			delete process.env[key];
+		}
+		touchedKeys.clear();
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it("returns only keys loaded from cwd dotenv files", () => {
+		const dir = mkdtempSync(join(tmpdir(), "maestro-load-env-"));
+		tempDirs.push(dir);
+		mkdirSync(dir, { recursive: true });
+		process.env.MAESTRO_EXISTING_ENV = "from-shell";
+		touchedKeys.add("MAESTRO_EXISTING_ENV");
+		touchedKeys.add("MAESTRO_FROM_DOTENV");
+		writeFileSync(
+			join(dir, ".env"),
+			"MAESTRO_EXISTING_ENV=from-dotenv\nMAESTRO_FROM_DOTENV=loaded\n",
+			"utf8",
+		);
+		process.chdir(dir);
+
+		const loaded = loadEnv();
+
+		expect(process.env.MAESTRO_EXISTING_ENV).toBe("from-shell");
+		expect(process.env.MAESTRO_FROM_DOTENV).toBe("loaded");
+		expect(loaded).toEqual(["MAESTRO_FROM_DOTENV"]);
+	});
+});

--- a/test/cli/startup-refresh.test.ts
+++ b/test/cli/startup-refresh.test.ts
@@ -10,7 +10,10 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getPackageName } from "../../src/package-metadata.js";
+import {
+	getPackageName,
+	getPackageVersion,
+} from "../../src/package-metadata.js";
 import {
 	attemptStartupUpdate,
 	isInstalledPackageEntrypoint,
@@ -99,6 +102,8 @@ describe("attemptStartupUpdate", () => {
 	const tempDirs: string[] = [];
 
 	afterEach(() => {
+		delete process.env.MAESTRO_PACKAGE_NAME;
+		delete process.env.MAESTRO_VERSION;
 		for (const dir of tempDirs.splice(0)) {
 			rmSync(dir, { force: true, recursive: true });
 		}
@@ -255,6 +260,42 @@ describe("attemptStartupUpdate", () => {
 		expect(checkForUpdateImpl).toHaveBeenCalledTimes(1);
 	});
 
+	it("uses sanitized env instead of dotenv-mutated process metadata", async () => {
+		process.env.MAESTRO_PACKAGE_NAME = "@attacker/maestro";
+		process.env.MAESTRO_VERSION = "999.0.0";
+		const checkForUpdateImpl = vi.fn().mockResolvedValue({
+			currentVersion: "0.10.0",
+			latestVersion: "0.10.0",
+			isUpdateAvailable: false,
+			sourceUrl: "https://storage.googleapis.com/example/maestro/version.json",
+		});
+		const sanitizedEnv: NodeJS.ProcessEnv = {};
+		const outcome = await attemptStartupUpdate({
+			argv: installedArgv,
+			currentVersion: getPackageVersion(sanitizedEnv),
+			env: sanitizedEnv,
+			isTty: true,
+			checkForUpdateImpl,
+		});
+		expect(outcome.status).toBe("current");
+		expect(checkForUpdateImpl).toHaveBeenCalledWith(
+			getPackageVersion(sanitizedEnv),
+			expect.objectContaining({
+				urls: expect.arrayContaining([
+					expect.stringContaining(
+						encodeURIComponent(getPackageName(sanitizedEnv)),
+					),
+				]),
+			}),
+		);
+		const checkOptions = checkForUpdateImpl.mock.calls[0]?.[1] as
+			| { urls?: string[] }
+			| undefined;
+		expect(checkOptions?.urls?.join("\n")).not.toContain(
+			encodeURIComponent("@attacker/maestro"),
+		);
+	});
+
 	it("installs and restarts when a newer version is available", async () => {
 		const installPackage = vi.fn().mockReturnValue({ status: 0 });
 		const restart = vi.fn().mockReturnValue({ status: 7 });
@@ -309,6 +350,59 @@ describe("attemptStartupUpdate", () => {
 		});
 		expect(installPackage).toHaveBeenCalledWith("bun", packageName, "0.10.1");
 		expect(outcome).toMatchObject({ status: "updated" });
+	});
+
+	it("preserves detected Bun home during sanitized automatic installs", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "maestro-startup-bun-env-"));
+		tempDirs.push(dir);
+		const binDir = join(dir, "bin");
+		const bunHome = join(dir, "custom-bun-home");
+		const bunGlobalPrefix = join(bunHome, "install", "global");
+		mkdirSync(binDir, { recursive: true });
+		const envLog = join(dir, "bun-env.log");
+		const bunShim = join(binDir, "bun");
+		writeFileSync(
+			bunShim,
+			`#!/bin/sh
+env > "${envLog}"
+exit 0
+`,
+			"utf8",
+		);
+		chmodSync(bunShim, 0o755);
+
+		const outcome = await attemptStartupUpdate({
+			argv: [
+				"/usr/local/bin/node",
+				`${bunGlobalPrefix}/node_modules/${packageName}/dist/cli.js`,
+			],
+			currentVersion: "0.10.0",
+			env: {
+				PATH: `${binDir}:${process.env.PATH ?? ""}`,
+				BUN_CONFIG_REGISTRY: "https://attacker.invalid/bun/",
+			},
+			globalInstallContexts: [
+				{
+					packageManager: "bun",
+					prefix: bunGlobalPrefix,
+				},
+			],
+			isTty: true,
+			statePath: statePath(),
+			checkForUpdateImpl: async () => ({
+				currentVersion: "0.10.0",
+				latestVersion: "0.10.1",
+				isUpdateAvailable: true,
+				sourceUrl:
+					"https://storage.googleapis.com/example/maestro/version.json",
+			}),
+			restart: false,
+		});
+
+		expect(outcome.status).toBe("updated");
+		const installedEnv = readFileSync(envLog, "utf8");
+		expect(installedEnv).toContain(`BUN_INSTALL=${bunHome}`);
+		expect(installedEnv).not.toContain("BUN_CONFIG_REGISTRY=");
 	});
 
 	it("can install without restarting for manual update commands", async () => {

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1323,8 +1323,13 @@ describe("ci workflow guardrails", () => {
 			encoding: "utf8",
 		});
 		const loadEnvImportIndex = source.indexOf('await import("./load-env.js")');
-		const loadEnvIndex = source.indexOf("loadEnv();", loadEnvImportIndex);
-		const refreshIndex = source.indexOf("await refreshInstalledCliOnStartup");
+		const loadEnvIndex = source.indexOf(
+			"loadedEnvKeys = loadEnv();",
+			loadEnvImportIndex,
+		);
+		const refreshIndex = source.indexOf(
+			"await refreshInstalledCliOnStartup(args, loadedEnvKeys)",
+		);
 
 		expect(loadEnvImportIndex).toBeGreaterThan(-1);
 		expect(loadEnvIndex).toBeGreaterThan(loadEnvImportIndex);


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"98472dd6eb9ec7232bcc983de8161fb229ee55c2"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `98472dd6eb9ec7232bcc983de8161fb229ee55c2`
- last generated public sync base: `7cceb8183c85aa7bc41549aebd1d1785c0e688a0`
- previewed public-tree drift: `8` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (98472dd6eb9e)`
- public projection: `https://github.com/evalops/maestro@main (7cceb8183c85)`
- files to copy or update: `8`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli.ts
- copy/update src/load-env.ts
- copy/update src/package-metadata.ts
- copy/update src/update/check.ts
- copy/update src/update/startup-refresh.ts
- copy/update test/cli/load-env.test.ts
- copy/update test/cli/startup-refresh.test.ts
- copy/update test/scripts/ci-guardrails.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli.ts
- copy/update src/load-env.ts
- copy/update src/package-metadata.ts
- copy/update src/update/check.ts
- copy/update src/update/startup-refresh.ts
- copy/update test/cli/load-env.test.ts
- copy/update test/cli/startup-refresh.test.ts
- copy/update test/scripts/ci-guardrails.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@98472dd6eb9ec7232bcc983de8161fb229ee55c2`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.