### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/bootstrap/tools-setup.ts
+++ b/src/bootstrap/tools-setup.ts
@@ -18,7 +18,6 @@ import {
 	createSandbox,
 	disposeSandbox,
 } from "../sandbox/index.js";
-import { codingTools, filterTools, toolRegistry } from "../tools/index.js";
 import { loadInlineTools } from "../tools/inline-tools.js";
 
 export interface ToolsSetupResult {
@@ -52,13 +51,16 @@ export async function createToolsAndSandbox(params: {
 	const shouldPrintMessages = params.shouldPrintMessages ?? true;
 
 	// Apply --tools filter if user specified a subset
-	let baseTools = codingTools;
+	let baseTools: AgentTool[];
 	if (parsedTools && parsedTools.length > 0) {
-		const filteredTools = filterTools(parsedTools);
+		const { lazyToolNames, loadFilteredTools } = await import(
+			"../tools/lazy-registry.js"
+		);
+		const filteredTools = await loadFilteredTools(parsedTools);
 		if (filteredTools.length === 0) {
 			throw new Error(
 				`No valid tools matched --tools filter: ${parsedTools.join(", ")}. ` +
-					`Available tools: ${Object.keys(toolRegistry).sort().join(", ")}`,
+					`Available tools: ${lazyToolNames.join(", ")}`,
 			);
 		}
 		baseTools = filteredTools;
@@ -70,10 +72,14 @@ export async function createToolsAndSandbox(params: {
 			);
 		}
 	} else if (isCodexAppServerApi(modelApi)) {
+		const { codingTools } = await import("../tools/index.js");
 		const profileName = resolveCodexToolProfileName(
 			process.env.MAESTRO_CODEX_TOOL_PROFILE,
 		);
 		baseTools = selectCodexToolProfile(codingTools, profileName);
+	} else {
+		const { codingTools } = await import("../tools/index.js");
+		baseTools = codingTools;
 	}
 
 	// Load inline tools from .maestro/tools.json and ~/.maestro/tools.json

--- a/src/tools/lazy-registry.ts
+++ b/src/tools/lazy-registry.ts
@@ -1,0 +1,53 @@
+import type { AgentTool } from "../agent/types.js";
+
+const lazyToolLoaders = {
+	read: async () => (await import("./read.js")).readTool,
+	list: async () => (await import("./list.js")).listTool,
+	oracle: async () => (await import("./oracle.js")).oracleTool,
+	find: async () => (await import("./find.js")).findTool,
+	extract_document: async () =>
+		(await import("./extract-document.js")).extractDocumentTool,
+	search: async () => (await import("./search.js")).searchTool,
+	parallel_ripgrep: async () =>
+		(await import("./parallel-ripgrep.js")).parallelRipgrepTool,
+	diff: async () => (await import("./diff.js")).diffTool,
+	bash: async () => (await import("./bash.js")).bashTool,
+	background_tasks: async () =>
+		(await import("./background/tool-handler.js")).backgroundTasksTool,
+	apply_patch: async () => (await import("./apply-patch.js")).applyPatchTool,
+	edit: async () => (await import("./edit.js")).editTool,
+	write: async () => (await import("./write.js")).writeTool,
+	notebook_edit: async () => (await import("./notebook.js")).notebookEditTool,
+	todo: async () => (await import("./todo.js")).todoTool,
+	ask_user: async () => (await import("./ask-user.js")).askUserTool,
+	websearch: async () => (await import("./websearch.js")).websearchTool,
+	codesearch: async () => (await import("./codesearch.js")).codesearchTool,
+	webfetch: async () => (await import("./webfetch.js")).webfetchTool,
+	status: async () => (await import("./status.js")).statusTool,
+	gh_pr: async () => (await import("./gh.js")).ghPrTool,
+	gh_issue: async () => (await import("./gh.js")).ghIssueTool,
+	gh_repo: async () => (await import("./gh.js")).ghRepoTool,
+	pipeline_search_contacts: async () =>
+		(await import("./pipeline.js")).pipelineSearchContactsTool,
+	pipeline_search_deals: async () =>
+		(await import("./pipeline.js")).pipelineSearchDealsTool,
+	pipeline_create_signal: async () =>
+		(await import("./pipeline.js")).pipelineCreateSignalTool,
+	pipeline_log_activity: async () =>
+		(await import("./pipeline.js")).pipelineLogActivityTool,
+} satisfies Record<string, () => Promise<AgentTool>>;
+
+export const lazyToolNames = Object.keys(lazyToolLoaders).sort();
+
+export async function loadFilteredTools(
+	toolNames: string[],
+): Promise<AgentTool[]> {
+	const filtered: AgentTool[] = [];
+	for (const name of toolNames) {
+		const loadTool = lazyToolLoaders[name as keyof typeof lazyToolLoaders];
+		if (loadTool) {
+			filtered.push(await loadTool());
+		}
+	}
+	return filtered;
+}

--- a/test/bootstrap/tools-setup.test.ts
+++ b/test/bootstrap/tools-setup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createToolsAndSandbox } from "../../src/bootstrap/tools-setup.js";
 import {
 	CODEX_DEFAULT_TOOL_PROFILE,
@@ -35,6 +35,27 @@ describe("createToolsAndSandbox", () => {
 			"read",
 			"status",
 		]);
+	});
+
+	it("does not import the full tool registry for explicit --tools selections", async () => {
+		vi.resetModules();
+		vi.doMock("../../src/tools/index.js", () => {
+			throw new Error("full tool registry should stay lazy");
+		});
+		try {
+			const { createToolsAndSandbox: createIsolatedToolsAndSandbox } =
+				await import("../../src/bootstrap/tools-setup.js");
+			const result = await createIsolatedToolsAndSandbox({
+				parsedTools: ["read"],
+				cwd: process.cwd(),
+				shouldPrintMessages: false,
+			});
+
+			expect(result.baseTools.map((tool) => tool.name)).toEqual(["read"]);
+		} finally {
+			vi.doUnmock("../../src/tools/index.js");
+			vi.resetModules();
+		}
 	});
 
 	it("can suppress explicit tool filter progress for machine-readable modes", async () => {


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"b1cbd7150b632011be3363da0ba63f6e294fa06f"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `b1cbd7150b632011be3363da0ba63f6e294fa06f`
- last generated public sync base: `aaab4f6cdd1d381ffec7b82cdfcb6348fa4d2b48`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (b1cbd7150b63)`
- public projection: `https://github.com/evalops/maestro@main (aaab4f6cdd1d)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/bootstrap/tools-setup.ts
- copy/update src/tools/lazy-registry.ts
- copy/update test/bootstrap/tools-setup.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/bootstrap/tools-setup.ts
- copy/update src/tools/lazy-registry.ts
- copy/update test/bootstrap/tools-setup.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@b1cbd7150b632011be3363da0ba63f6e294fa06f`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.