### PR TITLE
[maestro] Pin tag release permission assertions

### DIFF
--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -94,7 +94,7 @@ describe("tag-release workflow", () => {
 		);
 
 		expect(workflow.jobs["tag-current-version"]["timeout-minutes"]).toBe(45);
-		expect(workflow.jobs["tag-current-version"].permissions).toMatchObject({
+		expect(workflow.jobs["tag-current-version"].permissions).toEqual({
 			actions: "read",
 			contents: "write",
 		});
@@ -177,7 +177,7 @@ describe("tag-release workflow", () => {
 			"tag-current-version",
 			"verify-published-registry-package",
 		]);
-		expect(dispatchJob.permissions).toMatchObject({
+		expect(dispatchJob.permissions).toEqual({
 			actions: "write",
 			contents: "read",
 		});


### PR DESCRIPTION
## Summary
- Follow-up to merged #707 for EVA-112.
- Pin the remaining tag-release job permission assertions with exact equality for `tag-current-version` and `dispatch-public-release`.
- `verify-published-registry-package` was already exact on current public `main`; this completes the late dispatch-permissions review finding without reopening #707.

Refs EVA-112.
Source counterpart: evalops/maestro-internal#2421.

## Validation
- `bunx vitest --run test/workflows/tag-release.test.ts`
- `bunx vitest --run test/scripts/ci-guardrails.test.ts -t "blocks tag-release"`
- `actionlint .github/workflows/tag-release.yml`
- `git diff --check`
- Commit hook: Guardian staged scan, `bunx biome check .`, `bun run lint:evals`, and build/codegen checks passed.

Classification: Not Kyverno.