### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -174,4 +174,15 @@ jobs:
           RELEASE_VERSION: ${{ needs.tag-current-version.outputs.release_version }}
         run: |
           set -euo pipefail
+          active_count="$(
+            gh run list \
+              --workflow release \
+              --json headBranch,status \
+              --limit 50 \
+              --jq "[.[] | select(.headBranch == \"${RELEASE_TAG}\" and .status != \"completed\")] | length"
+          )"
+          if [[ "${active_count}" != "0" ]]; then
+            echo "Found ${active_count} active release workflow run(s) for ${RELEASE_TAG}; not dispatching another."
+            exit 0
+          fi
           gh workflow run release --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"

--- a/src/app-server/plugin-bundle-api.ts
+++ b/src/app-server/plugin-bundle-api.ts
@@ -70,12 +70,18 @@ function paramsRecord(params: unknown): UnknownRecord {
 }
 
 function projectRootFromParams(
-	params: UnknownRecord,
 	options: MaestroAppServerPluginBundleApiOptions,
+	params: UnknownRecord,
 ): string {
-	return resolve(
-		stringValue(params.projectRoot) ?? options.projectRoot ?? process.cwd(),
-	);
+	const projectRoot = resolve(options.projectRoot ?? process.cwd());
+	const requestedProjectRoot = stringValue(params.projectRoot);
+	if (requestedProjectRoot && resolve(requestedProjectRoot) !== projectRoot) {
+		throw new MaestroAppServerPluginBundleError(
+			-32602,
+			"Plugin bundle projectRoot is not available for this server",
+		);
+	}
+	return projectRoot;
 }
 
 function scopeFromParams(params: UnknownRecord): WritablePackageScope {
@@ -224,7 +230,7 @@ export function createMaestroAppServerPluginBundleApi(
 	return {
 		async listBundles(params = {}) {
 			const normalizedParams = paramsRecord(params);
-			const projectRoot = projectRootFromParams(normalizedParams, options);
+			const projectRoot = projectRootFromParams(options, normalizedParams);
 			const resources = loadConfiguredPackageResources(projectRoot);
 			return {
 				bundles: loadConfiguredPackageSpecs(projectRoot).map((entry) => ({
@@ -244,7 +250,7 @@ export function createMaestroAppServerPluginBundleApi(
 
 		async installBundle(params = {}) {
 			const normalizedParams = paramsRecord(params);
-			const projectRoot = projectRootFromParams(normalizedParams, options);
+			const projectRoot = projectRootFromParams(options, normalizedParams);
 			const spec = packageSpecFromParams(normalizedParams);
 			const source = sourceString(spec);
 			const scope = scopeFromParams(normalizedParams);
@@ -285,7 +291,7 @@ export function createMaestroAppServerPluginBundleApi(
 
 		async removeBundle(params = {}) {
 			const normalizedParams = paramsRecord(params);
-			const projectRoot = projectRootFromParams(normalizedParams, options);
+			const projectRoot = projectRootFromParams(options, normalizedParams);
 			const spec = packageSpecFromParams(normalizedParams);
 			const scope =
 				normalizedParams.scope === undefined

--- a/src/app-server/session-api.ts
+++ b/src/app-server/session-api.ts
@@ -198,6 +198,7 @@ export interface MaestroAppServerSessionApiOptions {
 	policyControl?: MaestroAppServerPolicyControl | false;
 	networkGovernance?: MaestroAppServerNetworkGovernance | false;
 	sandboxCheck?: MaestroAppServerSandboxCheck | false;
+	projectRoot?: string;
 	externalAgentImport?: MaestroAppServerExternalAgentImport | false;
 	pluginBundles?: MaestroAppServerPluginBundleApi | false;
 	daemonLifecycle?: MaestroAppServerDaemonLifecycle | false;
@@ -895,10 +896,16 @@ export function createMaestroAppServerSessionApi(
 		options.sandboxCheck === false
 			? undefined
 			: (options.sandboxCheck ?? createMaestroAppServerSandboxCheck());
+	const canMutateSessionPersistence = store.canCreateSession?.() ?? true;
 	const pluginBundles =
-		options.pluginBundles === false
+		options.pluginBundles === false ||
+		!canMutateSessionPersistence ||
+		!hostControl
 			? undefined
-			: (options.pluginBundles ?? createMaestroAppServerPluginBundleApi());
+			: (options.pluginBundles ??
+				createMaestroAppServerPluginBundleApi({
+					projectRoot: options.projectRoot,
+				}));
 	const daemonLifecycle =
 		options.daemonLifecycle === false
 			? undefined
@@ -924,7 +931,6 @@ export function createMaestroAppServerSessionApi(
 	const canUseThreadGoals = Boolean(
 		store.setSessionAppServerGoal && store.loadEntries,
 	);
-	const canMutateSessionPersistence = store.canCreateSession?.() ?? true;
 	const externalAgentImport =
 		options.externalAgentImport === false || !canMutateSessionPersistence
 			? undefined

--- a/test/app-server/plugin-bundle-api.test.ts
+++ b/test/app-server/plugin-bundle-api.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { Value } from "@sinclair/typebox/value";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { MaestroAppServerResponseSchema } from "../../packages/contracts/src/maestro-app-server.js";
+import { createMaestroAppServerPluginBundleApi } from "../../src/app-server/plugin-bundle-api.js";
 import {
 	createMaestroAppServerSessionApi,
 	handleMaestroAppServerRequest,
@@ -72,13 +73,68 @@ describe("Maestro app-server plugin bundle lifecycle API", () => {
 		});
 	});
 
+	it("does not expose plugin bundle lifecycle when session persistence is disabled", async () => {
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "disabled-plugin-sessions"),
+		});
+		manager.disable();
+		const api = createMaestroAppServerSessionApi(manager);
+
+		expect(api.initialize()).toMatchObject({
+			capabilities: {
+				pluginBundles: false,
+			},
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-install-disabled",
+			method: "pluginBundle/install",
+			params: { source: "npm:@scope/package" },
+		});
+
+		expect(response.error).toEqual({
+			code: -32601,
+			message: "Plugin bundle lifecycle is not available",
+		});
+	});
+
+	it("does not expose plugin bundle lifecycle when host control is disabled", async () => {
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "disabled-host-sessions"),
+		});
+		const api = createMaestroAppServerSessionApi(manager, {
+			hostControl: false,
+		});
+
+		expect(api.initialize()).toMatchObject({
+			capabilities: {
+				pluginBundles: false,
+			},
+		});
+
+		const response = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-install-host-disabled",
+			method: "pluginBundle/install",
+			params: { source: "npm:@scope/package" },
+		});
+
+		expect(response.error).toEqual({
+			code: -32601,
+			message: "Plugin bundle lifecycle is not available",
+		});
+	});
+
 	it("installs, lists, loads, and removes a local plugin bundle", async () => {
 		const projectRoot = join(testDir, "project");
 		const packageDir = writePluginBundle(projectRoot);
 		const manager = new SessionManager(false, undefined, {
 			sessionDir: join(testDir, "sessions"),
 		});
-		const api = createMaestroAppServerSessionApi(manager);
+		const api = createMaestroAppServerSessionApi(manager, {
+			pluginBundles: createMaestroAppServerPluginBundleApi({ projectRoot }),
+		});
 
 		const installed = await handleMaestroAppServerRequest(api, {
 			jsonrpc: "2.0",
@@ -180,13 +236,106 @@ describe("Maestro app-server plugin bundle lifecycle API", () => {
 		expect(listedAfterRemove.result?.bundles).toEqual([]);
 	});
 
+	it("uses the server project root for plugin bundle mutations", async () => {
+		const serverRoot = join(testDir, "server-cwd");
+		const projectRoot = join(testDir, "server-project");
+		mkdirSync(serverRoot, { recursive: true });
+		const packageDir = writePluginBundle(projectRoot);
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "server-root-sessions"),
+		});
+		const previousCwd = process.cwd();
+		process.chdir(serverRoot);
+		try {
+			const api = createMaestroAppServerSessionApi(manager, {
+				projectRoot,
+			});
+			const installed = await handleMaestroAppServerRequest(api, {
+				jsonrpc: "2.0",
+				id: "plugin-install-server-root",
+				method: "pluginBundle/install",
+				params: {
+					projectRoot,
+					scope: "local",
+					source: `local:${packageDir}`,
+				},
+			});
+
+			expect(installed.result).toMatchObject({
+				changed: true,
+				configPath: join(projectRoot, ".maestro", "config.local.toml"),
+				scope: "local",
+			});
+			expect(
+				existsSync(join(projectRoot, ".maestro", "config.local.toml")),
+			).toBe(true);
+			expect(
+				existsSync(join(serverRoot, ".maestro", "config.local.toml")),
+			).toBe(false);
+
+			const removed = await handleMaestroAppServerRequest(api, {
+				jsonrpc: "2.0",
+				id: "plugin-remove-server-root",
+				method: "pluginBundle/remove",
+				params: {
+					projectRoot,
+					source: `local:${packageDir}`,
+				},
+			});
+
+			expect(removed.result).toMatchObject({
+				changed: true,
+				configPath: join(projectRoot, ".maestro", "config.local.toml"),
+				scope: "local",
+			});
+			expect(
+				existsSync(join(serverRoot, ".maestro", "config.local.toml")),
+			).toBe(false);
+		} finally {
+			process.chdir(previousCwd);
+		}
+	});
+
+	it("rejects plugin bundle project roots outside the server root", async () => {
+		const projectRoot = join(testDir, "trusted-project");
+		const otherRoot = join(testDir, "other-project");
+		const packageDir = writePluginBundle(projectRoot);
+		const manager = new SessionManager(false, undefined, {
+			sessionDir: join(testDir, "untrusted-root-sessions"),
+		});
+		const api = createMaestroAppServerSessionApi(manager, {
+			projectRoot,
+		});
+
+		const rejected = await handleMaestroAppServerRequest(api, {
+			jsonrpc: "2.0",
+			id: "plugin-install-untrusted-root",
+			method: "pluginBundle/install",
+			params: {
+				projectRoot: otherRoot,
+				scope: "local",
+				source: `local:${packageDir}`,
+			},
+		});
+
+		expect(rejected.error).toEqual({
+			code: -32602,
+			message: "Plugin bundle projectRoot is not available for this server",
+		});
+		expect(existsSync(join(otherRoot, ".maestro", "config.local.toml"))).toBe(
+			false,
+		);
+	});
+
 	it("previews plugin bundle installs without writing config", async () => {
 		const projectRoot = join(testDir, "dry-run-project");
 		const packageDir = writePluginBundle(projectRoot);
 		const manager = new SessionManager(false, undefined, {
 			sessionDir: join(testDir, "dry-run-sessions"),
 		});
-		const api = createMaestroAppServerSessionApi(manager);
+		const api = createMaestroAppServerSessionApi(manager, {
+			pluginBundles: createMaestroAppServerPluginBundleApi({ projectRoot }),
+		});
 
 		const planned = await handleMaestroAppServerRequest(api, {
 			jsonrpc: "2.0",
@@ -214,7 +363,9 @@ describe("Maestro app-server plugin bundle lifecycle API", () => {
 		const manager = new SessionManager(false, undefined, {
 			sessionDir: join(testDir, "malformed-source-sessions"),
 		});
-		const api = createMaestroAppServerSessionApi(manager);
+		const api = createMaestroAppServerSessionApi(manager, {
+			pluginBundles: createMaestroAppServerPluginBundleApi({ projectRoot }),
+		});
 
 		const rejected = await handleMaestroAppServerRequest(api, {
 			jsonrpc: "2.0",
@@ -239,7 +390,9 @@ describe("Maestro app-server plugin bundle lifecycle API", () => {
 		const manager = new SessionManager(false, undefined, {
 			sessionDir: join(testDir, "invalid-sessions"),
 		});
-		const api = createMaestroAppServerSessionApi(manager);
+		const api = createMaestroAppServerSessionApi(manager, {
+			pluginBundles: createMaestroAppServerPluginBundleApi({ projectRoot }),
+		});
 
 		const invalidScope = await handleMaestroAppServerRequest(api, {
 			jsonrpc: "2.0",

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -216,6 +216,12 @@ describe("tag-release workflow", () => {
 		expect(dispatchStep?.run).toContain(
 			'gh workflow run release --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"',
 		);
+		expect(dispatchStep?.run).toContain("gh run list");
+		expect(dispatchStep?.run).toContain("--workflow release");
+		expect(dispatchStep?.run).toContain(".headBranch");
+		expect(dispatchStep?.run).toContain(
+			'if [[ "${active_count}" != "0" ]]; then',
+		);
 		expect(summaryStep?.run).toContain("is already published on npm");
 	});
 });


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"8b5869dbb0c06d082c800ae7e27ebdb679aa5712"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `8b5869dbb0c06d082c800ae7e27ebdb679aa5712`
- last generated public sync base: `c2aa9b4d472533ababd384771a73a0f03605a8a2`
- previewed public-tree drift: `5` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (8b5869dbb0c0)`
- public projection: `https://github.com/evalops/maestro@main (c2aa9b4d4725)`
- files to copy or update: `5`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/app-server/plugin-bundle-api.ts
- copy/update src/app-server/session-api.ts
- copy/update test/app-server/plugin-bundle-api.test.ts
- copy/update test/workflows/tag-release.test.ts
- copy/update .github/workflows/tag-release.yml

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/app-server/plugin-bundle-api.ts
- copy/update src/app-server/session-api.ts
- copy/update test/app-server/plugin-bundle-api.test.ts
- copy/update test/workflows/tag-release.test.ts
- copy/update .github/workflows/tag-release.yml

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@8b5869dbb0c06d082c800ae7e27ebdb679aa5712`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.