### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli-tui/commands/mcp-handlers.ts
+++ b/src/cli-tui/commands/mcp-handlers.ts
@@ -21,6 +21,7 @@ import {
 	removeMcpServerFromConfig,
 	resolveOfficialMcpRegistryEntry,
 	searchOfficialMcpRegistry,
+	serverRequiresProjectApproval,
 	setProjectMcpServerApprovalDecision,
 	updateMcpAuthPresetInConfig,
 	updateMcpServerInConfig,
@@ -1287,9 +1288,9 @@ async function handleMcpProjectApprovalCommand(
 				`MCP server "${parsed.name}" not found in merged config.`,
 			);
 		}
-		if (existingServer.scope !== "project") {
+		if (!serverRequiresProjectApproval(existingServer)) {
 			throw new Error(
-				`MCP server "${parsed.name}" is not loaded from project config.`,
+				`MCP server "${parsed.name}" does not require project approval.`,
 			);
 		}
 
@@ -1300,6 +1301,9 @@ async function handleMcpProjectApprovalCommand(
 			authPresets: currentConfig.authPresets,
 			decision,
 		});
+		if (decision === "denied") {
+			await mcpManager.reconnect(parsed.name);
+		}
 		await reloadMcpManager(projectRoot);
 
 		renderCtx.addContent(

--- a/src/mcp/fathom-cua.ts
+++ b/src/mcp/fathom-cua.ts
@@ -178,6 +178,7 @@ function buildFathomCuaServer(): McpServerConfig {
 		cwd,
 		env,
 		scope: "plugin",
+		requiresProjectApproval: true,
 	};
 }
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -41,6 +41,7 @@ export {
 export {
 	buildProjectMcpServerFingerprint,
 	getProjectMcpServerApprovalStatus,
+	serverRequiresProjectApproval,
 	setProjectMcpServerApprovalDecision,
 } from "./project-approvals.js";
 export { getFathomCuaPluginServers } from "./fathom-cua.js";

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -394,7 +394,8 @@ function serverConfigsEqual(
 		left.enabled === right.enabled &&
 		left.disabled === right.disabled &&
 		left.timeout === right.timeout &&
-		left.scope === right.scope
+		left.scope === right.scope &&
+		left.requiresProjectApproval === right.requiresProjectApproval
 	);
 }
 
@@ -562,6 +563,15 @@ interface ConnectedServer {
 	reconnectAttempts: number;
 }
 
+interface PendingConnection {
+	promise?: Promise<void>;
+	client?: Client;
+	transport?: Transport;
+	cancelled: boolean;
+}
+
+type ConnectServerResult = "connected" | "failed" | "cancelled";
+
 function normalizePromptDefinition(prompt: McpPrompt): McpPromptDefinition {
 	return {
 		name: prompt.name,
@@ -592,8 +602,8 @@ export class McpClientManager extends EventEmitter {
 	/** Map of server name to connected server state */
 	private servers = new Map<string, ConnectedServer>();
 
-	/** Map of server name to in-flight connection promise (prevents duplicates) */
-	private connecting = new Map<string, Promise<void>>();
+	/** Map of server name to in-flight connection state (prevents duplicates) */
+	private connecting = new Map<string, PendingConnection>();
 
 	/** Map of server name to pending reconnect timer */
 	private reconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -665,10 +675,6 @@ export class McpClientManager extends EventEmitter {
 		// Disconnect and reconnect updated servers so in-place edits take effect.
 		await Promise.allSettled(
 			toReconnect.map(async (server) => {
-				const pendingConnection = this.connecting.get(server.name);
-				if (pendingConnection) {
-					await Promise.allSettled([pendingConnection]);
-				}
 				await this.disconnectServer(server.name);
 				if (canConnectServer(server, nextApprovalMap)) {
 					await this.connectServer(server);
@@ -714,7 +720,11 @@ export class McpClientManager extends EventEmitter {
 		this.reconnectTimers.clear();
 
 		// Disconnect all servers
-		const promises = Array.from(this.servers.keys()).map((name) =>
+		const disconnectNames = new Set([
+			...this.servers.keys(),
+			...this.connecting.keys(),
+		]);
+		const promises = Array.from(disconnectNames).map((name) =>
 			this.disconnectServer(name),
 		);
 		await Promise.allSettled(promises);
@@ -724,29 +734,45 @@ export class McpClientManager extends EventEmitter {
 	 * Internal: Connect to a single server.
 	 * Handles deduplication of concurrent connection attempts.
 	 */
-	private async connectServer(config: McpServerConfig): Promise<void> {
+	private async connectServer(
+		config: McpServerConfig,
+		isReconnect = false,
+	): Promise<ConnectServerResult> {
 		const { name } = config;
 
 		// Avoid duplicate connections
 		if (this.servers.has(name)) {
-			return;
+			return "connected";
 		}
 
 		// Check for in-flight connection (prevent race conditions)
 		const existing = this.connecting.get(name);
-		if (existing) {
-			return existing;
+		if (existing?.promise) {
+			await existing.promise;
+			return existing.cancelled
+				? "cancelled"
+				: this.servers.has(name)
+					? "connected"
+					: "failed";
 		}
 
 		// Track this connection attempt
-		const task = this.doConnect(config);
-		this.connecting.set(name, task);
+		const pending: PendingConnection = { cancelled: false };
+		const task = this.doConnect(config, isReconnect, pending);
+		pending.promise = task;
+		this.connecting.set(name, pending);
 
 		try {
 			await task;
 		} finally {
-			this.connecting.delete(name);
+			if (this.connecting.get(name) === pending) {
+				this.connecting.delete(name);
+			}
 		}
+		if (pending.cancelled) {
+			return "cancelled";
+		}
+		return this.servers.has(name) ? "connected" : "failed";
 	}
 
 	/**
@@ -762,6 +788,7 @@ export class McpClientManager extends EventEmitter {
 	private async doConnect(
 		config: McpServerConfig,
 		isReconnect = false,
+		pending?: PendingConnection,
 	): Promise<void> {
 		const { name, transport: transportType } = config;
 
@@ -808,6 +835,9 @@ export class McpClientManager extends EventEmitter {
 					cwd: config.cwd,
 				});
 			}
+			if (pending) {
+				pending.transport = transport;
+			}
 
 			const client = new Client(
 				{
@@ -823,6 +853,9 @@ export class McpClientManager extends EventEmitter {
 					},
 				},
 			);
+			if (pending) {
+				pending.client = client;
+			}
 
 			client.setRequestHandler(ElicitRequestSchema, async (request, extra) => {
 				const clientToolService = getCurrentMcpClientToolService();
@@ -878,6 +911,14 @@ export class McpClientManager extends EventEmitter {
 					.filter((capability) => capability !== undefined),
 			);
 
+			if (
+				pending?.cancelled ||
+				!canConnectServer(config, buildProjectApprovalMap(this.config))
+			) {
+				await Promise.allSettled([client.close(), transport.close()]);
+				return;
+			}
+
 			this.servers.set(name, {
 				config,
 				client,
@@ -918,10 +959,28 @@ export class McpClientManager extends EventEmitter {
 			this.emit("error", { name, error: message });
 
 			// Schedule reconnection for non-reconnect attempts
-			if (!isReconnect) {
-				this.scheduleReconnect(config, 0);
+			const reconnectConfig = pending?.cancelled
+				? undefined
+				: this.getCurrentConnectableServer(config.name);
+			if (!isReconnect && reconnectConfig) {
+				this.scheduleReconnect(reconnectConfig, 0);
 			}
 		}
+	}
+
+	private getCurrentConnectableServer(
+		name: string,
+	): McpServerConfig | undefined {
+		const currentConfig = this.config.servers.find(
+			(server) => server.name === name,
+		);
+		if (
+			!currentConfig ||
+			!canConnectServer(currentConfig, buildProjectApprovalMap(this.config))
+		) {
+			return undefined;
+		}
+		return currentConfig;
 	}
 
 	private scheduleReconnect(config: McpServerConfig, attempt: number): void {
@@ -950,17 +1009,26 @@ export class McpClientManager extends EventEmitter {
 			if (this.servers.has(config.name)) {
 				return; // Already reconnected
 			}
+			const reconnectConfig = this.getCurrentConnectableServer(config.name);
+			if (!reconnectConfig) {
+				return;
+			}
 
 			try {
-				await this.doConnect(config, true);
+				const result = await this.connectServer(reconnectConfig, true);
 				// If doConnect succeeded (server is now connected), we're done
-				if (!this.servers.has(config.name)) {
+				if (
+					result === "failed" &&
+					this.getCurrentConnectableServer(config.name)
+				) {
 					// Connection failed (doConnect caught the error), schedule retry
 					this.scheduleReconnect(config, attempt + 1);
 				}
 			} catch {
 				// Unexpected error, schedule retry
-				this.scheduleReconnect(config, attempt + 1);
+				if (this.getCurrentConnectableServer(config.name)) {
+					this.scheduleReconnect(config, attempt + 1);
+				}
 			}
 		}, delay);
 
@@ -1134,6 +1202,16 @@ export class McpClientManager extends EventEmitter {
 		if (timer) {
 			clearTimeout(timer);
 			this.reconnectTimers.delete(name);
+		}
+
+		const pendingConnection = this.connecting.get(name);
+		if (pendingConnection) {
+			pendingConnection.cancelled = true;
+			this.connecting.delete(name);
+			await Promise.allSettled([
+				pendingConnection.client?.close(),
+				pendingConnection.transport?.close(),
+			]);
 		}
 
 		const server = this.servers.get(name);

--- a/src/mcp/project-approvals.ts
+++ b/src/mcp/project-approvals.ts
@@ -133,6 +133,37 @@ function getProjectRootKey(projectRoot: string): string {
 	return resolve(projectRoot);
 }
 
+const FATHOM_CUA_VOLATILE_ARG_FLAGS = new Set(["-session-id", "-turn-id"]);
+
+function isGeneratedFathomCuaServer(server: McpServerConfig): boolean {
+	return (
+		server.scope === "plugin" &&
+		server.requiresProjectApproval === true &&
+		server.env?.FATHOM_CALLER_PRODUCT === "maestro" &&
+		server.env?.FATHOM_CUA_PRODUCT === "maestro"
+	);
+}
+
+function approvalFingerprintArgs(server: McpServerConfig): string[] {
+	const args = server.args ?? [];
+	if (!isGeneratedFathomCuaServer(server)) {
+		return args;
+	}
+	const stableArgs: string[] = [];
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === undefined) {
+			continue;
+		}
+		if (FATHOM_CUA_VOLATILE_ARG_FLAGS.has(arg)) {
+			index += 1;
+			continue;
+		}
+		stableArgs.push(arg);
+	}
+	return stableArgs;
+}
+
 export function buildProjectMcpServerFingerprint(
 	server: McpServerConfig,
 	authPresets: readonly McpAuthPresetConfig[] = [],
@@ -141,7 +172,7 @@ export function buildProjectMcpServerFingerprint(
 		name: server.name,
 		transport: server.transport,
 		command: server.command,
-		args: server.args ?? [],
+		args: approvalFingerprintArgs(server),
 		env: normalizeStringRecord(server.env),
 		cwd: server.cwd,
 		url: server.url,
@@ -158,13 +189,19 @@ export function buildProjectMcpServerFingerprint(
 		.digest("hex");
 }
 
+export function serverRequiresProjectApproval(
+	server: McpServerConfig,
+): boolean {
+	return server.scope === "project" || server.requiresProjectApproval === true;
+}
+
 export function getProjectMcpServerApprovalStatus(options: {
 	projectRoot?: string;
 	server: McpServerConfig;
 	authPresets?: readonly McpAuthPresetConfig[];
 }): McpProjectApprovalStatus | undefined {
 	const { projectRoot, server, authPresets = [] } = options;
-	if (!projectRoot || server.scope !== "project") {
+	if (!projectRoot || !serverRequiresProjectApproval(server)) {
 		return undefined;
 	}
 
@@ -185,9 +222,9 @@ export function setProjectMcpServerApprovalDecision(options: {
 	decision: McpProjectApprovalDecision;
 }): void {
 	const { projectRoot, server, authPresets = [], decision } = options;
-	if (server.scope !== "project") {
+	if (!serverRequiresProjectApproval(server)) {
 		throw new Error(
-			`MCP server "${server.name}" is not project-scoped and does not require project approval.`,
+			`MCP server "${server.name}" does not require project approval.`,
 		);
 	}
 

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -122,6 +122,7 @@ export interface McpServerConfig {
 	timeout?: number;
 	supportsParallelToolCalls?: boolean;
 	scope?: McpScope;
+	requiresProjectApproval?: boolean;
 }
 
 export type McpParallelSafetyProvenance =

--- a/src/server/handlers/mcp.ts
+++ b/src/server/handlers/mcp.ts
@@ -17,6 +17,7 @@ import {
 	removeMcpServerFromConfig,
 	resolveOfficialMcpRegistryEntry,
 	searchOfficialMcpRegistry,
+	serverRequiresProjectApproval,
 	setProjectMcpServerApprovalDecision,
 	updateMcpAuthPresetInConfig,
 	updateMcpServerInConfig,
@@ -708,10 +709,10 @@ async function handleSetProjectApproval(
 			`MCP server "${body.name}" not found in merged config.`,
 		);
 	}
-	if (existingServer.scope !== "project") {
+	if (!serverRequiresProjectApproval(existingServer)) {
 		throw new ApiError(
 			400,
-			`MCP server "${body.name}" is not loaded from project config.`,
+			`MCP server "${body.name}" does not require project approval.`,
 		);
 	}
 
@@ -721,6 +722,9 @@ async function handleSetProjectApproval(
 		authPresets: config.authPresets,
 		decision: body.decision,
 	});
+	if (body.decision === "denied") {
+		await mcpManager.reconnect(body.name);
+	}
 	await reloadMcpManager(projectRoot);
 	const activeServer = mcpManager
 		.getStatus()
@@ -731,7 +735,7 @@ async function handleSetProjectApproval(
 		200,
 		{
 			name: body.name,
-			scope: "project",
+			scope: existingServer.scope,
 			decision: body.decision,
 			projectApproval: activeServer?.projectApproval ?? body.decision,
 		},

--- a/test/agent/mcp-fathom-cua-plugin.test.ts
+++ b/test/agent/mcp-fathom-cua-plugin.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loadMcpConfig } from "../../src/mcp/config.js";
+import {
+	loadMcpConfig,
+	removeMcpServerFromConfig,
+} from "../../src/mcp/config.js";
 import { getFathomCuaPluginServers } from "../../src/mcp/fathom-cua.js";
 
 describe("Fathom CUA MCP plugin server", () => {
@@ -29,6 +32,7 @@ describe("Fathom CUA MCP plugin server", () => {
 				command: "go",
 				cwd: "/tmp/fathom",
 				scope: "plugin",
+				requiresProjectApproval: true,
 				env: {
 					FATHOM_CALLER_PRODUCT: "maestro",
 					FATHOM_CUA_PRODUCT: "maestro",
@@ -106,7 +110,7 @@ describe("Fathom CUA MCP plugin server", () => {
 		});
 	});
 
-	it("participates in the merged MCP config as plugin scope", () => {
+	it("participates in the merged MCP config as plugin scope with project approval", () => {
 		vi.stubEnv("MAESTRO_FATHOM_CUA_ENABLED", "1");
 		vi.stubEnv("MAESTRO_FATHOM_CUA_REPO", "/tmp/fathom");
 
@@ -117,8 +121,23 @@ describe("Fathom CUA MCP plugin server", () => {
 		).toEqual(
 			expect.objectContaining({
 				scope: "plugin",
+				requiresProjectApproval: true,
 				command: "go",
 			}),
+		);
+	});
+
+	it("does not resolve generated Fathom servers to writable project config", () => {
+		vi.stubEnv("MAESTRO_FATHOM_CUA_ENABLED", "1");
+		vi.stubEnv("MAESTRO_FATHOM_CUA_REPO", "/tmp/fathom");
+
+		expect(() =>
+			removeMcpServerFromConfig({
+				projectRoot: "/tmp/project",
+				name: "fathom-cua",
+			}),
+		).toThrow(
+			'MCP server "fathom-cua" is managed by plugin scope and cannot be edited here.',
 		);
 	});
 });

--- a/test/agent/mcp-manager-transports.test.ts
+++ b/test/agent/mcp-manager-transports.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runWithMcpClientToolService } from "../../src/mcp/elicitation.js";
+import { setProjectMcpServerApprovalDecision } from "../../src/mcp/project-approvals.js";
 import { resolveMcpWorkspaceUri } from "../../src/mcp/workspace-trust.js";
 
 const mockClientConnect = vi.fn();
@@ -20,6 +21,7 @@ const mockSetNotificationHandler = vi.fn();
 const mockSetRequestHandler = vi.fn();
 const mockListTools = vi.fn().mockResolvedValue({ tools: [] });
 const mockListPrompts = vi.fn().mockResolvedValue({ prompts: [] });
+const mockTransportClose = vi.fn().mockResolvedValue(undefined);
 let mockServerCapabilities: Record<string, unknown> = {
 	tools: {},
 	resources: {},
@@ -56,7 +58,7 @@ vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
 			sseTransportCtor(url, options);
 		}
 
-		async close() {}
+		close = mockTransportClose;
 	},
 }));
 
@@ -66,7 +68,7 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
 			httpTransportCtor(url, options);
 		}
 
-		async close() {}
+		close = mockTransportClose;
 	},
 }));
 
@@ -81,6 +83,10 @@ describe("MCP manager remote transports", () => {
 		tempDir = join(tmpdir(), `maestro-mcp-transport-${Date.now()}`);
 		mkdirSync(tempDir, { recursive: true });
 		vi.stubEnv(
+			"MAESTRO_MCP_PROJECT_APPROVALS_FILE",
+			join(tempDir, "project-approvals.json"),
+		);
+		vi.stubEnv(
 			"MAESTRO_MCP_WORKSPACE_TRUST_FILE",
 			join(tempDir, "workspace-trust.json"),
 		);
@@ -89,6 +95,7 @@ describe("MCP manager remote transports", () => {
 		mockCallTool.mockClear();
 		mockSetNotificationHandler.mockClear();
 		mockSetRequestHandler.mockClear();
+		mockTransportClose.mockClear();
 		mockListTools.mockReset().mockResolvedValue({ tools: [] });
 		mockListPrompts.mockReset().mockResolvedValue({ prompts: [] });
 		mockServerCapabilities = {
@@ -965,6 +972,173 @@ describe("MCP manager remote transports", () => {
 			"https://example.com/mcp/v2",
 		);
 		expect(manager.isConnected("remote-http")).toBe(true);
+	});
+
+	it("does not install tools when approval is denied during an in-flight connection", async () => {
+		const server = {
+			name: "fathom-cua",
+			scope: "plugin" as const,
+			requiresProjectApproval: true,
+			transport: "http" as const,
+			url: "https://example.com/mcp",
+		};
+		setProjectMcpServerApprovalDecision({
+			projectRoot: tempDir,
+			server,
+			decision: "approved",
+		});
+		let resolveListTools!: (value: { tools: [] }) => void;
+		mockListTools.mockReturnValue(
+			new Promise((resolve) => {
+				resolveListTools = resolve;
+			}),
+		);
+
+		const configure = manager.configure({
+			projectRoot: tempDir,
+			authPresets: [],
+			servers: [server],
+		});
+		await vi.waitFor(() => {
+			expect(mockListTools).toHaveBeenCalled();
+		});
+
+		setProjectMcpServerApprovalDecision({
+			projectRoot: tempDir,
+			server,
+			decision: "denied",
+		});
+		const reconnect = manager.reconnect("fathom-cua");
+		resolveListTools({ tools: [] });
+
+		await expect(reconnect).resolves.toBe(false);
+		await configure;
+		expect(manager.isConnected("fathom-cua")).toBe(false);
+	});
+
+	it("closes a pending transport when approval is denied during a stuck connection", async () => {
+		const server = {
+			name: "fathom-cua",
+			scope: "plugin" as const,
+			requiresProjectApproval: true,
+			transport: "http" as const,
+			url: "https://example.com/mcp",
+		};
+		setProjectMcpServerApprovalDecision({
+			projectRoot: tempDir,
+			server,
+			decision: "approved",
+		});
+		let resolveListTools!: (value: { tools: [] }) => void;
+		mockListTools.mockReturnValue(
+			new Promise((resolve) => {
+				resolveListTools = resolve;
+			}),
+		);
+
+		const configure = manager.configure({
+			projectRoot: tempDir,
+			authPresets: [],
+			servers: [server],
+		});
+		await vi.waitFor(() => {
+			expect(mockListTools).toHaveBeenCalled();
+		});
+
+		setProjectMcpServerApprovalDecision({
+			projectRoot: tempDir,
+			server,
+			decision: "denied",
+		});
+		await expect(manager.reconnect("fathom-cua")).resolves.toBe(false);
+
+		expect(mockClientClose).toHaveBeenCalled();
+		expect(mockTransportClose).toHaveBeenCalled();
+		expect(manager.isConnected("fathom-cua")).toBe(false);
+
+		resolveListTools({ tools: [] });
+		await configure;
+		expect(manager.isConnected("fathom-cua")).toBe(false);
+	});
+
+	it("does not reconnect a cancelled pending connection after disconnectAll", async () => {
+		const server = {
+			name: "remote-http",
+			transport: "http" as const,
+			url: "https://example.com/mcp",
+		};
+		let rejectConnect!: (error: Error) => void;
+		mockClientConnect.mockReturnValueOnce(
+			new Promise((_resolve, reject) => {
+				rejectConnect = reject;
+			}),
+		);
+
+		const configure = manager.configure({
+			servers: [server],
+		});
+		await vi.waitFor(() => {
+			expect(mockClientConnect).toHaveBeenCalledTimes(1);
+		});
+
+		await manager.disconnectAll();
+
+		vi.useFakeTimers();
+		try {
+			rejectConnect(new Error("closed while pending"));
+			await configure;
+			await vi.advanceTimersByTimeAsync(5001);
+			expect(mockClientConnect).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("tracks reconnect retries so they can be cancelled while fetching capabilities", async () => {
+		const server = {
+			name: "remote-http",
+			transport: "http" as const,
+			url: "https://example.com/mcp",
+		};
+		const reconnectableManager = manager as unknown as {
+			config: { servers: [typeof server]; authPresets: [] };
+			scheduleReconnect(config: typeof server, attempt: number): void;
+		};
+		let resolveListTools!: (value: { tools: [] }) => void;
+		mockListTools.mockReturnValue(
+			new Promise((resolve) => {
+				resolveListTools = resolve;
+			}),
+		);
+
+		vi.useFakeTimers();
+		try {
+			reconnectableManager.config = { servers: [server], authPresets: [] };
+			reconnectableManager.scheduleReconnect(server, 0);
+			expect(vi.getTimerCount()).toBe(1);
+
+			mockClientClose.mockClear();
+			mockTransportClose.mockClear();
+			vi.advanceTimersByTime(5000);
+			for (let i = 0; i < 10; i += 1) {
+				await Promise.resolve();
+			}
+
+			expect(mockClientConnect).toHaveBeenCalledTimes(1);
+			expect(mockListTools).toHaveBeenCalledTimes(1);
+
+			await manager.disconnectAll();
+			expect(mockClientClose).toHaveBeenCalled();
+			expect(mockTransportClose).toHaveBeenCalled();
+
+			resolveListTools({ tools: [] });
+			for (let i = 0; i < 10; i += 1) {
+				await Promise.resolve();
+			}
+			expect(manager.isConnected("remote-http")).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("merges static headers with headersHelper output for remote transports", async () => {

--- a/test/agent/mcp-project-approvals.test.ts
+++ b/test/agent/mcp-project-approvals.test.ts
@@ -51,6 +51,91 @@ describe("project MCP approvals", () => {
 		).toBe("pending");
 	});
 
+	it("allows plugin servers to opt into project approval without writable project scope", () => {
+		const server = {
+			name: "fathom-cua",
+			scope: "plugin" as const,
+			requiresProjectApproval: true,
+			transport: "stdio" as const,
+			command: "fathom-client",
+		};
+
+		expect(
+			getProjectMcpServerApprovalStatus({
+				projectRoot: testDir,
+				server,
+			}),
+		).toBe("pending");
+
+		setProjectMcpServerApprovalDecision({
+			projectRoot: testDir,
+			server,
+			decision: "approved",
+		});
+
+		expect(
+			getProjectMcpServerApprovalStatus({
+				projectRoot: testDir,
+				server,
+			}),
+		).toBe("approved");
+		expect(server.scope).toBe("plugin");
+	});
+
+	it("keeps Fathom CUA approvals stable across volatile run lineage args", () => {
+		const server = {
+			name: "desktop-cua",
+			scope: "plugin" as const,
+			requiresProjectApproval: true,
+			transport: "stdio" as const,
+			command: "fathom-client",
+			args: [
+				"-tool-profile",
+				"default",
+				"-session-id",
+				"session-one",
+				"-turn-id",
+				"turn-one",
+			],
+			env: {
+				FATHOM_CALLER_PRODUCT: "maestro",
+				FATHOM_CUA_PRODUCT: "maestro",
+			},
+		};
+
+		setProjectMcpServerApprovalDecision({
+			projectRoot: testDir,
+			server,
+			decision: "approved",
+		});
+
+		expect(
+			getProjectMcpServerApprovalStatus({
+				projectRoot: testDir,
+				server: {
+					...server,
+					args: [
+						"-tool-profile",
+						"default",
+						"-session-id",
+						"session-two",
+						"-turn-id",
+						"turn-two",
+					],
+				},
+			}),
+		).toBe("approved");
+		expect(
+			getProjectMcpServerApprovalStatus({
+				projectRoot: testDir,
+				server: {
+					...server,
+					args: ["-tool-profile", "high", "-session-id", "session-two"],
+				},
+			}),
+		).toBe("pending");
+	});
+
 	it("resets approval when the project auth preset changes", () => {
 		const server = {
 			name: "linear",
@@ -121,6 +206,34 @@ describe("project MCP approvals", () => {
 
 		expect(manager.getStatus().servers[0]).toMatchObject({
 			name: "repo-server",
+			connected: false,
+			projectApproval: "pending",
+			error: undefined,
+		});
+	});
+
+	it("keeps approval-gated plugin servers disconnected until approved", async () => {
+		const manager = createManager();
+
+		await manager.configure({
+			projectRoot: testDir,
+			authPresets: [],
+			servers: [
+				{
+					name: "fathom-cua",
+					scope: "plugin",
+					requiresProjectApproval: true,
+					transport: "stdio",
+					command: "nonexistent-cmd",
+				},
+			],
+		});
+
+		await vi.advanceTimersByTimeAsync(100);
+
+		expect(manager.getStatus().servers[0]).toMatchObject({
+			name: "fathom-cua",
+			scope: "plugin",
 			connected: false,
 			projectApproval: "pending",
 			error: undefined,

--- a/test/cli-tui/commands/standalone-handlers.test.ts
+++ b/test/cli-tui/commands/standalone-handlers.test.ts
@@ -496,6 +496,7 @@ vi.mock("../../../src/mcp/index.js", () => ({
 	mcpManager: {
 		getStatus: vi.fn(() => createDefaultMcpStatus()),
 		configure: vi.fn().mockResolvedValue(undefined),
+		reconnect: vi.fn().mockResolvedValue(false),
 		readResource: vi.fn(),
 		getPrompt: vi.fn(),
 	},
@@ -521,6 +522,10 @@ vi.mock("../../../src/mcp/index.js", () => ({
 				: [],
 	})),
 	searchOfficialMcpRegistry: vi.fn(() => [mockOfficialRegistryEntry]),
+	serverRequiresProjectApproval: vi.fn(
+		(server: { scope?: string; requiresProjectApproval?: boolean }) =>
+			server.scope === "project" || server.requiresProjectApproval === true,
+	),
 	setProjectMcpServerApprovalDecision: vi.fn(),
 	updateMcpAuthPresetInConfig: vi.fn(() => ({
 		path: "/tmp/project/.maestro/mcp.local.json",
@@ -668,6 +673,43 @@ describe("mcp-handlers", () => {
 				});
 				expect(ctx.addContent).toHaveBeenCalledWith(
 					'Approved project MCP server "test-server".',
+				);
+			});
+		});
+
+		it("disconnects a generated plugin MCP server when project approval is denied", async () => {
+			vi.mocked(loadMcpConfig).mockReturnValueOnce({
+				projectRoot: process.cwd(),
+				servers: [
+					{
+						name: "fathom-cua",
+						scope: "plugin",
+						requiresProjectApproval: true,
+						transport: "stdio",
+						command: "fathom-client",
+					},
+				],
+				authPresets: [],
+			});
+
+			const ctx = createMcpCtx("/mcp deny fathom-cua");
+			handleMcpCommand(ctx);
+			await vi.waitFor(() => {
+				expect(setProjectMcpServerApprovalDecision).toHaveBeenCalledWith({
+					projectRoot: process.cwd(),
+					server: {
+						name: "fathom-cua",
+						scope: "plugin",
+						requiresProjectApproval: true,
+						transport: "stdio",
+						command: "fathom-client",
+					},
+					authPresets: [],
+					decision: "denied",
+				});
+				expect(mcpManager.reconnect).toHaveBeenCalledWith("fathom-cua");
+				expect(ctx.addContent).toHaveBeenCalledWith(
+					'Denied project MCP server "fathom-cua".',
 				);
 			});
 		});

--- a/test/web/mcp-handler.test.ts
+++ b/test/web/mcp-handler.test.ts
@@ -1229,4 +1229,136 @@ describe("handleMcpStatus", () => {
 			projectApproval: "approved",
 		});
 	});
+
+	it("updates project approval for generated plugin servers without changing their scope", async () => {
+		vi.spyOn(mcp, "loadMcpConfig").mockReturnValue({
+			projectRoot: process.cwd(),
+			servers: [
+				{
+					name: "fathom-cua",
+					scope: "plugin",
+					requiresProjectApproval: true,
+					transport: "stdio",
+					command: "fathom-client",
+				},
+			],
+			authPresets: [],
+		});
+		const setApproval = vi
+			.spyOn(mcp, "setProjectMcpServerApprovalDecision")
+			.mockReturnValue(undefined);
+		vi.spyOn(mcp.mcpManager, "configure").mockResolvedValue(undefined);
+		vi.spyOn(mcp.mcpManager, "getStatus").mockReturnValue({
+			authPresets: [],
+			servers: [
+				{
+					name: "fathom-cua",
+					connected: false,
+					scope: "plugin",
+					transport: "stdio",
+					tools: [],
+					resources: [],
+					prompts: [],
+					projectApproval: "approved",
+				},
+			],
+		});
+
+		const req = makeReq("/api/mcp?action=set-project-approval", {
+			method: "POST",
+			body: {
+				name: "fathom-cua",
+				decision: "approved",
+			},
+		});
+		const res = makeRes();
+
+		await handleMcpStatus(
+			req as unknown as IncomingMessage,
+			res as unknown as ServerResponse,
+			corsHeaders,
+		);
+
+		expect(setApproval).toHaveBeenCalledWith({
+			projectRoot: process.cwd(),
+			server: {
+				name: "fathom-cua",
+				scope: "plugin",
+				requiresProjectApproval: true,
+				transport: "stdio",
+				command: "fathom-client",
+			},
+			authPresets: [],
+			decision: "approved",
+		});
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.body)).toEqual({
+			name: "fathom-cua",
+			scope: "plugin",
+			decision: "approved",
+			projectApproval: "approved",
+		});
+	});
+
+	it("disconnects an approved generated plugin server when project approval is denied", async () => {
+		vi.spyOn(mcp, "loadMcpConfig").mockReturnValue({
+			projectRoot: process.cwd(),
+			servers: [
+				{
+					name: "fathom-cua",
+					scope: "plugin",
+					requiresProjectApproval: true,
+					transport: "stdio",
+					command: "fathom-client",
+				},
+			],
+			authPresets: [],
+		});
+		vi.spyOn(mcp, "setProjectMcpServerApprovalDecision").mockReturnValue(
+			undefined,
+		);
+		const reconnect = vi
+			.spyOn(mcp.mcpManager, "reconnect")
+			.mockResolvedValue(false);
+		vi.spyOn(mcp.mcpManager, "configure").mockResolvedValue(undefined);
+		vi.spyOn(mcp.mcpManager, "getStatus").mockReturnValue({
+			authPresets: [],
+			servers: [
+				{
+					name: "fathom-cua",
+					connected: false,
+					scope: "plugin",
+					transport: "stdio",
+					tools: [],
+					resources: [],
+					prompts: [],
+					projectApproval: "denied",
+				},
+			],
+		});
+
+		const req = makeReq("/api/mcp?action=set-project-approval", {
+			method: "POST",
+			body: {
+				name: "fathom-cua",
+				decision: "denied",
+			},
+		});
+		const res = makeRes();
+
+		await handleMcpStatus(
+			req as unknown as IncomingMessage,
+			res as unknown as ServerResponse,
+			corsHeaders,
+		);
+
+		expect(reconnect).toHaveBeenCalledWith("fathom-cua");
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.body)).toEqual({
+			name: "fathom-cua",
+			scope: "plugin",
+			decision: "denied",
+			projectApproval: "denied",
+		});
+	});
 });


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"9ae2ab92509c3098ba98306d4dbbe7045ed3eca2"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `9ae2ab92509c3098ba98306d4dbbe7045ed3eca2`
- last generated public sync base: `e0375a0083c9ddcf88a9a7dd9c317101f3090534`
- previewed public-tree drift: `12` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (9ae2ab92509c)`
- public projection: `https://github.com/evalops/maestro@main (e0375a0083c9)`
- files to copy or update: `12`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli-tui/commands/mcp-handlers.ts
- copy/update src/mcp/fathom-cua.ts
- copy/update src/mcp/index.ts
- copy/update src/mcp/manager.ts
- copy/update src/mcp/project-approvals.ts
- copy/update src/mcp/types.ts
- copy/update src/server/handlers/mcp.ts
- copy/update test/agent/mcp-fathom-cua-plugin.test.ts
- copy/update test/agent/mcp-manager-transports.test.ts
- copy/update test/agent/mcp-project-approvals.test.ts
- copy/update test/cli-tui/commands/standalone-handlers.test.ts
- copy/update test/web/mcp-handler.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli-tui/commands/mcp-handlers.ts
- copy/update src/mcp/fathom-cua.ts
- copy/update src/mcp/index.ts
- copy/update src/mcp/manager.ts
- copy/update src/mcp/project-approvals.ts
- copy/update src/mcp/types.ts
- copy/update src/server/handlers/mcp.ts
- copy/update test/agent/mcp-fathom-cua-plugin.test.ts
- copy/update test/agent/mcp-manager-transports.test.ts
- copy/update test/agent/mcp-project-approvals.test.ts
- copy/update test/cli-tui/commands/standalone-handlers.test.ts
- copy/update test/web/mcp-handler.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@9ae2ab92509c3098ba98306d4dbbe7045ed3eca2`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.