### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,61 @@ function isHeadlessInvocation(args: string[]): boolean {
 	return false;
 }
 
+// Keep this detector local: importing the shared command runtime detector is the
+// pre-main work the exec fast path avoids.
+const EXEC_RUNTIME_FLAGS_WITH_VALUES = new Set([
+	"--mode",
+	"--provider",
+	"--model",
+	"-m",
+	"--task-budget",
+	"--models",
+	"--models-file",
+	"--api-key",
+	"--port",
+	"--system-prompt",
+	"--append-system-prompt",
+	"--session",
+	"--approval-mode",
+	"--auth",
+	"--sandbox",
+	"--output-schema",
+	"--output-last-message",
+	"--tools",
+	"--composer",
+	"--format",
+	"--profile",
+	"--config",
+	"--junit",
+	"--replay",
+	"--record-scenario",
+]);
+
+function getLauncherRuntimeCommand(args: readonly string[]): string | null {
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
+		if (!arg) {
+			continue;
+		}
+		if (EXEC_RUNTIME_FLAGS_WITH_VALUES.has(arg) && index + 1 < args.length) {
+			index++;
+			continue;
+		}
+		if (arg.startsWith("-")) {
+			continue;
+		}
+		return arg;
+	}
+	return null;
+}
+
+function shouldUseFastUnbundledExecRuntime(args: readonly string[]): boolean {
+	if (typeof MAESTRO_BUNDLE_RUNTIME !== "undefined" && MAESTRO_BUNDLE_RUNTIME) {
+		return false;
+	}
+	return getLauncherRuntimeCommand(args) === "exec";
+}
+
 function emitHeadlessStartupError(error: unknown): void {
 	const message = error instanceof Error ? error.message : String(error);
 	const stack = error instanceof Error ? error.stack : undefined;
@@ -227,6 +282,10 @@ const run = async () => {
 			loadedEnvKeys = loadEnv();
 		}
 		await refreshInstalledCliOnStartup(args, loadedEnvKeys);
+		if (shouldUseFastUnbundledExecRuntime(args)) {
+			await runMainRuntime(args);
+			return;
+		}
 		if (await runCliCommandRuntime(args)) {
 			return;
 		}


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"c9d076d5986e6fd3901ee1ade3b540d4d2ebc8b2"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `c9d076d5986e6fd3901ee1ade3b540d4d2ebc8b2`
- last generated public sync base: `662180ce857d3abf138400ee17d82320908bc5cd`
- previewed public-tree drift: `1` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (c9d076d5986e)`
- public projection: `https://github.com/evalops/maestro@main (662180ce857d)`
- files to copy or update: `1`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@c9d076d5986e6fd3901ee1ade3b540d4d2ebc8b2`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.