### PR TITLE
[maestro] Harden release version bump git hooks

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -164,6 +164,8 @@ jobs:
           HUSKY: "0"
         run: |
           set -euo pipefail
+          hooks_dir="$(mktemp -d)"
+          git config --local core.hooksPath "$hooks_dir"
           git remote set-url origin "https://x-access-token:${RELEASE_PR_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           if [[ -z "$(git status --porcelain)" ]]; then
             if [[ "$BRANCH_EXISTS" == "true" ]] && [[ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$RELEASE_BRANCH")" ]]; then

--- a/src/package-metadata.ts
+++ b/src/package-metadata.ts
@@ -29,16 +29,16 @@ function loadPackageMetadata(): RootPackageMetadata {
 	}
 }
 
-export function getPackageVersion(): string {
-	return (
-		process.env.MAESTRO_VERSION ?? loadPackageMetadata().version ?? "unknown"
-	);
+export function getPackageVersion(
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	return env.MAESTRO_VERSION ?? loadPackageMetadata().version ?? "unknown";
 }
 
-export function getPackageName(): string {
+export function getPackageName(env: NodeJS.ProcessEnv = process.env): string {
 	const metadata = loadPackageMetadata();
 	return (
-		process.env.MAESTRO_PACKAGE_NAME ??
+		env.MAESTRO_PACKAGE_NAME ??
 		metadata.name ??
 		metadata.maestro?.canonicalPackageName ??
 		"@evalops/maestro"


### PR DESCRIPTION
### Motivation
- Prevent Git hooks from executing in the privileged release commit step after the release token is injected into the remote URL to avoid secret exfiltration via attacker-controlled hooks. 
- Preserve existing sanitized-env startup-refresh behavior and resolve a local typecheck issue by making package metadata helpers accept an explicit environment map.

### Description
- In `.github/workflows/version-bump.yml` restore an empty, ephemeral hooks directory immediately before the privileged `Commit release branch` step by creating `hooks_dir="$(mktemp -d)"` and running `git config --local core.hooksPath "$hooks_dir"` so arbitrary Git hooks cannot run while the release token is present.
- In `src/package-metadata.ts` change `getPackageVersion` and `getPackageName` to accept `env: NodeJS.ProcessEnv = process.env` and use that map for lookups to preserve sanitized-env call sites and avoid passing the real `process.env` inadvertently.

### Testing
- Ran `bun run bun:lint` and the lint step completed successfully. 
- Ran `bun run build` and the build completed successfully. 
- Ran the focused unit test `bunx vitest --run test/cli/startup-refresh.test.ts` which passed. 
- Ran `npx nx run maestro:test --skip-nx-cache` which executed builds and the test suite but reported existing, environment-sensitive test failures unrelated to this change (MarkItDown process cleanup, apply-patch rollback under this environment, shell startup stderr from `/etc/profile`, and a tool-surface smoke mismatch); these failures predate and are not caused by the workflow hardening.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1badbc09548326a709ba5cf6c54644)

Internal source PR: evalops/maestro-internal#2431
