### PR TITLE
[maestro] disable unsafe toolbox describe lint execution

### DIFF
--- a/docs/cookbook/skills/README.md
+++ b/docs/cookbook/skills/README.md
@@ -49,10 +49,10 @@ itself when `MAESTRO_TOOLBOX_ACTION=describe` is set:
 MAESTRO_TOOLBOX_ACTION=describe .maestro/skills/reviewing-prs/toolbox/list-pr-files
 ```
 
-Run strict validation with:
+Validate packages with:
 
 ```bash
-maestro skill lint .maestro/skills/reviewing-prs --describe-toolbox
+maestro skill lint .maestro/skills/reviewing-prs
 ```
 
 ## Model And Mode Hints

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -36,7 +36,6 @@ Options:
   --dir <path>                 Base directory for 'new' (default: .maestro/skills)
   --description <text>         Description for 'new'
   --force                      Allow 'new' to overwrite an existing directory
-  --describe-toolbox           Run Toolbox describe checks during lint
   --help, -h                   Show this help`;
 }
 
@@ -72,8 +71,7 @@ function parseOptions(args: string[]): {
 				options.force = true;
 				break;
 			case "--describe-toolbox":
-				options.describeToolbox = true;
-				break;
+				throw new Error("--describe-toolbox is disabled for security reasons.");
 			case "--help":
 			case "-h":
 				positionals.push(arg);

--- a/src/skills/linter.ts
+++ b/src/skills/linter.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process";
 import {
 	existsSync,
 	mkdirSync,
@@ -338,21 +337,14 @@ async function validateToolbox(
 			continue;
 		}
 		if (options.describeToolbox) {
-			const result = spawnSync(path, {
-				env: { ...process.env, MAESTRO_TOOLBOX_ACTION: "describe" },
-				encoding: "utf8",
-				timeout: 5000,
-			});
-			if (result.status !== 0) {
-				issues.push(
-					issue(
-						"toolbox_describe_failed",
-						"error",
-						path,
-						`Toolbox describe failed: ${result.stderr || result.stdout || "non-zero exit"}`,
-					),
-				);
-			}
+			issues.push(
+				issue(
+					"toolbox_describe_unsupported",
+					"warning",
+					path,
+					"Toolbox describe checks are disabled during lint for security.",
+				),
+			);
 		}
 	}
 	return issues;


### PR DESCRIPTION
### Motivation
- A recent linter feature executed attacker-controlled binaries under `toolbox/` when `--describe-toolbox` was used, which allowed arbitrary code execution with the linter/CI process environment and secrets.
- Prevent execution of untrusted package-controlled executables during lint and remove the publicly-documented CLI path that enabled this behavior.

### Description
- Stop spawning toolbox executables in `lint` by removing the `spawnSync` describe invocation and instead emit a security warning in `src/skills/linter.ts` when `describeToolbox` is requested.
- Reject the `--describe-toolbox` CLI option in `src/cli/commands/skill.ts` with an explicit error and remove it from the help text so callers cannot enable the unsafe path.
- Update the skill cookbook `docs/cookbook/skills/README.md` to remove the documented `--describe-toolbox` invocation and recommend standard `maestro skill lint` usage.

### Testing
- Ran `bun run bun:lint`, which completed successfully after formatting fixes and the changes above.
- Attempted the full test suite with `npx nx run maestro:test --skip-nx-cache`, which could not complete in this environment due to missing `tree-sitter` types and npm registry access errors (CI dependency resolution failures), so full project tests could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c5599c5883268e8360bdd567bb4b)

Internal source PR: evalops/maestro-internal#2430
