### PR TITLE
[maestro] Clear retained A2A auth when pairing identity changes

### DIFF
--- a/src/platform/a2a-peer-registry.ts
+++ b/src/platform/a2a-peer-registry.ts
@@ -147,6 +147,12 @@ export async function upsertA2APeerFromPairingPayload(
 		tokenFile: previousTokenFile,
 		...previousFields
 	} = previous ?? {};
+	const identityChanged =
+		trimString(previous?.url) !== connection.baseUrl ||
+		trimString(previous?.agentCardUrl) !== connection.agentCardUrl ||
+		trimString(previous?.displayName) !== connection.displayName ||
+		trimString(previous?.protocolBinding) !== connection.protocolBinding ||
+		trimString(previous?.protocolVersion) !== connection.protocolVersion;
 	const entry: A2APeerRegistryEntry = {
 		...previousFields,
 		url: connection.baseUrl,
@@ -159,6 +165,7 @@ export async function upsertA2APeerFromPairingPayload(
 			previousTokenFile,
 			tokenEnv: options.tokenEnv,
 			tokenFile: options.tokenFile,
+			retainExisting: !identityChanged,
 		}),
 		...(options.organizationId
 			? { organizationId: options.organizationId }
@@ -263,6 +270,7 @@ function resolveUpsertTokenFields(input: {
 	previousTokenFile?: string;
 	tokenEnv?: string;
 	tokenFile?: string;
+	retainExisting?: boolean;
 }): Pick<A2APeerRegistryEntry, "tokenEnv" | "tokenFile"> {
 	const tokenEnv = trimString(input.tokenEnv);
 	const tokenFile = trimString(input.tokenFile);
@@ -274,6 +282,9 @@ function resolveUpsertTokenFields(input: {
 	}
 	if (tokenFile) {
 		return { tokenFile: expandHome(tokenFile) };
+	}
+	if (!input.retainExisting) {
+		return {};
 	}
 	return {
 		...(input.previousTokenEnv ? { tokenEnv: input.previousTokenEnv } : {}),

--- a/test/platform/a2a-peer-registry.test.ts
+++ b/test/platform/a2a-peer-registry.test.ts
@@ -141,6 +141,41 @@ describe("A2A peer registry", () => {
 		).resolves.toBe("file-token");
 	});
 
+	it("clears existing auth sources when re-pairing changes peer identity", async () => {
+		const path = await registryPath();
+		await writeFile(
+			path,
+			JSON.stringify({
+				defaultPeer: "victim-peer",
+				peers: {
+					"victim-peer": {
+						url: "https://trusted.example",
+						tokenEnv: "OLD_A2A_TOKEN",
+					},
+				},
+			}),
+		);
+
+		const payload = createA2APeerPairingPayload({
+			displayName: "Attacker Relay",
+			agentCardUrl: "https://attacker.example/.well-known/agent-card.json",
+			transportUrl: "https://attacker.example",
+			peerId: "victim-peer",
+			now: NOW,
+		});
+
+		await upsertA2APeerFromPairingPayload(payload, { path });
+
+		await expect(loadA2APeerRegistry({ path })).resolves.toMatchObject({
+			peers: {
+				"victim-peer": {
+					url: "https://attacker.example",
+				},
+			},
+		});
+		const raw = await readFile(path, "utf8");
+		expect(raw).not.toContain("OLD_A2A_TOKEN");
+	});
 	it("clears stale alternate auth fields when re-accepting an existing peer", async () => {
 		const path = await registryPath();
 		await writeFile(


### PR DESCRIPTION
### Motivation
- A re-pairing flow could replace a peer's URL/identity while silently preserving the prior `tokenEnv`/`tokenFile`, enabling an attacker to cause stored bearer tokens to be sent to an attacker-controlled endpoint.  
- The change prevents credential carryover unless the peer identity remains the same or the user explicitly supplies new token options.  

### Description
- Detect peer identity changes by comparing `previous.url`, `previous.agentCardUrl`, `previous.displayName`, `previous.protocolBinding`, and `previous.protocolVersion` against the incoming pairing payload and compute `identityChanged`.  
- Thread a `retainExisting` flag into `resolveUpsertTokenFields` so previous token fields are only retained when `retainExisting` is true (i.e., identity did not change).  
- Update `resolveUpsertTokenFields` signature to accept `retainExisting?: boolean` and return an empty object when retention is disallowed, effectively clearing prior `tokenEnv`/`tokenFile`.  
- Add a regression test `clears existing auth sources when re-pairing changes peer identity` in `test/platform/a2a-peer-registry.test.ts` that verifies old token fields are removed when a peer is rebound to a different endpoint.  

### Testing
- Ran `bunx vitest --run test/platform/a2a-peer-registry.test.ts` and all tests in that file passed.  
- Ran formatting (`bunx biome format`) and `bun run bun:lint`, both completed successfully.  
- Attempted the full suite with `npx nx run maestro:test --skip-nx-cache`, but it failed in this environment due to missing native deps and registry 403s during hook-driven dependency resolution; the focused unit tests for the registry passed despite that environmental limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07f3d19d1883269cb8acfc1b9b083b)

Internal source PR: evalops/maestro-internal#2432
