### PR TITLE
[maestro] secure hosted runner headless endpoints

### DIFF
--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -40,7 +40,7 @@ pub const HOSTED_RUNNER_DRAIN_PROTOCOL_VERSION: &str = "evalops.remote-runner.dr
 pub const HOSTED_RUNNER_SNAPSHOT_MANIFEST_VERSION: &str =
     "evalops.remote-runner.snapshot-manifest.v1";
 
-const DEFAULT_LISTEN_HOST: &str = "0.0.0.0";
+const DEFAULT_LISTEN_HOST: &str = "127.0.0.1";
 const DEFAULT_LISTEN_PORT: u16 = 8080;
 const DEFAULT_HEARTBEAT_INTERVAL_MS: u64 = 15_000;
 const CONNECTION_IDLE_MS: i64 = (DEFAULT_HEARTBEAT_INTERVAL_MS as i64) * 3;
@@ -57,6 +57,7 @@ pub struct HostedRunnerConfig {
     pub agent_run_id: Option<String>,
     pub maestro_session_id: Option<String>,
     pub attach_audience: Option<String>,
+    pub auth_token: Option<String>,
 }
 
 impl HostedRunnerConfig {
@@ -91,6 +92,12 @@ impl HostedRunnerConfig {
             .or_else(|| env_value(env, "MAESTRO_HOSTED_RUNNER_HOST"))
             .unwrap_or_else(|| DEFAULT_LISTEN_HOST.to_string());
         let bind_addr = resolve_bind_addr(&host, port)?;
+        let auth_token = env_value(env, "MAESTRO_HOSTED_RUNNER_AUTH_TOKEN");
+        if !bind_addr.ip().is_loopback() && auth_token.is_none() {
+            return Err(HostedRunnerConfigError::new(
+                "maestro hosted-runner requires MAESTRO_HOSTED_RUNNER_AUTH_TOKEN when binding to non-loopback interfaces",
+            ));
+        }
         let snapshot_root = resolve_snapshot_root(
             first_env(
                 env,
@@ -122,6 +129,7 @@ impl HostedRunnerConfig {
             agent_run_id: env_value(env, "MAESTRO_AGENT_RUN_ID"),
             maestro_session_id: env_value(env, "MAESTRO_SESSION_ID"),
             attach_audience: env_value(env, "MAESTRO_ATTACH_AUDIENCE"),
+            auth_token,
         })
     }
 
@@ -143,6 +151,7 @@ impl HostedRunnerConfig {
             agent_run_id: None,
             maestro_session_id: None,
             attach_audience: None,
+            auth_token: None,
         })
     }
 
@@ -1302,6 +1311,9 @@ enum ResponseBody {
 }
 
 async fn route_request(request: HttpRequest, shared: SharedRunner) -> HostedResult<ResponseBody> {
+    if request.path == HOSTED_RUNNER_DRAIN_PATH || request.path.starts_with("/api/headless/") {
+        require_auth_header(&request.headers, shared.config.auth_token.as_deref())?;
+    }
     match (request.method.as_str(), request.path.as_str()) {
         ("GET", HOSTED_RUNNER_IDENTITY_PATH) => json_response(200, shared.identity()),
         ("GET", "/readyz" | "/healthz") => {
@@ -1373,6 +1385,32 @@ async fn route_request(request: HttpRequest, shared: SharedRunner) -> HostedResu
         }
         _ => Err(HostedError::new(404, "not_found", "route not found")),
     }
+}
+
+fn require_auth_header(
+    headers: &HashMap<String, String>,
+    expected_token: Option<&str>,
+) -> HostedResult<()> {
+    let Some(expected_token) = expected_token else {
+        return Ok(());
+    };
+    let token = headers
+        .get("authorization")
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .or_else(|| {
+            headers
+                .get("x-maestro-hosted-runner-token")
+                .map(|value| value.trim())
+        });
+    if token == Some(expected_token) {
+        return Ok(());
+    }
+    Err(HostedError::new(
+        401,
+        "unauthorized",
+        "missing or invalid hosted runner auth token",
+    ))
 }
 
 async fn handle_drain(shared: SharedRunner, input: DrainRequest) -> HostedResult<ResponseBody> {
@@ -2755,6 +2793,7 @@ mod tests {
             agent_run_id: Some("run_test".to_string()),
             maestro_session_id: Some("sess_test".to_string()),
             attach_audience: None,
+            auth_token: None,
         }
     }
 
@@ -2840,6 +2879,30 @@ mod tests {
             )
         );
         assert_eq!(config.workspace_id.as_deref(), Some("workspace_1"));
+        assert!(config.auth_token.is_none());
+    }
+
+    #[test]
+    fn rejects_non_loopback_bind_without_auth_token() {
+        let workspace = tempdir().expect("workspace");
+        let mut env = HashMap::new();
+        env.insert(
+            "MAESTRO_RUNNER_SESSION_ID".to_string(),
+            "mrs_123".to_string(),
+        );
+        env.insert(
+            "MAESTRO_WORKSPACE_ROOT".to_string(),
+            workspace.path().display().to_string(),
+        );
+        env.insert(
+            "MAESTRO_HOSTED_RUNNER_LISTEN".to_string(),
+            "0.0.0.0:9090".to_string(),
+        );
+
+        let error = HostedRunnerConfig::from_env_map(&env).expect_err("expected config error");
+        assert!(error
+            .to_string()
+            .contains("MAESTRO_HOSTED_RUNNER_AUTH_TOKEN"));
     }
 
     #[test]
@@ -2925,6 +2988,35 @@ mod tests {
             .await
             .expect("attach response");
         assert_eq!(attach.status(), StatusCode::SERVICE_UNAVAILABLE);
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn headless_routes_require_auth_token_when_configured() {
+        let workspace = tempdir().expect("workspace");
+        let mut config = test_config(workspace.path().to_path_buf());
+        config.auth_token = Some("secret-token".to_string());
+        let handle = start_hosted_runner(config)
+            .await
+            .expect("start hosted runner");
+        let client = reqwest::Client::new();
+
+        let unauthorized = client
+            .post(format!("{}/api/headless/connections", handle.base_url()))
+            .json(&json!({"sessionId": "sess_test", "role": "controller"}))
+            .send()
+            .await
+            .expect("unauthorized response");
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let authorized = client
+            .post(format!("{}/api/headless/connections", handle.base_url()))
+            .header("authorization", "Bearer secret-token")
+            .json(&json!({"sessionId": "sess_test", "role": "controller"}))
+            .send()
+            .await
+            .expect("authorized response");
+        assert_eq!(authorized.status(), StatusCode::OK);
         handle.shutdown().await;
     }
 


### PR DESCRIPTION
### Motivation
- The Rust hosted-runner exposed an unauthenticated headless control surface and defaulted to binding `0.0.0.0`, which allowed remote clients to create controller connections and execute arbitrary utility commands on the host. 
- The change aims to remove the insecure default exposure and require explicit authentication for non-loopback deployments to prevent unauthenticated remote command execution.

### Description
- Change the default listen host from `0.0.0.0` to loopback `127.0.0.1` so the runner is not remotely reachable by default. 
- Add optional `auth_token` to `HostedRunnerConfig` and read `MAESTRO_HOSTED_RUNNER_AUTH_TOKEN` from the environment. 
- Enforce that when the resolved bind address is non-loopback, `MAESTRO_HOSTED_RUNNER_AUTH_TOKEN` must be provided, returning a config error otherwise. 
- Require token authentication for sensitive routes (`/.well-known/.../drain` and all `/api/headless/*`) when a token is configured, accepting either `Authorization: Bearer <token>` or `x-maestro-hosted-runner-token`. 
- Add unit/integration tests that assert (1) non-loopback bind without an auth token is rejected and (2) headless routes return `401` when token-protected and accept requests with a valid token. All changes are in `packages/tui-rs/src/hosted_runner.rs`.

### Testing
- Ran `cargo fmt` successfully to format the modified Rust code. 
- Attempted `cargo test hosted_runner -- --nocapture` but test execution was blocked by crates.io index access (network 403) in this environment, so the new tests could not be executed here. 
- Attempted repository lint/test commands `bun run bun:lint` and `npx nx run maestro:test --skip-nx-cache`, but both were blocked by npm registry access (HTTP 403) in this environment and could not be completed. 
- The change includes new tests; they should pass in CI or a developer environment with network access to crates.io and npm registries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9ad880e388326b067448a8bbeadb8)

Internal source PR: evalops/maestro-internal#2433
