### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -414,6 +414,13 @@ pub async fn start_hosted_runner_with_message_executor(
     }
 
     let mut config = config;
+    config.auth_token = normalize_auth_token(config.auth_token.as_deref()).map(str::to_string);
+    if !config.bind_addr.ip().is_loopback() && config.auth_token.is_none() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "maestro hosted-runner requires auth_token when binding to non-loopback interfaces",
+        ));
+    }
     config.workspace_root = workspace_root;
     let restore_manifest = load_restore_manifest(&config).await?;
     let listener = TcpListener::bind(config.bind_addr).await?;
@@ -629,6 +636,9 @@ enum ResponseBody {
 }
 
 async fn route_request(request: HttpRequest, shared: SharedRunner) -> HostedResult<ResponseBody> {
+    if request.path == HOSTED_RUNNER_DRAIN_PATH || request.path.starts_with("/api/headless/") {
+        require_auth_header(&request.headers, shared.config.auth_token.as_deref())?;
+    }
     match (request.method.as_str(), request.path.as_str()) {
         ("GET", HOSTED_RUNNER_IDENTITY_PATH) => json_response(200, shared.identity()),
         ("GET", "/readyz" | "/healthz") => {
@@ -702,6 +712,33 @@ async fn route_request(request: HttpRequest, shared: SharedRunner) -> HostedResu
             "route not found",
         )),
     }
+}
+
+fn require_auth_header(
+    headers: &HashMap<String, String>,
+    expected_token: Option<&str>,
+) -> HostedResult<()> {
+    let Some(expected_token) = normalize_auth_token(expected_token) else {
+        return Ok(());
+    };
+    let bearer_token = headers
+        .get("authorization")
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .and_then(|value| normalize_auth_token(Some(value)));
+    let runner_token = headers
+        .get("x-maestro-hosted-runner-token")
+        .and_then(|value| normalize_auth_token(Some(value)));
+    if bearer_token == Some(expected_token) || runner_token == Some(expected_token) {
+        return Ok(());
+    }
+    Err(HostedError::new(
+        HostedRunnerErrorCode::AccessDenied,
+        "missing or invalid hosted runner auth token",
+    ))
+}
+
+fn normalize_auth_token(token: Option<&str>) -> Option<&str> {
+    token.map(str::trim).filter(|value| !value.is_empty())
 }
 
 async fn handle_drain(shared: SharedRunner, input: DrainRequest) -> HostedResult<ResponseBody> {

--- a/packages/tui-rs/src/hosted_runner/config.rs
+++ b/packages/tui-rs/src/hosted_runner/config.rs
@@ -19,6 +19,7 @@ pub struct HostedRunnerConfig {
     pub agent_run_id: Option<String>,
     pub maestro_session_id: Option<String>,
     pub attach_audience: Option<String>,
+    pub auth_token: Option<String>,
 }
 
 impl HostedRunnerConfig {
@@ -61,6 +62,12 @@ impl HostedRunnerConfig {
                 }
             });
         let bind_addr = resolve_bind_addr(&host, port)?;
+        let auth_token = env_value(env, "MAESTRO_HOSTED_RUNNER_AUTH_TOKEN");
+        if !bind_addr.ip().is_loopback() && auth_token.is_none() {
+            return Err(HostedRunnerConfigError::new(
+                "maestro hosted-runner requires MAESTRO_HOSTED_RUNNER_AUTH_TOKEN when binding to non-loopback interfaces",
+            ));
+        }
         let snapshot_root = resolve_snapshot_root(
             first_env(
                 env,
@@ -104,6 +111,7 @@ impl HostedRunnerConfig {
             agent_run_id: env_value(env, "MAESTRO_AGENT_RUN_ID"),
             maestro_session_id: env_value(env, "MAESTRO_SESSION_ID"),
             attach_audience: env_value(env, "MAESTRO_ATTACH_AUDIENCE"),
+            auth_token,
         })
     }
 
@@ -126,12 +134,19 @@ impl HostedRunnerConfig {
             agent_run_id: None,
             maestro_session_id: None,
             attach_audience: None,
+            auth_token: None,
         })
     }
 
     #[must_use]
     pub fn with_bind_addr(mut self, bind_addr: SocketAddr) -> Self {
         self.bind_addr = bind_addr;
+        self
+    }
+
+    #[must_use]
+    pub fn with_auth_token(mut self, auth_token: impl Into<String>) -> Self {
+        self.auth_token = Some(auth_token.into());
         self
     }
 

--- a/packages/tui-rs/src/hosted_runner/tests.rs
+++ b/packages/tui-rs/src/hosted_runner/tests.rs
@@ -113,6 +113,7 @@ fn test_config(workspace_root: PathBuf) -> HostedRunnerConfig {
         agent_run_id: Some("run_test".to_string()),
         maestro_session_id: Some("sess_test".to_string()),
         attach_audience: None,
+        auth_token: None,
     }
 }
 
@@ -265,6 +266,10 @@ fn preserves_wildcard_bind_for_port_only_hosted_runner_env() {
     ] {
         let mut env = base_hosted_runner_env(workspace.path());
         env.insert(key.to_string(), value.to_string());
+        env.insert(
+            "MAESTRO_HOSTED_RUNNER_AUTH_TOKEN".to_string(),
+            "secret-token".to_string(),
+        );
 
         let config = HostedRunnerConfig::from_env_map(&env).expect("config");
 
@@ -274,6 +279,50 @@ fn preserves_wildcard_bind_for_port_only_hosted_runner_env() {
             "{key} should preserve hosted ingress wildcard binding"
         );
     }
+}
+
+#[test]
+fn rejects_non_loopback_bind_without_auth_token() {
+    let workspace = tempdir().expect("workspace");
+    let mut env = base_hosted_runner_env(workspace.path());
+    env.insert(
+        "MAESTRO_HOSTED_RUNNER_LISTEN".to_string(),
+        "0.0.0.0:9090".to_string(),
+    );
+
+    let error = HostedRunnerConfig::from_env_map(&env).expect_err("expected config error");
+    assert!(error
+        .to_string()
+        .contains("MAESTRO_HOSTED_RUNNER_AUTH_TOKEN"));
+}
+
+#[tokio::test]
+async fn rejects_public_api_non_loopback_bind_without_auth_token() {
+    let workspace = tempdir().expect("workspace");
+    let config = test_config(workspace.path().to_path_buf())
+        .with_bind_addr("0.0.0.0:0".parse().expect("bind addr"));
+
+    let error = match start_hosted_runner(config).await {
+        Ok(_) => panic!("expected auth token error"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert!(error.to_string().contains("auth_token"));
+}
+
+#[tokio::test]
+async fn rejects_public_api_non_loopback_bind_with_blank_auth_token() {
+    let workspace = tempdir().expect("workspace");
+    let config = test_config(workspace.path().to_path_buf())
+        .with_bind_addr("0.0.0.0:0".parse().expect("bind addr"))
+        .with_auth_token("   ");
+
+    let error = match start_hosted_runner(config).await {
+        Ok(_) => panic!("expected auth token error"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert!(error.to_string().contains("auth_token"));
 }
 
 #[test]
@@ -289,6 +338,44 @@ fn explicit_host_env_overrides_port_only_wildcard_bind() {
     let config = HostedRunnerConfig::from_env_map(&env).expect("config");
 
     assert_eq!(config.bind_addr, "127.0.0.1:9090".parse().unwrap());
+}
+
+#[tokio::test]
+async fn headless_routes_require_auth_token_when_configured() {
+    let workspace = tempdir().expect("workspace");
+    let config = test_config(workspace.path().to_path_buf()).with_auth_token("secret-token");
+    let handle = start_hosted_runner(config)
+        .await
+        .expect("start hosted runner");
+    let client = reqwest::Client::new();
+
+    let unauthorized = client
+        .post(format!("{}/api/headless/connections", handle.base_url()))
+        .json(&json!({"sessionId": "sess_test", "role": "controller"}))
+        .send()
+        .await
+        .expect("unauthorized response");
+    assert_eq!(unauthorized.status(), StatusCode::FORBIDDEN);
+
+    let authorized = client
+        .post(format!("{}/api/headless/connections", handle.base_url()))
+        .header("authorization", "Bearer secret-token")
+        .json(&json!({"sessionId": "sess_test", "role": "controller"}))
+        .send()
+        .await
+        .expect("authorized response");
+    assert_eq!(authorized.status(), StatusCode::OK);
+
+    let custom_token_authorized = client
+        .post(format!("{}/api/headless/connections", handle.base_url()))
+        .header("authorization", "Bearer wrong-forwarded-token")
+        .header("x-maestro-hosted-runner-token", "secret-token")
+        .json(&json!({"sessionId": "sess_test", "role": "viewer"}))
+        .send()
+        .await
+        .expect("custom token authorized response");
+    assert_eq!(custom_token_authorized.status(), StatusCode::OK);
+    handle.shutdown().await;
 }
 
 #[test]


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"274b7d3487604ef6482efda8453aff04f940a54a"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `274b7d3487604ef6482efda8453aff04f940a54a`
- last generated public sync base: `eac39c30ba252d9dd7514e017930c5935f7244b2`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `2`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (274b7d348760)`
- public projection: `https://github.com/evalops/maestro@main (e3ab8314ac0a)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update packages/tui-rs/src/hosted_runner/config.rs
- copy/update packages/tui-rs/src/hosted_runner/tests.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update packages/tui-rs/src/hosted_runner/config.rs
- copy/update packages/tui-rs/src/hosted_runner/tests.rs

## Public-only commits since last generated sync

- e3ab8314 chore: sync release mirror for main
- 6a1dcad6 chore: sync release mirror for main

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@274b7d3487604ef6482efda8453aff04f940a54a`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.