### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/agent/swarm/executor.ts
+++ b/src/agent/swarm/executor.ts
@@ -26,6 +26,7 @@ import {
 	cancelA2ATask,
 	getA2ATask,
 	normalizeA2ABaseUrl,
+	resolveA2AServiceConfig,
 	sendA2AMessage,
 } from "../../platform/a2a-client.js";
 import { a2aDelegationLaneId } from "../../platform/a2a-completion-audit.js";
@@ -79,6 +80,12 @@ const DEFAULT_TASK_TIMEOUT_MS = 5 * 60 * 1000;
 /** Maximum concurrent teammates */
 const MAX_TEAMMATES = 10;
 const DEFAULT_A2A_POLL_INTERVAL_MS = 2_000;
+const DEDICATED_A2A_TOKEN_ENV_VARS = [
+	"MAESTRO_PLATFORM_A2A_TOKEN",
+	"MAESTRO_A2A_TOKEN",
+	"MAESTRO_AGENT_RUNTIME_SERVICE_TOKEN",
+	"AGENT_RUNTIME_SERVICE_TOKEN",
+] as const;
 const A2A_SKILL_PRIMARY_TASK_CLASSES = new Map<string, string>([
 	["maestro.subagent.code-writer", "code.implementation"],
 	["maestro.subagent.code-review", "code.review"],
@@ -1082,21 +1089,34 @@ export class SwarmExecutor {
 				"Platform Agent Registry service is not configured for A2A swarm discovery",
 			);
 		}
-		return {
+		const candidateAgentId = trimString(candidate.agent.id);
+		const registryTokenFallback = getEnvValue(DEDICATED_A2A_TOKEN_ENV_VARS)
+			? undefined
+			: platformConfig.token;
+		const serviceConfig = await resolveA2AServiceConfig({
 			baseUrl: normalizeA2ABaseUrl(candidate.endpointUrl),
-			...(platformConfig.token ? { token: platformConfig.token } : {}),
-			...(platformConfig.organizationId
-				? { organizationId: platformConfig.organizationId }
-				: {}),
+			token: registryTokenFallback,
+			organizationId: platformConfig.organizationId,
 			workspaceId:
 				candidate.agent.workspaceId ??
 				options.workspaceId ??
 				platformConfig.workspaceId,
-			...(candidate.agent.id ? { agentId: candidate.agent.id } : {}),
+			...(candidateAgentId ? { agentId: candidateAgentId } : {}),
 			actorId: "maestro-swarm",
 			timeoutMs: options.timeoutMs ?? platformConfig.timeoutMs,
 			maxAttempts: options.maxAttempts ?? platformConfig.maxAttempts,
-		};
+		});
+		if (!serviceConfig) {
+			throw new Error(
+				"Platform A2A peer discovery requires a workspace id for the selected peer",
+			);
+		}
+		if (!candidateAgentId) {
+			const { agentId: _defaultAgentId, ...anonymousServiceConfig } =
+				serviceConfig;
+			return anonymousServiceConfig;
+		}
+		return serviceConfig;
 	}
 
 	private selectA2APeerName(

--- a/src/platform/a2a-peer-registry.ts
+++ b/src/platform/a2a-peer-registry.ts
@@ -142,11 +142,30 @@ export async function upsertA2APeerFromPairingPayload(
 	const name = normalizePeerName(options.name ?? connection.peerId);
 	const now = (options.now ?? new Date()).toISOString();
 	const previous = registry.peers[name];
+	const nextBaseUrl = normalizedPeerUrl(connection.baseUrl);
 	const {
 		tokenEnv: previousTokenEnv,
 		tokenFile: previousTokenFile,
+		keyFingerprint: _previousKeyFingerprint,
 		...previousFields
 	} = previous ?? {};
+	const identityChanged = Boolean(
+		previous &&
+			(normalizedPeerUrl(previous.url) !== nextBaseUrl ||
+				identityFieldChanged(previous.agentCardUrl, connection.agentCardUrl) ||
+				identityFieldChanged(
+					previous.protocolBinding,
+					connection.protocolBinding,
+				) ||
+				identityFieldChanged(
+					previous.protocolVersion,
+					connection.protocolVersion,
+				) ||
+				identityOptionalFieldChanged(
+					previous.keyFingerprint,
+					connection.keyFingerprint,
+				)),
+	);
 	const entry: A2APeerRegistryEntry = {
 		...previousFields,
 		url: connection.baseUrl,
@@ -159,6 +178,7 @@ export async function upsertA2APeerFromPairingPayload(
 			previousTokenFile,
 			tokenEnv: options.tokenEnv,
 			tokenFile: options.tokenFile,
+			retainExisting: !identityChanged,
 		}),
 		...(options.organizationId
 			? { organizationId: options.organizationId }
@@ -263,6 +283,7 @@ function resolveUpsertTokenFields(input: {
 	previousTokenFile?: string;
 	tokenEnv?: string;
 	tokenFile?: string;
+	retainExisting?: boolean;
 }): Pick<A2APeerRegistryEntry, "tokenEnv" | "tokenFile"> {
 	const tokenEnv = trimString(input.tokenEnv);
 	const tokenFile = trimString(input.tokenFile);
@@ -275,10 +296,36 @@ function resolveUpsertTokenFields(input: {
 	if (tokenFile) {
 		return { tokenFile: expandHome(tokenFile) };
 	}
+	if (!input.retainExisting) {
+		return {};
+	}
 	return {
 		...(input.previousTokenEnv ? { tokenEnv: input.previousTokenEnv } : {}),
 		...(input.previousTokenFile ? { tokenFile: input.previousTokenFile } : {}),
 	};
+}
+
+function normalizedPeerUrl(url: string): string | undefined {
+	const peerUrl = trimString(url);
+	return peerUrl ? normalizeA2ABaseUrl(peerUrl) : undefined;
+}
+
+function identityFieldChanged(
+	previousValue: string | undefined,
+	nextValue: string | undefined,
+): boolean {
+	const previous = trimString(previousValue);
+	const next = trimString(nextValue);
+	return Boolean(previous && next && previous !== next);
+}
+
+function identityOptionalFieldChanged(
+	previousValue: string | undefined,
+	nextValue: string | undefined,
+): boolean {
+	const previous = trimString(previousValue);
+	const next = trimString(nextValue);
+	return previous !== next;
 }
 
 function normalizeRegistryEntry(

--- a/test/agent/swarm-executor.test.ts
+++ b/test/agent/swarm-executor.test.ts
@@ -705,6 +705,7 @@ describe("SwarmExecutor", () => {
 				],
 			},
 		]);
+		vi.stubEnv("MAESTRO_A2A_TOKEN", "a2a-peer-token");
 		const executor = new SwarmExecutor({
 			...createConfig({ subagentType: "review" }),
 			transport: "a2a",
@@ -752,7 +753,7 @@ describe("SwarmExecutor", () => {
 		expect(serviceConfig).toEqual(
 			expect.objectContaining({
 				baseUrl: "https://target.internal/a2a",
-				token: "platform-token",
+				token: "a2a-peer-token",
 				organizationId: "org_evalops",
 				workspaceId: "workspace-1",
 				agentId: "agent-target",
@@ -769,6 +770,107 @@ describe("SwarmExecutor", () => {
 			expect.objectContaining({
 				source: "platform-agent-registry",
 				peer: "Target Maestro",
+			}),
+		);
+	});
+
+	it("falls back to the registry service token for discovered A2A peers", async () => {
+		listA2APeerCandidatesWithPlatformMock.mockResolvedValue([
+			{
+				agent: {
+					id: "agent-auth-required",
+					name: "Auth Required Maestro",
+					workspaceId: "workspace-1",
+					status: "AGENT_STATUS_IDLE",
+					lastHeartbeatAt: new Date().toISOString(),
+				},
+				endpointUrl: "https://auth-required.internal/a2a",
+				endpointKind: "internal",
+				pushNotifications: true,
+				skills: [
+					{
+						id: "maestro.subagent.code-review",
+						name: "Code Review",
+						allowedTaskClasses: ["code.review"],
+					},
+				],
+			},
+		]);
+		const executor = new SwarmExecutor({
+			...createConfig({ subagentType: "review" }),
+			transport: "a2a",
+			a2a: {
+				discover: true,
+				skillId: "maestro.subagent.code-review",
+				workspaceId: "workspace-1",
+				capability: "code-review",
+				preferInternalEndpoint: true,
+				maxWaitMs: 50,
+				pollIntervalMs: 1,
+			},
+			mode: "smart",
+			modelProvider: "anthropic",
+		});
+
+		const result = await executeWithTimeout(executor);
+
+		expect(result.status).toBe("completed");
+		expect(sendA2AMessageMock.mock.calls[0]?.[0]).toEqual(
+			expect.objectContaining({
+				baseUrl: "https://auth-required.internal/a2a",
+				token: "platform-token",
+				agentId: "agent-auth-required",
+			}),
+		);
+	});
+
+	it("uses Agent Runtime A2A token aliases before registry fallback", async () => {
+		listA2APeerCandidatesWithPlatformMock.mockResolvedValue([
+			{
+				agent: {
+					id: "agent-runtime-token",
+					name: "Runtime Token Maestro",
+					workspaceId: "workspace-1",
+					status: "AGENT_STATUS_IDLE",
+					lastHeartbeatAt: new Date().toISOString(),
+				},
+				endpointUrl: "https://runtime-token.internal/a2a",
+				endpointKind: "internal",
+				pushNotifications: true,
+				skills: [
+					{
+						id: "maestro.subagent.code-review",
+						name: "Code Review",
+						allowedTaskClasses: ["code.review"],
+					},
+				],
+			},
+		]);
+		vi.stubEnv("MAESTRO_AGENT_RUNTIME_SERVICE_TOKEN", "runtime-a2a-token");
+		const executor = new SwarmExecutor({
+			...createConfig({ subagentType: "review" }),
+			transport: "a2a",
+			a2a: {
+				discover: true,
+				skillId: "maestro.subagent.code-review",
+				workspaceId: "workspace-1",
+				capability: "code-review",
+				preferInternalEndpoint: true,
+				maxWaitMs: 50,
+				pollIntervalMs: 1,
+			},
+			mode: "smart",
+			modelProvider: "anthropic",
+		});
+
+		const result = await executeWithTimeout(executor);
+
+		expect(result.status).toBe("completed");
+		expect(sendA2AMessageMock.mock.calls[0]?.[0]).toEqual(
+			expect.objectContaining({
+				baseUrl: "https://runtime-token.internal/a2a",
+				token: "runtime-a2a-token",
+				agentId: "agent-runtime-token",
 			}),
 		);
 	});
@@ -817,13 +919,14 @@ describe("SwarmExecutor", () => {
 			.digest("hex")}`;
 		const expectedPeer = `endpoint:${expectedHash}`;
 		const expectedLaneId = a2aDelegationLaneId(expectedPeer, "task-1");
-		const [, input] = sendA2AMessageMock.mock.calls[0] as [
-			unknown,
+		const [serviceConfig, input] = sendA2AMessageMock.mock.calls[0] as [
+			Record<string, unknown>,
 			{
 				message: { metadata?: Record<string, unknown> };
 				metadata?: Record<string, unknown>;
 			},
 		];
+		expect(serviceConfig).not.toHaveProperty("agentId");
 		expect(input.message.metadata).toEqual(
 			expect.objectContaining({
 				relayPeer: expectedPeer,

--- a/test/platform/a2a-peer-registry.test.ts
+++ b/test/platform/a2a-peer-registry.test.ts
@@ -181,6 +181,341 @@ describe("A2A peer registry", () => {
 		).resolves.toBe("file-token");
 	});
 
+	it("clears existing auth sources when re-pairing changes peer identity", async () => {
+		const path = await registryPath();
+		await writeFile(
+			path,
+			JSON.stringify({
+				defaultPeer: "victim-peer",
+				peers: {
+					"victim-peer": {
+						url: "https://trusted.example",
+						tokenEnv: "OLD_A2A_TOKEN",
+					},
+				},
+			}),
+		);
+
+		const payload = createA2APeerPairingPayload({
+			displayName: "Attacker Relay",
+			agentCardUrl: "https://attacker.example/.well-known/agent-card.json",
+			transportUrl: "https://attacker.example",
+			peerId: "victim-peer",
+			now: NOW,
+		});
+
+		await upsertA2APeerFromPairingPayload(payload, { path });
+
+		await expect(loadA2APeerRegistry({ path })).resolves.toMatchObject({
+			peers: {
+				"victim-peer": {
+					url: "https://attacker.example",
+				},
+			},
+		});
+		const raw = await readFile(path, "utf8");
+		expect(raw).not.toContain("OLD_A2A_TOKEN");
+	});
+
+	it("retains auth sources when re-pairing adds metadata for the same minimal peer", async () => {
+		const path = await registryPath();
+		await writeFile(
+			path,
+			JSON.stringify({
+				defaultPeer: "stable-peer",
+				peers: {
+					"stable-peer": {
+						url: "https://stable.example",
+						tokenEnv: "STABLE_A2A_TOKEN",
+					},
+				},
+			}),
+		);
+
+		const payload = createA2APeerPairingPayload({
+			displayName: "Stable Relay",
+			agentCardUrl: "https://stable.example/.well-known/agent-card.json",
+			transportUrl: "https://stable.example",
+			peerId: "stable-peer",
+			now: NOW,
+		});
+
+		await upsertA2APeerFromPairingPayload(payload, { path });
+
+		await expect(loadA2APeerRegistry({ path })).resolves.toMatchObject({
+			peers: {
+				"stable-peer": {
+					url: "https://stable.example",
+					tokenEnv: "STABLE_A2A_TOKEN",
+					displayName: "Stable Relay",
+				},
+			},
+		});
+	});
+
+	it("retains auth sources when re-pairing only renames a peer", async () => {
+		const path = await registryPath();
+		await writeFile(
+			path,
+			JSON.stringify({
+				defaultPeer: "renamed-peer",
+				peers: {
+					"renamed-peer": {
+						url: "https://stable.example/a2a",
+						displayName: "Old Relay",
+						tokenEnv: "STABLE_A2A_TOKEN",
+						keyFingerprint: "sha256:stable-key",
+					},
+				},
+			}),
+		);
+
+		const payload = createA2APeerPairingPayload({
+			displayName: "Renamed Relay",
+			agentCardUrl: "https://stable.example/a2a/.well-known/agent-card.json",
+			transportUrl: "https://stable.example/a2a",
+			peerId: "renamed-peer",
+			keyFingerprint: "sha256:stable-key",
+			now: NOW,
+		});
+
+		await upsertA2APeerFromPairingPayload(payload, { path });
+
+		await expect(loadA2APeerRegistry({ path })).resolves.toMatchObject({
+			peers: {
+				"renamed-peer": {
+					url: "https://stable.example/a2a",
+					displayName: "Renamed Relay",
+					tokenEnv: "STABLE_A2A_TOKEN",
+					keyFingerprint: "sha256:stable-key",
+				},
+			},
+		});
+	});
+
+	it("retains auth sources when re-pairing a peer stored with a trailing slash URL", async () => {
+		const path = await registryPath();
+		await writeFile(
+			path,
+			JSON.stringify({
+				defaultPeer: "slash-peer",
+				peers: {
+					"slash-peer": {
+						url: "https://stable.example/",
+						tokenEnv: "STABLE_A2A_TOKEN",
+					},
+				},
+			}),
+		);
+
+		const payload = createA2APeerPairingPayload({
+			displayName: "Stable Relay",
+			agentCardUrl: "https://stable.example/.well-known/agent-card.json",
+			transportUrl: "https://stable.example",
+			peerId: "slash-peer",
+			now: NOW,
+		});
+
+		await upsertA2APeerFromPairingPayload(payload, { path });
+
+		await expect(loadA2APeerRegistry({ path })).resolves.toMatchObject({
+			peers: {
+				"slash-peer": {
+					url: "https://stable.example",
+					tokenEnv: "STABLE_A2A_TOKEN",
+					displayName: "Stable Relay",
+				},
+			},
+		});
+	});
+
+	it("retains auth sources when re-pairing a peer stored with a message send URL", async () => {
+		const path = await registryPath();
+		await writeFile(
+			path,
+			JSON.stringify({
+				defaultPeer: "send-peer",
+				peers: {
+					"send-peer": {
+						url: "https://stable.example/a2a/message:send",
+						tokenFile: "~/stable-a2a-token",
+					},
+				},
+			}),
+		);
+
+		const payload = createA2APeerPairingPayload({
+			displayName: "Stable Relay",
+			agentCardUrl: "https://stable.example/a2a/.well-known/agent-card.json",
+			transportUrl: "https://stable.example/a2a",
+			peerId: "send-peer",
+			now: NOW,
+		});
+
+		await upsertA2APeerFromPairingPayload(payload, { path });
+
+		await expect(loadA2APeerRegistry({ path })).resolves.toMatchObject({
+			peers: {
+				"send-peer": {
+					url: "https://stable.example/a2a",
+					tokenFile: "~/stable-a2a-token",
+					displayName: "Stable Relay",
+				},
+			},
+		});
+	});
+
+	it("retains auth sources when re-pairing a canonical peer with a message send URL", async () => {
+		const path = await registryPath();
+		await writeFile(
+			path,
+			JSON.stringify({
+				defaultPeer: "send-peer",
+				peers: {
+					"send-peer": {
+						url: "https://stable.example/a2a",
+						tokenEnv: "STABLE_A2A_TOKEN",
+					},
+				},
+			}),
+		);
+
+		const payload = createA2APeerPairingPayload({
+			displayName: "Stable Relay",
+			agentCardUrl: "https://stable.example/a2a/.well-known/agent-card.json",
+			transportUrl: "https://stable.example/a2a/message:send",
+			peerId: "send-peer",
+			now: NOW,
+		});
+
+		await upsertA2APeerFromPairingPayload(payload, { path });
+
+		await expect(loadA2APeerRegistry({ path })).resolves.toMatchObject({
+			peers: {
+				"send-peer": {
+					url: "https://stable.example/a2a/message:send",
+					tokenEnv: "STABLE_A2A_TOKEN",
+					displayName: "Stable Relay",
+				},
+			},
+		});
+	});
+
+	it("clears existing auth sources when a peer key fingerprint changes", async () => {
+		const path = await registryPath();
+		await writeFile(
+			path,
+			JSON.stringify({
+				defaultPeer: "signed-peer",
+				peers: {
+					"signed-peer": {
+						url: "https://signed.example",
+						tokenEnv: "SIGNED_A2A_TOKEN",
+						keyFingerprint: "sha256:old-key",
+					},
+				},
+			}),
+		);
+
+		const payload = createA2APeerPairingPayload({
+			displayName: "Signed Relay",
+			agentCardUrl: "https://signed.example/.well-known/agent-card.json",
+			transportUrl: "https://signed.example",
+			peerId: "signed-peer",
+			keyFingerprint: "sha256:new-key",
+			now: NOW,
+		});
+
+		await upsertA2APeerFromPairingPayload(payload, { path });
+
+		await expect(loadA2APeerRegistry({ path })).resolves.toMatchObject({
+			peers: {
+				"signed-peer": {
+					url: "https://signed.example",
+					keyFingerprint: "sha256:new-key",
+				},
+			},
+		});
+		const raw = await readFile(path, "utf8");
+		expect(raw).not.toContain("SIGNED_A2A_TOKEN");
+	});
+
+	it("clears existing auth sources when a peer key fingerprint is removed", async () => {
+		const path = await registryPath();
+		await writeFile(
+			path,
+			JSON.stringify({
+				defaultPeer: "unsigned-peer",
+				peers: {
+					"unsigned-peer": {
+						url: "https://unsigned.example",
+						tokenEnv: "SIGNED_A2A_TOKEN",
+						keyFingerprint: "sha256:old-key",
+					},
+				},
+			}),
+		);
+
+		const payload = createA2APeerPairingPayload({
+			displayName: "Unsigned Relay",
+			agentCardUrl: "https://unsigned.example/.well-known/agent-card.json",
+			transportUrl: "https://unsigned.example",
+			peerId: "unsigned-peer",
+			now: NOW,
+		});
+
+		await upsertA2APeerFromPairingPayload(payload, { path });
+
+		await expect(loadA2APeerRegistry({ path })).resolves.toMatchObject({
+			peers: {
+				"unsigned-peer": {
+					url: "https://unsigned.example",
+				},
+			},
+		});
+		const raw = await readFile(path, "utf8");
+		expect(raw).not.toContain("SIGNED_A2A_TOKEN");
+		expect(raw).not.toContain("sha256:old-key");
+	});
+
+	it("retains auth sources when a peer key fingerprint is unchanged", async () => {
+		const path = await registryPath();
+		await writeFile(
+			path,
+			JSON.stringify({
+				defaultPeer: "stable-signed-peer",
+				peers: {
+					"stable-signed-peer": {
+						url: "https://stable-signed.example",
+						tokenEnv: "STABLE_SIGNED_A2A_TOKEN",
+						keyFingerprint: "sha256:stable-key",
+					},
+				},
+			}),
+		);
+
+		const payload = createA2APeerPairingPayload({
+			displayName: "Stable Signed Relay",
+			agentCardUrl: "https://stable-signed.example/.well-known/agent-card.json",
+			transportUrl: "https://stable-signed.example",
+			peerId: "stable-signed-peer",
+			keyFingerprint: "sha256:stable-key",
+			now: NOW,
+		});
+
+		await upsertA2APeerFromPairingPayload(payload, { path });
+
+		await expect(loadA2APeerRegistry({ path })).resolves.toMatchObject({
+			peers: {
+				"stable-signed-peer": {
+					url: "https://stable-signed.example",
+					tokenEnv: "STABLE_SIGNED_A2A_TOKEN",
+					keyFingerprint: "sha256:stable-key",
+				},
+			},
+		});
+	});
+
 	it("clears stale alternate auth fields when re-accepting an existing peer", async () => {
 		const path = await registryPath();
 		await writeFile(


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"772795910f873f643a9c7c6b3061deeb10d95ff9"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `772795910f873f643a9c7c6b3061deeb10d95ff9`
- last generated public sync base: `f9de144a4f987a976902a41f71a54e85c5fc126d`
- previewed public-tree drift: `4` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (772795910f87)`
- public projection: `https://github.com/evalops/maestro@main (f9de144a4f98)`
- files to copy or update: `4`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/agent/swarm/executor.ts
- copy/update src/platform/a2a-peer-registry.ts
- copy/update test/agent/swarm-executor.test.ts
- copy/update test/platform/a2a-peer-registry.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/agent/swarm/executor.ts
- copy/update src/platform/a2a-peer-registry.ts
- copy/update test/agent/swarm-executor.test.ts
- copy/update test/platform/a2a-peer-registry.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@772795910f873f643a9c7c6b3061deeb10d95ff9`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.