### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/docs/cookbook/skills/README.md
+++ b/docs/cookbook/skills/README.md
@@ -65,10 +65,10 @@ itself when `MAESTRO_TOOLBOX_ACTION=describe` is set:
 MAESTRO_TOOLBOX_ACTION=describe .maestro/skills/reviewing-prs/toolbox/list-pr-files
 ```
 
-Run strict validation with:
+Validate packages with:
 
 ```bash
-maestro skill lint .maestro/skills/reviewing-prs --describe-toolbox
+maestro skill lint .maestro/skills/reviewing-prs
 ```
 
 If a toolbox helper is shell-specific, include a same-stem Windows companion such

--- a/src/cli/commands/skill.ts
+++ b/src/cli/commands/skill.ts
@@ -56,7 +56,7 @@ Options:
   --dir <path>                 Base directory for 'new' (default: .maestro/skills)
   --description <text>         Description for 'new'
   --force                      Allow 'new' to overwrite an existing directory
-  --describe-toolbox           Run Toolbox describe checks during lint
+  --describe-toolbox           Eval/publish-check run describe; lint ignores it
   --help, -h                   Show this help`;
 }
 
@@ -284,7 +284,7 @@ async function handleLint(
 ) {
 	const lintPaths = paths.length > 0 ? paths : defaultLintPaths(workspaceDir);
 	const results = await lintSkillPaths(lintPaths, {
-		describeToolbox: options.describeToolbox,
+		describeToolbox: false,
 	});
 	if (options.json) {
 		console.log(JSON.stringify({ results }, null, 2));

--- a/test/skill-package-format.test.ts
+++ b/test/skill-package-format.test.ts
@@ -89,6 +89,41 @@ async function writeOssSkillPackageAt(packageDir: string): Promise<string> {
 	return packageDir;
 }
 
+async function writeDescribeFailingSkillPackageAt(packageDir: string): Promise<{
+	packageDir: string;
+	skillDir: string;
+}> {
+	const skillDir = join(packageDir, "skills", "strict-toolbox");
+	const toolboxDir = join(skillDir, "toolbox");
+	await mkdir(toolboxDir, { recursive: true });
+	writeFileSync(
+		join(packageDir, "package.json"),
+		JSON.stringify(
+			{
+				name: "@test/maestro-strict-toolbox",
+				version: "1.0.0",
+				keywords: ["maestro-package", "maestro-skill-package"],
+				maestro: {
+					skills: ["./skills"],
+				},
+			},
+			null,
+			2,
+		),
+	);
+	writeFileSync(
+		join(skillDir, "SKILL.md"),
+		`---\nname: strict-toolbox\ndescription: "Validate toolbox describe behavior. Use when testing strict package checks."\n---\n\n# Strict Toolbox\n`,
+	);
+	const toolboxPath = join(toolboxDir, "describe-fail");
+	writeFileSync(
+		toolboxPath,
+		'#!/usr/bin/env bash\nif [ "${MAESTRO_TOOLBOX_ACTION:-}" = "describe" ]; then\n  echo describe failed >&2\n  exit 42\nfi\necho ok\n',
+	);
+	chmodSync(toolboxPath, 0o755);
+	return { packageDir, skillDir };
+}
+
 async function captureSkillCommand(
 	subcommand: string,
 	args: string[],
@@ -818,6 +853,57 @@ describe("skill package format", () => {
 		);
 	});
 
+	it("does not execute toolbox describe checks from the plain lint compatibility flag", async () => {
+		const workspace = tempRoot();
+		const { skillDir } = await writeDescribeFailingSkillPackageAt(
+			join(workspace, "vendor", "strict-toolbox"),
+		);
+
+		const { logs, errors } = await captureSkillCommand(
+			"lint",
+			["--describe-toolbox", "--json", skillDir],
+			workspace,
+		);
+
+		const payload = JSON.parse(logs.join("\n")) as {
+			results: Array<{ issues: Array<{ code: string }> }>;
+		};
+		expect(errors).toEqual([]);
+		expect(payload.results[0]?.issues).not.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ code: "toolbox_describe_failed" }),
+			]),
+		);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("preserves strict toolbox describe validation for eval and publish-check", async () => {
+		const workspace = tempRoot();
+		const { packageDir, skillDir } = await writeDescribeFailingSkillPackageAt(
+			join(workspace, "vendor", "strict-toolbox"),
+		);
+
+		const report = await evaluateSkillPackages([{ path: skillDir }], {
+			describeToolbox: true,
+		});
+		expect(report.summary).toMatchObject({ total: 1, passed: 0, failed: 1 });
+		expect(report.results[0]?.issues).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ code: "toolbox_describe_failed" }),
+			]),
+		);
+
+		const contract = await buildSkillPackagePublishContract(packageDir, {
+			cwd: workspace,
+			describeToolbox: true,
+		});
+		expect(contract.issues).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ code: "skill_package_eval_failed" }),
+			]),
+		);
+	});
+
 	it("scaffolds a package that passes lint", async () => {
 		const root = tempRoot();
 		const scaffold = scaffoldSkill(root, "processing-incidents", {
@@ -914,6 +1000,21 @@ describe("skill package format", () => {
 		expect(parsed.command).toBe("skill");
 		expect(parsed.subcommand).toBe("lint");
 		expect(parsed.commandArgs).toEqual(["--json", ".maestro/skills"]);
+	});
+
+	it("documents describe-toolbox as strict outside lint", async () => {
+		const workspace = tempRoot();
+
+		const { logs, errors } = await captureSkillCommand(
+			"eval",
+			["--help"],
+			workspace,
+		);
+
+		expect(errors).toEqual([]);
+		expect(logs.join("\n")).toContain(
+			"--describe-toolbox           Eval/publish-check run describe; lint ignores it",
+		);
 	});
 
 	it("supports the skill CLI scaffold command", async () => {


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"ff86020606fb7a19cb068f902185cd4f657b8e54"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `ff86020606fb7a19cb068f902185cd4f657b8e54`
- last generated public sync base: `abe30b9c3f80b15c01f75ecc1dc6048f4b691e85`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (ff86020606fb)`
- public projection: `https://github.com/evalops/maestro@main (abe30b9c3f80)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update docs/cookbook/skills/README.md
- copy/update src/cli/commands/skill.ts
- copy/update test/skill-package-format.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update docs/cookbook/skills/README.md
- copy/update src/cli/commands/skill.ts
- copy/update test/skill-package-format.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@ff86020606fb7a19cb068f902185cd4f657b8e54`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.