### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/tui-rs/src/hosted_runner.rs
+++ b/packages/tui-rs/src/hosted_runner.rs
@@ -366,10 +366,6 @@ fn hosted_runner_error_from_async_transport(error: AsyncTransportError) -> Hoste
     HostedRunnerError::runtime_not_ready(format!("agent supervisor is not ready: {error}"))
 }
 
-fn json_value<T: Serialize>(value: &T) -> serde_json::Value {
-    serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
-}
-
 fn json_string_value<T: Serialize>(value: &T) -> String {
     serde_json::to_value(value)
         .ok()

--- a/packages/tui-rs/src/hosted_runner/shared.rs
+++ b/packages/tui-rs/src/hosted_runner/shared.rs
@@ -239,49 +239,14 @@ impl SharedRunner {
                     .or_else(|| restored_state.and_then(|state| state.cwd.clone()))
                     .or_else(|| Some(self.config.workspace_root.to_string_lossy().to_string())),
                 git_branch,
-                current_response: agent_state
-                    .and_then(|state| state.current_response.as_ref())
-                    .map(json_value)
-                    .or_else(|| restored_state.and_then(|state| state.current_response.clone())),
-                pending_approvals: agent_state
-                    .map(|state| state.pending_approvals.iter().map(json_value).collect())
-                    .or_else(|| restored_state.map(|state| state.pending_approvals.clone()))
-                    .unwrap_or_default(),
-                pending_client_tools: agent_state
-                    .map(|state| state.pending_client_tools.iter().map(json_value).collect())
-                    .or_else(|| restored_state.map(|state| state.pending_client_tools.clone()))
-                    .unwrap_or_default(),
-                pending_mcp_elicitations: restored_state
-                    .map(|state| state.pending_mcp_elicitations.clone())
-                    .unwrap_or_default(),
-                pending_user_inputs: agent_state
-                    .map(|state| state.pending_user_inputs.iter().map(json_value).collect())
-                    .or_else(|| restored_state.map(|state| state.pending_user_inputs.clone()))
-                    .unwrap_or_default(),
-                pending_tool_retries: agent_state
-                    .map(|state| state.pending_tool_retries.iter().map(json_value).collect())
-                    .or_else(|| restored_state.map(|state| state.pending_tool_retries.clone()))
-                    .unwrap_or_default(),
-                tracked_tools: agent_state
-                    .map(|state| state.tracked_tools.values().map(json_value).collect())
-                    .or_else(|| restored_state.map(|state| state.tracked_tools.clone()))
-                    .unwrap_or_default(),
-                active_tools: agent_state
-                    .map(|state| {
-                        state
-                            .active_tools
-                            .values()
-                            .map(|tool| {
-                                json!({
-                                    "call_id": tool.call_id,
-                                    "tool": tool.tool,
-                                    "output": tool.output,
-                                })
-                            })
-                            .collect()
-                    })
-                    .or_else(|| restored_state.map(|state| state.active_tools.clone()))
-                    .unwrap_or_default(),
+                current_response: None,
+                pending_approvals: Vec::new(),
+                pending_client_tools: Vec::new(),
+                pending_mcp_elicitations: Vec::new(),
+                pending_user_inputs: Vec::new(),
+                pending_tool_retries: Vec::new(),
+                tracked_tools: Vec::new(),
+                active_tools: Vec::new(),
                 codex_subagent_edges: agent_state
                     .map(|state| state.codex_subagent_edges.clone())
                     .or_else(|| restored_state.map(|state| state.codex_subagent_edges.clone()))

--- a/packages/tui-rs/src/hosted_runner/tests.rs
+++ b/packages/tui-rs/src/hosted_runner/tests.rs
@@ -1789,7 +1789,7 @@ async fn message_executor_publishes_runtime_handled_events() {
 }
 
 #[tokio::test]
-async fn state_snapshot_merges_supervisor_agent_state_with_hosted_connections() {
+async fn state_snapshot_redacts_sensitive_supervisor_state() {
     let workspace = tempdir().expect("workspace");
     let mut current_response = crate::headless::StreamingResponse::new("resp-state-1".to_string());
     current_response.append("working on hosted state", false);
@@ -1873,11 +1873,14 @@ async fn state_snapshot_merges_supervisor_agent_state_with_hosted_connections() 
     assert_eq!(state["state"]["session_id"], "supervisor-session-1");
     assert_eq!(state["state"]["cwd"], "/runtime/workspace");
     assert_eq!(state["state"]["git_branch"], "feature/runtime-state");
-    assert_eq!(
-        state["state"]["current_response"]["response_id"],
-        "resp-state-1"
-    );
-    assert_eq!(state["state"]["pending_approvals"][0]["call_id"], "call-1");
+    assert!(state["state"]["current_response"].is_null());
+    assert_eq!(state["state"]["pending_approvals"], json!([]));
+    assert_eq!(state["state"]["pending_client_tools"], json!([]));
+    assert_eq!(state["state"]["pending_mcp_elicitations"], json!([]));
+    assert_eq!(state["state"]["pending_user_inputs"], json!([]));
+    assert_eq!(state["state"]["pending_tool_retries"], json!([]));
+    assert_eq!(state["state"]["tracked_tools"], json!([]));
+    assert_eq!(state["state"]["active_tools"], json!([]));
     assert_eq!(state["state"]["last_status"], "thinking");
     assert_eq!(state["state"]["is_ready"], true);
     assert_eq!(state["state"]["is_responding"], true);


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"a68f7fad170aa317cdef9ddd1335a67ff99ef939"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `a68f7fad170aa317cdef9ddd1335a67ff99ef939`
- last generated public sync base: `81d477cf60ed2b206e0e03e64da3c109429c7674`
- previewed public-tree drift: `3` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (a68f7fad170a)`
- public projection: `https://github.com/evalops/maestro@main (81d477cf60ed)`
- files to copy or update: `3`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update packages/tui-rs/src/hosted_runner/shared.rs
- copy/update packages/tui-rs/src/hosted_runner/tests.rs

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/tui-rs/src/hosted_runner.rs
- copy/update packages/tui-rs/src/hosted_runner/shared.rs
- copy/update packages/tui-rs/src/hosted_runner/tests.rs

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@a68f7fad170aa317cdef9ddd1335a67ff99ef939`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.