### PR TITLE
Fix public workflow footgun guardrail inputs

### DIFF
--- a/.github/workflows/evalopsbot-review-request.yml
+++ b/.github/workflows/evalopsbot-review-request.yml
@@ -20,16 +20,20 @@ jobs:
       REQUESTED_REVIEWER: ${{ github.event.requested_reviewer.login }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - name: Require dispatch token
+      - name: Resolve dispatch token
+        id: dispatch-token
         shell: bash
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN}" ]; then
-            echo "::error::Set EVALOPS_PR_LENS_TOKEN for immediate EvalOpsBot review dispatch."
-            exit 2
+            echo "::warning::EVALOPS_PR_LENS_TOKEN is not configured; skipping immediate EvalOpsBot review dispatch."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch deep review
+        if: ${{ steps.dispatch-token.outputs.configured == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -54,6 +58,7 @@ jobs:
           gh api --method POST repos/evalops/.github/dispatches --input - <<<"${dispatch_payload}"
 
       - name: Mark deep review queued
+        if: ${{ steps.dispatch-token.outputs.configured == 'true' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/public-release-mirror.yml
+++ b/.github/workflows/public-release-mirror.yml
@@ -86,6 +86,8 @@ jobs:
           private-key: ${{ secrets.PUBLIC_MIRROR_APP_PRIVATE_KEY }}
           owner: ${{ env.PUBLIC_REPO_OWNER }}
           repositories: ${{ env.PUBLIC_REPO_NAME }}
+          permission-contents: write
+          permission-workflows: write
 
       - name: Build production artifacts from internal source
         run: |


### PR DESCRIPTION
## Summary
- make EvalOpsBot requested-review dispatch skip gracefully when `EVALOPS_PR_LENS_TOKEN` is unavailable
- request both `contents: write` and `workflows: write` on the public release mirror app token

## Context
This is the public-owned workflow companion for the generated mirror PR #759. The generated branch brings in `check:workflow-footguns`, but public-owned workflows are excluded from the internal mirror, so they need a public-side base fix before #759 can pass the new guardrail.

## Proof
- `node /Users/jonathanhaas/Documents/Projects/maestro-exec-entrypoint-runtime-slice-20260601/scripts/check-workflow-footguns.mjs` from this public checkout
- `actionlint -shellcheck= -pyflakes= .github/workflows/evalopsbot-review-request.yml .github/workflows/public-release-mirror.yml`

Unblocks #759 and issue #461.
