### PR TITLE
Run public workflow footgun smoke on infra PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,18 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || (needs.changes.outputs.ci_infrastructure_only != 'true' && needs.changes.outputs.proof_harness_only != 'true') }}
         run: npm run release:check:ci
 
+      - name: Release readiness script smoke
+        if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.ci_infrastructure_only == 'true' }}
+        run: |
+          set -euo pipefail
+          if [[ ! -f scripts/check-workflow-footguns.mjs ]]; then
+            echo "Workflow footgun guardrail script is not present on this public base; skipping."
+            exit 0
+          fi
+          node --check scripts/check-workflow-footguns.mjs
+          npm run check:workflow-footguns
+          node ./scripts/run-vitest.js --run test/scripts/workflow-footguns.test.ts
+
       - name: Upload Nx test logs (if any)
         if: ${{ always() && hashFiles('nx-tests-attempt-*.log', 'nx-tests-attempt-*.json') != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
- add a public CI-infrastructure smoke step for `scripts/check-workflow-footguns.mjs`
- run the workflow-footgun negative fixture suite when the mirrored checker exists
- keep the step inert on the current public base before the mirrored checker lands

## Context
This is the public-owned CI companion for generated mirror PR #759. Public CI is excluded from the internal mirror, so the generated checker needs a public smoke lane before checker-only public PRs can be considered tested.

## Proof
- `actionlint -shellcheck= -pyflakes= .github/workflows/ci.yml`
- On refreshed #759 head with this workflow patch applied: `node --check scripts/check-workflow-footguns.mjs`
- On refreshed #759 head with this workflow patch applied: `npm run check:workflow-footguns`
- On refreshed #759 head with this workflow patch applied after deps install: `node ./scripts/run-vitest.js --run test/scripts/workflow-footguns.test.ts`

Unblocks #759 and issue #461.
