### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/cli/commands/a2a.ts
+++ b/src/cli/commands/a2a.ts
@@ -832,7 +832,7 @@ async function handleA2ASend(parsed: ParsedA2AArgs): Promise<void> {
 			text,
 			metadata,
 		}),
-		...(wait ? { configuration: { returnImmediately: true } } : {}),
+		configuration: { returnImmediately: true },
 	});
 	await persistA2ALedgerBestEffort("record sent task locally", () =>
 		recordA2ATaskStart({

--- a/test/cli/commands/a2a-fleet-delegation.test.ts
+++ b/test/cli/commands/a2a-fleet-delegation.test.ts
@@ -1007,6 +1007,35 @@ describe("A2A fleet delegation CLI", () => {
 		expect(JSON.stringify(ledger)).not.toContain("super-secret-token");
 	});
 
+	it("keeps default A2A sends non-blocking unless --wait is parsed", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-send-nonblocking-"));
+		const registryPath = join(dir, "peers.json");
+		const tasksPath = join(dir, "tasks.json");
+		await writeRegistry(registryPath, baseUrl);
+		vi.stubEnv("MAC_MINI_A2A_TOKEN", "super-secret-token");
+
+		await handleA2ACommand([
+			"send",
+			"mac-mini",
+			"queue",
+			"repo",
+			"smoke",
+			"--registry",
+			registryPath,
+			"--tasks",
+			tasksPath,
+			"--timeout-ms",
+			"1000",
+		]);
+
+		expect(requests).toHaveLength(1);
+		expect(recordValue(requests[0]!.body, "configuration")).toEqual({
+			returnImmediately: true,
+		});
+		expect(taskFetches).toBe(0);
+		expect(plainLogs(logs)).toContain("Task task-mac-mini-1");
+	});
+
 	it("preserves an input-required delegated task and completes it after an operator reply", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "maestro-a2a-input-required-"));
 		const registryPath = join(dir, "peers.json");


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"6a07e4fe16fdfda24a879e0ddd80c89c48666228"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `6a07e4fe16fdfda24a879e0ddd80c89c48666228`
- last generated public sync base: `f39c4b90a3cd4605a92ed9a597c6afcfa91ff953`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (6a07e4fe16fd)`
- public projection: `https://github.com/evalops/maestro@main (f39c4b90a3cd)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/cli/commands/a2a.ts
- copy/update test/cli/commands/a2a-fleet-delegation.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/cli/commands/a2a.ts
- copy/update test/cli/commands/a2a-fleet-delegation.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@6a07e4fe16fdfda24a879e0ddd80c89c48666228`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.