### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1441,18 +1441,19 @@ export async function main(args: string[]) {
 		);
 		earlyExecJsonThreadId = earlyFreshExecJsonThreadId;
 	}
-	const sessionManager = (
-		useFreshExecSessionManager
-			? new (
-					await import("./session/fresh-exec-session-manager.js")
-				).FreshExecSessionManager({
-					sessionId: earlyFreshExecJsonThreadId ?? undefined,
-				})
-			: new (await import("./session/manager.js")).SessionManager(
-					parsed.continue && !parsed.resume, // continueSession: auto-load most recent
-					parsed.session, // customSessionPath: explicit session file
-				)
-	) as SessionManager;
+	const sessionManager = await withExecJsonStartupCleanup(
+		async () =>
+			(useFreshExecSessionManager
+				? new (
+						await import("./session/fresh-exec-session-manager.js")
+					).FreshExecSessionManager({
+						sessionId: earlyFreshExecJsonThreadId ?? undefined,
+					})
+				: new (await import("./session/manager.js")).SessionManager(
+						parsed.continue && !parsed.resume, // continueSession: auto-load most recent
+						parsed.session, // customSessionPath: explicit session file
+					)) as SessionManager,
+	);
 	let scenarioRecorder:
 		| import("./server/scenario-recorder.js").ScriptedScenarioRecorder
 		| undefined;

--- a/test/cli/cli.integration.test.ts
+++ b/test/cli/cli.integration.test.ts
@@ -320,6 +320,7 @@ describe("CLI integration", () => {
 	const originalClaude = process.env.CLAUDE_CODE_TOKEN;
 	const originalSharedMemoryBase = process.env.MAESTRO_SHARED_MEMORY_BASE;
 	const originalSharedMemoryApiKey = process.env.MAESTRO_SHARED_MEMORY_API_KEY;
+	const originalSessionDir = process.env.MAESTRO_SESSION_DIR;
 	const originalLog = console.log;
 	const originalError = console.error;
 	const originalStdoutWrite = process.stdout.write;
@@ -391,6 +392,11 @@ describe("CLI integration", () => {
 			Reflect.deleteProperty(process.env, "MAESTRO_HOME");
 		} else {
 			process.env.MAESTRO_HOME = originalMaestroHome;
+		}
+		if (originalSessionDir === undefined) {
+			Reflect.deleteProperty(process.env, "MAESTRO_SESSION_DIR");
+		} else {
+			process.env.MAESTRO_SESSION_DIR = originalSessionDir;
 		}
 		if (tempAgentDir) {
 			rmSync(tempAgentDir, { recursive: true, force: true });
@@ -1291,6 +1297,50 @@ describe("CLI integration", () => {
 
 		await expect(
 			main(["exec", "--tools", "not-a-tool", "Plan work", "--json"]),
+		).rejects.toThrow("exit:1");
+
+		const events = output
+			.flatMap((chunk) => chunk.trim().split("\n"))
+			.filter((line) => line.startsWith("{"))
+			.map((line) => JSON.parse(line) as Record<string, unknown>);
+		const threadStarts = events.filter(
+			(event) => event.type === "thread" && event.phase === "start",
+		);
+		const threadEnds = events.filter(
+			(event) => event.type === "thread" && event.phase === "end",
+		);
+		const doneEvents = events.filter((event) => event.type === "done");
+		const errorEvents = events.filter((event) => event.type === "error");
+
+		expect(exitSpy).toHaveBeenCalledWith(1);
+		expect(threadStarts).toHaveLength(1);
+		expect(errorEvents.at(-1)).toMatchObject({
+			type: "error",
+		});
+		expect(threadEnds.at(-1)).toMatchObject({
+			type: "thread",
+			phase: "end",
+			threadId: threadStarts[0]?.threadId,
+			sessionId: threadStarts[0]?.sessionId,
+			status: "error",
+		});
+		expect(doneEvents.at(-1)).toMatchObject({
+			type: "done",
+			status: "error",
+			sessionId: threadStarts[0]?.sessionId,
+		});
+	});
+
+	it("closes early exec json thread when fresh session construction fails", async () => {
+		const blockedSessionRoot = join(tempAgentDir, "sessions-file");
+		writeFileSync(blockedSessionRoot, "not a directory");
+		process.env.MAESTRO_SESSION_DIR = blockedSessionRoot;
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+			throw new Error(`exit:${String(code ?? 0)}`);
+		});
+
+		await expect(
+			main(["exec", "--tools", "read", "Plan work", "--json"]),
 		).rejects.toThrow("exit:1");
 
 		const events = output


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"c2193f2a604bc338cb2a38c379e6dff6a8389d80"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `c2193f2a604bc338cb2a38c379e6dff6a8389d80`
- last generated public sync base: `fc4850505b0d20fa89549b53381d0c3a969e42d5`
- previewed public-tree drift: `2` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (c2193f2a604b)`
- public projection: `https://github.com/evalops/maestro@main (fc4850505b0d)`
- files to copy or update: `2`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update src/main.ts
- copy/update test/cli/cli.integration.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update src/main.ts
- copy/update test/cli/cli.integration.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@c2193f2a604bc338cb2a38c379e6dff6a8389d80`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.