### PR TITLE
[maestro] Ignore project MCP workspace trust policy entries

### DIFF
--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -600,16 +600,22 @@ function parseConfigFile(path: string, scope: McpScope): ParsedConfig {
 		return {
 			servers,
 			authPresets,
-			trustedWorkspaces: normalizeTrustedWorkspaces(
-				parsed.data.trustedWorkspaces,
-				scope,
-				path,
-			),
-			workspaceTrustDefault: normalizeWorkspaceTrustDefault(
-				parsed.data.workspaceTrustDefault,
-				scope,
-				path,
-			),
+			trustedWorkspaces:
+				scope === "project"
+					? {}
+					: normalizeTrustedWorkspaces(
+							parsed.data.trustedWorkspaces,
+							scope,
+							path,
+						),
+			workspaceTrustDefault:
+				scope === "project"
+					? undefined
+					: normalizeWorkspaceTrustDefault(
+							parsed.data.workspaceTrustDefault,
+							scope,
+							path,
+						),
 		};
 	} catch (error) {
 		logger.warn("Failed to parse MCP config file", {

--- a/test/agent/mcp.test.ts
+++ b/test/agent/mcp.test.ts
@@ -74,7 +74,7 @@ describe("MCP config loader", () => {
 		const configDir = join(testDir, ".maestro");
 		mkdirSync(configDir, { recursive: true });
 		writeFileSync(
-			join(configDir, "mcp.json"),
+			join(configDir, "mcp.local.json"),
 			JSON.stringify({
 				servers: [
 					{
@@ -129,7 +129,7 @@ describe("MCP config loader", () => {
 		const configDir = join(testDir, ".maestro");
 		mkdirSync(configDir, { recursive: true });
 		writeFileSync(
-			join(configDir, "mcp.json"),
+			join(configDir, "mcp.local.json"),
 			JSON.stringify({
 				mcpServers: {
 					"my-server": {
@@ -151,7 +151,7 @@ describe("MCP config loader", () => {
 		const configDir = join(testDir, ".maestro");
 		mkdirSync(configDir, { recursive: true });
 		writeFileSync(
-			join(configDir, "mcp.json"),
+			join(configDir, "mcp.local.json"),
 			JSON.stringify({
 				mcpServers: {
 					enabled: { command: "node", args: [] },
@@ -169,7 +169,7 @@ describe("MCP config loader", () => {
 		const configDir = join(testDir, ".maestro");
 		mkdirSync(configDir, { recursive: true });
 		writeFileSync(
-			join(configDir, "mcp.json"),
+			join(configDir, "mcp.local.json"),
 			JSON.stringify({
 				mcpServers: {
 					remote: { url: "http://localhost:3000/mcp" },
@@ -241,7 +241,7 @@ describe("MCP config loader", () => {
 		const configDir = join(testDir, ".maestro");
 		mkdirSync(configDir, { recursive: true });
 		writeFileSync(
-			join(configDir, "mcp.json"),
+			join(configDir, "mcp.local.json"),
 			JSON.stringify({
 				mcpServers: {
 					docs: {
@@ -319,6 +319,36 @@ describe("MCP config loader", () => {
 		const config = loadMcpConfig(testDir);
 		expect(config.servers).toHaveLength(1);
 		expect(config.servers[0]!.name).toBe("docs");
+		expect(config.workspaceTrustDefault).toBeUndefined();
+	});
+
+	it("does not load workspace trust policy from project config", () => {
+		const configDir = join(testDir, ".maestro");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			join(configDir, "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					docs: {
+						url: "https://example.com/mcp",
+					},
+				},
+				trustedWorkspaces: {
+					docs: [
+						{
+							workspaceUri: "git:https://github.com/evalops/platform.git",
+							mode: "trusted",
+						},
+					],
+				},
+				workspaceTrustDefault: "untrusted",
+			}),
+		);
+
+		const config = loadMcpConfig(testDir);
+		expect(config.servers).toHaveLength(1);
+		expect(config.servers[0]!.name).toBe("docs");
+		expect(config.trustedWorkspaces).toBeUndefined();
 		expect(config.workspaceTrustDefault).toBeUndefined();
 	});
 


### PR DESCRIPTION
### Motivation
- A project-scoped `.maestro/mcp.json` could declare `trustedWorkspaces` or `workspaceTrustDefault` and thereby override enterprise/user trust policies, allowing a malicious repository to bypass workspace trust prompts.

### Description
- Update `parseConfigFile` in `src/mcp/config.ts` to ignore `trustedWorkspaces` and `workspaceTrustDefault` when `scope === "project"`, preserving server and auth preset loading but preventing repository-controlled trust policy from being merged.
- Adjust tests in `test/agent/mcp.test.ts` to use `mcp.local.json` for local-scope trust parsing and add a regression test `does not load workspace trust policy from project config` asserting project config trust entries are ignored.
- This is a minimal, security-focused change that keeps existing behavior for user/local/enterprise/plugin scopes while blocking project-supplied trust entries.

### Source provenance
- Private source-of-truth PR: evalops/maestro-internal#2458
- Internal source PR merged: https://github.com/evalops/maestro-internal/pull/2458

### Testing
- Ran `bun run bun:lint` and the lint checks passed successfully.
- Ran unit tests for MCP parsing with `bunx vitest --run test/agent/mcp.test.ts`, and all tests passed (`30/30`).
- Attempted full test run with `npx nx run maestro:test --skip-nx-cache`, but it failed in this environment due to external dependency fetch failures (private/registry 403s) and an unrelated `tree-sitter` module missing during a dependent package build, not due to the introduced code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce9d788348326a648ae8158d15fef)