### PR TITLE
[maestro] restrict /api/run to an explicit script allowlist

### DIFF
--- a/packages/control-plane-rs/src/main.rs
+++ b/packages/control-plane-rs/src/main.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::io::{Cursor, Read};
 use std::path::{Component, Path, PathBuf};
@@ -2897,8 +2897,24 @@ fn add_usage_to_bucket(bucket: &mut UsageBucket, cost: f64, tokens: u64, entry: 
     bucket.tokens_detailed.total += tokens;
 }
 
+fn allowed_run_scripts() -> HashSet<String> {
+    let configured =
+        env::var("MAESTRO_RUN_SCRIPT_ALLOWLIST").unwrap_or_else(|_| "db:migrate".to_string());
+    configured
+        .split(',')
+        .map(str::trim)
+        .filter(|script| !script.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
 async fn package_scripts(cwd: &Path) -> Vec<String> {
-    let mut scripts: Vec<String> = package_script_map(cwd).await.into_keys().collect();
+    let allowlist = allowed_run_scripts();
+    let mut scripts: Vec<String> = package_script_map(cwd)
+        .await
+        .into_keys()
+        .filter(|script| allowlist.contains(script))
+        .collect();
     scripts.sort();
     scripts
 }
@@ -2946,9 +2962,26 @@ async fn run_script_response(cwd: &Path, request: RunScriptRequest) -> Vec<u8> {
         );
     }
 
+    let allowlist = allowed_run_scripts();
+    if !allowlist.contains(script) {
+        let mut allowed: Vec<String> = allowlist.iter().cloned().collect();
+        allowed.sort();
+        return json_response(
+            403,
+            &serde_json::json!({
+                "error": format!("Script \"{script}\" is not allowed in this environment"),
+                "allowed": allowed,
+            }),
+        );
+    }
+
     let available_scripts = package_script_map(cwd).await;
     if !available_scripts.contains_key(script) {
-        let mut available: Vec<String> = available_scripts.keys().cloned().collect();
+        let mut available: Vec<String> = available_scripts
+            .keys()
+            .filter(|name| allowlist.contains(*name))
+            .cloned()
+            .collect();
         available.sort();
         return json_response(
             400,


### PR DESCRIPTION
### Motivation
- The runtime image now contains the repository root package.json and node runtime artifacts, which made the existing `/api/run` endpoint enumerate and execute arbitrary root npm scripts in production.
- The change limits blast radius by keeping `/api/run` usable for intended migration tasks while preventing execution of development/admin scripts from the served working directory.

### Description
- Add an `allowed_run_scripts()` helper that reads `MAESTRO_RUN_SCRIPT_ALLOWLIST` and defaults to `db:migrate` to define a strict allowlist of runnable scripts.
- Filter `GET /api/run?action=scripts` by the allowlist so only allowed script names are enumerated by `package_scripts`.
- Check the allowlist in `run_script_response` and return HTTP 403 when a requested script is not in the allowlist, and limit the "available" suggestions to allowlisted names.
- Import `HashSet` and make minimal code changes in `packages/control-plane-rs/src/main.rs` to implement the allowlist gate.

### Source provenance
- Private source-of-truth PR: evalops/maestro-internal#2459
- Internal source PR merged: https://github.com/evalops/maestro-internal/pull/2459
- Follow-up source hardening for lifecycle-suppression review blockers: evalops/maestro-internal#2463

### Testing
- Ran `cargo test validates_run_script_inputs` inside `packages/control-plane-rs`, and the test passed.
- Ran `bun run bun:lint` at the repo root but it failed due to external npm registry access errors (403) in this environment.
- Ran `npx nx run maestro:test --skip-nx-cache` at the repo root but it failed due to external npm registry access errors (403) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d0aca130832697ffccc3663a7bd9)