### PR TITLE
Add operating layer platform primitives

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -69,7 +69,6 @@ jobs:
           set -euo pipefail
           active_count="$(
             gh run list \
-              --repo "${GITHUB_REPOSITORY}" \
               --workflow release \
               --json headBranch,status \
               --limit 50 \
@@ -186,4 +185,4 @@ jobs:
             echo "Found ${active_count} active release workflow run(s) for ${RELEASE_TAG}; not dispatching another."
             exit 0
           fi
-          gh workflow run release --repo "${GITHUB_REPOSITORY}" --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"
+          gh workflow run release --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -69,6 +69,7 @@ jobs:
           set -euo pipefail
           active_count="$(
             gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
               --workflow release \
               --json headBranch,status \
               --limit 50 \
@@ -185,4 +186,4 @@ jobs:
             echo "Found ${active_count} active release workflow run(s) for ${RELEASE_TAG}; not dispatching another."
             exit 0
           fi
-          gh workflow run release --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"
+          gh workflow run release --repo "${GITHUB_REPOSITORY}" --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"

--- a/src/platform/operating-layer.ts
+++ b/src/platform/operating-layer.ts
@@ -353,7 +353,10 @@ export function evaluateExtensionGovernance(
 	const blockers: string[] = [];
 	const reasons = [`source:${candidate.source}`];
 	const allowedSources = new Set(policy.allowedSources ?? []);
-	if (allowedSources.size > 0 && !allowedSources.has(candidate.source)) {
+	if (
+		policy.allowedSources !== undefined &&
+		!allowedSources.has(candidate.source)
+	) {
 		blockers.push(`source_not_allowed:${candidate.source}`);
 	}
 	if (policy.requireSignature && !candidate.signed) {
@@ -370,19 +373,21 @@ export function evaluateExtensionGovernance(
 	const trustedPublishers = new Set(policy.trustedPublishers ?? []);
 	if (
 		candidate.source === "marketplace" &&
-		trustedPublishers.size > 0 &&
 		candidate.publisher &&
 		trustedPublishers.has(candidate.publisher)
 	) {
 		reasons.push(`trusted_publisher:${candidate.publisher}`);
-	} else if (trustedPublishers.size > 0 && candidate.source === "marketplace") {
+	} else if (
+		policy.trustedPublishers !== undefined &&
+		candidate.source === "marketplace"
+	) {
 		blockers.push(`publisher_not_trusted:${candidate.publisher ?? "unknown"}`);
 	}
 
 	const allowedScopes = new Set(policy.allowedScopes ?? []);
 	const requestedScopes = normalizedList(candidate.requestedScopes);
 	for (const scope of requestedScopes) {
-		if (allowedScopes.size > 0 && !allowedScopes.has(scope)) {
+		if (policy.allowedScopes !== undefined && !allowedScopes.has(scope)) {
 			blockers.push(`scope_not_allowed:${scope}`);
 		}
 	}
@@ -482,23 +487,26 @@ export const DEFAULT_RELEASE_CANARY_STAGES: ReleaseCanaryStage[] = [
 ];
 
 export function buildReleaseCanaryPlan(
-	stages: ReleaseCanaryStage[] = DEFAULT_RELEASE_CANARY_STAGES,
+	stages?: ReleaseCanaryStage[],
 ): ReleaseCanaryPlan {
-	const stageIds = new Set(stages.map((stage) => stage.id));
+	const planStages = cloneReleaseCanaryStages(
+		stages ?? DEFAULT_RELEASE_CANARY_STAGES,
+	);
+	const stageIds = new Set(planStages.map((stage) => stage.id));
 	const stageIndexes = new Map<string, number>();
-	for (const [index, stage] of stages.entries()) {
+	for (const [index, stage] of planStages.entries()) {
 		if (!stageIndexes.has(stage.id)) {
 			stageIndexes.set(stage.id, index);
 		}
 	}
 	const blockers = [
-		...detectDuplicateReleaseCanaryStages(stages),
-		...stages.flatMap((stage) =>
+		...detectDuplicateReleaseCanaryStages(planStages),
+		...planStages.flatMap((stage) =>
 			stage.requires
 				.filter((required) => !stageIds.has(required))
 				.map((required) => `missing_stage:${stage.id}:${required}`),
 		),
-		...stages.flatMap((stage, index) =>
+		...planStages.flatMap((stage, index) =>
 			stage.requires
 				.filter((required) => {
 					const requiredIndex = stageIndexes.get(required);
@@ -506,14 +514,24 @@ export function buildReleaseCanaryPlan(
 				})
 				.map((required) => `out_of_order_stage:${stage.id}:${required}`),
 		),
-		...detectReleaseCanaryCycles(stages),
+		...detectReleaseCanaryCycles(planStages),
 	];
 
 	return {
 		version: MAESTRO_OPERATING_LAYER_VERSION,
-		stages,
+		stages: planStages,
 		blockers,
 	};
+}
+
+function cloneReleaseCanaryStages(
+	stages: ReleaseCanaryStage[],
+): ReleaseCanaryStage[] {
+	return stages.map((stage) => ({
+		...stage,
+		requires: [...stage.requires],
+		evidenceKinds: [...stage.evidenceKinds],
+	}));
 }
 
 function detectDuplicateReleaseCanaryStages(

--- a/src/platform/operating-layer.ts
+++ b/src/platform/operating-layer.ts
@@ -526,7 +526,14 @@ function detectDuplicateReleaseCanaryStages(
 }
 
 function detectReleaseCanaryCycles(stages: ReleaseCanaryStage[]): string[] {
-	const stagesById = new Map(stages.map((stage) => [stage.id, stage]));
+	const requirementsById = new Map<string, Set<string>>();
+	for (const stage of stages) {
+		const requirements = requirementsById.get(stage.id) ?? new Set<string>();
+		for (const required of stage.requires) {
+			requirements.add(required);
+		}
+		requirementsById.set(stage.id, requirements);
+	}
 	const visiting = new Set<string>();
 	const visited = new Set<string>();
 	const blockers: string[] = [];
@@ -542,13 +549,13 @@ function detectReleaseCanaryCycles(stages: ReleaseCanaryStage[]): string[] {
 			return;
 		}
 
-		const stage = stagesById.get(stageId);
-		if (!stage) {
+		const requirements = requirementsById.get(stageId);
+		if (!requirements) {
 			return;
 		}
 
 		visiting.add(stageId);
-		for (const required of stage.requires) {
+		for (const required of requirements) {
 			visit(required, [...path, required]);
 		}
 		visiting.delete(stageId);

--- a/src/platform/operating-layer.ts
+++ b/src/platform/operating-layer.ts
@@ -300,7 +300,7 @@ export function classifySyncOutcome(
 		};
 	}
 
-	if (nextAttempt >= item.maxAttempts) {
+	if (item.attempt >= item.maxAttempts) {
 		return {
 			action: "block",
 			reason: outcome.errorCode ?? "max_attempts_exhausted",
@@ -369,6 +369,7 @@ export function evaluateExtensionGovernance(
 
 	const trustedPublishers = new Set(policy.trustedPublishers ?? []);
 	if (
+		candidate.source === "marketplace" &&
 		trustedPublishers.size > 0 &&
 		candidate.publisher &&
 		trustedPublishers.has(candidate.publisher)
@@ -486,6 +487,7 @@ export function buildReleaseCanaryPlan(
 	const stageIds = new Set(stages.map((stage) => stage.id));
 	const stageIndexes = new Map(stages.map((stage, index) => [stage.id, index]));
 	const blockers = [
+		...detectDuplicateReleaseCanaryStages(stages),
 		...stages.flatMap((stage) =>
 			stage.requires
 				.filter((required) => !stageIds.has(required))
@@ -507,6 +509,20 @@ export function buildReleaseCanaryPlan(
 		stages,
 		blockers,
 	};
+}
+
+function detectDuplicateReleaseCanaryStages(
+	stages: ReleaseCanaryStage[],
+): string[] {
+	const seen = new Set<string>();
+	const blockers: string[] = [];
+	for (const stage of stages) {
+		if (seen.has(stage.id)) {
+			blockers.push(`duplicate_stage:${stage.id}`);
+		}
+		seen.add(stage.id);
+	}
+	return unique(blockers);
 }
 
 function detectReleaseCanaryCycles(stages: ReleaseCanaryStage[]): string[] {

--- a/src/platform/operating-layer.ts
+++ b/src/platform/operating-layer.ts
@@ -1,0 +1,497 @@
+export const MAESTRO_OPERATING_LAYER_VERSION =
+	"evalops.maestro.operating-layer.v1";
+
+export type OperatingLayerCapabilityId =
+	| "protocol-boundary"
+	| "policy-resolution"
+	| "sync-outbox"
+	| "approval-evidence"
+	| "extension-governance"
+	| "run-readiness"
+	| "run-effectiveness"
+	| "release-canary";
+
+export interface OperatingLayerCapability {
+	id: OperatingLayerCapabilityId;
+	name: string;
+	description: string;
+	evidenceKinds: string[];
+}
+
+export interface OperatingLayerManifest {
+	version: typeof MAESTRO_OPERATING_LAYER_VERSION;
+	capabilities: OperatingLayerCapability[];
+}
+
+export const OPERATING_LAYER_CAPABILITIES: OperatingLayerCapability[] = [
+	{
+		id: "protocol-boundary",
+		name: "Protocol boundary",
+		description:
+			"Treats versioned protocols as the product integration surface.",
+		evidenceKinds: ["protocol.version", "protocol.contract", "protocol.owner"],
+	},
+	{
+		id: "policy-resolution",
+		name: "Policy resolution",
+		description:
+			"Explains the source and override chain for resolved settings.",
+		evidenceKinds: ["policy.subject", "policy.source", "policy.resolved_value"],
+	},
+	{
+		id: "sync-outbox",
+		name: "Sync outbox",
+		description:
+			"Classifies cloud/session sync outcomes into durable retry actions.",
+		evidenceKinds: ["sync.item", "sync.outcome", "sync.next_action"],
+	},
+	{
+		id: "approval-evidence",
+		name: "Approval evidence",
+		description:
+			"Normalizes permission decisions across tool and product surfaces.",
+		evidenceKinds: [
+			"approval.request",
+			"approval.decision",
+			"approval.surface",
+		],
+	},
+	{
+		id: "extension-governance",
+		name: "Extension governance",
+		description:
+			"Evaluates extensions against marketplace trust and scope policy.",
+		evidenceKinds: [
+			"extension.source",
+			"extension.signature",
+			"extension.scopes",
+		],
+	},
+	{
+		id: "run-readiness",
+		name: "Run readiness",
+		description: "Scores whether a run has enough evidence to proceed or ship.",
+		evidenceKinds: ["readiness.signal", "readiness.score", "readiness.blocker"],
+	},
+	{
+		id: "run-effectiveness",
+		name: "Run effectiveness",
+		description:
+			"Scores completed work against outcome and confidence signals.",
+		evidenceKinds: [
+			"effectiveness.signal",
+			"effectiveness.score",
+			"effectiveness.evidence",
+		],
+	},
+	{
+		id: "release-canary",
+		name: "Release canary",
+		description:
+			"Defines ordered gates for publish, smoke, replay, and notification.",
+		evidenceKinds: ["release.stage", "release.gate", "release.evidence"],
+	},
+];
+
+export interface ProtocolBoundaryInput {
+	protocolId: string;
+	version: string;
+	owners?: string[];
+	contracts?: string[];
+	compatibility?: "experimental" | "stable" | "deprecated";
+}
+
+export interface ProtocolBoundaryDescriptor extends ProtocolBoundaryInput {
+	compatibility: "experimental" | "stable" | "deprecated";
+	reasons: string[];
+}
+
+export interface PolicyResolutionSource<T = unknown> {
+	layer:
+		| "default"
+		| "runtime"
+		| "user"
+		| "workspace"
+		| "project"
+		| "organization"
+		| "session";
+	id: string;
+	value: T;
+	reason?: string;
+}
+
+export interface PolicyResolutionExplanation<T = unknown> {
+	subject: string;
+	resolvedValue: T | undefined;
+	activeSource?: PolicyResolutionSource<T>;
+	chain: Array<
+		PolicyResolutionSource<T> & {
+			overrides: string[];
+		}
+	>;
+	reasons: string[];
+}
+
+export type SyncOutboxKind =
+	| "session_create"
+	| "session_update"
+	| "message"
+	| "settings"
+	| "artifact"
+	| "approval";
+
+export interface SyncOutboxItem {
+	id: string;
+	kind: SyncOutboxKind;
+	sessionId?: string;
+	status: "pending" | "in_flight" | "succeeded" | "failed" | "blocked";
+	attempt: number;
+	maxAttempts: number;
+}
+
+export interface SyncOutcome {
+	ok: boolean;
+	statusCode?: number;
+	errorCode?: string;
+}
+
+export interface SyncOutboxDecision {
+	action: "complete" | "retry" | "self_heal_session" | "block";
+	reason: string;
+	nextAttempt: number;
+}
+
+export interface ApprovalDecisionInput {
+	requestId: string;
+	surface: "cli" | "tui" | "web" | "mcp" | "api";
+	mode: "suggest" | "ask" | "auto" | "deny";
+	decision: "approved" | "denied" | "expired";
+	toolNames?: string[];
+	policyRefs?: string[];
+}
+
+export interface ApprovalDecisionEvidence extends ApprovalDecisionInput {
+	approvedTools: string[];
+	blockedTools: string[];
+	reasons: string[];
+}
+
+export interface ExtensionCandidate {
+	id: string;
+	source: "builtin" | "marketplace" | "local" | "git";
+	publisher?: string;
+	signed?: boolean;
+	pinnedRef?: string;
+	requestedScopes?: string[];
+}
+
+export interface ExtensionGovernancePolicy {
+	allowedSources?: ExtensionCandidate["source"][];
+	trustedPublishers?: string[];
+	allowedScopes?: string[];
+	requireSignature?: boolean;
+	requirePinnedGitRef?: boolean;
+}
+
+export interface ExtensionGovernanceDecision {
+	allowed: boolean;
+	blockers: string[];
+	reasons: string[];
+}
+
+export interface OperatingLayerSignal {
+	id: string;
+	label: string;
+	status: "pass" | "warn" | "fail" | "unknown";
+	weight?: number;
+	evidence?: string[];
+}
+
+export interface OperatingLayerScoreReport {
+	version: typeof MAESTRO_OPERATING_LAYER_VERSION;
+	score: number;
+	blockers: string[];
+	warnings: string[];
+	signals: OperatingLayerSignal[];
+}
+
+export interface ReleaseCanaryStage {
+	id: string;
+	name: string;
+	requires: string[];
+	evidenceKinds: string[];
+}
+
+export interface ReleaseCanaryPlan {
+	version: typeof MAESTRO_OPERATING_LAYER_VERSION;
+	stages: ReleaseCanaryStage[];
+	blockers: string[];
+}
+
+function unique(values: string[]): string[] {
+	return [...new Set(values)];
+}
+
+function normalizedList(values: string[] | undefined): string[] {
+	return unique((values ?? []).map((value) => value.trim()).filter(Boolean));
+}
+
+export function buildOperatingLayerManifest(): OperatingLayerManifest {
+	return {
+		version: MAESTRO_OPERATING_LAYER_VERSION,
+		capabilities: OPERATING_LAYER_CAPABILITIES,
+	};
+}
+
+export function buildProtocolBoundaryDescriptor(
+	input: ProtocolBoundaryInput,
+): ProtocolBoundaryDescriptor {
+	const owners = normalizedList(input.owners);
+	const contracts = normalizedList(input.contracts);
+	const reasons = [
+		`protocol:${input.protocolId}`,
+		`version:${input.version}`,
+		...owners.map((owner) => `owner:${owner}`),
+		...contracts.map((contract) => `contract:${contract}`),
+	];
+
+	return {
+		...input,
+		owners,
+		contracts,
+		compatibility: input.compatibility ?? "experimental",
+		reasons,
+	};
+}
+
+export function explainResolvedPolicy<T>(
+	subject: string,
+	sources: PolicyResolutionSource<T>[],
+): PolicyResolutionExplanation<T> {
+	const activeSource = sources.at(-1);
+	return {
+		subject,
+		resolvedValue: activeSource?.value,
+		...(activeSource ? { activeSource } : {}),
+		chain: sources.map((source, index) => ({
+			...source,
+			overrides: sources.slice(0, index).map((prior) => prior.id),
+		})),
+		reasons: [
+			`subject:${subject}`,
+			...(activeSource ? [`active_source:${activeSource.id}`] : []),
+			...sources.flatMap((source) =>
+				source.reason ? [`reason:${source.id}:${source.reason}`] : [],
+			),
+		],
+	};
+}
+
+export function classifySyncOutcome(
+	item: SyncOutboxItem,
+	outcome: SyncOutcome,
+): SyncOutboxDecision {
+	const nextAttempt = item.attempt + 1;
+	if (outcome.ok) {
+		return {
+			action: "complete",
+			reason: "sync_ok",
+			nextAttempt,
+		};
+	}
+
+	if (
+		item.kind !== "session_create" &&
+		(outcome.statusCode === 404 || outcome.statusCode === 410)
+	) {
+		return {
+			action: "self_heal_session",
+			reason: "remote_session_missing",
+			nextAttempt,
+		};
+	}
+
+	if (nextAttempt >= item.maxAttempts) {
+		return {
+			action: "block",
+			reason: outcome.errorCode ?? "max_attempts_exhausted",
+			nextAttempt,
+		};
+	}
+
+	return {
+		action: "retry",
+		reason: outcome.errorCode ?? `http_${outcome.statusCode ?? "unknown"}`,
+		nextAttempt,
+	};
+}
+
+export function buildApprovalDecisionEvidence(
+	input: ApprovalDecisionInput,
+): ApprovalDecisionEvidence {
+	const toolNames = normalizedList(input.toolNames);
+	const approved = input.decision === "approved";
+	return {
+		...input,
+		toolNames,
+		policyRefs: normalizedList(input.policyRefs),
+		approvedTools: approved ? toolNames : [],
+		blockedTools: approved ? [] : toolNames,
+		reasons: [
+			`surface:${input.surface}`,
+			`mode:${input.mode}`,
+			`decision:${input.decision}`,
+		],
+	};
+}
+
+export function evaluateExtensionGovernance(
+	candidate: ExtensionCandidate,
+	policy: ExtensionGovernancePolicy = {},
+): ExtensionGovernanceDecision {
+	const blockers: string[] = [];
+	const reasons = [`source:${candidate.source}`];
+	const allowedSources = new Set(policy.allowedSources ?? []);
+	if (allowedSources.size > 0 && !allowedSources.has(candidate.source)) {
+		blockers.push(`source_not_allowed:${candidate.source}`);
+	}
+	if (policy.requireSignature && !candidate.signed) {
+		blockers.push("signature_required");
+	}
+	if (
+		policy.requirePinnedGitRef &&
+		candidate.source === "git" &&
+		!candidate.pinnedRef
+	) {
+		blockers.push("pinned_git_ref_required");
+	}
+
+	const trustedPublishers = new Set(policy.trustedPublishers ?? []);
+	if (
+		trustedPublishers.size > 0 &&
+		candidate.publisher &&
+		trustedPublishers.has(candidate.publisher)
+	) {
+		reasons.push(`trusted_publisher:${candidate.publisher}`);
+	} else if (trustedPublishers.size > 0 && candidate.source === "marketplace") {
+		blockers.push(`publisher_not_trusted:${candidate.publisher ?? "unknown"}`);
+	}
+
+	const allowedScopes = new Set(policy.allowedScopes ?? []);
+	const requestedScopes = normalizedList(candidate.requestedScopes);
+	for (const scope of requestedScopes) {
+		if (allowedScopes.size > 0 && !allowedScopes.has(scope)) {
+			blockers.push(`scope_not_allowed:${scope}`);
+		}
+	}
+	reasons.push(...requestedScopes.map((scope) => `scope:${scope}`));
+	if (candidate.signed) {
+		reasons.push("signed");
+	}
+	if (candidate.pinnedRef) {
+		reasons.push(`pinned_ref:${candidate.pinnedRef}`);
+	}
+
+	return {
+		allowed: blockers.length === 0,
+		blockers: unique(blockers),
+		reasons: unique(reasons),
+	};
+}
+
+export function buildRunReadinessReport(
+	signals: OperatingLayerSignal[],
+): OperatingLayerScoreReport {
+	return buildScoreReport(signals, "readiness");
+}
+
+export function buildRunEffectivenessReport(
+	signals: OperatingLayerSignal[],
+): OperatingLayerScoreReport {
+	return buildScoreReport(signals, "effectiveness");
+}
+
+function buildScoreReport(
+	signals: OperatingLayerSignal[],
+	prefix: "readiness" | "effectiveness",
+): OperatingLayerScoreReport {
+	let earned = 0;
+	let possible = 0;
+	const blockers: string[] = [];
+	const warnings: string[] = [];
+
+	for (const signal of signals) {
+		const weight = signal.weight ?? 1;
+		if (signal.status !== "unknown") {
+			possible += weight;
+		}
+		if (signal.status === "pass") {
+			earned += weight;
+		}
+		if (signal.status === "warn") {
+			earned += weight / 2;
+			warnings.push(`${prefix}:${signal.id}`);
+		}
+		if (signal.status === "fail") {
+			blockers.push(`${prefix}:${signal.id}`);
+		}
+	}
+
+	return {
+		version: MAESTRO_OPERATING_LAYER_VERSION,
+		score: possible === 0 ? 0 : Math.round((earned / possible) * 100),
+		blockers,
+		warnings,
+		signals,
+	};
+}
+
+export const DEFAULT_RELEASE_CANARY_STAGES: ReleaseCanaryStage[] = [
+	{
+		id: "local_release_gate",
+		name: "Local release gate",
+		requires: [],
+		evidenceKinds: ["lint", "test", "build", "release.check"],
+	},
+	{
+		id: "publish_package",
+		name: "Publish package",
+		requires: ["local_release_gate"],
+		evidenceKinds: ["npm.publish", "git.tag", "github.release"],
+	},
+	{
+		id: "registry_install_smoke",
+		name: "Registry install smoke",
+		requires: ["publish_package"],
+		evidenceKinds: ["npm.install", "cli.smoke"],
+	},
+	{
+		id: "published_replay_evidence",
+		name: "Published replay evidence",
+		requires: ["registry_install_smoke"],
+		evidenceKinds: ["replay.e2e", "evidence.verify"],
+	},
+	{
+		id: "release_notification",
+		name: "Release notification",
+		requires: ["published_replay_evidence"],
+		evidenceKinds: ["release.notes", "channel.notification"],
+	},
+];
+
+export function buildReleaseCanaryPlan(
+	stages: ReleaseCanaryStage[] = DEFAULT_RELEASE_CANARY_STAGES,
+): ReleaseCanaryPlan {
+	const stageIds = new Set(stages.map((stage) => stage.id));
+	const blockers = stages.flatMap((stage) =>
+		stage.requires
+			.filter((required) => !stageIds.has(required))
+			.map((required) => `missing_stage:${stage.id}:${required}`),
+	);
+
+	return {
+		version: MAESTRO_OPERATING_LAYER_VERSION,
+		stages,
+		blockers,
+	};
+}

--- a/src/platform/operating-layer.ts
+++ b/src/platform/operating-layer.ts
@@ -485,7 +485,12 @@ export function buildReleaseCanaryPlan(
 	stages: ReleaseCanaryStage[] = DEFAULT_RELEASE_CANARY_STAGES,
 ): ReleaseCanaryPlan {
 	const stageIds = new Set(stages.map((stage) => stage.id));
-	const stageIndexes = new Map(stages.map((stage, index) => [stage.id, index]));
+	const stageIndexes = new Map<string, number>();
+	for (const [index, stage] of stages.entries()) {
+		if (!stageIndexes.has(stage.id)) {
+			stageIndexes.set(stage.id, index);
+		}
+	}
 	const blockers = [
 		...detectDuplicateReleaseCanaryStages(stages),
 		...stages.flatMap((stage) =>

--- a/src/platform/operating-layer.ts
+++ b/src/platform/operating-layer.ts
@@ -310,6 +310,7 @@ export function classifySyncOutcome(
 
 	if (
 		item.kind !== "session_create" &&
+		item.sessionId &&
 		(outcome.statusCode === 404 || outcome.statusCode === 410)
 	) {
 		return {
@@ -483,11 +484,20 @@ export function buildReleaseCanaryPlan(
 	stages: ReleaseCanaryStage[] = DEFAULT_RELEASE_CANARY_STAGES,
 ): ReleaseCanaryPlan {
 	const stageIds = new Set(stages.map((stage) => stage.id));
+	const stageIndexes = new Map(stages.map((stage, index) => [stage.id, index]));
 	const blockers = [
 		...stages.flatMap((stage) =>
 			stage.requires
 				.filter((required) => !stageIds.has(required))
 				.map((required) => `missing_stage:${stage.id}:${required}`),
+		),
+		...stages.flatMap((stage, index) =>
+			stage.requires
+				.filter((required) => {
+					const requiredIndex = stageIndexes.get(required);
+					return requiredIndex !== undefined && requiredIndex > index;
+				})
+				.map((required) => `out_of_order_stage:${stage.id}:${required}`),
 		),
 		...detectReleaseCanaryCycles(stages),
 	];

--- a/src/platform/operating-layer.ts
+++ b/src/platform/operating-layer.ts
@@ -300,6 +300,14 @@ export function classifySyncOutcome(
 		};
 	}
 
+	if (nextAttempt >= item.maxAttempts) {
+		return {
+			action: "block",
+			reason: outcome.errorCode ?? "max_attempts_exhausted",
+			nextAttempt,
+		};
+	}
+
 	if (
 		item.kind !== "session_create" &&
 		(outcome.statusCode === 404 || outcome.statusCode === 410)
@@ -307,14 +315,6 @@ export function classifySyncOutcome(
 		return {
 			action: "self_heal_session",
 			reason: "remote_session_missing",
-			nextAttempt,
-		};
-	}
-
-	if (nextAttempt >= item.maxAttempts) {
-		return {
-			action: "block",
-			reason: outcome.errorCode ?? "max_attempts_exhausted",
 			nextAttempt,
 		};
 	}
@@ -483,15 +483,55 @@ export function buildReleaseCanaryPlan(
 	stages: ReleaseCanaryStage[] = DEFAULT_RELEASE_CANARY_STAGES,
 ): ReleaseCanaryPlan {
 	const stageIds = new Set(stages.map((stage) => stage.id));
-	const blockers = stages.flatMap((stage) =>
-		stage.requires
-			.filter((required) => !stageIds.has(required))
-			.map((required) => `missing_stage:${stage.id}:${required}`),
-	);
+	const blockers = [
+		...stages.flatMap((stage) =>
+			stage.requires
+				.filter((required) => !stageIds.has(required))
+				.map((required) => `missing_stage:${stage.id}:${required}`),
+		),
+		...detectReleaseCanaryCycles(stages),
+	];
 
 	return {
 		version: MAESTRO_OPERATING_LAYER_VERSION,
 		stages,
 		blockers,
 	};
+}
+
+function detectReleaseCanaryCycles(stages: ReleaseCanaryStage[]): string[] {
+	const stagesById = new Map(stages.map((stage) => [stage.id, stage]));
+	const visiting = new Set<string>();
+	const visited = new Set<string>();
+	const blockers: string[] = [];
+
+	function visit(stageId: string, path: string[]): void {
+		if (visiting.has(stageId)) {
+			const cycleStart = path.indexOf(stageId);
+			const cycle = path.slice(cycleStart).join(">");
+			blockers.push(`cycle:${cycle}`);
+			return;
+		}
+		if (visited.has(stageId)) {
+			return;
+		}
+
+		const stage = stagesById.get(stageId);
+		if (!stage) {
+			return;
+		}
+
+		visiting.add(stageId);
+		for (const required of stage.requires) {
+			visit(required, [...path, required]);
+		}
+		visiting.delete(stageId);
+		visited.add(stageId);
+	}
+
+	for (const stage of stages) {
+		visit(stage.id, [stage.id]);
+	}
+
+	return unique(blockers);
 }

--- a/test/platform/operating-layer.test.ts
+++ b/test/platform/operating-layer.test.ts
@@ -388,6 +388,28 @@ describe("operating layer primitives", () => {
 		expect(
 			buildReleaseCanaryPlan([
 				{
+					id: "local_release_gate",
+					name: "Local release gate",
+					requires: [],
+					evidenceKinds: ["test"],
+				},
+				{
+					id: "publish_package",
+					name: "Publish package",
+					requires: ["local_release_gate"],
+					evidenceKinds: ["npm.publish"],
+				},
+				{
+					id: "local_release_gate",
+					name: "Duplicate local release gate",
+					requires: [],
+					evidenceKinds: ["build"],
+				},
+			]).blockers,
+		).toEqual(["duplicate_stage:local_release_gate"]);
+		expect(
+			buildReleaseCanaryPlan([
+				{
 					id: "a",
 					name: "A",
 					requires: ["b"],

--- a/test/platform/operating-layer.test.ts
+++ b/test/platform/operating-layer.test.ts
@@ -129,7 +129,7 @@ describe("operating layer primitives", () => {
 					id: "item-2",
 					kind: "session_update",
 					status: "failed",
-					attempt: 4,
+					attempt: 5,
 					maxAttempts: 5,
 				},
 				{ ok: false, statusCode: 503, errorCode: "service_unavailable" },
@@ -137,7 +137,7 @@ describe("operating layer primitives", () => {
 		).toEqual({
 			action: "block",
 			reason: "service_unavailable",
-			nextAttempt: 5,
+			nextAttempt: 6,
 		});
 		expect(
 			classifySyncOutcome(
@@ -151,6 +151,22 @@ describe("operating layer primitives", () => {
 				{ ok: false, statusCode: 503 },
 			).action,
 		).toBe("retry");
+		expect(
+			classifySyncOutcome(
+				{
+					id: "item-final-attempt",
+					kind: "message",
+					status: "failed",
+					attempt: 4,
+					maxAttempts: 5,
+				},
+				{ ok: false, statusCode: 503 },
+			),
+		).toEqual({
+			action: "retry",
+			reason: "http_503",
+			nextAttempt: 5,
+		});
 		expect(
 			classifySyncOutcome(
 				{
@@ -173,7 +189,7 @@ describe("operating layer primitives", () => {
 					id: "item-4",
 					kind: "message",
 					status: "failed",
-					attempt: 4,
+					attempt: 5,
 					maxAttempts: 5,
 				},
 				{ ok: false, statusCode: 404 },
@@ -181,7 +197,7 @@ describe("operating layer primitives", () => {
 		).toEqual({
 			action: "block",
 			reason: "max_attempts_exhausted",
-			nextAttempt: 5,
+			nextAttempt: 6,
 		});
 	});
 
@@ -232,6 +248,19 @@ describe("operating layer primitives", () => {
 				]),
 			}),
 		);
+
+		expect(
+			evaluateExtensionGovernance(
+				{
+					id: "plugin-local",
+					source: "local",
+					publisher: "evalops",
+				},
+				{
+					trustedPublishers: ["evalops"],
+				},
+			).reasons,
+		).not.toContain("trusted_publisher:evalops");
 
 		expect(
 			evaluateExtensionGovernance(
@@ -340,5 +369,21 @@ describe("operating layer primitives", () => {
 				},
 			]).blockers,
 		).toEqual(["out_of_order_stage:publish_package:local_release_gate"]);
+		expect(
+			buildReleaseCanaryPlan([
+				{
+					id: "publish_package",
+					name: "Publish package",
+					requires: [],
+					evidenceKinds: ["npm.publish"],
+				},
+				{
+					id: "publish_package",
+					name: "Duplicate publish package",
+					requires: [],
+					evidenceKinds: ["npm.publish"],
+				},
+			]).blockers,
+		).toEqual(["duplicate_stage:publish_package"]);
 	});
 });

--- a/test/platform/operating-layer.test.ts
+++ b/test/platform/operating-layer.test.ts
@@ -265,6 +265,28 @@ describe("operating layer primitives", () => {
 		expect(
 			evaluateExtensionGovernance(
 				{
+					id: "plugin-lockdown",
+					source: "marketplace",
+					publisher: "evalops",
+					requestedScopes: ["repo:read"],
+				},
+				{
+					allowedSources: [],
+					trustedPublishers: [],
+					allowedScopes: [],
+				},
+			).blockers,
+		).toEqual(
+			expect.arrayContaining([
+				"source_not_allowed:marketplace",
+				"publisher_not_trusted:evalops",
+				"scope_not_allowed:repo:read",
+			]),
+		);
+
+		expect(
+			evaluateExtensionGovernance(
+				{
 					id: "plugin-2",
 					source: "git",
 					requestedScopes: ["secrets:read"],
@@ -324,6 +346,14 @@ describe("operating layer primitives", () => {
 			"release_notification",
 		]);
 		expect(plan.blockers).toEqual([]);
+		plan.stages[0]!.requires.push("mutated");
+		plan.stages[1]!.evidenceKinds.push("mutated");
+		expect(buildReleaseCanaryPlan().stages[0]!.requires).toEqual([]);
+		expect(buildReleaseCanaryPlan().stages[1]!.evidenceKinds).toEqual([
+			"npm.publish",
+			"git.tag",
+			"github.release",
+		]);
 		expect(
 			buildReleaseCanaryPlan([
 				...DEFAULT_RELEASE_CANARY_STAGES,

--- a/test/platform/operating-layer.test.ts
+++ b/test/platform/operating-layer.test.ts
@@ -142,6 +142,23 @@ describe("operating layer primitives", () => {
 		expect(
 			classifySyncOutcome(
 				{
+					id: "item-2b",
+					kind: "message",
+					sessionId: "session-1",
+					status: "failed",
+					attempt: 5,
+					maxAttempts: 5,
+				},
+				{ ok: false, statusCode: 404 },
+			),
+		).toEqual({
+			action: "block",
+			reason: "max_attempts_exhausted",
+			nextAttempt: 6,
+		});
+		expect(
+			classifySyncOutcome(
+				{
 					id: "item-3",
 					kind: "session_create",
 					status: "failed",

--- a/test/platform/operating-layer.test.ts
+++ b/test/platform/operating-layer.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_RELEASE_CANARY_STAGES,
+	MAESTRO_OPERATING_LAYER_VERSION,
+	buildApprovalDecisionEvidence,
+	buildOperatingLayerManifest,
+	buildProtocolBoundaryDescriptor,
+	buildReleaseCanaryPlan,
+	buildRunEffectivenessReport,
+	buildRunReadinessReport,
+	classifySyncOutcome,
+	evaluateExtensionGovernance,
+	explainResolvedPolicy,
+} from "../../src/platform/operating-layer.js";
+
+describe("operating layer primitives", () => {
+	it("declares the platform capabilities that make up the operating layer", () => {
+		const manifest = buildOperatingLayerManifest();
+
+		expect(manifest.version).toBe(MAESTRO_OPERATING_LAYER_VERSION);
+		expect(manifest.capabilities.map((capability) => capability.id)).toEqual([
+			"protocol-boundary",
+			"policy-resolution",
+			"sync-outbox",
+			"approval-evidence",
+			"extension-governance",
+			"run-readiness",
+			"run-effectiveness",
+			"release-canary",
+		]);
+		expect(
+			manifest.capabilities.every(
+				(capability) => capability.evidenceKinds.length > 0,
+			),
+		).toBe(true);
+	});
+
+	it("turns protocol surfaces into explicit versioned boundaries", () => {
+		expect(
+			buildProtocolBoundaryDescriptor({
+				protocolId: "maestro.headless",
+				version: "v1",
+				owners: [" platform ", "platform"],
+				contracts: ["session-wire", "rpc"],
+				compatibility: "stable",
+			}),
+		).toEqual(
+			expect.objectContaining({
+				protocolId: "maestro.headless",
+				version: "v1",
+				owners: ["platform"],
+				contracts: ["session-wire", "rpc"],
+				compatibility: "stable",
+				reasons: expect.arrayContaining([
+					"protocol:maestro.headless",
+					"version:v1",
+					"owner:platform",
+					"contract:session-wire",
+				]),
+			}),
+		);
+	});
+
+	it("explains policy resolution with the active source and override chain", () => {
+		const explanation = explainResolvedPolicy("approvals.mode", [
+			{
+				layer: "default",
+				id: "defaults",
+				value: "ask",
+				reason: "safe default",
+			},
+			{
+				layer: "workspace",
+				id: "workspace",
+				value: "suggest",
+				reason: "workspace policy",
+			},
+			{
+				layer: "session",
+				id: "session",
+				value: "deny",
+				reason: "incident response",
+			},
+		]);
+
+		expect(explanation.resolvedValue).toBe("deny");
+		expect(explanation.activeSource).toEqual(
+			expect.objectContaining({ id: "session", layer: "session" }),
+		);
+		expect(explanation.chain[2]).toEqual(
+			expect.objectContaining({
+				id: "session",
+				overrides: ["defaults", "workspace"],
+			}),
+		);
+		expect(explanation.reasons).toEqual(
+			expect.arrayContaining([
+				"subject:approvals.mode",
+				"active_source:session",
+				"reason:session:incident response",
+			]),
+		);
+	});
+
+	it("classifies missing remote sessions as self-healing sync work", () => {
+		expect(
+			classifySyncOutcome(
+				{
+					id: "item-1",
+					kind: "message",
+					sessionId: "session-1",
+					status: "failed",
+					attempt: 1,
+					maxAttempts: 5,
+				},
+				{ ok: false, statusCode: 404 },
+			),
+		).toEqual({
+			action: "self_heal_session",
+			reason: "remote_session_missing",
+			nextAttempt: 2,
+		});
+	});
+
+	it("blocks exhausted sync retries and keeps retryable errors durable", () => {
+		expect(
+			classifySyncOutcome(
+				{
+					id: "item-2",
+					kind: "session_update",
+					status: "failed",
+					attempt: 4,
+					maxAttempts: 5,
+				},
+				{ ok: false, statusCode: 503, errorCode: "service_unavailable" },
+			),
+		).toEqual({
+			action: "block",
+			reason: "service_unavailable",
+			nextAttempt: 5,
+		});
+		expect(
+			classifySyncOutcome(
+				{
+					id: "item-3",
+					kind: "session_create",
+					status: "failed",
+					attempt: 1,
+					maxAttempts: 5,
+				},
+				{ ok: false, statusCode: 503 },
+			).action,
+		).toBe("retry");
+	});
+
+	it("normalizes approval decisions across surfaces", () => {
+		const evidence = buildApprovalDecisionEvidence({
+			requestId: "approval-1",
+			surface: "tui",
+			mode: "ask",
+			decision: "denied",
+			toolNames: [" shell ", "shell", "write"],
+			policyRefs: ["policy:workspace"],
+		});
+
+		expect(evidence.toolNames).toEqual(["shell", "write"]);
+		expect(evidence.approvedTools).toEqual([]);
+		expect(evidence.blockedTools).toEqual(["shell", "write"]);
+		expect(evidence.reasons).toEqual(
+			expect.arrayContaining(["surface:tui", "mode:ask", "decision:denied"]),
+		);
+	});
+
+	it("governs extensions by source, signature, publisher, pin, and scope", () => {
+		expect(
+			evaluateExtensionGovernance(
+				{
+					id: "plugin-1",
+					source: "marketplace",
+					publisher: "evalops",
+					signed: true,
+					requestedScopes: ["repo:read", "session:write"],
+				},
+				{
+					allowedSources: ["builtin", "marketplace"],
+					trustedPublishers: ["evalops"],
+					allowedScopes: ["repo:read", "session:write"],
+					requireSignature: true,
+				},
+			),
+		).toEqual(
+			expect.objectContaining({
+				allowed: true,
+				blockers: [],
+				reasons: expect.arrayContaining([
+					"source:marketplace",
+					"trusted_publisher:evalops",
+					"signed",
+					"scope:repo:read",
+				]),
+			}),
+		);
+
+		expect(
+			evaluateExtensionGovernance(
+				{
+					id: "plugin-2",
+					source: "git",
+					requestedScopes: ["secrets:read"],
+				},
+				{
+					allowedSources: ["git"],
+					allowedScopes: ["repo:read"],
+					requireSignature: true,
+					requirePinnedGitRef: true,
+				},
+			).blockers,
+		).toEqual(
+			expect.arrayContaining([
+				"signature_required",
+				"pinned_git_ref_required",
+				"scope_not_allowed:secrets:read",
+			]),
+		);
+	});
+
+	it("builds readiness and effectiveness scorecards with blockers and warnings", () => {
+		const readiness = buildRunReadinessReport([
+			{ id: "tests", label: "Tests", status: "pass", weight: 2 },
+			{ id: "release-gate", label: "Release gate", status: "fail", weight: 2 },
+			{ id: "telemetry", label: "Telemetry", status: "warn", weight: 1 },
+			{ id: "optional", label: "Optional", status: "unknown", weight: 10 },
+		]);
+
+		expect(readiness.score).toBe(50);
+		expect(readiness.blockers).toEqual(["readiness:release-gate"]);
+		expect(readiness.warnings).toEqual(["readiness:telemetry"]);
+
+		const effectiveness = buildRunEffectivenessReport([
+			{
+				id: "task-complete",
+				label: "Task complete",
+				status: "pass",
+				weight: 3,
+			},
+			{ id: "follow-up", label: "Follow-up", status: "warn", weight: 1 },
+		]);
+
+		expect(effectiveness.score).toBe(88);
+		expect(effectiveness.blockers).toEqual([]);
+		expect(effectiveness.warnings).toEqual(["effectiveness:follow-up"]);
+	});
+
+	it("defines ordered release canary gates and reports invalid dependencies", () => {
+		const plan = buildReleaseCanaryPlan();
+
+		expect(plan.version).toBe(MAESTRO_OPERATING_LAYER_VERSION);
+		expect(plan.stages.map((stage) => stage.id)).toEqual([
+			"local_release_gate",
+			"publish_package",
+			"registry_install_smoke",
+			"published_replay_evidence",
+			"release_notification",
+		]);
+		expect(plan.blockers).toEqual([]);
+		expect(
+			buildReleaseCanaryPlan([
+				...DEFAULT_RELEASE_CANARY_STAGES,
+				{
+					id: "broken",
+					name: "Broken",
+					requires: ["missing"],
+					evidenceKinds: ["evidence"],
+				},
+			]).blockers,
+		).toEqual(["missing_stage:broken:missing"]);
+	});
+});

--- a/test/platform/operating-layer.test.ts
+++ b/test/platform/operating-layer.test.ts
@@ -385,5 +385,27 @@ describe("operating layer primitives", () => {
 				},
 			]).blockers,
 		).toEqual(["duplicate_stage:publish_package"]);
+		expect(
+			buildReleaseCanaryPlan([
+				{
+					id: "a",
+					name: "A",
+					requires: ["b"],
+					evidenceKinds: ["a"],
+				},
+				{
+					id: "b",
+					name: "B",
+					requires: ["a"],
+					evidenceKinds: ["b"],
+				},
+				{
+					id: "a",
+					name: "Duplicate A",
+					requires: [],
+					evidenceKinds: ["a"],
+				},
+			]).blockers,
+		).toEqual(expect.arrayContaining(["duplicate_stage:a", "cycle:a>b>a"]));
 	});
 });

--- a/test/platform/operating-layer.test.ts
+++ b/test/platform/operating-layer.test.ts
@@ -154,6 +154,22 @@ describe("operating layer primitives", () => {
 		expect(
 			classifySyncOutcome(
 				{
+					id: "item-5",
+					kind: "settings",
+					status: "failed",
+					attempt: 1,
+					maxAttempts: 5,
+				},
+				{ ok: false, statusCode: 404 },
+			),
+		).toEqual({
+			action: "retry",
+			reason: "http_404",
+			nextAttempt: 2,
+		});
+		expect(
+			classifySyncOutcome(
+				{
 					id: "item-4",
 					kind: "message",
 					status: "failed",
@@ -305,6 +321,24 @@ describe("operating layer primitives", () => {
 					evidenceKinds: ["b"],
 				},
 			]).blockers,
-		).toEqual(["cycle:a>b>a"]);
+		).toEqual(
+			expect.arrayContaining(["out_of_order_stage:a:b", "cycle:a>b>a"]),
+		);
+		expect(
+			buildReleaseCanaryPlan([
+				{
+					id: "publish_package",
+					name: "Publish package",
+					requires: ["local_release_gate"],
+					evidenceKinds: ["npm.publish"],
+				},
+				{
+					id: "local_release_gate",
+					name: "Local release gate",
+					requires: [],
+					evidenceKinds: ["test"],
+				},
+			]).blockers,
+		).toEqual(["out_of_order_stage:publish_package:local_release_gate"]);
 	});
 });

--- a/test/platform/operating-layer.test.ts
+++ b/test/platform/operating-layer.test.ts
@@ -151,6 +151,22 @@ describe("operating layer primitives", () => {
 				{ ok: false, statusCode: 503 },
 			).action,
 		).toBe("retry");
+		expect(
+			classifySyncOutcome(
+				{
+					id: "item-4",
+					kind: "message",
+					status: "failed",
+					attempt: 4,
+					maxAttempts: 5,
+				},
+				{ ok: false, statusCode: 404 },
+			),
+		).toEqual({
+			action: "block",
+			reason: "max_attempts_exhausted",
+			nextAttempt: 5,
+		});
 	});
 
 	it("normalizes approval decisions across surfaces", () => {
@@ -274,5 +290,21 @@ describe("operating layer primitives", () => {
 				},
 			]).blockers,
 		).toEqual(["missing_stage:broken:missing"]);
+		expect(
+			buildReleaseCanaryPlan([
+				{
+					id: "a",
+					name: "A",
+					requires: ["b"],
+					evidenceKinds: ["a"],
+				},
+				{
+					id: "b",
+					name: "B",
+					requires: ["a"],
+					evidenceKinds: ["b"],
+				},
+			]).blockers,
+		).toEqual(["cycle:a>b>a"]);
 	});
 });

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -214,9 +214,10 @@ describe("tag-release workflow", () => {
 			"${{ needs.tag-current-version.outputs.release_version }}",
 		);
 		expect(dispatchStep?.run).toContain(
-			'gh workflow run release --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"',
+			'gh workflow run release --repo "${GITHUB_REPOSITORY}" --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"',
 		);
 		expect(dispatchStep?.run).toContain("gh run list");
+		expect(dispatchStep?.run).toContain('--repo "${GITHUB_REPOSITORY}"');
 		expect(dispatchStep?.run).toContain("--workflow release");
 		expect(dispatchStep?.run).toContain(".headBranch");
 		expect(dispatchStep?.run).toContain(


### PR DESCRIPTION
## Summary
- add a versioned operating-layer manifest covering protocol boundaries, policy explanation, durable sync, approval evidence, extension governance, readiness, effectiveness, and release canaries
- add pure typed evaluators/builders for those platform primitives
- cover each primitive with focused Vitest tests

## Verification
- node ./scripts/run-vitest.js --run test/platform/operating-layer.test.ts
- bunx biome check src/platform/operating-layer.ts test/platform/operating-layer.test.ts
- bunx tsc -p tsconfig.build.json --noEmit --pretty false
- commit hooks: guardian, biome check ., lint:evals, build, compile

Source-of-truth: evalops/maestro-internal#2788