### PR TITLE
Add operating layer backend persistence

### DIFF
--- a/deploy/helm/maestro/templates/deployment.yaml
+++ b/deploy/helm/maestro/templates/deployment.yaml
@@ -57,6 +57,14 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- if .Values.operatingLayer.enabled }}
+            - name: MAESTRO_OPERATING_LAYER_ENABLED
+              value: "1"
+            - name: MAESTRO_OPERATING_LAYER_EVIDENCE_STORE
+              value: {{ .Values.operatingLayer.evidenceStore | quote }}
+            - name: MAESTRO_OPERATING_LAYER_EVIDENCE_RETENTION_DAYS
+              value: {{ .Values.operatingLayer.evidenceRetentionDays | quote }}
+            {{- end }}
           {{- if .Values.writableTmp.enabled }}
           volumeMounts:
             - name: tmp

--- a/deploy/helm/maestro/values.yaml
+++ b/deploy/helm/maestro/values.yaml
@@ -14,6 +14,13 @@ headlessRuntime:
     # durable-owner when Platform routes by a durable runtime-owner record.
     mode: single-replica
 
+operatingLayer:
+  # Enables production operating-layer evidence capture. Requires a configured
+  # MAESTRO_DATABASE_URL/DATABASE_URL secret so evidence persists in Postgres.
+  enabled: false
+  evidenceStore: database
+  evidenceRetentionDays: 90
+
 image:
   repository: ghcr.io/evalops/maestro
   # Defaults to Chart.appVersion when empty. Prefer immutable sha-* tags or digest.

--- a/src/db/health.ts
+++ b/src/db/health.ts
@@ -10,6 +10,7 @@ export const CRITICAL_DATABASE_TABLES = [
 	"distributed_locks",
 	"usage_metrics",
 	"execution_traces",
+	"operating_layer_evidence",
 	"workspace_config",
 	"revenue_attribution",
 ] as const;
@@ -38,6 +39,15 @@ const CRITICAL_DATABASE_COLUMNS: Partial<
 		"last_response_time_ms",
 		"delivered_at",
 		"created_at",
+	],
+	operating_layer_evidence: [
+		"id",
+		"capability_id",
+		"evidence_kind",
+		"subject",
+		"status",
+		"evidence",
+		"recorded_at",
 	],
 };
 

--- a/src/db/migrations/0009_operating_layer_evidence.sql
+++ b/src/db/migrations/0009_operating_layer_evidence.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS "operating_layer_evidence" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid,
+	"session_id" varchar(255),
+	"capability_id" varchar(64) NOT NULL,
+	"evidence_kind" varchar(128) NOT NULL,
+	"subject" varchar(255) NOT NULL,
+	"status" varchar(32) DEFAULT 'recorded' NOT NULL,
+	"score" integer,
+	"blockers" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"warnings" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"evidence" jsonb NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb,
+	"recorded_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone,
+	CONSTRAINT "operating_layer_evidence_org_id_organizations_id_fk"
+		FOREIGN KEY ("org_id") REFERENCES "organizations"("id") ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "operating_layer_evidence_capability_recorded_idx"
+	ON "operating_layer_evidence" ("capability_id", "recorded_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "operating_layer_evidence_org_recorded_idx"
+	ON "operating_layer_evidence" ("org_id", "recorded_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "operating_layer_evidence_session_recorded_idx"
+	ON "operating_layer_evidence" ("session_id", "recorded_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "operating_layer_evidence_expiry_idx"
+	ON "operating_layer_evidence" ("expires_at");

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1777303800000,
 			"tag": "0008_reconcile_legacy_webhook_deliveries",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1781749800000,
+			"tag": "0009_operating_layer_evidence",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -416,6 +416,47 @@ export const hostedSessionEntries = pgTable(
 );
 
 // ============================================================================
+// OPERATING LAYER EVIDENCE
+// ============================================================================
+
+export const operatingLayerEvidence = pgTable(
+	"operating_layer_evidence",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+		orgId: uuid("org_id").references(() => organizations.id, {
+			onDelete: "cascade",
+		}),
+		sessionId: varchar("session_id", { length: 255 }),
+		capabilityId: varchar("capability_id", { length: 64 }).notNull(),
+		evidenceKind: varchar("evidence_kind", { length: 128 }).notNull(),
+		subject: varchar("subject", { length: 255 }).notNull(),
+		status: varchar("status", { length: 32 }).default("recorded").notNull(),
+		score: integer("score"),
+		blockers: jsonb("blockers").$type<string[]>().default([]).notNull(),
+		warnings: jsonb("warnings").$type<string[]>().default([]).notNull(),
+		evidence: jsonb("evidence").$type<unknown>().notNull(),
+		metadata: jsonb("metadata").$type<Record<string, unknown>>().default({}),
+		recordedAt: timestamp("recorded_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+		expiresAt: timestamp("expires_at", { withTimezone: true }),
+	},
+	(table) => ({
+		capabilityRecordedIdx: index(
+			"operating_layer_evidence_capability_recorded_idx",
+		).on(table.capabilityId, table.recordedAt),
+		orgRecordedIdx: index("operating_layer_evidence_org_recorded_idx").on(
+			table.orgId,
+			table.recordedAt,
+		),
+		sessionRecordedIdx: index(
+			"operating_layer_evidence_session_recorded_idx",
+		).on(table.sessionId, table.recordedAt),
+		expiryIdx: index("operating_layer_evidence_expiry_idx").on(table.expiresAt),
+	}),
+);
+
+// ============================================================================
 // AUDIT LOGS
 // ============================================================================
 

--- a/test/db/hosted-session-storage.integration.test.ts
+++ b/test/db/hosted-session-storage.integration.test.ts
@@ -19,7 +19,7 @@ vi.mock("../../src/session/session-memory.js", () => ({
 const BASE_DB_URL =
 	process.env.MAESTRO_DATABASE_URL || process.env.DATABASE_URL;
 const describeDb = BASE_DB_URL ? describe : describe.skip;
-const EXPECTED_MIGRATION_COUNT = 9;
+const EXPECTED_MIGRATION_COUNT = 10;
 
 const originalEnv = { ...process.env };
 

--- a/test/db/migration-files.test.ts
+++ b/test/db/migration-files.test.ts
@@ -37,6 +37,9 @@ describe("database migration packaging", () => {
 		expect(journal.entries.map((entry) => entry.tag)).toContain(
 			"0008_reconcile_legacy_webhook_deliveries",
 		);
+		expect(journal.entries.map((entry) => entry.tag)).toContain(
+			"0009_operating_layer_evidence",
+		);
 
 		for (const entry of journal.entries) {
 			expect(
@@ -151,5 +154,26 @@ describe("database migration packaging", () => {
 			"IF to_regclass('public.webhook_deliveries') IS NOT NULL THEN",
 		);
 		expect(migration).toContain("webhook_delivery_retry_idx");
+	});
+
+	it("adds the operating layer evidence migration for production readiness", () => {
+		const migration = readFileSync(
+			path.join(migrationsDir, "0009_operating_layer_evidence.sql"),
+			"utf8",
+		);
+
+		expect(migration).toContain(
+			'CREATE TABLE IF NOT EXISTS "operating_layer_evidence"',
+		);
+		expect(migration).toContain('"capability_id" varchar(64) NOT NULL');
+		expect(migration).toContain('"evidence_kind" varchar(128) NOT NULL');
+		expect(migration).toContain('"evidence" jsonb NOT NULL');
+		expect(migration).toContain(
+			"operating_layer_evidence_org_id_organizations_id_fk",
+		);
+		expect(migration).toContain(
+			"operating_layer_evidence_capability_recorded_idx",
+		);
+		expect(migration).toContain("operating_layer_evidence_expiry_idx");
 	});
 });

--- a/test/deploy/helm-maestro.test.ts
+++ b/test/deploy/helm-maestro.test.ts
@@ -45,6 +45,7 @@ describe("maestro Helm chart", () => {
 		expect(result.stdout).toMatch(/mountPath:\s+\/tmp/);
 		expect(result.stdout).toContain("name: HOME");
 		expect(result.stdout).toContain("name: XDG_CACHE_HOME");
+		expect(result.stdout).not.toContain("MAESTRO_OPERATING_LAYER_ENABLED");
 		expect(result.stdout).toContain("startupProbe:");
 		expect(result.stdout).toContain("preStop:");
 		expect(result.stdout).toContain("/.well-known/evalops/remote-runner/drain");
@@ -79,6 +80,30 @@ describe("maestro Helm chart", () => {
 			expect(result.stdout).toContain(
 				'image: "ghcr.io/evalops/maestro@sha256:0123456789abcdef"',
 			);
+		},
+	);
+
+	helmIt(
+		"renders production operating layer evidence settings when enabled",
+		() => {
+			const result = renderChart([
+				"--set",
+				"operatingLayer.enabled=true",
+				"--set",
+				"operatingLayer.evidenceRetentionDays=120",
+			]);
+
+			expect(result.status).toBe(0);
+			expect(result.stdout).toContain("name: MAESTRO_OPERATING_LAYER_ENABLED");
+			expect(result.stdout).toContain('value: "1"');
+			expect(result.stdout).toContain(
+				"name: MAESTRO_OPERATING_LAYER_EVIDENCE_STORE",
+			);
+			expect(result.stdout).toContain('value: "database"');
+			expect(result.stdout).toContain(
+				"name: MAESTRO_OPERATING_LAYER_EVIDENCE_RETENTION_DAYS",
+			);
+			expect(result.stdout).toContain('value: "120"');
 		},
 	);
 

--- a/test/web-health.test.ts
+++ b/test/web-health.test.ts
@@ -15,6 +15,7 @@ vi.mock("../src/db/health.js", () => ({
 		"distributed_locks",
 		"usage_metrics",
 		"execution_traces",
+		"operating_layer_evidence",
 		"workspace_config",
 		"revenue_attribution",
 	],
@@ -67,6 +68,7 @@ describe("Health Checks", () => {
 				{ name: "distributed_locks", exists: true },
 				{ name: "usage_metrics", exists: true },
 				{ name: "execution_traces", exists: true },
+				{ name: "operating_layer_evidence", exists: true },
 				{ name: "workspace_config", exists: true },
 				{ name: "revenue_attribution", exists: true },
 			]);
@@ -102,6 +104,7 @@ describe("Health Checks", () => {
 				{ name: "distributed_locks", exists: false },
 				{ name: "usage_metrics", exists: true },
 				{ name: "execution_traces", exists: true },
+				{ name: "operating_layer_evidence", exists: true },
 				{ name: "workspace_config", exists: true },
 				{ name: "revenue_attribution", exists: true },
 			]);
@@ -132,6 +135,7 @@ describe("Health Checks", () => {
 				{ name: "distributed_locks", exists: true },
 				{ name: "usage_metrics", exists: true },
 				{ name: "execution_traces", exists: true },
+				{ name: "operating_layer_evidence", exists: true },
 				{ name: "workspace_config", exists: true },
 				{ name: "revenue_attribution", exists: true },
 			]);


### PR DESCRIPTION
## Summary
- add operating_layer_evidence persistence table and migration
- include the table in database health validation
- add Helm values/env wiring for production operating-layer evidence capture

Source-of-truth: evalops/maestro-internal#2789

## Verification
- node ./scripts/run-vitest.js --run test/db/migration-files.test.ts test/web-health.test.ts test/deploy/helm-maestro.test.ts
- bunx biome check src/db/schema.ts src/db/health.ts test/db/hosted-session-storage.integration.test.ts test/db/migration-files.test.ts test/web-health.test.ts test/deploy/helm-maestro.test.ts deploy/helm/maestro/values.yaml deploy/helm/maestro/templates/deployment.yaml
- bunx tsc -p tsconfig.build.json --noEmit --pretty false