### PR TITLE
Fix tag release workflow dispatch

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -177,6 +177,7 @@ jobs:
           set -euo pipefail
           active_count="$(
             gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
               --workflow release \
               --json headBranch,status \
               --limit 50 \

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -216,7 +216,9 @@ describe("tag-release workflow", () => {
 		expect(dispatchStep?.run).toContain(
 			'gh workflow run release --repo "${GITHUB_REPOSITORY}" --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"',
 		);
-		expect(dispatchStep?.run).toContain("gh run list");
+		expect(dispatchStep?.run).toMatch(
+			/gh run list\s+\\\n\s+--repo "\$\{GITHUB_REPOSITORY\}"/,
+		);
 		expect(dispatchStep?.run).toContain('--repo "${GITHUB_REPOSITORY}"');
 		expect(dispatchStep?.run).toContain("--workflow release");
 		expect(dispatchStep?.run).toContain(".headBranch");


### PR DESCRIPTION
## Summary
- pass the explicit repository to the tag-release dispatch job active-run lookup
- tighten the tag-release workflow regression test so gh run list cannot rely on cwd git metadata

Source-of-truth: evalops/maestro-internal#2791

## Verification
- node ./scripts/run-vitest.js --run test/workflows/tag-release.test.ts test/scripts/ci-guardrails.test.ts test/scripts/workflow-footguns.test.ts
- bunx biome check test/workflows/tag-release.test.ts
- npm run check:workflow-footguns
- pre-commit release validators ran during commit