### PR TITLE
Harden tag release dispatch

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -186,13 +186,13 @@ jobs:
               --jq "[.[] | select(.headBranch == \"${RELEASE_TAG}\" and .status != \"completed\")] | length"
           }
 
-          release_run_count() {
+          latest_release_run_id() {
             gh run list \
               --repo "${GITHUB_REPOSITORY}" \
               --workflow release \
-              --json headBranch \
+              --json databaseId,headBranch \
               --limit 50 \
-              --jq "[.[] | select(.headBranch == \"${RELEASE_TAG}\")] | length"
+              --jq "([.[] | select(.headBranch == \"${RELEASE_TAG}\") | .databaseId] | .[0]) // \"\""
           }
 
           retry() {
@@ -217,13 +217,13 @@ jobs:
             echo "Found ${active_count} active release workflow run(s) for ${RELEASE_TAG}; not dispatching another."
             exit 0
           fi
-          existing_count="$(retry "List release workflows" release_run_count)"
+          existing_run_id="$(retry "List release workflows" latest_release_run_id)"
           retry "Dispatch release workflow" gh workflow run release --repo "${GITHUB_REPOSITORY}" --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"
 
           for attempt in 1 2 3 4 5 6; do
-            release_count="$(retry "Confirm dispatched release workflow" release_run_count)"
-            if (( release_count > existing_count )); then
-              echo "Confirmed release workflow dispatch for ${RELEASE_TAG}; found ${release_count} matching run(s)."
+            latest_run_id="$(retry "Confirm dispatched release workflow" latest_release_run_id)"
+            if [[ -n "${latest_run_id}" && "${latest_run_id}" != "${existing_run_id}" ]]; then
+              echo "Confirmed release workflow dispatch for ${RELEASE_TAG}; observed run ${latest_run_id}."
               exit 0
             fi
             echo "Release workflow for ${RELEASE_TAG} has not appeared yet; confirmation attempt ${attempt}/6."

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -175,16 +175,50 @@ jobs:
           RELEASE_VERSION: ${{ needs.tag-current-version.outputs.release_version }}
         run: |
           set -euo pipefail
-          active_count="$(
+
+          # shellcheck disable=SC2317 # Invoked indirectly through retry.
+          release_run_count() {
             gh run list \
               --repo "${GITHUB_REPOSITORY}" \
               --workflow release \
               --json headBranch,status \
               --limit 50 \
               --jq "[.[] | select(.headBranch == \"${RELEASE_TAG}\" and .status != \"completed\")] | length"
-          )"
+          }
+
+          retry() {
+            local description="$1"
+            shift
+            local attempt
+            for attempt in 1 2 3; do
+              if "$@"; then
+                return 0
+              fi
+              if [[ "$attempt" == "3" ]]; then
+                echo "::error::${description} failed after ${attempt} attempts." >&2
+                return 1
+              fi
+              echo "::warning::${description} failed on attempt ${attempt}; retrying..." >&2
+              sleep $((attempt * 5))
+            done
+          }
+
+          active_count="$(retry "List active release workflows" release_run_count)"
           if [[ "${active_count}" != "0" ]]; then
             echo "Found ${active_count} active release workflow run(s) for ${RELEASE_TAG}; not dispatching another."
             exit 0
           fi
-          gh workflow run release --repo "${GITHUB_REPOSITORY}" --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"
+          retry "Dispatch release workflow" gh workflow run release --repo "${GITHUB_REPOSITORY}" --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"
+
+          for attempt in 1 2 3 4 5 6; do
+            active_count="$(retry "Confirm active release workflow" release_run_count)"
+            if [[ "${active_count}" != "0" ]]; then
+              echo "Confirmed ${active_count} active release workflow run(s) for ${RELEASE_TAG}."
+              exit 0
+            fi
+            echo "Release workflow for ${RELEASE_TAG} has not appeared yet; confirmation attempt ${attempt}/6."
+            sleep 10
+          done
+
+          echo "::error::Release workflow dispatch did not produce an active run for ${RELEASE_TAG}."
+          exit 1

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -186,13 +186,13 @@ jobs:
               --jq "[.[] | select(.headBranch == \"${RELEASE_TAG}\" and .status != \"completed\")] | length"
           }
 
-          latest_release_run_id() {
+          dispatched_release_run_count() {
             gh run list \
               --repo "${GITHUB_REPOSITORY}" \
               --workflow release \
-              --json databaseId,headBranch \
+              --json event,headBranch \
               --limit 50 \
-              --jq "([.[] | select(.headBranch == \"${RELEASE_TAG}\") | .databaseId] | .[0]) // \"\""
+              --jq "[.[] | select(.headBranch == \"${RELEASE_TAG}\" and .event == \"workflow_dispatch\")] | length"
           }
 
           retry() {
@@ -217,13 +217,13 @@ jobs:
             echo "Found ${active_count} active release workflow run(s) for ${RELEASE_TAG}; not dispatching another."
             exit 0
           fi
-          existing_run_id="$(retry "List release workflows" latest_release_run_id)"
+          existing_count="$(retry "List dispatched release workflows" dispatched_release_run_count)"
           retry "Dispatch release workflow" gh workflow run release --repo "${GITHUB_REPOSITORY}" --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"
 
           for attempt in 1 2 3 4 5 6; do
-            latest_run_id="$(retry "Confirm dispatched release workflow" latest_release_run_id)"
-            if [[ -n "${latest_run_id}" && "${latest_run_id}" != "${existing_run_id}" ]]; then
-              echo "Confirmed release workflow dispatch for ${RELEASE_TAG}; observed run ${latest_run_id}."
+            release_count="$(retry "Confirm dispatched release workflow" dispatched_release_run_count)"
+            if (( release_count > existing_count )); then
+              echo "Confirmed release workflow dispatch for ${RELEASE_TAG}; found ${release_count} matching dispatched run(s)."
               exit 0
             fi
             echo "Release workflow for ${RELEASE_TAG} has not appeared yet; confirmation attempt ${attempt}/6."

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -177,13 +177,22 @@ jobs:
           set -euo pipefail
 
           # shellcheck disable=SC2317 # Invoked indirectly through retry.
-          release_run_count() {
+          active_release_run_count() {
             gh run list \
               --repo "${GITHUB_REPOSITORY}" \
               --workflow release \
               --json headBranch,status \
               --limit 50 \
               --jq "[.[] | select(.headBranch == \"${RELEASE_TAG}\" and .status != \"completed\")] | length"
+          }
+
+          release_run_count() {
+            gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow release \
+              --json headBranch \
+              --limit 50 \
+              --jq "[.[] | select(.headBranch == \"${RELEASE_TAG}\")] | length"
           }
 
           retry() {
@@ -203,22 +212,23 @@ jobs:
             done
           }
 
-          active_count="$(retry "List active release workflows" release_run_count)"
+          active_count="$(retry "List active release workflows" active_release_run_count)"
           if [[ "${active_count}" != "0" ]]; then
             echo "Found ${active_count} active release workflow run(s) for ${RELEASE_TAG}; not dispatching another."
             exit 0
           fi
+          existing_count="$(retry "List release workflows" release_run_count)"
           retry "Dispatch release workflow" gh workflow run release --repo "${GITHUB_REPOSITORY}" --ref "${RELEASE_TAG}" --field "version=${RELEASE_VERSION}"
 
           for attempt in 1 2 3 4 5 6; do
-            active_count="$(retry "Confirm active release workflow" release_run_count)"
-            if [[ "${active_count}" != "0" ]]; then
-              echo "Confirmed ${active_count} active release workflow run(s) for ${RELEASE_TAG}."
+            release_count="$(retry "Confirm dispatched release workflow" release_run_count)"
+            if (( release_count > existing_count )); then
+              echo "Confirmed release workflow dispatch for ${RELEASE_TAG}; found ${release_count} matching run(s)."
               exit 0
             fi
             echo "Release workflow for ${RELEASE_TAG} has not appeared yet; confirmation attempt ${attempt}/6."
             sleep 10
           done
 
-          echo "::error::Release workflow dispatch did not produce an active run for ${RELEASE_TAG}."
+          echo "::error::Release workflow dispatch did not produce a new run for ${RELEASE_TAG}."
           exit 1

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -186,6 +186,7 @@ jobs:
               --jq "[.[] | select(.headBranch == \"${RELEASE_TAG}\" and .status != \"completed\")] | length"
           }
 
+          # shellcheck disable=SC2317 # Invoked indirectly through retry.
           dispatched_release_run_count() {
             gh run list \
               --repo "${GITHUB_REPOSITORY}" \

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -219,6 +219,21 @@ describe("tag-release workflow", () => {
 		expect(dispatchStep?.run).toMatch(
 			/gh run list\s+\\\n\s+--repo "\$\{GITHUB_REPOSITORY\}"/,
 		);
+		expect(dispatchStep?.run).toContain("release_run_count()");
+		expect(dispatchStep?.run).toContain("retry()");
+		expect(dispatchStep?.run).toContain(
+			'retry "List active release workflows" release_run_count',
+		);
+		expect(dispatchStep?.run).toContain(
+			'retry "Dispatch release workflow" gh workflow run release',
+		);
+		expect(dispatchStep?.run).toContain(
+			'retry "Confirm active release workflow" release_run_count',
+		);
+		expect(dispatchStep?.run).toContain("confirmation attempt ${attempt}/6");
+		expect(dispatchStep?.run).toContain(
+			"Release workflow dispatch did not produce an active run",
+		);
 		expect(dispatchStep?.run).toContain('--repo "${GITHUB_REPOSITORY}"');
 		expect(dispatchStep?.run).toContain("--workflow release");
 		expect(dispatchStep?.run).toContain(".headBranch");

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -220,16 +220,19 @@ describe("tag-release workflow", () => {
 			/gh run list\s+\\\n\s+--repo "\$\{GITHUB_REPOSITORY\}"/,
 		);
 		expect(dispatchStep?.run).toContain("active_release_run_count()");
-		expect(dispatchStep?.run).toContain("latest_release_run_id()");
+		expect(dispatchStep?.run).toContain("dispatched_release_run_count()");
 		expect(dispatchStep?.run).toContain("retry()");
 		expect(dispatchStep?.run).toContain(
 			'retry "List active release workflows" active_release_run_count',
 		);
 		expect(dispatchStep?.run).toContain(
+			'retry "List dispatched release workflows" dispatched_release_run_count',
+		);
+		expect(dispatchStep?.run).toContain(
 			'retry "Dispatch release workflow" gh workflow run release',
 		);
 		expect(dispatchStep?.run).toContain(
-			'retry "Confirm dispatched release workflow" latest_release_run_id',
+			'retry "Confirm dispatched release workflow" dispatched_release_run_count',
 		);
 		expect(dispatchStep?.run).toContain("confirmation attempt ${attempt}/6");
 		expect(dispatchStep?.run).toContain(
@@ -238,6 +241,7 @@ describe("tag-release workflow", () => {
 		expect(dispatchStep?.run).toContain('--repo "${GITHUB_REPOSITORY}"');
 		expect(dispatchStep?.run).toContain("--workflow release");
 		expect(dispatchStep?.run).toContain(".headBranch");
+		expect(dispatchStep?.run).toContain('.event == \\"workflow_dispatch\\"');
 		expect(dispatchStep?.run).toContain(
 			'if [[ "${active_count}" != "0" ]]; then',
 		);

--- a/test/workflows/tag-release.test.ts
+++ b/test/workflows/tag-release.test.ts
@@ -219,20 +219,21 @@ describe("tag-release workflow", () => {
 		expect(dispatchStep?.run).toMatch(
 			/gh run list\s+\\\n\s+--repo "\$\{GITHUB_REPOSITORY\}"/,
 		);
-		expect(dispatchStep?.run).toContain("release_run_count()");
+		expect(dispatchStep?.run).toContain("active_release_run_count()");
+		expect(dispatchStep?.run).toContain("latest_release_run_id()");
 		expect(dispatchStep?.run).toContain("retry()");
 		expect(dispatchStep?.run).toContain(
-			'retry "List active release workflows" release_run_count',
+			'retry "List active release workflows" active_release_run_count',
 		);
 		expect(dispatchStep?.run).toContain(
 			'retry "Dispatch release workflow" gh workflow run release',
 		);
 		expect(dispatchStep?.run).toContain(
-			'retry "Confirm active release workflow" release_run_count',
+			'retry "Confirm dispatched release workflow" latest_release_run_id',
 		);
 		expect(dispatchStep?.run).toContain("confirmation attempt ${attempt}/6");
 		expect(dispatchStep?.run).toContain(
-			"Release workflow dispatch did not produce an active run",
+			"Release workflow dispatch did not produce a new run for",
 		);
 		expect(dispatchStep?.run).toContain('--repo "${GITHUB_REPOSITORY}"');
 		expect(dispatchStep?.run).toContain("--workflow release");


### PR DESCRIPTION
## Summary
- retry transient release-run listing and workflow dispatch failures
- confirm a dispatched release workflow appears for the release tag before exiting
- cover the retry and confirmation behavior in the tag-release workflow test

Source-of-truth: evalops/maestro-internal#2792

## Verification
- actionlint .github/workflows/tag-release.yml
- node ./scripts/run-vitest.js --run test/workflows/tag-release.test.ts test/scripts/ci-guardrails.test.ts test/scripts/workflow-footguns.test.ts
- bunx biome check .github/workflows/tag-release.yml test/workflows/tag-release.test.ts
- npm run check:workflow-footguns
- pre-commit release validators ran during commit