### PR TITLE
[maestro] Restore public Bzlmod module name and guard it

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 module(
-    name = "evalops_maestro_internal",
+    name = "evalops_maestro",
     version = "0.0.0",
 )
 

--- a/scripts/guardrail-regression-suite.json
+++ b/scripts/guardrail-regression-suite.json
@@ -213,6 +213,24 @@
 			]
 		},
 		{
+			"id": "public-bazel-module-identity",
+			"title": "Public Bazel module identity",
+			"owner": "release",
+			"bugClass": "mirror sync leaking the internal Bzlmod module name to public consumers",
+			"why": "The public evalops/maestro MODULE.bazel must declare module(name = \"evalops_maestro\"); an internal mirror sync must not rename it to evalops_maestro_internal or downstream bazel_dep(name = \"evalops_maestro\", ...) consumers break.",
+			"evidence": [
+				{
+					"path": "MODULE.bazel",
+					"contains": ["name = \"evalops_maestro\""],
+					"notContains": ["evalops_maestro_internal"]
+				},
+				{
+					"path": "test/scripts/ci-guardrails.test.ts",
+					"contains": ["keeps the public Bazel module name public-facing"]
+				}
+			]
+		},
+		{
 			"id": "a2a-cancel-canonical-state-guard",
 			"title": "A2A cancel canonical state guard",
 			"owner": "a2a",

--- a/scripts/guardrail-regression-suite.json
+++ b/scripts/guardrail-regression-suite.json
@@ -189,6 +189,30 @@
 			]
 		},
 		{
+			"id": "release-train-drift",
+			"title": "Release train drift from unguarded Rust test modules",
+			"owner": "release",
+			"bugClass": "unguarded mod tests edits skipped by release-impact filtering",
+			"why": "rustProductionContent must only strip cfg(test)-gated test modules so edits inside an unguarded inline `mod tests` block remain package-impacting and force the required version bump instead of silently letting a tag mismatch through.",
+			"evidence": [
+				{
+					"path": "scripts/release-impact-filter.mjs",
+					"contains": [
+						"cfgTestAttributePattern",
+						"gatedByCfgTest",
+						"Only cfg(test)-gated test modules are test-only"
+					]
+				},
+				{
+					"path": "test/scripts/release-impact-filter.test.ts",
+					"contains": [
+						"treats unguarded inline Rust test module edits as package-impacting",
+						"ignores cfg(test)-gated inline Rust test module edits"
+					]
+				}
+			]
+		},
+		{
 			"id": "a2a-cancel-canonical-state-guard",
 			"title": "A2A cancel canonical state guard",
 			"owner": "a2a",

--- a/scripts/release-impact-filter.mjs
+++ b/scripts/release-impact-filter.mjs
@@ -261,6 +261,8 @@ function braceDelta(line, state) {
 	return delta;
 }
 
+const cfgTestAttributePattern = /^\s*#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]/;
+
 /**
  * @param {string} source
  */
@@ -278,9 +280,29 @@ export function stripRustTestModules(source) {
 			continue;
 		}
 
-		while (output.length > 0 && /^\s*#\[/.test(output[output.length - 1])) {
-			output.pop();
+		// Collect the contiguous outer attribute group immediately preceding the
+		// `mod tests` declaration so the cfg(test) gate can be evaluated before
+		// any preceding attributes or the module body are stripped.
+		let attributeStart = output.length;
+		while (
+			attributeStart > 0 &&
+			/^\s*#\[/.test(output[attributeStart - 1])
+		) {
+			attributeStart -= 1;
 		}
+		const gatedByCfgTest = output
+			.slice(attributeStart)
+			.some((attribute) => cfgTestAttributePattern.test(attribute));
+
+		// Only cfg(test)-gated test modules are test-only. An unguarded
+		// `mod tests` block is compiled in production builds, so edits inside it
+		// are package-impacting and must not be stripped from release diffs.
+		if (!gatedByCfgTest) {
+			output.push(line);
+			continue;
+		}
+
+		output.length = attributeStart;
 
 		if (moduleMatch[1] === ";") {
 			continue;

--- a/scripts/release-impact-filter.mjs
+++ b/scripts/release-impact-filter.mjs
@@ -264,6 +264,59 @@ function braceDelta(line, state) {
 const cfgTestAttributePattern = /^\s*#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]/;
 
 /**
+ * @param {string[]} lines
+ */
+function rustOuterAttributeGroupInfo(lines) {
+	let attributeStart = -1;
+	let gatedByCfgTest = false;
+
+	for (let index = lines.length - 1; index >= 0; index -= 1) {
+		if (!/^\s*#\[/.test(lines[index])) {
+			continue;
+		}
+
+		let blockCommentDepth = 0;
+		let spanGatedByCfgTest = false;
+		let validSpan = true;
+		for (let spanIndex = index; spanIndex < lines.length; spanIndex += 1) {
+			const spanLine = lines[spanIndex];
+			const trimmed = spanLine.trim();
+			if (!trimmed) {
+				continue;
+			}
+			if (blockCommentDepth > 0) {
+				blockCommentDepth = rustBlockCommentDepthAfterLine(
+					trimmed,
+					blockCommentDepth,
+				);
+				continue;
+			}
+			if (trimmed.startsWith("//")) {
+				continue;
+			}
+			if (trimmed.startsWith("/*")) {
+				blockCommentDepth = rustBlockCommentDepthAfterLine(trimmed, 0);
+				continue;
+			}
+			if (/^\s*#\[/.test(spanLine)) {
+				if (cfgTestAttributePattern.test(spanLine)) {
+					spanGatedByCfgTest = true;
+				}
+				continue;
+			}
+			validSpan = false;
+			break;
+		}
+		if (validSpan) {
+			attributeStart = index;
+			gatedByCfgTest = spanGatedByCfgTest;
+		}
+	}
+
+	return attributeStart === -1 ? null : { attributeStart, gatedByCfgTest };
+}
+
+/**
  * @param {string} source
  */
 export function stripRustTestModules(source) {
@@ -280,19 +333,8 @@ export function stripRustTestModules(source) {
 			continue;
 		}
 
-		// Collect the contiguous outer attribute group immediately preceding the
-		// `mod tests` declaration so the cfg(test) gate can be evaluated before
-		// any preceding attributes or the module body are stripped.
-		let attributeStart = output.length;
-		while (
-			attributeStart > 0 &&
-			/^\s*#\[/.test(output[attributeStart - 1])
-		) {
-			attributeStart -= 1;
-		}
-		const gatedByCfgTest = output
-			.slice(attributeStart)
-			.some((attribute) => cfgTestAttributePattern.test(attribute));
+		const attributeGroup = rustOuterAttributeGroupInfo(output);
+		const gatedByCfgTest = attributeGroup?.gatedByCfgTest ?? false;
 
 		// Only cfg(test)-gated test modules are test-only. An unguarded
 		// `mod tests` block is compiled in production builds, so edits inside it
@@ -302,7 +344,7 @@ export function stripRustTestModules(source) {
 			continue;
 		}
 
-		output.length = attributeStart;
+		output.length = attributeGroup.attributeStart;
 
 		if (moduleMatch[1] === ";") {
 			continue;

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -1115,6 +1115,16 @@ describe("ci workflow guardrails", () => {
 		expect(script).not.toContain('spawnSync("npx"');
 	});
 
+	it("keeps the public Bazel module name public-facing", () => {
+		const moduleBazel = readFileSync(
+			new URL("../../MODULE.bazel", import.meta.url),
+			{ encoding: "utf8" },
+		);
+
+		expect(moduleBazel).toMatch(/module\(\s*name\s*=\s*"evalops_maestro"/);
+		expect(moduleBazel).not.toContain("evalops_maestro_internal");
+	});
+
 	it("keeps GitHub App token actions on the Node24-compatible pin", () => {
 		const workflowsDir = new URL("../../.github/workflows/", import.meta.url);
 		const workflowFiles = readdirSync(workflowsDir)

--- a/test/scripts/release-impact-filter.test.ts
+++ b/test/scripts/release-impact-filter.test.ts
@@ -152,6 +152,24 @@ mod tests { // a comment with a semicolon should not look like mod tests;
 }
 `;
 
+const inlineRustTestsWithDiscontiguousCfg = `pub fn cache_key(path: &str) -> String {
+	format!("cache:{path}")
+}
+
+#[cfg(test)]
+
+// Keep inline tests with the production module for rust-analyzer.
+#[allow(clippy::float_cmp)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn includes_path() {
+		assert_eq!(cache_key("fixture"), "cache:fixture");
+	}
+}
+`;
+
 const extractedRustModule = `pub fn cache_key(path: &str) -> String {
 	format!("cache:{path}")
 }
@@ -433,6 +451,28 @@ describe("release impact filter", () => {
 			inlineRustTests.replace("cache:fixture", "cache:test-only-change"),
 		);
 		commit(root, "edit cfg(test) inline test module");
+
+		expect(packageChangedSinceTag({ cwd: root, tagTarget })).toBe(false);
+	});
+
+	it("ignores comments and blank lines between cfg(test) and inline Rust test modules", () => {
+		const root = makeRepo();
+		writeFixtureFile(
+			root,
+			"packages/tui-rs/src/tools/cache.rs",
+			inlineRustTestsWithDiscontiguousCfg,
+		);
+		const tagTarget = commit(root, "initial package source");
+
+		writeFixtureFile(
+			root,
+			"packages/tui-rs/src/tools/cache.rs",
+			inlineRustTestsWithDiscontiguousCfg.replace(
+				"cache:fixture",
+				"cache:test-only-change",
+			),
+		);
+		commit(root, "edit cfg(test) inline test module with trivia");
 
 		expect(packageChangedSinceTag({ cwd: root, tagTarget })).toBe(false);
 	});

--- a/test/scripts/release-impact-filter.test.ts
+++ b/test/scripts/release-impact-filter.test.ts
@@ -179,6 +179,19 @@ const unguardedRustModule = `pub fn cache_key(path: &str) -> String {
 mod tests;
 `;
 
+const unguardedInlineRustTests = `pub fn cache_key(path: &str) -> String {
+	format!("cache:{path}")
+}
+
+mod tests {
+	use super::*;
+
+	pub fn exported_helper() -> u32 {
+		42
+	}
+}
+`;
+
 const extractedRustTests = `use super::*;
 
 #[test]
@@ -382,6 +395,44 @@ describe("release impact filter", () => {
 			extractedRustTests.replace("cache:fixture", "cache:still-test-only"),
 		);
 		commit(root, "change extracted tests");
+
+		expect(packageChangedSinceTag({ cwd: root, tagTarget })).toBe(false);
+	});
+
+	it("treats unguarded inline Rust test module edits as package-impacting", () => {
+		const root = makeRepo();
+		writeFixtureFile(
+			root,
+			"packages/tui-rs/src/tools/cache.rs",
+			unguardedInlineRustTests,
+		);
+		const tagTarget = commit(root, "initial package source");
+
+		writeFixtureFile(
+			root,
+			"packages/tui-rs/src/tools/cache.rs",
+			unguardedInlineRustTests.replace("42", "99"),
+		);
+		commit(root, "edit unguarded inline test module");
+
+		expect(packageChangedSinceTag({ cwd: root, tagTarget })).toBe(true);
+	});
+
+	it("ignores cfg(test)-gated inline Rust test module edits", () => {
+		const root = makeRepo();
+		writeFixtureFile(
+			root,
+			"packages/tui-rs/src/tools/cache.rs",
+			inlineRustTests,
+		);
+		const tagTarget = commit(root, "initial package source");
+
+		writeFixtureFile(
+			root,
+			"packages/tui-rs/src/tools/cache.rs",
+			inlineRustTests.replace("cache:fixture", "cache:test-only-change"),
+		);
+		commit(root, "edit cfg(test) inline test module");
 
 		expect(packageChangedSinceTag({ cwd: root, tagTarget })).toBe(false);
 	});


### PR DESCRIPTION
> **Note:** Stacked on #798 (both add a guardrail-regression-suite entry). Once #798 merges, this PR's diff shrinks to just the MODULE.bazel fix + guard test. Reviewing this one is fine independently.

## Summary

Guardrail for #394 (`other-feedback`). Manual review conclusion: convert this class into a repo-local guardrail.

The public `evalops/maestro` MODULE.bazel declared `module(name = "evalops_maestro_internal")`, leaking the internal module identity to public Bzlmod consumers — any downstream workspace using `bazel_dep(name = "evalops_maestro", ...)` stops resolving. This was introduced by the mirror sync in #417 and flagged by both cursor and codex review as a breaking Bzlmod change; no later commit restored it.

## Change

- **Fix:** `MODULE.bazel` `evalops_maestro_internal` → `evalops_maestro`. Safe and self-contained — nothing in-repo self-references the module name (`BUILD.bazel`/`.bzl`), and `MODULE.bazel.lock` carries only BCR dependency hashes (no root-module identity), so no lock change is needed.
- **Guard test** (`test/scripts/ci-guardrails.test.ts`): `keeps the public Bazel module name public-facing` — asserts `module(name = "evalops_maestro")` and forbids `evalops_maestro_internal`, so a future mirror sync that re-leaks the internal name fails CI.
- **Guardrail registry:** adds the `public-bazel-module-identity` entry to `scripts/guardrail-regression-suite.json`.

## Acceptance (#394)

- [x] A repo-local guardrail fails for the representative feedback shape (the guard test fails while MODULE.bazel reads `evalops_maestro_internal`).
- [x] Wired into the smallest relevant test target — `test/scripts/ci-guardrails.test.ts` (run by `ci-nx-tests.sh` / Nx `maestro:test`).
- [ ] Sentinel re-scan reports the `other-feedback` fingerprint closed/absent (happens after merge).

## Verification

- `bunx vitest --run test/scripts/ci-guardrails.test.ts` — 172 passed
- `node scripts/check-guardrail-regression-suite.mjs` — covers 13 bug classes
- `bunx biome check test/scripts/ci-guardrails.test.ts` — clean
- Pre-commit hook (buf + biome + tsc build + bundle) — passed

## Follow-up (out of scope here)

If the internal→public mirror sync rewrites module names, the rewrite (`evalops_maestro_internal` → `evalops_maestro`) belongs in the internal sync path (`maestro-internal`). The guardrail here will catch any sync that fails to do so.

Closes #394.