### PR TITLE
chore: sync public mirror from internal

### DIFF
--- a/packages/control-plane-rs/src/a2a/push_notifications.rs
+++ b/packages/control-plane-rs/src/a2a/push_notifications.rs
@@ -165,6 +165,9 @@ pub(crate) async fn handle_platform_a2a_push_endpoint(
             );
         }
     };
+    if let Err(response) = validate_platform_a2a_push_callback_payload_binding(&head, &payload) {
+        return response;
+    }
     match record_platform_a2a_push_payload(state, payload).await {
         Ok(accepted) => json_response(202, &accepted),
         Err(message) => a2a_error_response(400, "INVALID_REQUEST", &message),
@@ -198,6 +201,33 @@ fn validate_platform_a2a_push_callback_auth(head: &RequestHead) -> Result<(), Ve
                 return Ok(());
             }
         }
+    }
+    Err(unauthorized_callback_token_response())
+}
+
+fn validate_platform_a2a_push_callback_payload_binding(
+    head: &RequestHead,
+    payload: &Value,
+) -> Result<(), Vec<u8>> {
+    let Some(expected) = platform_a2a_push_callback_token() else {
+        return Ok(());
+    };
+    let Some(provided) = platform_a2a_push_request_token(head) else {
+        return Ok(());
+    };
+    if !provided.starts_with(A2A_WORKSPACE_NOTIFICATION_TOKEN_PREFIX) {
+        return Ok(());
+    }
+    let Some(workspace_id) = platform_a2a_push_payload_workspace(payload)
+        .or_else(|| platform_a2a_push_request_workspace(head))
+    else {
+        return Err(unauthorized_callback_token_response());
+    };
+    let Some(derived) = workspace_notification_token(&expected, &workspace_id) else {
+        return Err(unauthorized_callback_token_response());
+    };
+    if constant_time_eq(provided.as_bytes(), derived.as_bytes()) {
+        return Ok(());
     }
     Err(unauthorized_callback_token_response())
 }
@@ -238,6 +268,61 @@ fn platform_a2a_push_request_workspace(head: &RequestHead) -> Option<String> {
         }
     }
     None
+}
+
+fn platform_a2a_push_payload_workspace(payload: &Value) -> Option<String> {
+    let object = payload.as_object()?;
+    if let Some(status_update) = object.get("statusUpdate") {
+        return first_platform_a2a_push_workspace(&[
+            status_update,
+            payload,
+            status_update.get("status").unwrap_or(&Value::Null),
+            status_update
+                .get("status")
+                .and_then(|status| status.get("message"))
+                .unwrap_or(&Value::Null),
+        ]);
+    }
+    if let Some(task) = object.get("task") {
+        return first_platform_a2a_push_workspace(&[
+            task,
+            payload,
+            task.get("status").unwrap_or(&Value::Null),
+            task.get("status")
+                .and_then(|status| status.get("message"))
+                .unwrap_or(&Value::Null),
+            task.get("artifact").unwrap_or(&Value::Null),
+        ]);
+    }
+    if let Some(artifact_update) = object.get("artifactUpdate") {
+        return first_platform_a2a_push_workspace(&[
+            artifact_update,
+            payload,
+            artifact_update.get("artifact").unwrap_or(&Value::Null),
+        ]);
+    }
+    None
+}
+
+fn first_platform_a2a_push_workspace(values: &[&Value]) -> Option<String> {
+    values
+        .iter()
+        .find_map(|value| platform_a2a_push_workspace_marker(value))
+}
+
+fn platform_a2a_push_workspace_marker(value: &Value) -> Option<String> {
+    let object = value.as_object()?;
+    optional_string_field(object, "workspaceId")
+        .or_else(|| optional_string_field(object, "workspace_id"))
+        .or_else(|| {
+            object
+                .get("metadata")
+                .and_then(Value::as_object)
+                .and_then(|metadata| {
+                    optional_string_field(metadata, "workspaceId")
+                        .or_else(|| optional_string_field(metadata, "workspace_id"))
+                })
+        })
 }
 
 fn platform_a2a_push_callback_token() -> Option<String> {

--- a/packages/control-plane-rs/src/a2a/push_notifications.rs
+++ b/packages/control-plane-rs/src/a2a/push_notifications.rs
@@ -1,4 +1,8 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use hmac::{Hmac, Mac};
 use serde_json::{Map, Value};
+use sha2::Sha256;
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::time::Duration;
 use tokio::net::TcpStream;
@@ -9,6 +13,27 @@ use crate::http::{
     RequestHead,
 };
 use crate::{env_u64, now_rfc3339, trimmed_env, truthy_env, AppState};
+
+// Agent-runtime derives a per-workspace HMAC token from the shared secret and
+// sends that in X-A2a-Notification-Token instead of the raw secret. See
+// PushNotificationTokenForWorkspace in evalops/platform
+// internal/agentruntime/a2a/push.go — prefix kept in sync.
+const A2A_WORKSPACE_NOTIFICATION_TOKEN_PREFIX: &str = "workspace-v1.";
+
+fn workspace_notification_token(secret: &str, workspace_id: &str) -> Option<String> {
+    let secret = secret.trim();
+    let workspace = workspace_id.trim();
+    if secret.is_empty() || workspace.is_empty() {
+        return None;
+    }
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).ok()?;
+    mac.update(workspace.as_bytes());
+    let digest = mac.finalize().into_bytes();
+    Some(format!(
+        "{A2A_WORKSPACE_NOTIFICATION_TOKEN_PREFIX}{}",
+        URL_SAFE_NO_PAD.encode(digest)
+    ))
+}
 
 use super::ledger::persist_a2a_tasks;
 use super::tasks::{
@@ -158,20 +183,61 @@ fn validate_platform_a2a_push_callback_auth(head: &RequestHead) -> Result<(), Ve
             }),
         ));
     };
-    let provided = platform_a2a_push_request_token(head);
-    if provided.as_deref() == Some(expected.as_str()) {
-        Ok(())
-    } else {
-        Err(json_response(
-            401,
-            &serde_json::json!({
-                "error": {
-                    "code": "UNAUTHORIZED",
-                    "message": "A2A push callback token is invalid"
-                }
-            }),
-        ))
+    let Some(provided) = platform_a2a_push_request_token(head) else {
+        return Err(unauthorized_callback_token_response());
+    };
+    if constant_time_eq(provided.as_bytes(), expected.as_bytes()) {
+        return Ok(());
     }
+    // Agent-runtime derives a per-workspace HMAC token from the same shared
+    // secret when X-Evalops-Workspace-Id is present and the callback
+    // host/path is allowed; accept that variant too.
+    if let Some(workspace_id) = platform_a2a_push_request_workspace(head) {
+        if let Some(derived) = workspace_notification_token(&expected, &workspace_id) {
+            if constant_time_eq(provided.as_bytes(), derived.as_bytes()) {
+                return Ok(());
+            }
+        }
+    }
+    Err(unauthorized_callback_token_response())
+}
+
+fn unauthorized_callback_token_response() -> Vec<u8> {
+    json_response(
+        401,
+        &serde_json::json!({
+            "error": {
+                "code": "UNAUTHORIZED",
+                "message": "A2A push callback token is invalid"
+            }
+        }),
+    )
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+fn platform_a2a_push_request_workspace(head: &RequestHead) -> Option<String> {
+    for header in ["x-evalops-workspace-id", "x-workspace-id"] {
+        if let Some(value) = head
+            .headers
+            .get(header)
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
 }
 
 fn platform_a2a_push_callback_token() -> Option<String> {

--- a/packages/control-plane-rs/src/tests.rs
+++ b/packages/control-plane-rs/src/tests.rs
@@ -3340,6 +3340,57 @@ async fn platform_a2a_push_callback_rejects_workspace_derived_token_with_wrong_w
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn platform_a2a_push_callback_rejects_workspace_derived_token_with_mismatched_payload_workspace(
+) {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let _guard = ENV_LOCK.lock().await;
+    let previous_token = env::var_os("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN");
+    let shared_secret = "callback-token";
+    let header_workspace_id = "evalops";
+    env::set_var("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", shared_secret);
+
+    let mut mac = Hmac::<Sha256>::new_from_slice(shared_secret.as_bytes()).unwrap();
+    mac.update(header_workspace_id.as_bytes());
+    let derived = format!(
+        "workspace-v1.{}",
+        URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes())
+    );
+
+    let body = r#"{
+        "statusUpdate": {
+            "taskId": "platform-run-4",
+            "workspaceId": "some-other-workspace",
+            "status": {
+                "state": "TASK_STATE_WORKING"
+            }
+        }
+    }"#;
+    let request = format!(
+        "POST /api/platform/a2a/push HTTP/1.1\r\nHost: localhost\r\nX-A2a-Notification-Token: {derived}\r\nX-Evalops-Workspace-Id: {header_workspace_id}\r\nContent-Type: application/a2a+json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    let mut initial = request.into_bytes();
+    let head = parse_request_head(&initial).expect("request should parse");
+    let (_client, mut server) = tcp_stream_pair().await;
+    let state = test_app_state_with_sessions(HashMap::new());
+
+    let response = handle_platform_a2a_push_endpoint(&mut server, &mut initial, head, &state).await;
+
+    assert_eq!(response_status(&response), 401);
+    assert!(state.a2a_tasks.lock().await.is_empty());
+
+    if let Some(previous_token) = previous_token {
+        env::set_var("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", previous_token);
+    } else {
+        env::remove_var("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN");
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn platform_a2a_push_callback_rejects_invalid_token() {
     let _guard = ENV_LOCK.lock().await;
     let previous_token = env::var_os("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN");

--- a/packages/control-plane-rs/src/tests.rs
+++ b/packages/control-plane-rs/src/tests.rs
@@ -3252,6 +3252,94 @@ async fn platform_a2a_push_callback_accepts_status_updates() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn platform_a2a_push_callback_accepts_workspace_derived_token() {
+    // Mirrors PushNotificationTokenForWorkspace in evalops/platform
+    // internal/agentruntime/a2a/push.go. The smoke and any other client whose
+    // callback host/path matches the agent-runtime allowlist will send this
+    // HMAC variant instead of the raw shared secret.
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let _guard = ENV_LOCK.lock().await;
+    let previous_token = env::var_os("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN");
+    let shared_secret = "callback-token";
+    let workspace_id = "evalops";
+    env::set_var("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", shared_secret);
+
+    let mut mac = Hmac::<Sha256>::new_from_slice(shared_secret.as_bytes()).unwrap();
+    mac.update(workspace_id.as_bytes());
+    let derived = format!(
+        "workspace-v1.{}",
+        URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes())
+    );
+
+    let body =
+        r#"{"statusUpdate":{"taskId":"platform-run-2","status":{"state":"TASK_STATE_WORKING"}}}"#;
+    let request = format!(
+        "POST /api/platform/a2a/push HTTP/1.1\r\nHost: localhost\r\nX-A2a-Notification-Token: {derived}\r\nX-Evalops-Workspace-Id: {workspace_id}\r\nContent-Type: application/a2a+json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    let mut initial = request.into_bytes();
+    let head = parse_request_head(&initial).expect("request should parse");
+    let (_client, mut server) = tcp_stream_pair().await;
+    let state = test_app_state_with_sessions(HashMap::new());
+
+    let response = handle_platform_a2a_push_endpoint(&mut server, &mut initial, head, &state).await;
+
+    assert_eq!(response_status(&response), 202);
+
+    if let Some(previous_token) = previous_token {
+        env::set_var("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", previous_token);
+    } else {
+        env::remove_var("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN");
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn platform_a2a_push_callback_rejects_workspace_derived_token_with_wrong_workspace() {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let _guard = ENV_LOCK.lock().await;
+    let previous_token = env::var_os("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN");
+    env::set_var("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", "callback-token");
+
+    // Token derived for a different workspace than the request header claims.
+    let mut mac = Hmac::<Sha256>::new_from_slice(b"callback-token").unwrap();
+    mac.update(b"some-other-workspace");
+    let mismatched = format!(
+        "workspace-v1.{}",
+        URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes())
+    );
+
+    let body =
+        r#"{"statusUpdate":{"taskId":"platform-run-3","status":{"state":"TASK_STATE_WORKING"}}}"#;
+    let request = format!(
+        "POST /api/platform/a2a/push HTTP/1.1\r\nHost: localhost\r\nX-A2a-Notification-Token: {mismatched}\r\nX-Evalops-Workspace-Id: evalops\r\nContent-Type: application/a2a+json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    let mut initial = request.into_bytes();
+    let head = parse_request_head(&initial).expect("request should parse");
+    let (_client, mut server) = tcp_stream_pair().await;
+    let state = test_app_state_with_sessions(HashMap::new());
+
+    let response = handle_platform_a2a_push_endpoint(&mut server, &mut initial, head, &state).await;
+
+    assert_eq!(response_status(&response), 401);
+    assert!(state.a2a_tasks.lock().await.is_empty());
+
+    if let Some(previous_token) = previous_token {
+        env::set_var("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", previous_token);
+    } else {
+        env::remove_var("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN");
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn platform_a2a_push_callback_rejects_invalid_token() {
     let _guard = ENV_LOCK.lock().await;
     let previous_token = env::var_os("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN");

--- a/src/api/enterprise-routes.ts
+++ b/src/api/enterprise-routes.ts
@@ -4,19 +4,23 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { AUDIT_ACTIONS, AuditLogger } from "../audit/logger.js";
 import { TokenTracker } from "../billing/token-tracker.js";
 import { getDb } from "../db/client.js";
 import {
 	type OrganizationSettings,
+	type UserSettings,
 	alerts,
 	organizations,
 	roles,
+	users,
 } from "../db/schema.js";
 import {
 	decryptOrgSettings,
+	decryptUserSettings,
 	encryptOrgSettings,
+	encryptUserSettings,
 } from "../db/settings-encryption.js";
 import {
 	ACTIONS,
@@ -27,6 +31,7 @@ import {
 import type { Route } from "../server/router.js";
 import { readJsonBody, sendJson } from "../server/server-utils.js";
 import { resolveInternalTelemetryDisabledSetting } from "../telemetry/disablement.js";
+import { isPlainObject } from "../utils/json.js";
 import { createLogger } from "../utils/logger.js";
 import {
 	handleLogin,
@@ -52,6 +57,7 @@ import {
 	handleGetModelApprovals,
 } from "./enterprise/model-approval-handlers.js";
 import { mergeOrganizationSettings } from "./org-settings-merge.js";
+import { mergeUserSettings } from "./user-settings-merge.js";
 
 const logger = createLogger("enterprise-api");
 
@@ -305,6 +311,105 @@ async function handleUpdateOrgSettings(
 	sendJson(res, 200, { success: true }, cors, req);
 }
 
+async function handleGetUserSettings(
+	req: IncomingMessage,
+	res: ServerResponse,
+	cors: Record<string, string>,
+): Promise<void> {
+	const auth = await authenticateJWT(req);
+	if (!auth) {
+		sendJson(res, 401, { error: "Unauthorized" }, cors, req);
+		return;
+	}
+
+	const db = getDb();
+	const user = await db.query.users.findFirst({
+		where: eq(users.id, auth.userId),
+	});
+
+	if (!user) {
+		sendJson(res, 404, { error: "User not found" }, cors, req);
+		return;
+	}
+
+	// Decrypt sensitive fields (twoFactor secret) before returning.
+	const decryptedSettings = decryptUserSettings(user.settings) || {};
+	sendJson(res, 200, decryptedSettings, cors, req);
+}
+
+async function handleUpdateUserSettings(
+	req: IncomingMessage,
+	res: ServerResponse,
+	cors: Record<string, string>,
+): Promise<void> {
+	const auth = await authenticateJWT(req);
+	if (!auth) {
+		sendJson(res, 401, { error: "Unauthorized" }, cors, req);
+		return;
+	}
+
+	const body = await readJsonBody<unknown>(req);
+	if (!isPlainObject(body)) {
+		sendJson(res, 400, { error: "Settings body must be an object" }, cors, req);
+		return;
+	}
+	const requestedSettings = body as UserSettings;
+
+	const db = getDb();
+	for (let attempt = 0; attempt < 3; attempt++) {
+		const user = await db.query.users.findFirst({
+			where: eq(users.id, auth.userId),
+		});
+		if (!user) {
+			sendJson(res, 404, { error: "User not found" }, cors, req);
+			return;
+		}
+
+		// Self-scoped: the caller can only touch their own user settings. 2FA
+		// state is preserved from the latest committed row by retrying on
+		// concurrent settings writes, and the maestro runtime-knob namespace is
+		// validated against the MaestroSettings catalog.
+		const previousSettings = decryptUserSettings(user.settings) || {};
+		const mergedSettings = mergeUserSettings(
+			previousSettings,
+			requestedSettings,
+		);
+		const encryptedSettings = encryptUserSettings(mergedSettings);
+		const storedSettingsMatch =
+			user.settings == null
+				? sql`${users.settings} IS NULL`
+				: sql`${users.settings} IS NOT DISTINCT FROM ${JSON.stringify(user.settings)}::jsonb`;
+
+		const updatedRows = await db
+			.update(users)
+			.set({ settings: encryptedSettings })
+			.where(and(eq(users.id, auth.userId), storedSettingsMatch))
+			.returning({ id: users.id });
+
+		if (updatedRows.length > 0) {
+			await AuditLogger.log({
+				orgId: auth.orgId,
+				userId: auth.userId,
+				action: AUDIT_ACTIONS.CONFIG_WRITE,
+				resourceType: "user_settings",
+				status: "success",
+				metadata: {},
+			});
+
+			sendJson(res, 200, { success: true }, cors, req);
+			return;
+		}
+	}
+
+	sendJson(
+		res,
+		409,
+		{ error: "Settings changed concurrently; please retry" },
+		cors,
+		req,
+	);
+}
+
 // ============================================================================
 // ROLES
 // ============================================================================
@@ -450,6 +555,18 @@ export function createEnterpriseRoutes(cors: Record<string, string>): Route[] {
 			method: "PUT",
 			path: "/api/org/settings",
 			handler: (req, res) => handleUpdateOrgSettings(req, res, cors),
+		},
+
+		// User Settings (self-scoped to the authenticated user)
+		{
+			method: "GET",
+			path: "/api/user/settings",
+			handler: (req, res) => handleGetUserSettings(req, res, cors),
+		},
+		{
+			method: "PUT",
+			path: "/api/user/settings",
+			handler: (req, res) => handleUpdateUserSettings(req, res, cors),
 		},
 
 		// Roles

--- a/src/api/user-settings-merge.ts
+++ b/src/api/user-settings-merge.ts
@@ -1,0 +1,46 @@
+import { mergeMaestroSettings } from "@evalops/contracts";
+import type { UserSettings } from "../db/schema.js";
+
+/**
+ * Merge an incoming user-settings patch onto the previously stored settings.
+ *
+ * The `maestro` namespace is deep-merged and normalized against the
+ * MaestroSettings catalog (`mergeMaestroSettings`), so only typed, valid
+ * runtime knobs are ever stored on `users.settings`. Scalar/array fields are
+ * replaced.
+ *
+ * `twoFactor` is managed exclusively by the dedicated 2FA enrollment flow and
+ * is never accepted from a generic settings patch — the previous value is
+ * always preserved so this endpoint cannot be used to overwrite or strip 2FA
+ * state (e.g. backup codes or the TOTP secret).
+ */
+export function mergeUserSettings(
+	previous: UserSettings | null | undefined,
+	incoming: UserSettings,
+): UserSettings {
+	const previousSettings: UserSettings = previous ?? {};
+
+	const result: UserSettings = {
+		...previousSettings,
+		...incoming,
+	};
+
+	const mergedMaestro = mergeMaestroSettings(
+		previousSettings.maestro,
+		incoming.maestro,
+	);
+	if (Object.keys(mergedMaestro).length > 0) {
+		result.maestro = mergedMaestro;
+	} else {
+		delete result.maestro;
+	}
+
+	// twoFactor is intentionally pinned to the previous value (see docstring).
+	if (previousSettings.twoFactor !== undefined) {
+		result.twoFactor = previousSettings.twoFactor;
+	} else {
+		delete result.twoFactor;
+	}
+
+	return result;
+}

--- a/src/server/handlers/platform-a2a-push.ts
+++ b/src/server/handlers/platform-a2a-push.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HostedRunnerContext, WebServerContext } from "../app-context.js";
 import {
@@ -7,6 +8,29 @@ import {
 	secureCompare,
 	sendJson,
 } from "../server-utils.js";
+
+// Agent-runtime derives a per-workspace notification token via HMAC and sends
+// that in X-A2a-Notification-Token instead of the raw shared secret. See
+// PushNotificationTokenForWorkspace in evalops/platform
+// internal/agentruntime/a2a/push.go (constant prefix kept in sync).
+const A2A_WORKSPACE_NOTIFICATION_TOKEN_PREFIX = "workspace-v1.";
+
+function workspaceNotificationToken(
+	secret: string,
+	workspaceId: string,
+): string {
+	const trimmedSecret = secret.trim();
+	const trimmedWorkspace = workspaceId.trim();
+	if (!trimmedSecret || !trimmedWorkspace) {
+		return "";
+	}
+	const mac = createHmac("sha256", trimmedSecret);
+	mac.update(trimmedWorkspace);
+	return (
+		A2A_WORKSPACE_NOTIFICATION_TOKEN_PREFIX +
+		mac.digest("base64url").replace(/=+$/, "")
+	);
+}
 
 export const PLATFORM_A2A_PUSH_CALLBACK_PATH = "/api/platform/a2a/push";
 
@@ -65,6 +89,7 @@ export async function handlePlatformA2APushCallback(
 	if (!snapshot) {
 		throw new ApiError(400, "Invalid A2A push notification payload");
 	}
+	assertWorkspaceScopedCallbackTokenSnapshot(req, snapshot);
 	const hostedRunner = context.hostedRunner;
 	assertHostedRunnerA2APushBoundary(hostedRunner, snapshot);
 	if (hostedRunner) {
@@ -79,7 +104,50 @@ function assertCallbackToken(req: IncomingMessage): void {
 		return;
 	}
 	const provided = getRequestHeader(req, "x-a2a-notification-token");
-	if (!provided || !secureCompare(provided, expected)) {
+	if (!provided) {
+		throw new ApiError(401, "Invalid A2A notification token");
+	}
+	if (secureCompare(provided, expected)) {
+		return;
+	}
+	// Agent-runtime derives a workspace-scoped HMAC token from the same shared
+	// secret when X-Evalops-Workspace-Id is present and the callback host/path
+	// matches its allowlist; accept that variant too.
+	const workspaceId = getRequestHeader(
+		req,
+		"x-workspace-id",
+		"x-evalops-workspace-id",
+	);
+	if (workspaceId) {
+		const derived = workspaceNotificationToken(expected, workspaceId);
+		if (derived && secureCompare(provided, derived)) {
+			return;
+		}
+	}
+	throw new ApiError(401, "Invalid A2A notification token");
+}
+
+function assertWorkspaceScopedCallbackTokenSnapshot(
+	req: IncomingMessage,
+	snapshot: PlatformA2APushSnapshot,
+): void {
+	const expected = callbackToken();
+	if (!expected) {
+		return;
+	}
+	const provided = getRequestHeader(req, "x-a2a-notification-token");
+	if (
+		!provided ||
+		!provided.startsWith(A2A_WORKSPACE_NOTIFICATION_TOKEN_PREFIX)
+	) {
+		return;
+	}
+	const workspaceId = snapshot.workspaceId;
+	if (!workspaceId) {
+		throw new ApiError(401, "Invalid A2A notification token");
+	}
+	const derived = workspaceNotificationToken(expected, workspaceId);
+	if (!derived || !secureCompare(provided, derived)) {
 		throw new ApiError(401, "Invalid A2A notification token");
 	}
 }

--- a/src/server/handlers/platform-a2a-push.ts
+++ b/src/server/handlers/platform-a2a-push.ts
@@ -115,8 +115,8 @@ function assertCallbackToken(req: IncomingMessage): void {
 	// matches its allowlist; accept that variant too.
 	const workspaceId = getRequestHeader(
 		req,
-		"x-workspace-id",
 		"x-evalops-workspace-id",
+		"x-workspace-id",
 	);
 	if (workspaceId) {
 		const derived = workspaceNotificationToken(expected, workspaceId);
@@ -278,7 +278,7 @@ function platformA2APushRequestContext(
 			getRequestHeader(req, "x-organization-id", "x-evalops-organization-id") ??
 			undefined,
 		workspaceId:
-			getRequestHeader(req, "x-workspace-id", "x-evalops-workspace-id") ??
+			getRequestHeader(req, "x-evalops-workspace-id", "x-workspace-id") ??
 			undefined,
 		agentId:
 			getRequestHeader(req, "x-evalops-agent-id", "x-maestro-agent-id") ??

--- a/src/server/route-auth.ts
+++ b/src/server/route-auth.ts
@@ -193,6 +193,8 @@ export const ENTERPRISE_ROUTE_AUTH_POLICIES: readonly RouteAuthPolicyEntry[] = [
 	p("DELETE", "/api/org/members/:userId", "authenticated"),
 	p("GET", "/api/org/settings", "authenticated"),
 	p("PUT", "/api/org/settings", "authenticated"),
+	p("GET", "/api/user/settings", "authenticated"),
+	p("PUT", "/api/user/settings", "authenticated"),
 	p("GET", "/api/roles", "authenticated"),
 	p("GET", "/api/models/approvals", "authenticated"),
 	p("POST", "/api/models/approvals/:modelId/approve", "authenticated"),

--- a/test/api/user-settings-merge.test.ts
+++ b/test/api/user-settings-merge.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { mergeUserSettings } from "../../src/api/user-settings-merge.js";
+import type { UserSettings } from "../../src/db/schema.js";
+
+describe("mergeUserSettings", () => {
+	it("deep-merges the maestro namespace against the catalog", () => {
+		const previous: UserSettings = {
+			maestro: { compaction: { thresholdPercent: 80, enabled: true } },
+		};
+		const incoming: UserSettings = {
+			maestro: { compaction: { thresholdPercent: 95 }, model: "gpt-5" },
+		};
+
+		const merged = mergeUserSettings(previous, incoming);
+
+		expect(merged.maestro).toEqual({
+			compaction: { thresholdPercent: 95, enabled: true },
+			model: "gpt-5",
+		});
+	});
+
+	it("normalizes invalid maestro values so only typed data is stored", () => {
+		// @ts-expect-error -- simulating untyped JSONB input
+		const incoming: UserSettings = {
+			maestro: { compaction: { thresholdPercent: "nope" } },
+		};
+
+		const merged = mergeUserSettings(undefined, incoming);
+
+		expect(merged).not.toHaveProperty("maestro");
+	});
+
+	it("preserves the previous twoFactor state and ignores a patch attempt", () => {
+		const previous: UserSettings = {
+			twoFactor: { enabled: true, enabledAt: "2026-01-01" },
+		};
+		// @ts-expect-error -- malicious/incorrect patch tries to disable 2FA
+		const incoming: UserSettings = { twoFactor: { enabled: false } };
+
+		const merged = mergeUserSettings(previous, incoming);
+
+		expect(merged.twoFactor).toEqual({
+			enabled: true,
+			enabledAt: "2026-01-01",
+		});
+	});
+
+	it("drops twoFactor entirely when the user never enrolled", () => {
+		const merged = mergeUserSettings(undefined, {
+			// @ts-expect-error -- patch attempts to inject 2FA state
+			twoFactor: { enabled: true },
+		});
+
+		expect(merged).not.toHaveProperty("twoFactor");
+	});
+
+	it("replaces scalar/array fields rather than merging them", () => {
+		const previous: UserSettings = {
+			preferredModels: ["anthropic/claude", "openai/gpt"],
+			notificationEmail: "old@example.com",
+		};
+		const incoming: UserSettings = { preferredModels: ["anthropic/claude"] };
+
+		const merged = mergeUserSettings(previous, incoming);
+
+		expect(merged.preferredModels).toEqual(["anthropic/claude"]);
+		expect(merged.notificationEmail).toBe("old@example.com");
+	});
+});

--- a/test/api/user-settings-route.test.ts
+++ b/test/api/user-settings-route.test.ts
@@ -1,0 +1,172 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+	const readJsonBodyMock = vi.fn();
+	const sendJsonMock = vi.fn();
+	const authenticateJWTMock = vi.fn();
+	const findFirstMock = vi.fn();
+	const updateMock = vi.fn();
+	const setMock = vi.fn();
+	const whereMock = vi.fn();
+	const returningMock = vi.fn();
+	const decryptUserSettingsMock = vi.fn();
+	const encryptUserSettingsMock = vi.fn();
+	const auditLogMock = vi.fn();
+
+	return {
+		readJsonBodyMock,
+		sendJsonMock,
+		authenticateJWTMock,
+		findFirstMock,
+		updateMock,
+		setMock,
+		whereMock,
+		returningMock,
+		decryptUserSettingsMock,
+		encryptUserSettingsMock,
+		auditLogMock,
+	};
+});
+
+vi.mock("../../src/server/server-utils.js", () => ({
+	readJsonBody: mocks.readJsonBodyMock,
+	sendJson: mocks.sendJsonMock,
+}));
+
+vi.mock("../../src/api/enterprise/middleware.js", () => ({
+	authenticateJWT: mocks.authenticateJWTMock,
+}));
+
+vi.mock("../../src/db/client.js", () => ({
+	getDb: () => ({
+		query: {
+			users: {
+				findFirst: mocks.findFirstMock,
+			},
+		},
+		update: mocks.updateMock,
+	}),
+}));
+
+vi.mock("../../src/db/settings-encryption.js", () => ({
+	decryptUserSettings: mocks.decryptUserSettingsMock,
+	encryptUserSettings: mocks.encryptUserSettingsMock,
+	decryptOrgSettings: vi.fn(),
+	encryptOrgSettings: vi.fn(),
+}));
+
+vi.mock("../../src/audit/logger.js", () => ({
+	AUDIT_ACTIONS: {
+		CONFIG_WRITE: "config_write",
+	},
+	AuditLogger: {
+		log: mocks.auditLogMock,
+	},
+}));
+
+import { createEnterpriseRoutes } from "../../src/api/enterprise-routes.js";
+
+describe.sequential("PUT /api/user/settings", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.authenticateJWTMock.mockResolvedValue({
+			userId: "user-1",
+			orgId: "org-1",
+			roleId: "role-1",
+		});
+		mocks.decryptUserSettingsMock.mockImplementation((settings) => settings);
+		mocks.encryptUserSettingsMock.mockImplementation((settings) => settings);
+		mocks.updateMock.mockReturnValue({
+			set: mocks.setMock,
+		});
+		mocks.setMock.mockReturnValue({
+			where: mocks.whereMock,
+		});
+		mocks.whereMock.mockReturnValue({
+			returning: mocks.returningMock,
+		});
+		mocks.returningMock.mockResolvedValue([{ id: "user-1" }]);
+	});
+
+	it("rejects non-object JSON bodies before merging settings", async () => {
+		mocks.readJsonBodyMock.mockResolvedValue(["bad-patch"]);
+
+		await getHandler()(request("PUT"), {} as ServerResponse);
+
+		expect(mocks.sendJsonMock).toHaveBeenCalledWith(
+			expect.anything(),
+			400,
+			{ error: "Settings body must be an object" },
+			{},
+			expect.anything(),
+		);
+		expect(mocks.findFirstMock).not.toHaveBeenCalled();
+		expect(mocks.auditLogMock).not.toHaveBeenCalled();
+	});
+
+	it("retries with the latest row so concurrent twoFactor writes survive", async () => {
+		const concurrentTwoFactor = {
+			enabled: true,
+			enabledAt: "2026-01-01T00:00:00.000Z",
+			secret: "enc:latest",
+		};
+
+		mocks.readJsonBodyMock.mockResolvedValue({
+			notificationEmail: "new@example.com",
+		});
+		mocks.findFirstMock
+			.mockResolvedValueOnce({
+				settings: {
+					notificationEmail: "old@example.com",
+				},
+			})
+			.mockResolvedValueOnce({
+				settings: {
+					notificationEmail: "old@example.com",
+					twoFactor: concurrentTwoFactor,
+				},
+			});
+		mocks.returningMock
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([{ id: "user-1" }]);
+
+		await getHandler()(request("PUT"), {} as ServerResponse);
+
+		expect(mocks.findFirstMock).toHaveBeenCalledTimes(2);
+		expect(mocks.encryptUserSettingsMock).toHaveBeenNthCalledWith(1, {
+			notificationEmail: "new@example.com",
+		});
+		expect(mocks.encryptUserSettingsMock).toHaveBeenNthCalledWith(2, {
+			notificationEmail: "new@example.com",
+			twoFactor: concurrentTwoFactor,
+		});
+		expect(mocks.auditLogMock).toHaveBeenCalledTimes(1);
+		expect(mocks.sendJsonMock).toHaveBeenLastCalledWith(
+			expect.anything(),
+			200,
+			{ success: true },
+			{},
+			expect.anything(),
+		);
+	});
+});
+
+function getHandler() {
+	const route = createEnterpriseRoutes({}).find(
+		(candidate) =>
+			candidate.method === "PUT" && candidate.path === "/api/user/settings",
+	);
+	if (!route) {
+		throw new Error("PUT /api/user/settings route not found");
+	}
+	return route.handler;
+}
+
+function request(method: string): IncomingMessage {
+	return {
+		headers: { host: "localhost" },
+		method,
+		url: "/api/user/settings",
+	} as IncomingMessage;
+}

--- a/test/cli/cli.integration.test.ts
+++ b/test/cli/cli.integration.test.ts
@@ -446,21 +446,43 @@ describe("CLI integration", () => {
 		}
 	}
 
-	async function readJsonFileEventually<T>(path: string): Promise<T> {
-		const deadline = Date.now() + 1000;
+	async function readJsonFileEventually<T>(
+		path: string,
+		predicate?: (value: T) => boolean,
+	): Promise<T> {
+		// The beacon-buffer flushes are concurrent with the CLI command, so the
+		// file is often written through transient intermediate states (e.g.
+		// `{counts:{}}`) before reaching the value a caller wants to assert on.
+		// Without a predicate the helper returns at the first parseable read,
+		// which sometimes captures an empty snapshot and produces flakes like
+		// "expected undefined to be 1" on `counts["cli.command.<name>"]`.
+		// Pass a predicate to keep polling until the relevant fields are set.
+		const deadline = Date.now() + 2000;
 		let lastError: unknown;
+		let lastParsed: T | undefined;
 		while (Date.now() < deadline) {
 			if (existsSync(path)) {
 				const content = readFileSync(path, "utf8").trim();
 				if (content.length > 0) {
 					try {
-						return JSON.parse(content) as T;
+						const parsed = JSON.parse(content) as T;
+						if (!predicate || predicate(parsed)) {
+							return parsed;
+						}
+						lastParsed = parsed;
 					} catch (error) {
 						lastError = error;
 					}
 				}
 			}
 			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+		if (lastParsed !== undefined) {
+			throw new Error(
+				`Timed out waiting for predicate to hold on ${path}; last value: ${JSON.stringify(
+					lastParsed,
+				)}`,
+			);
 		}
 		const reason = lastError instanceof Error ? `: ${lastError.message}` : "";
 		throw new Error(`Timed out waiting for parseable JSON in ${path}${reason}`);
@@ -816,7 +838,10 @@ describe("CLI integration", () => {
 			);
 			const commandBuffer = await readJsonFileEventually<{
 				counts: Record<string, number>;
-			}>(bufferFile);
+			}>(
+				bufferFile,
+				(value) => typeof value.counts?.["cli.command.version"] === "number",
+			);
 			expect(startupEvent).toMatchObject({
 				feature: "cli.startup",
 				action: "version",
@@ -1102,7 +1127,11 @@ describe("CLI integration", () => {
 			expect(output.join("\n")).toContain("openrouter");
 			const commandBuffer = await readJsonFileEventually<{
 				counts: Record<string, number>;
-			}>(bufferFile);
+			}>(
+				bufferFile,
+				(value) =>
+					typeof value.counts?.["cli.command.models.providers"] === "number",
+			);
 			const startupEvents = await readJsonLinesEventually<{
 				feature: string;
 				action: string;

--- a/test/web/platform-a2a-push-handler.test.ts
+++ b/test/web/platform-a2a-push-handler.test.ts
@@ -143,6 +143,39 @@ describe("handlePlatformA2APushCallback", () => {
 		expect(res.statusCode).toBe(202);
 	});
 
+	it("prefers the EvalOps workspace header when both workspace headers are present", async () => {
+		const sharedSecret = "callback-secret";
+		const workspaceId = "ws_hosted";
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", sharedSecret);
+		const derived = workspaceNotificationToken(sharedSecret, workspaceId);
+
+		const ctx = context();
+		const res = new MockResponse();
+		await handlePlatformA2APushCallback(
+			jsonRequest(
+				{
+					statusUpdate: {
+						taskId: "run_1",
+						contextId: "ctx_1",
+						final: true,
+						status: { state: "TASK_STATE_COMPLETED" },
+					},
+				},
+				{
+					"x-a2a-notification-token": derived,
+					"x-evalops-workspace-id": workspaceId,
+					"x-workspace-id": "ws_legacy",
+				},
+			),
+			res as unknown as ServerResponse,
+			ctx,
+		);
+		expect(res.statusCode).toBe(202);
+		expect(JSON.parse(res.body)).toMatchObject({
+			workspaceId,
+		});
+	});
+
 	it("rejects a workspace-scoped HMAC notification token when the payload workspace differs from the header workspace", async () => {
 		const sharedSecret = "callback-secret";
 		vi.stubEnv("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", sharedSecret);

--- a/test/web/platform-a2a-push-handler.test.ts
+++ b/test/web/platform-a2a-push-handler.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
@@ -93,9 +94,119 @@ function context(): WebServerContext {
 	};
 }
 
+function workspaceNotificationToken(
+	secret: string,
+	workspaceId: string,
+): string {
+	return `workspace-v1.${createHmac("sha256", secret)
+		.update(workspaceId)
+		.digest("base64url")
+		.replace(/=+$/, "")}`;
+}
+
 describe("handlePlatformA2APushCallback", () => {
 	afterEach(() => {
 		vi.unstubAllEnvs();
+	});
+
+	it("accepts a workspace-scoped HMAC notification token derived from the shared secret", async () => {
+		const sharedSecret = "callback-secret";
+		const workspaceId = "ws_hosted";
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", sharedSecret);
+		const derived = workspaceNotificationToken(sharedSecret, workspaceId);
+
+		const ctx = context();
+		const res = new MockResponse();
+		await handlePlatformA2APushCallback(
+			jsonRequest(
+				{
+					statusUpdate: {
+						taskId: "run_1",
+						contextId: "ctx_1",
+						final: true,
+						status: { state: "TASK_STATE_COMPLETED" },
+						metadata: {
+							messageId: "message_1",
+							workspaceId,
+							organizationId: "org_1",
+						},
+					},
+				},
+				{
+					"x-a2a-notification-token": derived,
+					"x-evalops-workspace-id": workspaceId,
+				},
+			),
+			res as unknown as ServerResponse,
+			ctx,
+		);
+		expect(res.statusCode).toBe(202);
+	});
+
+	it("rejects a workspace-scoped HMAC notification token when the payload workspace differs from the header workspace", async () => {
+		const sharedSecret = "callback-secret";
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", sharedSecret);
+		const derived = workspaceNotificationToken(sharedSecret, "ws_hosted");
+		const ctx = context();
+		const res = new MockResponse();
+
+		await expect(() =>
+			handlePlatformA2APushCallback(
+				jsonRequest(
+					{
+						statusUpdate: {
+							taskId: "run_1",
+							contextId: "ctx_1",
+							final: true,
+							status: { state: "TASK_STATE_COMPLETED" },
+							metadata: {
+								messageId: "message_1",
+								workspaceId: "ws_other",
+								organizationId: "org_1",
+							},
+						},
+					},
+					{
+						"x-a2a-notification-token": derived,
+						"x-evalops-workspace-id": "ws_hosted",
+					},
+				),
+				res as unknown as ServerResponse,
+				ctx,
+			),
+		).rejects.toThrow("Invalid A2A notification token");
+		expect(ctx.hostedRunner?.lastPlatformA2APush).toBeUndefined();
+	});
+
+	it("rejects a callback when the notification token matches neither the raw secret nor the workspace HMAC", async () => {
+		vi.stubEnv("MAESTRO_PLATFORM_A2A_CALLBACK_TOKEN", "callback-secret");
+		const ctx = context();
+		const res = new MockResponse();
+		await expect(() =>
+			handlePlatformA2APushCallback(
+				jsonRequest(
+					{
+						statusUpdate: {
+							taskId: "run_1",
+							contextId: "ctx_1",
+							final: true,
+							status: { state: "TASK_STATE_COMPLETED" },
+							metadata: {
+								messageId: "message_1",
+								workspaceId: "ws_hosted",
+								organizationId: "org_1",
+							},
+						},
+					},
+					{
+						"x-a2a-notification-token": "workspace-v1.not-a-real-mac",
+						"x-evalops-workspace-id": "ws_hosted",
+					},
+				),
+				res as unknown as ServerResponse,
+				ctx,
+			),
+		).rejects.toThrow("Invalid A2A notification token");
 	});
 
 	it("only exempts the callback route from auth middleware when a callback token is configured", () => {


### PR DESCRIPTION
<!-- maestro-public-mirror-source: {"schemaVersion":1,"scope":"public-tree","sourceRepo":"evalops/maestro-internal","sourceSha":"a870c32ae0dab73ef4af0c85efda5e11e62310e2"} -->

## Summary

- sync the sanitized public tree from `evalops/maestro-internal`
- keep `evalops/maestro` as a generated public mirror of the private source of truth
- preserve public-owned CI and trusted-publishing workflows from the public checkout
- internal source SHA: `a870c32ae0dab73ef4af0c85efda5e11e62310e2`
- last generated public sync base: `55156928b38c0ed6e28e7a36919e244584dd1932`
- previewed public-tree drift: `10` file(s) to copy/update and `0` stale file(s) to delete
- public-only commits since last generated sync: `0`

## Source-of-truth status

## Public Mirror Drift Audit

- package: `@evalops/maestro`
- private source: `https://github.com/evalops/maestro-internal@main (a870c32ae0da)`
- public projection: `https://github.com/evalops/maestro@main (55156928b38c)`
- files to copy or update: `10`
- stale files to delete: `0`
- result: drift detected
- invariant: `public_projection_has_drift`

### Sample Changed Paths
- copy/update packages/control-plane-rs/src/a2a/push_notifications.rs
- copy/update packages/control-plane-rs/src/tests.rs
- copy/update src/api/enterprise-routes.ts
- copy/update src/api/user-settings-merge.ts
- copy/update src/server/handlers/platform-a2a-push.ts
- copy/update src/server/route-auth.ts
- copy/update test/api/user-settings-merge.test.ts
- copy/update test/api/user-settings-route.test.ts
- copy/update test/cli/cli.integration.test.ts
- copy/update test/web/platform-a2a-push-handler.test.ts

### Guidance

Let internal main generate and merge the public sync PR before relying on public main.

## Drift sample

- copy/update packages/control-plane-rs/src/a2a/push_notifications.rs
- copy/update packages/control-plane-rs/src/tests.rs
- copy/update src/api/enterprise-routes.ts
- copy/update src/api/user-settings-merge.ts
- copy/update src/server/handlers/platform-a2a-push.ts
- copy/update src/server/route-auth.ts
- copy/update test/api/user-settings-merge.test.ts
- copy/update test/api/user-settings-route.test.ts
- copy/update test/cli/cli.integration.test.ts
- copy/update test/web/platform-a2a-push-handler.test.ts

## Public-only commits since last generated sync

- none detected since last generated sync

## Validation

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode

## Test Plan

- generated by the `sync-public-release-mirror` workflow in `public-tree` mode
- public-source-provenance `require-internal-pr` check confirms internal source PR lineage
- CI, integration, rust-hosted-conformance, coverage, Socket, and Cursor checks must pass before merge
- **Do not merge until Cursor Bugbot review completes** — Bugbot catches bugs that CI guardrails may not cover yet. If Bugbot finds issues, address them on this branch before merging.

## Staged Rollout

- Staging is unnecessary for this generated mirror PR: it does not independently promote user-visible behavior. It mirrors already-reviewed internal source from `evalops/maestro-internal@a870c32ae0dab73ef4af0c85efda5e11e62310e2`, including existing hidden/evaluation surfaces, and keeps public package parity behind the established public-source-provenance gate.

## Supersedes

- updates existing generated public sync PR #802 to internal source `a870c32ae0dab73ef4af0c85efda5e11e62310e2`