### PR TITLE
[maestro] adopt profile-based model routing

### DIFF
--- a/docs/AGENT_PROFILES.md
+++ b/docs/AGENT_PROFILES.md
@@ -1,0 +1,52 @@
+# Agent Profiles
+
+Agent profiles are versioned runtime bundles. A profile selects the primary model invocation, reasoning effort, complementary read-only Oracle, specialist invocations, fallbacks, and task budgets together. This prevents model comparisons from accidentally comparing different prompts, tools, or reasoning settings.
+
+## Capability dial
+
+| Level | Use it for |
+| --- | --- |
+| `low` | Bounded, obvious, reversible changes |
+| `medium` | Ordinary repository work with moderate uncertainty |
+| `high` | Ambiguous or cross-cutting work where a miss is expensive |
+| `ultra` | Migrations, architecture, and discovery-heavy work |
+
+Existing names remain accepted during migration: `free` and `rush` map to `low`, `smart` and `custom` map to `medium`, and `frontier` maps to `ultra`.
+
+## Project profiles
+
+Place YAML files in `.maestro/agent-profiles/`. A complete profile looks like:
+
+```yaml
+id: security-review-v1
+version: 1
+level: high
+description: Cross-provider security review
+primary:
+  provider: openai-codex
+  model: gpt-5.5
+  reasoningEffort: high
+oracle:
+  provider: anthropic
+  model: claude-opus-4-6
+  reasoningEffort: high
+  readOnly: true
+specialists:
+  reviewer:
+    provider: anthropic
+    model: claude-opus-4-6
+    reasoningEffort: high
+fallbackLevels: [medium, low]
+budgets:
+  maxAttempts: 2
+  maxToolCalls: 40
+  maxCostUsd: 5
+```
+
+Oracle configurations must be read-only and reasoning-capable at runtime. The built-in profiles prefer a different provider family for the Oracle on higher levels.
+
+## Routing evidence
+
+An assistant response completing without an error is not a verified success. Automatic promotion requires at least 20 verified outcomes for the workload. Verification results, explicit user acceptance, rejection, and retries can supply outcome evidence; unverified runs remain useful for latency and cost observations only.
+
+Clients can request a profile through `X-Maestro-Agent-Profile` (or the compatibility `X-Composer-Agent-Profile`) and inspect the versioned resolved profile on the routing decision.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,5 +1,7 @@
 # Feature Guide
 
+Maestro provides a capability dial (`low`, `medium`, `high`, and `ultra`) backed by versioned agent profiles. Legacy `free`, `rush`, `smart`, `custom`, and `frontier` names remain available as migration aliases. See [Agent Profiles](AGENT_PROFILES.md).
+
 Audience: users exploring TUI/CLI flows; skim first.  
 Nav: [Docs index](README.md) · [Quickstart](QUICKSTART.md) · [Tools Reference](TOOLS_REFERENCE.md) · [Web UI](WEB_UI.md)
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,5 +1,7 @@
 # Providers & Factory Integration
 
+For task-level selection, prefer the `low`, `medium`, `high`, and `ultra` agent profiles over selecting a model alone. Profiles keep the model, reasoning effort, Oracle, specialists, fallbacks, and budgets reproducible as one versioned unit. See [Agent Profiles](AGENT_PROFILES.md).
+
 Audience: contributors/operator tweaking model registry and provider configs.  
 Nav: [Docs index](README.md) · [Quickstart](QUICKSTART.md) · [Safety](SAFETY.md) · [AI SDK](../packages/ai/README.md)
 

--- a/docs/superpowers/plans/2026-07-13-agent-profile-routing.md
+++ b/docs/superpowers/plans/2026-07-13-agent-profile-routing.md
@@ -1,0 +1,211 @@
+# Agent Profile Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace fragmented model-only selection with a single, versioned agent-profile routing boundary while retaining compatibility for existing Maestro modes and clients.
+
+**Architecture:** A new profile module owns user-facing capability levels and complete invocation bundles. Existing mode and intelligent-router entry points adapt to that module during migration, so every surface receives the same model, reasoning, oracle, specialist, and budget configuration. Routing promotion remains conservative until verified outcome evidence meets an explicit sample threshold.
+
+**Tech Stack:** TypeScript, Bun, Vitest, existing Maestro model registry and routing services.
+
+## Global Constraints
+
+- Preserve `smart`, `rush`, `free`, `custom`, `frontier`, and `replay` as accepted compatibility inputs.
+- Expose `low`, `medium`, `high`, and `ultra` as the canonical user-facing capability levels.
+- Keep provider/model identifiers in the model registry layer; profiles reference registered identifiers and capabilities.
+- No routing promotion based solely on an assistant message completing without an error.
+- Every behavior change follows a failing-test, passing-test cycle.
+
+---
+
+### Task 1: Versioned agent profiles and compatibility aliases
+
+**Files:**
+- Create: `src/agent/profiles.ts`
+- Modify: `src/agent/modes.ts`
+- Modify: `src/agent/index.ts`
+- Test: `test/agent/profiles.test.ts`
+- Test: `test/agent/modes.test.ts`
+
+**Interfaces:**
+- Produces: `AgentProfileLevel`, `AgentProfile`, `AGENT_PROFILES`, `resolveAgentProfile(input, provider)`, and `parseAgentProfileLevel(input)`.
+- Consumes: existing `ModelProvider`, `ReasoningEffort`, `SubagentType`, and model-tier resolution during the compatibility period.
+
+- [ ] **Step 1: Write failing profile tests**
+
+```ts
+expect(parseAgentProfileLevel("rush")).toBe("low");
+expect(parseAgentProfileLevel("smart")).toBe("medium");
+expect(resolveAgentProfile("high", "openai-codex")).toMatchObject({
+  id: "high-v1",
+  level: "high",
+  primary: { provider: "openai-codex", reasoningEffort: "xhigh" },
+  oracle: { provider: "anthropic" },
+});
+```
+
+- [ ] **Step 2: Run the tests and verify missing exports fail**
+
+Run: `bunx vitest --run test/agent/profiles.test.ts test/agent/modes.test.ts`
+Expected: FAIL because `src/agent/profiles.ts` and its exports do not exist.
+
+- [ ] **Step 3: Implement immutable profile definitions and alias parsing**
+
+Define `low-v1`, `medium-v1`, `high-v1`, and `ultra-v1` profiles. Each profile contains primary and oracle invocation configurations, specialist dispatch, fallback levels, and task budgets. Adapt `parseMode`, `getModelForMode`, and subagent dispatch through canonical levels without removing legacy inputs.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `bunx vitest --run test/agent/profiles.test.ts test/agent/modes.test.ts test/codex/subagent-dispatch-table.test.ts`
+Expected: PASS.
+
+### Task 2: Route profiles through the intelligent router
+
+**Files:**
+- Modify: `src/services/intelligent-router/types.ts`
+- Modify: `src/services/intelligent-router/normalize.ts`
+- Modify: `src/services/intelligent-router/service.ts`
+- Modify: `src/services/intelligent-router/recorder.ts`
+- Modify: `src/server/handlers/chat.ts`
+- Test: `test/services/intelligent-router.test.ts`
+- Test: `test/web/chat-handler-routing.test.ts`
+
+**Interfaces:**
+- Consumes: `AgentProfile` and `resolveAgentProfile` from Task 1.
+- Produces: routing decisions containing `selectedProfile`, `fallbackProfiles`, and the resolved invocation profile while retaining `selectedModel` for wire compatibility.
+
+- [ ] **Step 1: Write failing decision-contract tests**
+
+```ts
+expect(decision.selectedProfile).toMatchObject({ level: "medium", id: "medium-v1" });
+expect(decision.fallbackProfiles.map(profile => profile.level)).toContain("low");
+```
+
+- [ ] **Step 2: Run focused tests and verify the new contract is absent**
+
+Run: `bunx vitest --run test/services/intelligent-router.test.ts test/web/chat-handler-routing.test.ts`
+Expected: FAIL because routing decisions contain models only.
+
+- [ ] **Step 3: Implement the profile adapter and compatibility projection**
+
+Resolve a profile before candidate scoring, constrain candidates to profile policy, return the selected immutable profile, and project its primary invocation into the legacy model fields.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `bunx vitest --run test/services/intelligent-router.test.ts test/web/chat-handler-routing.test.ts`
+Expected: PASS.
+
+### Task 3: Verified outcome evidence and conservative promotion
+
+**Files:**
+- Modify: `src/services/intelligent-router/types.ts`
+- Modify: `src/services/intelligent-router/normalize.ts`
+- Modify: `src/services/intelligent-router/service.ts`
+- Modify: `src/services/intelligent-router/recorder.ts`
+- Create: `src/services/intelligent-router/outcome.ts`
+- Test: `test/services/intelligent-router.test.ts`
+- Create: `test/services/intelligent-router-outcome.test.ts`
+
+**Interfaces:**
+- Produces: `RoutingOutcomeEvidence`, `deriveRoutingOutcome(evidence)`, `MIN_VERIFIED_SAMPLES`, and confidence metadata on routing scores.
+- Consumes: verifier results, user acceptance/retry signals, task cost, and terminal assistant status.
+
+- [ ] **Step 1: Write failing outcome tests**
+
+```ts
+expect(deriveRoutingOutcome({ assistantCompleted: true })).toEqual({ verified: false });
+expect(deriveRoutingOutcome({ assistantCompleted: true, verificationPassed: true }))
+  .toMatchObject({ verified: true, success: true });
+```
+
+- [ ] **Step 2: Run tests and verify the outcome module is missing**
+
+Run: `bunx vitest --run test/services/intelligent-router-outcome.test.ts test/services/intelligent-router.test.ts`
+Expected: FAIL because outcome evidence is not implemented.
+
+- [ ] **Step 3: Implement verified metrics and promotion guards**
+
+Do not record production quality or success from stop reason alone. Record unverified completions separately, require at least 20 verified samples for automatic promotion, expose sample sufficiency in routing reasons, and include total attempts plus total task cost in aggregates.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `bunx vitest --run test/services/intelligent-router-outcome.test.ts test/services/intelligent-router.test.ts test/web/chat-handler-routing.test.ts`
+Expected: PASS.
+
+### Task 4: Complementary oracle selection
+
+**Files:**
+- Modify: `src/tools/oracle.ts`
+- Modify: `src/agent/profiles.ts`
+- Test: `test/tools/oracle.test.ts`
+
+**Interfaces:**
+- Consumes: profile oracle invocation configuration and active primary provider.
+- Produces: `selectComplementaryOracleModel` that prefers a different provider family and never silently falls back to an arbitrary non-reasoning model.
+
+- [ ] **Step 1: Write failing oracle-selection tests**
+
+```ts
+expect(selectComplementaryOracleModel(models, { primaryProvider: "openai-codex" }))
+  .toMatchObject({ provider: "anthropic", reasoning: true });
+expect(() => selectComplementaryOracleModel(nonReasoningModels, options)).toThrow();
+```
+
+- [ ] **Step 2: Run the test and verify current arbitrary fallback fails it**
+
+Run: `bunx vitest --run test/tools/oracle.test.ts`
+Expected: FAIL because current selection accepts the first configured model.
+
+- [ ] **Step 3: Implement complementary selection and profile defaults**
+
+Select an explicit override first, then the active profile's oracle, then a reasoning-capable model from another provider. If none exists, use a same-provider reasoning model and record the degraded choice; never choose a non-reasoning model.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `bunx vitest --run test/tools/oracle.test.ts test/agent/profiles.test.ts`
+Expected: PASS.
+
+### Task 5: Profile packages, telemetry, documentation, and full verification
+
+**Files:**
+- Create: `src/agent/profile-loader.ts`
+- Modify: `src/cli/commands/modes.ts`
+- Modify: `docs/MODELS.md`
+- Modify: `docs/FEATURES.md`
+- Create: `docs/AGENT_PROFILES.md`
+- Create: `test/agent/profile-loader.test.ts`
+
+**Interfaces:**
+- Consumes: the Task 1 profile schema.
+- Produces: project/user profile loading, validation, versioned telemetry fields, and CLI descriptions of resolved complete profiles.
+
+- [ ] **Step 1: Write failing loader tests**
+
+```ts
+expect(loadAgentProfiles(fixtureDir)).toContainEqual(
+  expect.objectContaining({ id: "security-review-v1", level: "custom" }),
+);
+expect(() => loadAgentProfiles(invalidFixtureDir)).toThrow(/oracle.model/);
+```
+
+- [ ] **Step 2: Run tests and verify loader absence**
+
+Run: `bunx vitest --run test/agent/profile-loader.test.ts`
+Expected: FAIL because the loader does not exist.
+
+- [ ] **Step 3: Implement declarative loading and document the schema**
+
+Load `.maestro/agent-profiles/*.yaml` and user profiles with project precedence, validate complete invocation bundles, show resolved primary/oracle/specialists/budgets in `maestro modes describe`, and document migration aliases.
+
+- [ ] **Step 4: Run repository verification**
+
+Run: `bun run bun:lint`
+Expected: PASS.
+
+Run: `npx nx run maestro:test --skip-nx-cache`
+Expected: PASS.
+
+Run: `npx nx run maestro:evals --skip-nx-cache`
+Expected: PASS.
+
+Run: `npx nx run maestro:build --skip-nx-cache`
+Expected: PASS.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -112,6 +112,20 @@ export {
 	type SubagentDispatch,
 } from "./modes.js";
 export {
+	AGENT_PROFILES,
+	AGENT_PROFILE_LEVELS,
+	type AgentProfile,
+	type AgentProfileBudgets,
+	type AgentProfileLevel,
+	type ModelInvocationProfile,
+	parseAgentProfileLevel,
+	resolveAgentProfile,
+} from "./profiles.js";
+export {
+	loadAgentProfiles,
+	loadAgentProfilesFromDirectory,
+} from "./profile-loader.js";
+export {
 	ContextHandoffManager,
 	createContextHandoffManager,
 	estimateTokenCount,

--- a/src/agent/modes.ts
+++ b/src/agent/modes.ts
@@ -61,6 +61,10 @@ const logger = createLogger("agent:modes");
  * - "custom": User-defined settings for specialized workflows
  */
 export type AgentMode =
+	| "low"
+	| "medium"
+	| "high"
+	| "ultra"
 	| "smart"
 	| "rush"
 	| "free"
@@ -189,6 +193,62 @@ const PROVIDERS: ModelProvider[] = [
  * - **custom**: Balanced defaults that users can override
  */
 export const MODE_CONFIGS: Record<AgentMode, ModeConfig> = {
+	low: {
+		displayName: "Low",
+		description: "Bounded, obvious, and reversible work",
+		primaryTier: "haiku",
+		fallbackTier: "haiku",
+		enableThinking: false,
+		reasoningEffort: "low",
+		thinkingBudget: 2000,
+		useExtendedContext: false,
+		maxRetries: 1,
+		costMultiplier: 0.1,
+		speedHint: 10,
+		visible: true,
+	},
+	medium: {
+		displayName: "Medium",
+		description: "Ordinary repository work with moderate uncertainty",
+		primaryTier: "opus",
+		fallbackTier: "haiku",
+		enableThinking: true,
+		reasoningEffort: "medium",
+		thinkingBudget: 16000,
+		useExtendedContext: true,
+		maxRetries: 2,
+		costMultiplier: 1,
+		speedHint: 5,
+		visible: true,
+	},
+	high: {
+		displayName: "High",
+		description: "Ambiguous or cross-cutting work where misses are expensive",
+		primaryTier: "opus",
+		fallbackTier: "sonnet",
+		enableThinking: true,
+		reasoningEffort: "xhigh",
+		thinkingBudget: 20000,
+		useExtendedContext: true,
+		maxRetries: 2,
+		costMultiplier: 1.25,
+		speedHint: 4,
+		visible: true,
+	},
+	ultra: {
+		displayName: "Ultra",
+		description: "Migrations, architecture, and discovery-heavy work",
+		primaryTier: "opus",
+		fallbackTier: "opus",
+		enableThinking: true,
+		reasoningEffort: "xhigh",
+		thinkingBudget: 32000,
+		useExtendedContext: true,
+		maxRetries: 3,
+		costMultiplier: 1.5,
+		speedHint: 3,
+		visible: true,
+	},
 	// Smart mode: Maximum capability for complex reasoning tasks
 	smart: {
 		displayName: "Smart",

--- a/src/agent/profile-loader.ts
+++ b/src/agent/profile-loader.ts
@@ -1,0 +1,154 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { extname, join } from "node:path";
+import YAML from "yaml";
+import { PATHS } from "../config/constants.js";
+import { isRecord } from "../utils/json.js";
+import type { ReasoningEffort } from "./modes.js";
+import {
+	type AgentProfile,
+	type AgentProfileBudgets,
+	type AgentProfileLevel,
+	type ModelInvocationProfile,
+	parseAgentProfileLevel,
+} from "./profiles.js";
+import { parseSubagentType } from "./subagent-specs.js";
+
+const REASONING_EFFORTS = new Set<ReasoningEffort>([
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+]);
+
+function requiredString(value: unknown, path: string): string {
+	if (typeof value !== "string" || !value.trim()) {
+		throw new Error(`${path} must be a non-empty string`);
+	}
+	return value.trim();
+}
+
+function positiveInteger(value: unknown, path: string): number {
+	if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+		throw new Error(`${path} must be a positive integer`);
+	}
+	return value;
+}
+
+function invocation(
+	value: unknown,
+	path: string,
+	options: { requireReadOnly?: boolean } = {},
+): ModelInvocationProfile {
+	if (!isRecord(value)) throw new Error(`${path} must be an object`);
+	const reasoningEffort = requiredString(
+		value.reasoningEffort,
+		`${path}.reasoningEffort`,
+	) as ReasoningEffort;
+	if (!REASONING_EFFORTS.has(reasoningEffort)) {
+		throw new Error(`${path}.reasoningEffort is invalid`);
+	}
+	if (options.requireReadOnly && value.readOnly !== true) {
+		throw new Error(`${path}.readOnly must be true`);
+	}
+	return Object.freeze({
+		provider: requiredString(value.provider, `${path}.provider`),
+		model: requiredString(value.model, `${path}.model`),
+		reasoningEffort,
+		...(value.readOnly === true ? { readOnly: true } : {}),
+	});
+}
+
+function parseProfile(value: unknown, source: string): AgentProfile {
+	if (!isRecord(value)) throw new Error(`${source} must contain an object`);
+	const parsedLevel = parseAgentProfileLevel(
+		requiredString(value.level, `${source}.level`),
+	);
+	if (!parsedLevel) throw new Error(`${source}.level is invalid`);
+	const version = positiveInteger(value.version, `${source}.version`);
+	const fallbackLevels = Array.isArray(value.fallbackLevels)
+		? value.fallbackLevels.map((entry, index) => {
+				const level = parseAgentProfileLevel(
+					requiredString(entry, `${source}.fallbackLevels[${index}]`),
+				);
+				if (!level) {
+					throw new Error(`${source}.fallbackLevels[${index}] is invalid`);
+				}
+				return level;
+			})
+		: [];
+	if (!isRecord(value.budgets)) {
+		throw new Error(`${source}.budgets must be an object`);
+	}
+	const budgets: AgentProfileBudgets = Object.freeze({
+		maxAttempts: positiveInteger(
+			value.budgets.maxAttempts,
+			`${source}.budgets.maxAttempts`,
+		),
+		maxToolCalls: positiveInteger(
+			value.budgets.maxToolCalls,
+			`${source}.budgets.maxToolCalls`,
+		),
+		...(typeof value.budgets.maxCostUsd === "number"
+			? { maxCostUsd: value.budgets.maxCostUsd }
+			: {}),
+	});
+	const specialists: AgentProfile["specialists"] = {};
+	if (isRecord(value.specialists)) {
+		for (const [rawType, config] of Object.entries(value.specialists)) {
+			const type = parseSubagentType(rawType);
+			if (!type) throw new Error(`${source}.specialists.${rawType} is invalid`);
+			specialists[type] = invocation(
+				config,
+				`${source}.specialists.${rawType}`,
+			);
+		}
+	}
+	return Object.freeze({
+		id: requiredString(value.id, `${source}.id`),
+		version,
+		level: parsedLevel as AgentProfileLevel,
+		description: requiredString(value.description, `${source}.description`),
+		primary: invocation(value.primary, `${source}.primary`),
+		oracle: invocation(value.oracle, `${source}.oracle`, {
+			requireReadOnly: true,
+		}),
+		specialists: Object.freeze(specialists),
+		fallbackLevels: Object.freeze(fallbackLevels) as AgentProfileLevel[],
+		budgets,
+	});
+}
+
+export function loadAgentProfilesFromDirectory(
+	directory: string,
+): AgentProfile[] {
+	if (!existsSync(directory)) return [];
+	return readdirSync(directory)
+		.filter((file) => [".yaml", ".yml"].includes(extname(file).toLowerCase()))
+		.sort()
+		.map((file) => {
+			const path = join(directory, file);
+			return parseProfile(YAML.parse(readFileSync(path, "utf8")), path);
+		});
+}
+
+export function loadAgentProfiles(
+	options: {
+		workspaceDir?: string;
+		homeDir?: string;
+	} = {},
+): AgentProfile[] {
+	const workspaceDir = options.workspaceDir ?? process.cwd();
+	const homeDir = options.homeDir ?? PATHS.MAESTRO_HOME;
+	const profiles = new Map<string, AgentProfile>();
+	for (const profile of loadAgentProfilesFromDirectory(
+		join(homeDir, "agent-profiles"),
+	)) {
+		profiles.set(profile.id, profile);
+	}
+	for (const profile of loadAgentProfilesFromDirectory(
+		join(workspaceDir, ".maestro", "agent-profiles"),
+	)) {
+		profiles.set(profile.id, profile);
+	}
+	return Array.from(profiles.values()).sort((a, b) => a.id.localeCompare(b.id));
+}

--- a/src/agent/profiles.ts
+++ b/src/agent/profiles.ts
@@ -1,0 +1,243 @@
+import {
+	type ModelProvider,
+	type ModelTier,
+	type ReasoningEffort,
+	getModelForTier,
+} from "./modes.js";
+import type { SubagentType } from "./subagent-specs.js";
+
+export const AGENT_PROFILE_LEVELS = ["low", "medium", "high", "ultra"] as const;
+
+export type AgentProfileLevel = (typeof AGENT_PROFILE_LEVELS)[number];
+
+export interface ModelInvocationProfile {
+	provider: string;
+	model: string;
+	reasoningEffort: ReasoningEffort;
+	readOnly?: boolean;
+}
+
+export interface AgentProfileBudgets {
+	maxAttempts: number;
+	maxToolCalls: number;
+	maxCostUsd?: number;
+}
+
+export interface AgentProfile {
+	id: string;
+	version: number;
+	level: AgentProfileLevel;
+	description: string;
+	primary: ModelInvocationProfile;
+	oracle: ModelInvocationProfile;
+	specialists: Partial<Record<SubagentType, ModelInvocationProfile>>;
+	fallbackLevels: AgentProfileLevel[];
+	budgets: AgentProfileBudgets;
+}
+
+interface AgentProfileTemplate {
+	description: string;
+	primaryTier: ModelTier;
+	primaryReasoningEffort: ReasoningEffort;
+	oracleProvider: ModelProvider;
+	oracleTier: ModelTier;
+	oracleReasoningEffort: ReasoningEffort;
+	specialists: Partial<
+		Record<
+			SubagentType,
+			{
+				provider?: ModelProvider;
+				tier: ModelTier;
+				reasoningEffort: ReasoningEffort;
+			}
+		>
+	>;
+	fallbackLevels: AgentProfileLevel[];
+	budgets: AgentProfileBudgets;
+}
+
+const LEGACY_LEVEL_ALIASES: Readonly<Record<string, AgentProfileLevel>> =
+	Object.freeze({
+		free: "low",
+		rush: "low",
+		smart: "medium",
+		custom: "medium",
+		frontier: "ultra",
+	});
+
+const PROFILE_TEMPLATES: Readonly<
+	Record<AgentProfileLevel, AgentProfileTemplate>
+> = Object.freeze({
+	low: {
+		description: "Bounded, obvious, and reversible work",
+		primaryTier: "haiku",
+		primaryReasoningEffort: "low",
+		oracleProvider: "openai-codex",
+		oracleTier: "opus",
+		oracleReasoningEffort: "medium",
+		specialists: {
+			explorer: { tier: "haiku", reasoningEffort: "low" },
+			coder: { tier: "haiku", reasoningEffort: "low" },
+			reviewer: { tier: "sonnet", reasoningEffort: "low" },
+		},
+		fallbackLevels: [],
+		budgets: { maxAttempts: 1, maxToolCalls: 15 },
+	},
+	medium: {
+		description: "Ordinary repository work with moderate uncertainty",
+		primaryTier: "opus",
+		primaryReasoningEffort: "medium",
+		oracleProvider: "anthropic",
+		oracleTier: "opus",
+		oracleReasoningEffort: "medium",
+		specialists: {
+			explorer: { tier: "haiku", reasoningEffort: "low" },
+			planner: { tier: "sonnet", reasoningEffort: "medium" },
+			coder: {
+				provider: "openai-codex",
+				tier: "opus",
+				reasoningEffort: "medium",
+			},
+			reviewer: { tier: "sonnet", reasoningEffort: "medium" },
+		},
+		fallbackLevels: ["low"],
+		budgets: { maxAttempts: 2, maxToolCalls: 30 },
+	},
+	high: {
+		description: "Ambiguous or cross-cutting work where misses are expensive",
+		primaryTier: "opus",
+		primaryReasoningEffort: "xhigh",
+		oracleProvider: "anthropic",
+		oracleTier: "opus",
+		oracleReasoningEffort: "high",
+		specialists: {
+			explorer: { tier: "sonnet", reasoningEffort: "medium" },
+			planner: { tier: "opus", reasoningEffort: "high" },
+			coder: {
+				provider: "openai-codex",
+				tier: "opus",
+				reasoningEffort: "xhigh",
+			},
+			reviewer: {
+				provider: "anthropic",
+				tier: "opus",
+				reasoningEffort: "high",
+			},
+		},
+		fallbackLevels: ["medium", "low"],
+		budgets: { maxAttempts: 2, maxToolCalls: 45 },
+	},
+	ultra: {
+		description: "Migrations, architecture, and discovery-heavy work",
+		primaryTier: "opus",
+		primaryReasoningEffort: "xhigh",
+		oracleProvider: "openai-codex",
+		oracleTier: "opus",
+		oracleReasoningEffort: "xhigh",
+		specialists: {
+			explorer: { tier: "sonnet", reasoningEffort: "high" },
+			planner: { tier: "opus", reasoningEffort: "xhigh" },
+			coder: { tier: "opus", reasoningEffort: "xhigh" },
+			reviewer: {
+				provider: "openai-codex",
+				tier: "opus",
+				reasoningEffort: "xhigh",
+			},
+		},
+		fallbackLevels: ["high", "medium"],
+		budgets: { maxAttempts: 3, maxToolCalls: 60 },
+	},
+});
+
+function deepFreeze<T>(value: T): Readonly<T> {
+	if (value && typeof value === "object" && !Object.isFrozen(value)) {
+		Object.freeze(value);
+		for (const child of Object.values(value as Record<string, unknown>)) {
+			deepFreeze(child);
+		}
+	}
+	return value;
+}
+
+function invocation(
+	provider: ModelProvider,
+	tier: ModelTier,
+	reasoningEffort: ReasoningEffort,
+	readOnly = false,
+): ModelInvocationProfile {
+	return {
+		provider,
+		model: getModelForTier(tier, provider),
+		reasoningEffort,
+		...(readOnly ? { readOnly: true } : {}),
+	};
+}
+
+function buildProfile(
+	level: AgentProfileLevel,
+	provider: ModelProvider,
+): AgentProfile {
+	const template = PROFILE_TEMPLATES[level];
+	const specialists = Object.fromEntries(
+		Object.entries(template.specialists).map(([type, specialist]) => {
+			const specialistProvider = specialist.provider ?? provider;
+			return [
+				type,
+				invocation(
+					specialistProvider,
+					specialist.tier,
+					specialist.reasoningEffort,
+				),
+			];
+		}),
+	) as Partial<Record<SubagentType, ModelInvocationProfile>>;
+	return deepFreeze({
+		id: `${level}-v1`,
+		version: 1,
+		level,
+		description: template.description,
+		primary: invocation(
+			provider,
+			template.primaryTier,
+			template.primaryReasoningEffort,
+		),
+		oracle: invocation(
+			template.oracleProvider,
+			template.oracleTier,
+			template.oracleReasoningEffort,
+			true,
+		),
+		specialists,
+		fallbackLevels: [...template.fallbackLevels],
+		budgets: { ...template.budgets },
+	}) as AgentProfile;
+}
+
+export function parseAgentProfileLevel(
+	input: string,
+): AgentProfileLevel | null {
+	const normalized = input.trim().toLowerCase();
+	if (AGENT_PROFILE_LEVELS.includes(normalized as AgentProfileLevel)) {
+		return normalized as AgentProfileLevel;
+	}
+	return LEGACY_LEVEL_ALIASES[normalized] ?? null;
+}
+
+export function resolveAgentProfile(
+	input: string,
+	provider: ModelProvider = "openai-codex",
+): AgentProfile {
+	const level = parseAgentProfileLevel(input);
+	if (!level) throw new Error(`Unknown agent profile: ${input}`);
+	return buildProfile(level, provider);
+}
+
+export const AGENT_PROFILES: Readonly<Record<AgentProfileLevel, AgentProfile>> =
+	deepFreeze(
+		Object.fromEntries(
+			AGENT_PROFILE_LEVELS.map((level) => [
+				level,
+				buildProfile(level, "openai-codex"),
+			]),
+		) as Record<AgentProfileLevel, AgentProfile>,
+	);

--- a/src/cli/commands/modes.ts
+++ b/src/cli/commands/modes.ts
@@ -11,6 +11,11 @@ import {
 	resolveSubagentDispatch,
 } from "../../agent/modes.js";
 import {
+	type AgentProfile,
+	parseAgentProfileLevel,
+	resolveAgentProfile,
+} from "../../agent/profiles.js";
+import {
 	SUBAGENT_SPECS,
 	type SubagentType,
 } from "../../agent/subagent-specs.js";
@@ -61,6 +66,7 @@ type ModeDescription = {
 			description: string;
 		}
 	>;
+	agentProfile?: AgentProfile;
 };
 
 function parseProvider(provider: string | undefined): ModelProvider {
@@ -84,6 +90,7 @@ function buildModeDescription(
 	provider: ModelProvider,
 ): ModeDescription {
 	const config = getModeConfig(mode);
+	const profileLevel = parseAgentProfileLevel(mode);
 	return {
 		mode,
 		displayName: config.displayName,
@@ -120,6 +127,9 @@ function buildModeDescription(
 				description: spec.description,
 			};
 		}),
+		...(profileLevel
+			? { agentProfile: resolveAgentProfile(profileLevel, provider) }
+			: {}),
 	};
 }
 
@@ -140,6 +150,12 @@ function renderModeDescription(description: ModeDescription): string {
 		`Thinking: ${description.thinking.enabled ? "enabled" : "disabled"} (budget ${description.thinking.budget})`,
 		`Context: ${description.context.extended ? "extended" : "standard"}`,
 		`Retries: ${description.retries}`,
+		...(description.agentProfile
+			? [
+					`Profile: ${description.agentProfile.id}`,
+					`Oracle: ${description.agentProfile.oracle.provider}/${description.agentProfile.oracle.model} (${description.agentProfile.oracle.reasoningEffort})`,
+				]
+			: []),
 		"",
 		`Subagent dispatch (provider: ${description.primary.provider})`,
 		`${pad("Type", 12)} ${pad("Source", 8)} ${pad("Provider", 14)} ${pad("Model", 34)} ${pad("Effort", 8)} Tier`,

--- a/src/services/intelligent-router/index.ts
+++ b/src/services/intelligent-router/index.ts
@@ -18,6 +18,11 @@ export {
 	setIntelligentRouterServiceForTest,
 } from "./service.js";
 export {
+	type RoutingOutcome,
+	type RoutingOutcomeEvidence,
+	deriveRoutingOutcome,
+} from "./outcome.js";
+export {
 	MODEL_PERFORMANCE_METRIC_SOURCES,
 	ROUTING_STRATEGIES,
 	type ModelPerformanceAggregate,

--- a/src/services/intelligent-router/normalize.ts
+++ b/src/services/intelligent-router/normalize.ts
@@ -1,3 +1,4 @@
+import { parseAgentProfileLevel } from "../../agent/profiles.js";
 import { isRecord } from "../../utils/json.js";
 import {
 	MODEL_PERFORMANCE_METRIC_SOURCES,
@@ -162,6 +163,16 @@ export function normalizeRoutingRequest(
 	}
 	const requestInput = input as RoutingRequestInput;
 	const taskType = cleanOptionalString(requestInput.taskType) ?? "chat";
+	const profileInput =
+		cleanOptionalString(requestInput.profileHint) ??
+		cleanOptionalString(requestInput.profile_hint) ??
+		"medium";
+	const profileLevel = parseAgentProfileLevel(profileInput);
+	if (!profileLevel) {
+		throw new IntelligentRouterValidationError(
+			"Invalid agent profile. Use low, medium, high, or ultra.",
+		);
+	}
 	const modelHint =
 		cleanOptionalString(requestInput.modelHint) ??
 		cleanOptionalString(requestInput.model_hint);
@@ -173,6 +184,7 @@ export function normalizeRoutingRequest(
 	);
 	return {
 		taskType,
+		profileLevel,
 		strategy: parseRoutingStrategy(requestInput.strategy),
 		unavailableModels,
 		availableModels:
@@ -186,6 +198,7 @@ export type NormalizedModelPerformanceMetricInput =
 		source: ModelPerformanceMetricSource;
 		latencyMs: number;
 		success: boolean;
+		verified: boolean;
 		costUsd: number;
 		qualityScore: number;
 		occurredAt: Date | string;
@@ -215,6 +228,10 @@ export function normalizePerformanceMetricInput(
 		source: parseMetricSource(metricInput.source),
 		latencyMs,
 		success: parseOptionalBoolean(metricInput.success) ?? true,
+		verified:
+			typeof metricInput.verified === "boolean"
+				? metricInput.verified
+				: parseMetricSource(metricInput.source) === "eval",
 		costUsd,
 		qualityScore: Math.max(0, Math.min(1, qualityScore)),
 		...(cleanOptionalString(metricInput.evalSuite)

--- a/src/services/intelligent-router/outcome.ts
+++ b/src/services/intelligent-router/outcome.ts
@@ -1,0 +1,71 @@
+export interface RoutingOutcomeEvidence {
+	assistantCompleted: boolean;
+	verificationPassed?: boolean;
+	userAccepted?: boolean;
+	userRejected?: boolean;
+	userRetried?: boolean;
+	attempts?: number;
+	totalCostUsd?: number;
+}
+
+export interface RoutingOutcome {
+	verified: boolean;
+	success: boolean;
+	qualityScore: number;
+	reasons: string[];
+	attempts?: number;
+	totalCostUsd?: number;
+}
+
+export function deriveRoutingOutcome(
+	evidence: RoutingOutcomeEvidence,
+): RoutingOutcome {
+	const shared = {
+		...(evidence.attempts !== undefined
+			? { attempts: Math.max(1, Math.floor(evidence.attempts)) }
+			: {}),
+		...(evidence.totalCostUsd !== undefined
+			? { totalCostUsd: Math.max(0, evidence.totalCostUsd) }
+			: {}),
+	};
+	if (evidence.userRejected) {
+		return {
+			verified: true,
+			success: false,
+			qualityScore: 0,
+			reasons: ["user_rejected"],
+			...shared,
+		};
+	}
+	if (evidence.userRetried) {
+		return {
+			verified: true,
+			success: false,
+			qualityScore: 0,
+			reasons: ["user_retried"],
+			...shared,
+		};
+	}
+	if (evidence.verificationPassed || evidence.userAccepted) {
+		return {
+			verified: true,
+			success: true,
+			qualityScore: 1,
+			reasons: [
+				evidence.verificationPassed ? "verification_passed" : "user_accepted",
+			],
+			...shared,
+		};
+	}
+	return {
+		verified: false,
+		success: false,
+		qualityScore: 0,
+		reasons: [
+			evidence.assistantCompleted
+				? "assistant_completed_without_verification"
+				: "assistant_did_not_complete",
+		],
+		...shared,
+	};
+}

--- a/src/services/intelligent-router/recorder.ts
+++ b/src/services/intelligent-router/recorder.ts
@@ -87,11 +87,23 @@ export function selectIntelligentRouterModel(params: {
 	const taskType = resolveIntelligentRouterTaskType(params.req, params.body);
 	const modelHint = params.requestedModel ?? undefined;
 	const strategy = resolveIntelligentRouterStrategy(params.req);
+	const profileHint =
+		firstHeader(params.req, [
+			"x-maestro-agent-profile",
+			"x-composer-agent-profile",
+		]) ??
+		(params.body &&
+		typeof params.body === "object" &&
+		"profile" in params.body &&
+		typeof (params.body as { profile?: unknown }).profile === "string"
+			? (params.body as { profile: string }).profile
+			: undefined);
 	const decision = getIntelligentRouterService().routeRequest({
 		taskType,
 		availableModels: registeredRoutingModels(),
 		...(modelHint ? { modelHint } : {}),
 		...(strategy ? { strategy } : {}),
+		...(profileHint ? { profileHint } : {}),
 	});
 	return {
 		taskType,
@@ -119,7 +131,8 @@ export function recordIntelligentRouterChatMetric(params: {
 				provider: params.provider,
 				model: params.model,
 				latencyMs: Date.now() - params.startedAt,
-				success: params.message.stopReason !== "error",
+				success: false,
+				verified: false,
 				occurredAt: new Date(params.message.timestamp),
 				...(typeof costUsd === "number" ? { costUsd } : {}),
 			});

--- a/src/services/intelligent-router/service.ts
+++ b/src/services/intelligent-router/service.ts
@@ -1,4 +1,9 @@
 import { createHash } from "node:crypto";
+import type { ModelProvider } from "../../agent/modes.js";
+import {
+	type AgentProfile,
+	resolveAgentProfile,
+} from "../../agent/profiles.js";
 import {
 	type ServiceAuthorityResolution,
 	resolveServiceAuthority,
@@ -17,12 +22,13 @@ import type {
 	RoutingModelCandidate,
 	RoutingOverride,
 	RoutingOverrideInput,
+	RoutingRequest,
 	RoutingRequestInput,
 	RoutingScore,
 	RoutingStrategy,
 } from "./types.js";
 
-const MIN_HISTORY_SAMPLES = 2;
+export const MIN_VERIFIED_SAMPLES = 20;
 const MAX_LATENCIES = 100;
 const MAX_DECISIONS = 100;
 
@@ -31,6 +37,7 @@ interface MetricState {
 	provider: string;
 	model: string;
 	samples: number;
+	verifiedSamples: number;
 	productionSamples: number;
 	evalSamples: number;
 	successCount: number;
@@ -93,10 +100,14 @@ function aggregateFromState(state: MetricState): ModelPerformanceAggregate {
 		provider: state.provider,
 		model: state.model,
 		samples: state.samples,
+		verifiedSamples: state.verifiedSamples,
 		productionSamples: state.productionSamples,
 		evalSamples: state.evalSamples,
 		successCount: state.successCount,
-		successRate: state.samples > 0 ? state.successCount / state.samples : 0,
+		successRate:
+			state.verifiedSamples > 0
+				? state.successCount / state.verifiedSamples
+				: 0,
 		evalSuccessRate:
 			state.evalSamples > 0 ? state.evalSuccessCount / state.evalSamples : 0,
 		averageLatencyMs:
@@ -104,7 +115,9 @@ function aggregateFromState(state: MetricState): ModelPerformanceAggregate {
 		p95LatencyMs: percentile(state.latenciesMs, 0.95),
 		averageCostUsd: state.samples > 0 ? state.totalCostUsd / state.samples : 0,
 		qualityScore:
-			state.samples > 0 ? state.qualityScoreTotal / state.samples : 0.5,
+			state.verifiedSamples > 0
+				? state.qualityScoreTotal / state.verifiedSamples
+				: 0.5,
 		evalQualityScore:
 			state.evalSamples > 0
 				? state.evalQualityScoreTotal / state.evalSamples
@@ -172,14 +185,14 @@ function latencyScore(
 function successScore(
 	aggregate: ModelPerformanceAggregate | undefined,
 ): number {
-	if (!aggregate?.samples) return 0.5;
+	if (!aggregate?.verifiedSamples) return 0.5;
 	return aggregate.successRate;
 }
 
 function qualityScore(
 	aggregate: ModelPerformanceAggregate | undefined,
 ): number {
-	if (!aggregate?.samples) return 0.5;
+	if (!aggregate?.verifiedSamples) return 0.5;
 	return aggregate.qualityScore;
 }
 
@@ -212,6 +225,11 @@ function scoreCandidate(params: {
 	if (params.aggregate?.productionSamples) {
 		reasons.push(`production_samples=${params.aggregate.productionSamples}`);
 	}
+	if ((params.aggregate?.verifiedSamples ?? 0) < MIN_VERIFIED_SAMPLES) {
+		reasons.push(
+			`verified_samples=${params.aggregate?.verifiedSamples ?? 0}/${MIN_VERIFIED_SAMPLES}`,
+		);
+	}
 	if (params.aggregate?.evalSamples && !params.aggregate.productionSamples) {
 		reasons.push("eval_backed");
 	}
@@ -230,6 +248,9 @@ function scoreCandidate(params: {
 		costScore: cost,
 		qualityScore: quality,
 		samples: params.aggregate?.samples ?? 0,
+		verifiedSamples: params.aggregate?.verifiedSamples ?? 0,
+		promotionEligible:
+			(params.aggregate?.verifiedSamples ?? 0) >= MIN_VERIFIED_SAMPLES,
 		productionSamples: params.aggregate?.productionSamples ?? 0,
 		evalSamples: params.aggregate?.evalSamples ?? 0,
 		evalBacked: Boolean(
@@ -245,6 +266,30 @@ function routedModelFromScore(score: RoutingScore): RoutedModel {
 		provider: score.provider,
 		model: score.model,
 	};
+}
+
+function profileProvider(provider: string): ModelProvider {
+	return ["anthropic", "openai", "openai-codex", "google"].includes(provider)
+		? (provider as ModelProvider)
+		: "openai-codex";
+}
+
+function selectedAgentProfile(
+	level: RoutingRequest["profileLevel"],
+	selected: RoutedModel,
+): AgentProfile {
+	const profile = resolveAgentProfile(
+		level,
+		profileProvider(selected.provider),
+	);
+	return Object.freeze({
+		...profile,
+		primary: Object.freeze({
+			...profile.primary,
+			provider: selected.provider,
+			model: selected.model,
+		}),
+	});
 }
 
 function overrideExpired(override: RoutingOverride, now: Date): boolean {
@@ -280,6 +325,7 @@ export class IntelligentRouterService {
 				provider: metric.provider,
 				model: metric.model,
 				samples: 0,
+				verifiedSamples: 0,
 				productionSamples: 0,
 				evalSamples: 0,
 				successCount: 0,
@@ -294,7 +340,11 @@ export class IntelligentRouterService {
 			} satisfies MetricState);
 
 		state.samples += 1;
-		if (metric.success) state.successCount += 1;
+		if (metric.verified) {
+			state.verifiedSamples += 1;
+			if (metric.success) state.successCount += 1;
+			state.qualityScoreTotal += metric.qualityScore;
+		}
 		if (metric.source === "eval") {
 			state.evalSamples += 1;
 			if (metric.success) state.evalSuccessCount += 1;
@@ -309,7 +359,6 @@ export class IntelligentRouterService {
 			state.latenciesMs.splice(0, state.latenciesMs.length - MAX_LATENCIES);
 		}
 		state.totalCostUsd += metric.costUsd;
-		state.qualityScoreTotal += metric.qualityScore;
 		state.updatedAt =
 			metric.occurredAt instanceof Date
 				? metric.occurredAt
@@ -380,19 +429,36 @@ export class IntelligentRouterService {
 					),
 				)
 			: undefined;
+		const baselineCandidate = request.availableModels[0];
+		const baselineScore = baselineCandidate
+			? availableScores.find(
+					(score) =>
+						score.provider === baselineCandidate.provider &&
+						score.model === baselineCandidate.model,
+				)
+			: undefined;
 		const enoughHistory = availableScores.some(
-			(score) => score.samples >= MIN_HISTORY_SAMPLES,
+			(score) => score.verifiedSamples >= MIN_VERIFIED_SAMPLES,
 		);
 		const selectedScore =
 			overrideScore ??
-			(!enoughHistory && hintScore ? hintScore : firstAvailable);
+			(!enoughHistory
+				? (hintScore ?? baselineScore ?? firstAvailable)
+				: firstAvailable);
 		const overrideApplied = overrideScore !== undefined;
 		const reason = overrideApplied
 			? "override"
 			: !enoughHistory && hintScore
-				? "insufficient_history_model_hint"
+				? "insufficient_verified_history_model_hint"
 				: "highest_score";
 		const selected = routedModelFromScore(selectedScore);
+		const selectedProfile = selectedAgentProfile(
+			request.profileLevel,
+			selected,
+		);
+		const fallbackProfiles = selectedProfile.fallbackLevels.map((level) =>
+			resolveAgentProfile(level, profileProvider(selected.provider)),
+		);
 		const fallbackChain = availableScores
 			.filter(
 				(score) =>
@@ -411,6 +477,8 @@ export class IntelligentRouterService {
 			taskType: request.taskType,
 			strategy: request.strategy,
 			selectedModel: selected,
+			selectedProfile,
+			fallbackProfiles,
 			fallbackChain,
 			scores,
 			overrideApplied,

--- a/src/services/intelligent-router/types.ts
+++ b/src/services/intelligent-router/types.ts
@@ -1,3 +1,5 @@
+import type { AgentProfile, AgentProfileLevel } from "../../agent/profiles.js";
+
 export const ROUTING_STRATEGIES = [
 	"balanced",
 	"quality",
@@ -34,6 +36,7 @@ export interface ModelPerformanceMetricInput {
 	source?: ModelPerformanceMetricSource;
 	latencyMs?: number;
 	success?: boolean;
+	verified?: boolean;
 	costUsd?: number;
 	qualityScore?: number;
 	evalSuite?: string;
@@ -46,6 +49,7 @@ export interface ModelPerformanceAggregate {
 	provider: string;
 	model: string;
 	samples: number;
+	verifiedSamples: number;
 	productionSamples: number;
 	evalSamples: number;
 	successCount: number;
@@ -62,6 +66,8 @@ export interface ModelPerformanceAggregate {
 
 export interface RoutingRequestInput {
 	taskType?: string;
+	profileHint?: string;
+	profile_hint?: string;
 	modelHint?: string;
 	model_hint?: string;
 	strategy?: string;
@@ -72,6 +78,7 @@ export interface RoutingRequestInput {
 
 export interface RoutingRequest {
 	taskType: string;
+	profileLevel: AgentProfileLevel;
 	modelHint?: string;
 	strategy: RoutingStrategy;
 	unavailableModels: string[];
@@ -87,6 +94,8 @@ export interface RoutingScore {
 	costScore: number;
 	qualityScore: number;
 	samples: number;
+	verifiedSamples: number;
+	promotionEligible: boolean;
 	productionSamples: number;
 	evalSamples: number;
 	evalBacked: boolean;
@@ -104,6 +113,8 @@ export interface RoutingDecision {
 	taskType: string;
 	strategy: RoutingStrategy;
 	selectedModel: RoutedModel;
+	selectedProfile: AgentProfile;
+	fallbackProfiles: AgentProfile[];
 	fallbackChain: RoutedModel[];
 	scores: RoutingScore[];
 	modelHint?: string;

--- a/src/tools/oracle.ts
+++ b/src/tools/oracle.ts
@@ -48,6 +48,44 @@ export interface OracleToolDetails {
 	files?: string[];
 }
 
+export interface OracleModelCandidate {
+	id: string;
+	provider?: string;
+	reasoning?: boolean;
+}
+
+export function selectComplementaryOracleModel<T extends OracleModelCandidate>(
+	models: T[],
+	options: { primaryProvider?: string; preferredId?: string } = {},
+): T {
+	const preferred = options.preferredId?.trim();
+	if (preferred) {
+		const preferredRefs = new Set([
+			preferred,
+			preferred.startsWith("openai/") ? preferred : `openai/${preferred}`,
+		]);
+		const explicit = models.find(
+			(model) => model.reasoning === true && preferredRefs.has(model.id),
+		);
+		if (explicit) return explicit;
+	}
+
+	const complementary = models.find(
+		(model) =>
+			model.reasoning === true &&
+			Boolean(model.provider) &&
+			model.provider !== options.primaryProvider,
+	);
+	if (complementary) return complementary;
+
+	const reasoning = models.find((model) => model.reasoning === true);
+	if (reasoning) return reasoning;
+
+	throw new Error(
+		"No reasoning-capable model is configured for Oracle. Configure an explicit Oracle model or add a reasoning model.",
+	);
+}
+
 export const oracleTool = createTool<typeof oracleSchema, OracleToolDetails>({
 	name: "oracle",
 	description:
@@ -241,34 +279,8 @@ function selectOracleModel(inputOverride?: string): string {
 	const preferred =
 		inputOverride?.trim() ||
 		(envOverride && envOverride.length > 0 ? envOverride : "o3-mini");
-	const models = getRegisteredModels();
-
-	// Try the preferred id and common provider-qualified variant
-	const candidates = [
-		preferred,
-		preferred.startsWith("openai/") ? preferred : `openai/${preferred}`,
-	];
-	const found = models.find((m) => candidates.includes(m.id));
-	if (found) {
-		return found.id;
-	}
-
-	// Fall back to any reasoning-capable model
-	const reasoning = models.find((m) => m.reasoning === true);
-	if (reasoning) {
-		return reasoning.id;
-	}
-
-	// As a last resort, fall back to any configured model so the tool can still run.
-	// This prevents hard runtime failures while surfacing a clear warning.
-	const fallback = models.at(0);
-	if (fallback) {
-		return fallback.id;
-	}
-
-	// No acceptable model configured
-	const available = models.map((m) => m.id).join(", ");
-	throw new Error(
-		`No model configured for Oracle. Tried ${preferred}. Set MAESTRO_ORACLE_MODEL to an available model or add a reasoning-capable model. Available models: ${available || "none"}.`,
-	);
+	return selectComplementaryOracleModel(getRegisteredModels(), {
+		preferredId: preferred,
+		primaryProvider: process.env.MAESTRO_PRIMARY_MODEL_PROVIDER?.trim(),
+	}).id;
 }

--- a/test/agent/modes.test.ts
+++ b/test/agent/modes.test.ts
@@ -19,6 +19,10 @@ import {
 describe("agent/modes", () => {
 	describe("MODE_CONFIGS", () => {
 		it("defines all expected modes", () => {
+			expect(MODE_CONFIGS.low).toBeDefined();
+			expect(MODE_CONFIGS.medium).toBeDefined();
+			expect(MODE_CONFIGS.high).toBeDefined();
+			expect(MODE_CONFIGS.ultra).toBeDefined();
 			expect(MODE_CONFIGS.smart).toBeDefined();
 			expect(MODE_CONFIGS.rush).toBeDefined();
 			expect(MODE_CONFIGS.free).toBeDefined();
@@ -180,6 +184,8 @@ describe("agent/modes", () => {
 
 	describe("parseMode", () => {
 		it("parses valid modes (case-insensitive)", () => {
+			expect(parseMode("LOW")).toBe("low");
+			expect(parseMode("High")).toBe("high");
 			expect(parseMode("smart")).toBe("smart");
 			expect(parseMode("SMART")).toBe("smart");
 			expect(parseMode("Rush")).toBe("rush");
@@ -235,7 +241,10 @@ describe("agent/modes", () => {
 	describe("getAllModes", () => {
 		it("returns all modes with configs", () => {
 			const modes = getAllModes();
-			expect(modes.length).toBe(4);
+			expect(modes.length).toBe(8);
+			expect(modes.map((m) => m.mode)).toEqual(
+				expect.arrayContaining(["low", "medium", "high", "ultra"]),
+			);
 			expect(modes.map((m) => m.mode)).toContain("smart");
 			expect(modes.map((m) => m.mode)).toContain("rush");
 			expect(modes.map((m) => m.mode)).toContain("free");
@@ -246,6 +255,10 @@ describe("agent/modes", () => {
 		it("returns hidden modes only when requested", () => {
 			const modes = getAllModes({ includeHidden: true });
 			expect(modes.map((m) => m.mode)).toEqual([
+				"low",
+				"medium",
+				"high",
+				"ultra",
 				"smart",
 				"rush",
 				"free",

--- a/test/agent/profile-loader.test.ts
+++ b/test/agent/profile-loader.test.ts
@@ -1,0 +1,98 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	loadAgentProfiles,
+	loadAgentProfilesFromDirectory,
+} from "../../src/agent/profile-loader.js";
+
+function fixtureDir(): string {
+	const root = mkdtempSync(join(tmpdir(), "maestro-profiles-"));
+	const profiles = join(root, ".maestro", "agent-profiles");
+	mkdirSync(profiles, { recursive: true });
+	return profiles;
+}
+
+describe("agent profile loader", () => {
+	it("loads a complete declarative profile", () => {
+		const directory = fixtureDir();
+		writeFileSync(
+			join(directory, "security-review.yaml"),
+			`id: security-review-v1
+version: 1
+level: high
+description: Cross-provider security review
+primary:
+  provider: openai-codex
+  model: gpt-5.5
+  reasoningEffort: high
+oracle:
+  provider: anthropic
+  model: claude-opus-4-6
+  reasoningEffort: high
+  readOnly: true
+fallbackLevels: [medium, low]
+budgets:
+  maxAttempts: 2
+  maxToolCalls: 40
+`,
+		);
+
+		expect(loadAgentProfilesFromDirectory(directory)).toContainEqual(
+			expect.objectContaining({
+				id: "security-review-v1",
+				level: "high",
+				oracle: expect.objectContaining({ readOnly: true }),
+			}),
+		);
+	});
+
+	it("rejects profiles without a read-only oracle", () => {
+		const directory = fixtureDir();
+		writeFileSync(
+			join(directory, "invalid.yaml"),
+			`id: invalid-v1
+version: 1
+level: medium
+description: Invalid profile
+primary: { provider: openai, model: gpt-5.5, reasoningEffort: medium }
+oracle: { provider: anthropic, model: claude-opus, reasoningEffort: high }
+fallbackLevels: [low]
+budgets: { maxAttempts: 2, maxToolCalls: 20 }
+`,
+		);
+
+		expect(() => loadAgentProfilesFromDirectory(directory)).toThrow(
+			/oracle.readOnly/,
+		);
+	});
+
+	it("lets project profiles override user profiles by id", () => {
+		const root = mkdtempSync(join(tmpdir(), "maestro-profile-precedence-"));
+		const homeDir = join(root, "home");
+		const workspaceDir = join(root, "workspace");
+		const userProfiles = join(homeDir, "agent-profiles");
+		const projectProfiles = join(workspaceDir, ".maestro", "agent-profiles");
+		mkdirSync(userProfiles, { recursive: true });
+		mkdirSync(projectProfiles, { recursive: true });
+		const profile = (description: string) => `id: review-v1
+version: 1
+level: high
+description: ${description}
+primary: { provider: openai, model: gpt-5.5, reasoningEffort: high }
+oracle: { provider: anthropic, model: claude-opus, reasoningEffort: high, readOnly: true }
+fallbackLevels: [medium]
+budgets: { maxAttempts: 2, maxToolCalls: 20 }
+`;
+		writeFileSync(join(userProfiles, "review.yaml"), profile("User profile"));
+		writeFileSync(
+			join(projectProfiles, "review.yaml"),
+			profile("Project profile"),
+		);
+
+		expect(loadAgentProfiles({ homeDir, workspaceDir })).toMatchObject([
+			{ id: "review-v1", description: "Project profile" },
+		]);
+	});
+});

--- a/test/agent/profiles.test.ts
+++ b/test/agent/profiles.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+	AGENT_PROFILES,
+	parseAgentProfileLevel,
+	resolveAgentProfile,
+} from "../../src/agent/profiles.js";
+
+describe("agent profiles", () => {
+	it("maps legacy modes to canonical capability levels", () => {
+		expect(parseAgentProfileLevel("free")).toBe("low");
+		expect(parseAgentProfileLevel("rush")).toBe("low");
+		expect(parseAgentProfileLevel("smart")).toBe("medium");
+		expect(parseAgentProfileLevel("frontier")).toBe("ultra");
+	});
+
+	it("accepts canonical capability levels case-insensitively", () => {
+		expect(parseAgentProfileLevel("LOW")).toBe("low");
+		expect(parseAgentProfileLevel("High")).toBe("high");
+		expect(parseAgentProfileLevel("unknown")).toBeNull();
+	});
+
+	it("defines immutable, versioned profiles", () => {
+		expect(Object.isFrozen(AGENT_PROFILES)).toBe(true);
+		expect(AGENT_PROFILES.medium.id).toBe("medium-v1");
+		expect(AGENT_PROFILES.medium.version).toBe(1);
+		expect(Object.isFrozen(AGENT_PROFILES.medium)).toBe(true);
+	});
+
+	it("resolves a complete profile with a complementary oracle", () => {
+		expect(resolveAgentProfile("high", "openai-codex")).toMatchObject({
+			id: "high-v1",
+			level: "high",
+			primary: {
+				provider: "openai-codex",
+				reasoningEffort: "xhigh",
+			},
+			oracle: {
+				provider: "anthropic",
+				reasoningEffort: "high",
+				readOnly: true,
+			},
+			fallbackLevels: ["medium", "low"],
+		});
+	});
+
+	it("resolves legacy aliases to their canonical profile", () => {
+		expect(resolveAgentProfile("rush", "anthropic")).toMatchObject({
+			id: "low-v1",
+			level: "low",
+			primary: { provider: "anthropic", reasoningEffort: "low" },
+		});
+	});
+});

--- a/test/cli/modes-command.test.ts
+++ b/test/cli/modes-command.test.ts
@@ -58,4 +58,21 @@ describe("modes command", () => {
 		).not.toHaveBeenCalled();
 		expect(output.join("\n")).toContain("Mode: Smart (smart)");
 	});
+
+	it("describes the complete versioned profile for canonical levels", async () => {
+		await handleModesCommand("describe", ["high"], {
+			provider: "openai-codex",
+			json: true,
+		});
+
+		expect(JSON.parse(output.join("\n"))).toMatchObject({
+			mode: "high",
+			agentProfile: {
+				id: "high-v1",
+				level: "high",
+				primary: { provider: "openai-codex", reasoningEffort: "xhigh" },
+				oracle: { provider: "anthropic", readOnly: true },
+			},
+		});
+	});
 });

--- a/test/services/intelligent-router-outcome.test.ts
+++ b/test/services/intelligent-router-outcome.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { deriveRoutingOutcome } from "../../src/services/intelligent-router/outcome.js";
+
+describe("intelligent router outcome evidence", () => {
+	it("does not treat assistant completion as verified success", () => {
+		expect(deriveRoutingOutcome({ assistantCompleted: true })).toEqual({
+			verified: false,
+			success: false,
+			qualityScore: 0,
+			reasons: ["assistant_completed_without_verification"],
+		});
+	});
+
+	it("accepts an explicit passing verification result", () => {
+		expect(
+			deriveRoutingOutcome({
+				assistantCompleted: true,
+				verificationPassed: true,
+			}),
+		).toMatchObject({
+			verified: true,
+			success: true,
+			qualityScore: 1,
+			reasons: ["verification_passed"],
+		});
+	});
+
+	it("treats retries and user rejection as verified failures", () => {
+		expect(
+			deriveRoutingOutcome({ assistantCompleted: true, userRejected: true }),
+		).toMatchObject({ verified: true, success: false, qualityScore: 0 });
+		expect(
+			deriveRoutingOutcome({ assistantCompleted: true, userRetried: true }),
+		).toMatchObject({ verified: true, success: false, qualityScore: 0 });
+	});
+
+	it("records total task cost and attempts", () => {
+		expect(
+			deriveRoutingOutcome({
+				assistantCompleted: true,
+				verificationPassed: true,
+				attempts: 3,
+				totalCostUsd: 0.42,
+			}),
+		).toMatchObject({ attempts: 3, totalCostUsd: 0.42 });
+	});
+});

--- a/test/services/intelligent-router.e2e.test.ts
+++ b/test/services/intelligent-router.e2e.test.ts
@@ -154,6 +154,7 @@ describe("intelligent router E2E", () => {
 				success: true,
 				costUsd: 0.001,
 				qualityScore: 0.8,
+				verified: true,
 			});
 			await postMetric(server.baseUrl, {
 				taskType: "coding",
@@ -163,6 +164,7 @@ describe("intelligent router E2E", () => {
 				success: true,
 				costUsd: 0.0012,
 				qualityScore: 0.82,
+				verified: true,
 			});
 			await postMetric(server.baseUrl, {
 				taskType: "coding",
@@ -172,6 +174,7 @@ describe("intelligent router E2E", () => {
 				success: false,
 				costUsd: 0.02,
 				qualityScore: 0.95,
+				verified: true,
 			});
 			await postMetric(server.baseUrl, {
 				taskType: "coding",
@@ -181,6 +184,7 @@ describe("intelligent router E2E", () => {
 				success: true,
 				costUsd: 0.02,
 				qualityScore: 0.95,
+				verified: true,
 			});
 
 			const metrics = await requestJson<{
@@ -343,7 +347,7 @@ describe("intelligent router E2E", () => {
 			);
 			expect(hintDecision.status).toBe(200);
 			expect(hintDecision.body.decision).toMatchObject({
-				reason: "insufficient_history_model_hint",
+				reason: "insufficient_verified_history_model_hint",
 				overrideApplied: false,
 				selectedModel: { provider: "openai", model: "gpt-4o-mini" },
 			});

--- a/test/services/intelligent-router.test.ts
+++ b/test/services/intelligent-router.test.ts
@@ -89,7 +89,7 @@ describe("intelligent router service", () => {
 			modelHint: "anthropic/claude-sonnet",
 		});
 
-		expect(decision.reason).toBe("insufficient_history_model_hint");
+		expect(decision.reason).toBe("insufficient_verified_history_model_hint");
 		expect(decision.selectedModel).toEqual({
 			provider: "anthropic",
 			model: "claude-sonnet",
@@ -97,6 +97,31 @@ describe("intelligent router service", () => {
 		expect(decision.fallbackChain).toEqual([
 			{ provider: "openai", model: "gpt-4o-mini" },
 		]);
+	});
+
+	it("returns a complete, versioned profile with legacy model fields", () => {
+		const service = createService();
+
+		const decision = service.routeRequest({
+			taskType: "coding",
+			profileHint: "rush",
+			modelHint: "openai/gpt-4o-mini",
+		});
+
+		expect(decision.selectedProfile).toMatchObject({
+			id: "low-v1",
+			level: "low",
+			primary: {
+				provider: "openai",
+				model: "gpt-4o-mini",
+				reasoningEffort: "low",
+			},
+		});
+		expect(decision.fallbackProfiles).toEqual([]);
+		expect(decision.selectedModel).toEqual({
+			provider: "openai",
+			model: "gpt-4o-mini",
+		});
 	});
 
 	it("preserves colon-delimited model hints until enough production history exists", () => {
@@ -107,7 +132,7 @@ describe("intelligent router service", () => {
 			modelHint: "anthropic:claude-sonnet",
 		});
 
-		expect(decision.reason).toBe("insufficient_history_model_hint");
+		expect(decision.reason).toBe("insufficient_verified_history_model_hint");
 		expect(decision.selectedModel).toEqual({
 			provider: "anthropic",
 			model: "claude-sonnet",
@@ -127,6 +152,7 @@ describe("intelligent router service", () => {
 			success: true,
 			costUsd: 0.001,
 			qualityScore: 0.8,
+			verified: true,
 		});
 		service.recordPerformanceMetric({
 			taskType: "summarization",
@@ -136,6 +162,7 @@ describe("intelligent router service", () => {
 			success: true,
 			costUsd: 0.0012,
 			qualityScore: 0.82,
+			verified: true,
 		});
 		service.recordPerformanceMetric({
 			taskType: "summarization",
@@ -145,6 +172,7 @@ describe("intelligent router service", () => {
 			success: false,
 			costUsd: 0.02,
 			qualityScore: 0.9,
+			verified: true,
 		});
 		service.recordPerformanceMetric({
 			taskType: "summarization",
@@ -154,6 +182,7 @@ describe("intelligent router service", () => {
 			success: true,
 			costUsd: 0.02,
 			qualityScore: 0.9,
+			verified: true,
 		});
 
 		const decision = service.routeRequest({
@@ -174,9 +203,38 @@ describe("intelligent router service", () => {
 		});
 	});
 
+	it("does not promote a model from unverified assistant completions", () => {
+		const service = createService();
+		for (let sample = 0; sample < 25; sample += 1) {
+			service.recordPerformanceMetric({
+				taskType: "coding",
+				provider: "openai",
+				model: "gpt-4o-mini",
+				latencyMs: 100,
+				success: true,
+				verified: false,
+				qualityScore: 1,
+			});
+		}
+
+		const decision = service.routeRequest({
+			taskType: "coding",
+			modelHint: "anthropic/claude-sonnet",
+		});
+
+		expect(decision.reason).toBe("insufficient_verified_history_model_hint");
+		expect(decision.selectedModel.provider).toBe("anthropic");
+		expect(
+			decision.scores.find((score) => score.provider === "openai"),
+		).toMatchObject({ verifiedSamples: 0, promotionEligible: false });
+	});
+
 	it("keeps eval-backed routing evidence separate from production samples", () => {
 		const service = createService();
-		for (const qualityScore of [0.95, 0.97]) {
+		for (const qualityScore of Array.from(
+			{ length: 20 },
+			(_, index) => 0.95 + (index % 2) * 0.02,
+		)) {
 			service.recordPerformanceMetric({
 				taskType: "code_review",
 				provider: "anthropic",
@@ -190,7 +248,10 @@ describe("intelligent router service", () => {
 				qualityScore,
 			});
 		}
-		for (const qualityScore of [0.55, 0.58]) {
+		for (const qualityScore of Array.from(
+			{ length: 20 },
+			(_, index) => 0.55 + (index % 2) * 0.03,
+		)) {
 			service.recordPerformanceMetric({
 				taskType: "code_review",
 				provider: "openai",
@@ -209,9 +270,10 @@ describe("intelligent router service", () => {
 			.listMetrics("code_review")
 			.find((metric) => metric.provider === "anthropic");
 		expect(anthropic).toMatchObject({
-			samples: 2,
+			samples: 20,
+			verifiedSamples: 20,
 			productionSamples: 0,
-			evalSamples: 2,
+			evalSamples: 20,
 			evalSuccessRate: 1,
 			evalSuites: ["trajectory-replay"],
 		});
@@ -229,10 +291,11 @@ describe("intelligent router service", () => {
 		});
 		expect(decision.scores[0]).toMatchObject({
 			provider: "anthropic",
-			evalSamples: 2,
+			evalSamples: 20,
+			verifiedSamples: 20,
 			productionSamples: 0,
 			evalBacked: true,
-			reasons: expect.arrayContaining(["eval_samples=2", "eval_backed"]),
+			reasons: expect.arrayContaining(["eval_samples=20", "eval_backed"]),
 		});
 	});
 

--- a/test/tools/oracle.test.ts
+++ b/test/tools/oracle.test.ts
@@ -27,7 +27,36 @@ vi.mock("../../src/oauth/index.js", () => ({
 	issueEvalOpsDelegationToken: issueEvalOpsDelegationTokenMock,
 }));
 
-import { oracleTool } from "../../src/tools/oracle.js";
+import {
+	oracleTool,
+	selectComplementaryOracleModel,
+} from "../../src/tools/oracle.js";
+
+describe("selectComplementaryOracleModel", () => {
+	it("prefers a reasoning model from a different provider", () => {
+		const selected = selectComplementaryOracleModel(
+			[
+				{ id: "gpt-5.5", provider: "openai-codex", reasoning: true },
+				{ id: "claude-opus", provider: "anthropic", reasoning: true },
+			],
+			{ primaryProvider: "openai-codex" },
+		);
+
+		expect(selected).toMatchObject({
+			id: "claude-opus",
+			provider: "anthropic",
+		});
+	});
+
+	it("never falls back to a non-reasoning model", () => {
+		expect(() =>
+			selectComplementaryOracleModel(
+				[{ id: "fast", provider: "openai", reasoning: false }],
+				{ primaryProvider: "openai-codex" },
+			),
+		).toThrow(/reasoning-capable model/);
+	});
+});
 
 function createMockChildProcess(output: string) {
 	const proc = new EventEmitter() as EventEmitter & {

--- a/test/web/chat-handler-routing.test.ts
+++ b/test/web/chat-handler-routing.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../src/services/intelligent-router/recorder.js", async () => {
 	};
 });
 
+import { resolveAgentProfile } from "../../src/agent/profiles.js";
 import type { RegisteredModel } from "../../src/models/registry.js";
 import type { WebServerContext } from "../../src/server/app-context.js";
 import { handleChat } from "../../src/server/handlers/chat.js";
@@ -87,6 +88,7 @@ function makeRes(): MockResponse {
 }
 
 function routingDecision(): RoutingDecision {
+	const selectedProfile = resolveAgentProfile("medium", "anthropic");
 	return {
 		decisionId: "decision-1",
 		taskType: "chat",
@@ -95,6 +97,8 @@ function routingDecision(): RoutingDecision {
 			provider: selectedModel.provider,
 			model: selectedModel.id,
 		},
+		selectedProfile,
+		fallbackProfiles: [resolveAgentProfile("low", "openai")],
 		fallbackChain: [
 			{
 				provider: fallbackModel.provider,


### PR DESCRIPTION
## What changed

- add canonical `low`, `medium`, `high`, and `ultra` capability profiles while preserving legacy mode aliases
- route complete, versioned agent profiles containing the primary invocation, reasoning effort, Oracle, specialists, fallbacks, and budgets
- load declarative YAML profiles with project-over-user precedence
- require verified outcome evidence before model promotion and retain unverified runs only for latency/cost observations
- prefer a complementary reasoning-capable provider for Oracle review
- expose resolved profiles through routing decisions, request headers, CLI mode descriptions, tests, and documentation

## Why

Maestro previously had overlapping model-selection abstractions and could treat ordinary assistant completion as routing success. This made comparisons model-centric, weakly attributable, and too eager to learn from unverified outcomes.

The new profile boundary makes the complete agent configuration reproducible and gives routing a conservative, evidence-backed promotion policy.

## Impact

Users can select task difficulty through the capability dial rather than model vendor tiers. Existing mode names continue to work during migration. Operators can install project or user profiles and inspect the exact versioned bundle selected for a run.

## Validation

- `bun run bun:lint`
- `npx nx run maestro:build --skip-nx-cache`
- `npx nx run maestro:evals --skip-nx-cache` — 34/34 scenarios passed
- `npx nx run maestro:test --skip-nx-cache` — 11,582 passed, 44 skipped, 0 failed (with ambient Git/ripgrep user config neutralized for hermetic fixtures)
- pre-commit Guardian, Semgrep, evidence-integrity, protocol-conformance, TypeScript, and binary compilation checks

Internal source of truth: https://github.com/evalops/maestro-internal/pull/2850

## Staged rollout

Staging is unnecessary: this change adds the profile-routing primitive and canonical names while preserving every legacy mode alias and the existing model fields. User/project YAML overrides are opt-in, and the default profile preserves current routing behavior.