### PR TITLE
ci: move static-validation jobs off the trusted evalops-internal lane

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   tag-current-version:
-    runs-on: ${{ github.repository == 'evalops/maestro-internal' && (vars.INTERNAL_CONFIRMATION_RUNNER || 'ubuntu-latest') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
+    runs-on: ${{ github.repository == 'evalops/maestro-internal' && 'evalops-private-ci' || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
     timeout-minutes: 45
     permissions:
       actions: read

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   version-bump:
     if: ${{ github.event_name != 'schedule' || github.repository == 'evalops/maestro-internal' }}
-    runs-on: ${{ github.repository == 'evalops/maestro-internal' && (vars.INTERNAL_CONFIRMATION_RUNNER || 'ubuntu-latest') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
+    runs-on: ${{ github.repository == 'evalops/maestro-internal' && 'evalops-private-ci' || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary

`tag-release.yml` and `version-bump.yml` are shared verbatim between
`evalops/maestro` and `evalops/maestro-internal`, and route to the trusted
`evalops-internal` lane whenever `github.repository == 'evalops/maestro-internal'`.
This PR updates that branch to `evalops-private-ci` (companion PR open on
maestro-internal for the same files).

`policy/dual-cloud-runner-lanes.yaml` in evalops/deploy forbids the
`static_validation` and `audit_metadata_only` workflow families on the
`evalops-internal` lane, and `docs/operations/internal-runner-capacity.md`
states the rule this PR enforces:

> PR-only metadata checks and static validation should stay on the private
> CI lane or GitHub-hosted fallback, not the trusted cluster lane.

`tag-current-version` and `version-bump` tag/commit/push a release branch
and open a PR via git and the GitHub API — no private GKE, GCP Secret
Manager, or Terraform access — so the internal-repo branch belongs on the
Hetzner-backed `evalops-private-ci` lane.

Found by the org-wide runner audit: evalops/deploy#7260

## Jobs moved

- `tag-release.yml :: tag-current-version` (maestro-internal branch only)
- `version-bump.yml :: version-bump` (maestro-internal branch only)

## Diff scope

`runs-on:` lines only, preserving the existing conditional expression
shape.