### PR TITLE
[maestro] Guard CI timeouts and clear independent main red

### DIFF
--- a/.github/workflows/bazel-rbe.yml
+++ b/.github/workflows/bazel-rbe.yml
@@ -39,7 +39,15 @@ env:
 
 jobs:
   smoke:
-    if: github.event_name == 'workflow_dispatch' || vars.BAZEL_RBE_ENABLED == 'true'
+    # timeout-minutes only applies after a runner is assigned. A push job that
+    # targets a self-hosted label with zero online runners sits in queue for up
+    # to GitHub's 24h default and then cancels as a red/cancelled main check.
+    # Require an explicit readiness flag in addition to BAZEL_RBE_ENABLED so a
+    # missing RBE pool cannot brick default-branch CI. Manual workflow_dispatch
+    # remains available for intentional smoke runs.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (vars.BAZEL_RBE_ENABLED == 'true' && vars.BAZEL_RBE_RUNNER_READY == 'true')
     runs-on:
       - self-hosted
       - Linux

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -29,6 +29,9 @@ jobs:
           - os: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
             chunkIndex: 2
     runs-on: ${{ matrix.os }}
+    # Guardian + build + two vitest shards + evals chunk; keep a hard ceiling so a
+    # hung shard cannot hold the concurrency group open indefinitely.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -31,11 +32,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: github.event_name == 'push'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
         if: github.event_name == 'push'
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,7 +45,7 @@ jobs:
       - name: Extract image metadata
         if: github.event_name == 'push'
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -54,7 +55,7 @@ jobs:
 
       - name: Build image
         if: github.event_name == 'push'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -83,7 +83,11 @@ jobs:
           fi
 
       - name: Require version bump for existing release tag
-        if: ${{ github.repository == 'evalops/maestro' && steps.release.outputs.tag_exists == 'true' && steps.release.outputs.tag_matches_head != 'true' && steps.release.outputs.package_changed_since_tag == 'true' && steps.registry-release.outputs.published != 'true' }}
+        # Hard-fail only when there is no in-flight release for this tag. A
+        # waiting/in_progress release (e.g. environment approval) already owns
+        # the tagged version; fail-on-drift during that window turns every main
+        # mirror push red without unblocking publish.
+        if: ${{ github.repository == 'evalops/maestro' && steps.release.outputs.tag_exists == 'true' && steps.release.outputs.tag_matches_head != 'true' && steps.release.outputs.package_changed_since_tag == 'true' && steps.registry-release.outputs.published != 'true' && (steps.active-release.outputs.active_count == '0' || steps.active-release.outputs.active_count == '') }}
         env:
           RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
           RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
@@ -105,6 +109,9 @@ jobs:
           elif [[ "${{ steps.release.outputs.tag_exists }}" == "true" && "${{ steps.release.outputs.package_changed_since_tag }}" == "true" ]]; then
             echo "Semver tag ${{ steps.release.outputs.release_tag }} already exists at another commit."
             echo "Package-impacting source inputs changed since the existing tag."
+            if [[ "${{ steps.active-release.outputs.active_count }}" != "" && "${{ steps.active-release.outputs.active_count }}" != "0" ]]; then
+              echo "Active release run(s) still own this tag (count=${{ steps.active-release.outputs.active_count }}); version-bump gate deferred until that release completes."
+            fi
           elif [[ "${{ steps.release.outputs.tag_exists }}" == "true" ]]; then
             echo "Semver tag ${{ steps.release.outputs.release_tag }} already exists."
             echo "No package-impacting source inputs changed since the existing tag."


### PR DESCRIPTION
## Summary

Unblocks three independent `main` reds from the 2026-07-16 push (`777200e3` / mirror sync #826) and hardens job timeouts. Does **not** touch Rust TUI — that is already covered by an in-flight internal fix.

## Root causes (from failed runs)

| Check | Run | Root cause |
| --- | --- | --- |
| **tag-release** | [29480042232](https://github.com/evalops/maestro/actions/runs/29480042232) | `v0.10.51` is tagged at `9a8010cf` but **not** published on npm (latest is `0.10.50`). Release [29288466412](https://github.com/evalops/maestro/actions/runs/29288466412) has been **waiting** on `publish` since 2026-07-13. Main continued to receive package-impacting mirror commits, so `Require version bump for existing release tag` hard-failed every push even though an in-flight release already owns the tag. |
| **evals** | [29480042287](https://github.com/evalops/maestro/actions/runs/29480042287) | Maestro Guardian / semgrep: **4 blocking** `github-actions-mutable-action-tag` findings in `.github/workflows/ghcr-publish.yml` (`docker/setup-buildx-action@v4`, `docker/login-action@v4`, `docker/metadata-action@v6`, `docker/build-push-action@v7`). |
| **Bazel RBE** | [29480042313](https://github.com/evalops/maestro/actions/runs/29480042313) | Job already had `timeout-minutes: 20`, but that only applies **after** a runner is assigned. Public repo has **0** self-hosted runners with label `evalops-maestro-rbe`, yet `BAZEL_RBE_ENABLED=true`, so the job sat in queue for GitHub’s **24h** default and cancelled. |
| **Rust TUI** | [29480042233](https://github.com/evalops/maestro/actions/runs/29480042233) | `cargo clippy -D warnings` in `packages/tui-rs` (`float_cmp`, `manual_assert_eq`, etc.). **Not fixed here.** |

## Wave coverage

- **ts-tui-rip** local worktrees (`ts-tui-rip/1-detach-consumers`, `2-entry-cutover`, `3-release-packaging` on `maestro-internal`) exist but are still at `origin/main` with no commits / no open PRs — not covering these failures.
- **Rust TUI clippy** is exactly covered by open internal PR: [evalops/maestro-internal#2882](https://github.com/evalops/maestro-internal/pull/2882) (`fix/main-red-rust-tui-clippy`) — Rust TUI build + hooks-coverage green on that PR. Left alone to avoid duplicate work; public will pick it up via the next mirror once merged.
- Open public PRs `#827` (mirror sync) and `#822` (trusted-lane reroute) do not address these failures.

## Fixes in this PR

1. **`bazel-rbe.yml`** — Keep `timeout-minutes: 20`. Require `vars.BAZEL_RBE_RUNNER_READY == 'true'` in addition to `BAZEL_RBE_ENABLED` for push auto-runs so a missing pool cannot queue for 24h. `workflow_dispatch` still works. To re-enable auto RBE smoke once runners exist: set repo variable `BAZEL_RBE_RUNNER_READY=true`.
2. **`ghcr-publish.yml`** — Pin the four docker actions to full 40-char SHAs (with version comments) to clear Guardian; add `timeout-minutes: 45`.
3. **`tag-release.yml`** — Defer the version-bump hard-fail while `active_count > 0` for the tagged release (covers the stuck `waiting` publish). Gate still fails when the tag is stuck with package drift and **no** in-flight release.
4. **`evals.yml`** — Job-level `timeout-minutes: 90` (step timeouts alone do not bound the whole job).

Workflows under `.github/workflows/**` are excluded from the public release mirror (`prepare-public-release-mirror.mjs`), so these public-only workflow fixes will not be overwritten by the next internal→public sync.

## Remaining red after merge

- **Rust TUI on main** stays red until [maestro-internal#2882](https://github.com/evalops/maestro-internal/pull/2882) merges and mirrors (or an equivalent clippy fix lands).
- **Release ops**: `v0.10.51` publish is still **waiting** on environment approval ([run 29288466412](https://github.com/evalops/maestro/actions/runs/29288466412)). Approve/cancel that publish; after it completes, if main still has package-impacting drift vs the tag and npm is published, tag-release is green; if the release is abandoned unpublished with no active run, the version-bump gate will correctly fail again until internal `version-bump` cuts the next version.
- Optional: set `BAZEL_RBE_ENABLED=false` (or leave it true and only flip `BAZEL_RBE_RUNNER_READY` when the pool is online).

## Test plan

- [ ] PR CI: `evals` Guardian step clean (no mutable-tag findings)
- [ ] PR CI: `GHCR Publish` PR path still no-ops successfully
- [ ] After merge to main: `tag-release` no longer fails solely because of the waiting `v0.10.51` release
- [ ] After merge to main: `Bazel RBE` skips (or only runs on `workflow_dispatch`) rather than queuing 24h
- [ ] Confirm Rust TUI still tracked via internal #2882 (out of scope here)