### PR TITLE
Fix eval Guardian failure and unblock 0.10.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,30 @@ versioning when releases are cut.
   and keep scheduled public runs inert so public publishing stays downstream of
   the internal source-of-truth release.
 
+## [0.10.53] - 2026-07-20
+
+### Added
+
+- Move agents command to Rust (#2924). <!-- maestro-release-note:bf73aac1a8dd -->
+- Adopt Grok-inspired session chrome (#2926). <!-- maestro-release-note:78870912899b -->
+- Migrate modes command to Rust (#2921). <!-- maestro-release-note:0ba92aff6ac1 -->
+
+### Changed
+
+- Move skill CLI and package runtime to Rust (#2919). <!-- maestro-release-note:f3a840301d0a -->
+- [maestro] Move update command to Rust and delete TypeScript handler (#2918). <!-- maestro-release-note:5f73114f3beb -->
+- [maestro] Delete legacy TypeScript hosted runner command (#2917). <!-- maestro-release-note:d0c2ec8a540c -->
+- [maestro] Delete migrated TypeScript utility commands (#2916). <!-- maestro-release-note:cf20e9e09c07 -->
+- [maestro] Move hosted runner lifecycle to Rust (#2914). <!-- maestro-release-note:00b2db4e7c8b -->
+
+### Fixed
+
+- Hand off utilities before replay setup (#2925). <!-- maestro-release-note:d9552c52997f -->
+- Align native utility global flags (#2923). <!-- maestro-release-note:0c5f04580384 -->
+- Consume named worktree before native utilities (#2922). <!-- maestro-release-note:326239dc0057 -->
+- Enforce native skill package validation (#2920). <!-- maestro-release-note:077875bf3882 -->
+- Accept public runner failover variable (#2915). <!-- maestro-release-note:e94c6cadf8e5 -->
+
 ## [0.10.52] - 2026-07-20
 
 ### Breaking

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Maestro Web API",
-    "version": "0.10.52",
+    "version": "0.10.53",
     "description": "Auto-generated from src/web-server.ts routes. Components seeded from runtime schemas."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evalops/maestro",
   "description": "Maestro by EvalOps - Deterministic coding agent with TUI/CLI and Web UI for AI-assisted development",
-  "version": "0.10.52",
+  "version": "0.10.53",
   "private": false,
   "type": "module",
   "workspaces": [

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/ai",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Shared Maestro AI SDK (models, transport, and agent event stream facade).",
 	"type": "module",
 	"main": "./dist/packages/ai/src/index.js",
@@ -131,7 +131,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.52",
+		"@evalops/contracts": "^0.10.53",
 		"@google/genai": "^1.29.1",
 		"@sinclair/typebox": "^0.34.0",
 		"nats": "^2.29.3"

--- a/packages/consumer-sdk/package.json
+++ b/packages/consumer-sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/consumer",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Unified EvalOps consumer SDK for Maestro service integrations",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -28,7 +28,7 @@
 		"directory": "packages/consumer-sdk"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.52"
+		"@evalops/contracts": "^0.10.53"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/contracts",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Shared Maestro contracts for frontend/backend integration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-core",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Maestro agent loop, transport, types, and sandbox primitives — the engine behind all Maestro interfaces",
 	"type": "module",
 	"main": "./dist/packages/core/src/index.js",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-desktop",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Maestro Desktop - Beautiful Electron app for AI-assisted development",
 	"type": "module",
 	"main": "dist-electron/main/index.js",
@@ -37,7 +37,7 @@
 		"directory": "packages/desktop"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.52",
+		"@evalops/contracts": "^0.10.53",
 		"electron-store": "^10.0.1",
 		"electron-updater": "^6.3.9"
 	},

--- a/packages/github-agent/package.json
+++ b/packages/github-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/github-agent",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Autonomous GitHub agent - Maestro building Maestro",
 	"type": "module",
 	"bin": {
@@ -36,8 +36,8 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/ai": "^0.10.52",
-		"@evalops/contracts": "^0.10.52",
+		"@evalops/ai": "^0.10.53",
+		"@evalops/contracts": "^0.10.53",
 		"@octokit/rest": "^21.0.0",
 		"@octokit/webhooks": "^13.0.0",
 		"@sinclair/typebox": "^0.34.0",

--- a/packages/governance-mcp-server/package.json
+++ b/packages/governance-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance-mcp-server",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "MCP server exposing Platform governance proxy tools to any MCP-compatible agent.",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -43,7 +43,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@evalops/governance": "^0.10.52",
+		"@evalops/governance": "^0.10.53",
 		"@modelcontextprotocol/sdk": "^1.25.2",
 		"zod": "^4.3.5"
 	},

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/governance",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Thin Platform governance proxy for MCP-compatible agents.",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/memory",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"private": true,
 	"type": "module",
 	"sideEffects": false,

--- a/packages/slack-agent-ui/package.json
+++ b/packages/slack-agent-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent-ui",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Web UI for Slack Agent - Dashboard gallery, connector management, OAuth flows",
 	"type": "module",
 	"private": true,

--- a/packages/slack-agent/package.json
+++ b/packages/slack-agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/slack-agent",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Slack teammate agent with sandbox support for Maestro",
 	"type": "module",
 	"bin": {
@@ -30,8 +30,8 @@
 	},
 	"dependencies": {
 		"@daytonaio/sdk": "^0.139.0",
-		"@evalops/ai": "^0.10.52",
-		"@evalops/contracts": "^0.10.52",
+		"@evalops/ai": "^0.10.53",
+		"@evalops/contracts": "^0.10.53",
 		"@sinclair/typebox": "^0.34.0",
 		"@slack/socket-mode": "^2.0.0",
 		"@slack/web-api": "^7.0.0",

--- a/packages/tui-rs/src/session_transfer.rs
+++ b/packages/tui-rs/src/session_transfer.rs
@@ -481,6 +481,10 @@ fn canonicalish(path: &Path) -> PathBuf {
 mod tests {
     use super::*;
 
+    fn fixture_secret(prefix: &str) -> String {
+        [prefix, "abcdefghijklmnopqrstuvwxyz123456"].concat()
+    }
+
     fn entry(id: &str, parent: Option<&str>, content: &str) -> Vec<Value> {
         vec![
             serde_json::json!({
@@ -506,7 +510,7 @@ mod tests {
             &entry(
                 "child",
                 Some("parent"),
-                "apiKey=sk-ant-abcdefghijklmnopqrstuvwxyz123456",
+                &format!("apiKey={}", fixture_secret("sk-ant-")),
             ),
         )
         .unwrap();
@@ -560,11 +564,11 @@ mod tests {
     fn jsonl_redaction_preserves_valid_entries_and_drops_partial_lines() {
         let root = tempfile::tempdir().unwrap();
         let source = root.path().join("source.jsonl");
-        fs::write(
-            &source,
-            "{\"type\":\"session\",\"id\":\"one\"}\npartial\n{\"type\":\"user\",\"message\":\"Bearer sk-abcdefghijklmnopqrstuvwxyz123456\"}\n",
-        )
-        .unwrap();
+        let source_contents = format!(
+            "{{\"type\":\"session\",\"id\":\"one\"}}\npartial\n{{\"type\":\"user\",\"message\":\"Bearer {}\"}}\n",
+            fixture_secret("sk-")
+        );
+        fs::write(&source, source_contents).unwrap();
         let entries = portable_entries(&source, true).unwrap();
         assert_eq!(entries.len(), 2);
         assert!(!serde_json::to_string(&entries).unwrap().contains("sk-abc"));

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Maestro",
 	"description": "Use Maestro's deterministic AI assistant inside VS Code.",
 	"publisher": "evalops",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"license": "MIT",
 	"type": "commonjs",
 	"main": "./dist/extension.js",
@@ -139,7 +139,7 @@
 		"test": "vitest --run"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.52"
+		"@evalops/contracts": "^0.10.53"
 	},
 	"devDependencies": {
 		"@types/node": "^24.10.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@evalops/maestro-web",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Web UI for Maestro - Browser-based AI coding assistant interface",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -24,7 +24,7 @@
 		"directory": "packages/web"
 	},
 	"dependencies": {
-		"@evalops/contracts": "^0.10.52",
+		"@evalops/contracts": "^0.10.53",
 		"docx-preview": "^0.3.7",
 		"dompurify": "^3.3.0",
 		"exceljs": "^4.4.0",


### PR DESCRIPTION
## Summary
- assemble session-transfer redaction fixtures at runtime so Guardian no longer mistakes test data for a committed credential
- release the complete workspace and OpenAPI surface as v0.10.53
- retain the single canonical npm `maestro` bin, which is callable as `Maestro` on the supported macOS case-insensitive install target without creating conflicting case-only npm links

Source of truth: https://github.com/evalops/maestro-internal/pull/2935

## Verification
- `bash scripts/guardian.sh --all --trigger ci`
- `bun vitest run test/openapi-spec.test.ts test/packages/core/naming-consistency.test.ts`
- `cargo test --manifest-path packages/tui-rs/Cargo.toml session_transfer::tests`
- clean-shell `Maestro --version` reports 0.10.53 and no-arg `Maestro` launches the embedded Rust TUI

## Staged rollout
Staging is unnecessary: this is a test-fixture construction change plus a lockstep patch release; runtime redaction behavior is unchanged.