### PR TITLE
ci: remove Blacksmith runner usage

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,7 +4,3 @@ self-hosted-runner:
     - evalops-internal
     - evalops-maestro-internal-rbe
     - evalops-maestro-rbe
-    - blacksmith-4vcpu-ubuntu-2404
-    - blacksmith-4vcpu-ubuntu-2404-arm
-    - blacksmith-6vcpu-macos-15
-    - blacksmith-8vcpu-ubuntu-2404

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   tag-current-version:
-    runs-on: ${{ github.repository == 'evalops/maestro-internal' && (vars.INTERNAL_CONFIRMATION_RUNNER || vars.BLACKSMITH_RUNNER || 'blacksmith-4vcpu-ubuntu-2404') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
+    runs-on: ${{ github.repository == 'evalops/maestro-internal' && (vars.INTERNAL_CONFIRMATION_RUNNER || 'ubuntu-latest') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
     timeout-minutes: 45
     permissions:
       actions: read

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   version-bump:
     if: ${{ github.event_name != 'schedule' || github.repository == 'evalops/maestro-internal' }}
-    runs-on: ${{ github.repository == 'evalops/maestro-internal' && (vars.INTERNAL_CONFIRMATION_RUNNER || vars.BLACKSMITH_RUNNER || 'blacksmith-4vcpu-ubuntu-2404') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
+    runs-on: ${{ github.repository == 'evalops/maestro-internal' && (vars.INTERNAL_CONFIRMATION_RUNNER || 'ubuntu-latest') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/scripts/check-workflow-footguns.mjs
+++ b/scripts/check-workflow-footguns.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -113,9 +113,8 @@ function evaluatePublicReleaseMirrorWorkflowPermission(root) {
  * PR CI must not steal the trusted `evalops-internal` lane.
  *
  * Policy (aligned with test/scripts/ci-guardrails.test.ts):
- * - PR jobs route through vars.PR_CHECKS_RUNNER / vars.BLACKSMITH_* with
- *   ubuntu-latest / blacksmith-* fallbacks so automation works when fleets
- *   are offline.
+ * - PR jobs route through vars.PR_CHECKS_RUNNER with an ubuntu-latest
+ *   fallback so automation works when the var is unset.
  * - `evalops-internal` is reserved for non-PR confirmation (via
  *   INTERNAL_CONFIRMATION_RUNNER), never as a hard-coded PR target.
  */
@@ -144,23 +143,46 @@ function evaluatePullRequestRunnerOverrides(root) {
 				/&&\s*"evalops-internal"/.test(line)
 			) {
 				failures.push(
-					`${workflowFile}: pull_request jobs must not hard-code evalops-internal; route PR CI through BLACKSMITH_* / PR_CHECKS_RUNNER (or ubuntu-latest)`,
+					`${workflowFile}: pull_request jobs must not hard-code evalops-internal; route PR CI through PR_CHECKS_RUNNER (or ubuntu-latest)`,
 				);
 			}
 		}
 
-		// Primary ci.yml PR lanes must keep Blacksmith failover vars so release
-		// automation is not pinned to offline self-hosted fleets.
+		// Primary ci.yml PR lanes must keep a runner failover var so release
+		// automation is not pinned to a single fleet.
 		if (workflowFile.endsWith("ci.yml") && workflowText.includes("pr-checks")) {
 			if (
-				!/\bvars\.BLACKSMITH_RUNNER\b/.test(workflowText) &&
 				!/\bvars\.PR_CHECKS_RUNNER\b/.test(workflowText) &&
 				!/\bvars\.PUBLIC_PR_VALIDATION_RUNNER\b/.test(workflowText)
 			) {
 				failures.push(
-					`${workflowFile}: PR jobs must expose vars.PR_CHECKS_RUNNER, vars.BLACKSMITH_RUNNER, or vars.PUBLIC_PR_VALIDATION_RUNNER for runner failover`,
+					`${workflowFile}: PR jobs must expose vars.PR_CHECKS_RUNNER or vars.PUBLIC_PR_VALIDATION_RUNNER for runner failover`,
 				);
 			}
+		}
+	}
+
+	return failures;
+}
+
+/**
+ * Blacksmith runners are retired org-wide (owner decision 2026-07-20).
+ * Fail any workflow that still references a blacksmith-* runner label or a
+ * BLACKSMITH_* fallback var so the fleet cannot silently creep back in.
+ */
+function evaluateNoBlacksmithReferences(root) {
+	const failures = [];
+	const workflowsDir = join(root, ".github/workflows");
+	if (!existsSync(workflowsDir)) return failures;
+
+	for (const entry of readdirSync(workflowsDir)) {
+		if (!/\.ya?ml$/.test(entry)) continue;
+		const workflowFile = `.github/workflows/${entry}`;
+		const workflowText = readIfExists(join(root, workflowFile));
+		if (/blacksmith/i.test(workflowText)) {
+			failures.push(
+				`${workflowFile}: Blacksmith runners are retired; use GitHub-hosted runners (e.g. ubuntu-latest, macos-15, ubuntu-24.04-arm) instead of blacksmith-* labels or BLACKSMITH_* vars`,
+			);
 		}
 	}
 
@@ -172,6 +194,7 @@ export function evaluateWorkflowFootguns({ root = defaultRoot } = {}) {
 		...evaluateEvalOpsBotDispatch(root),
 		...evaluatePublicReleaseMirrorWorkflowPermission(root),
 		...evaluatePullRequestRunnerOverrides(root),
+		...evaluateNoBlacksmithReferences(root),
 	];
 }
 

--- a/scripts/check-workflow-footguns.mjs
+++ b/scripts/check-workflow-footguns.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const defaultRoot = fileURLToPath(new URL("..", import.meta.url));
@@ -167,21 +167,25 @@ function evaluatePullRequestRunnerOverrides(root) {
 
 /**
  * Blacksmith runners are retired org-wide (owner decision 2026-07-20).
- * Fail any workflow that still references a blacksmith-* runner label or a
- * BLACKSMITH_* fallback var so the fleet cannot silently creep back in.
+ * Fail any workflow, composite action, or actionlint config that still
+ * references a blacksmith-* runner label or a BLACKSMITH_* fallback var so
+ * the fleet cannot silently creep back in. Scans all of .github/ (not just
+ * .github/workflows/) so a composite action under .github/actions/** or the
+ * self-hosted-runner label registry in .github/actionlint.yaml can't
+ * reintroduce a reference unnoticed.
  */
 function evaluateNoBlacksmithReferences(root) {
 	const failures = [];
-	const workflowsDir = join(root, ".github/workflows");
-	if (!existsSync(workflowsDir)) return failures;
+	const githubDir = join(root, ".github");
+	if (!existsSync(githubDir)) return failures;
 
-	for (const entry of readdirSync(workflowsDir)) {
+	for (const entry of readdirSync(githubDir, { recursive: true })) {
 		if (!/\.ya?ml$/.test(entry)) continue;
-		const workflowFile = `.github/workflows/${entry}`;
-		const workflowText = readIfExists(join(root, workflowFile));
-		if (/blacksmith/i.test(workflowText)) {
+		const relativePath = `.github/${entry.split(sep).join("/")}`;
+		const fileText = readIfExists(join(root, relativePath));
+		if (/blacksmith/i.test(fileText)) {
 			failures.push(
-				`${workflowFile}: Blacksmith runners are retired; use GitHub-hosted runners (e.g. ubuntu-latest, macos-15, ubuntu-24.04-arm) instead of blacksmith-* labels or BLACKSMITH_* vars`,
+				`${relativePath}: Blacksmith runners are retired; use GitHub-hosted runners (e.g. ubuntu-latest, macos-15, ubuntu-24.04-arm) instead of blacksmith-* labels or BLACKSMITH_* vars`,
 			);
 		}
 	}

--- a/test/scripts/ci-guardrails.test.ts
+++ b/test/scripts/ci-guardrails.test.ts
@@ -172,14 +172,14 @@ function expectRustTuiRunnerLane(runsOn: string): void {
 		return;
 	}
 
-	// Heavy PR work uses Blacksmith (or override); main confirmation falls back
-	// through INTERNAL_CONFIRMATION_RUNNER / BLACKSMITH_RUNNER.
+	// Heavy PR work runs on GitHub-hosted ubuntu-latest (Blacksmith retired
+	// 2026-07-20); main confirmation falls back through
+	// INTERNAL_CONFIRMATION_RUNNER.
 	expect(runsOn).not.toContain("PR_RUST_RUNNER");
 	expect(runsOn).not.toContain("evalops-private-heavy");
-	expect(runsOn).toContain("BLACKSMITH_HEAVY_RUNNER");
-	expect(runsOn).toContain("blacksmith-8vcpu-ubuntu-2404");
+	expect(runsOn).not.toContain("BLACKSMITH");
+	expect(runsOn).not.toContain("blacksmith");
 	expect(runsOn).toContain("INTERNAL_CONFIRMATION_RUNNER");
-	expect(runsOn).toContain("BLACKSMITH_RUNNER");
 }
 
 describe("planCiChecks", () => {
@@ -936,22 +936,20 @@ describe("ci workflow guardrails", () => {
 
 		expect(prChecksRunsOn).toContain("ubuntu-latest");
 		expect(prChecksRunsOn).toContain("light_pr_checks");
-		// Light PR lane: PR_CHECKS_RUNNER → BLACKSMITH_RUNNER → ubuntu-latest
-		// Heavy PR lane: BLACKSMITH_HEAVY_RUNNER → blacksmith-8vcpu
+		// Light PR lane: PR_CHECKS_RUNNER → ubuntu-latest
+		// Heavy PR lane: ubuntu-latest (Blacksmith retired 2026-07-20)
 		expect(prChecksRunsOn).toContain("PR_CHECKS_RUNNER");
-		expect(prChecksRunsOn).toContain("BLACKSMITH_RUNNER");
-		expect(prChecksRunsOn).toContain("BLACKSMITH_HEAVY_RUNNER");
-		expect(prChecksRunsOn).toContain("blacksmith-8vcpu-ubuntu-2404");
+		expect(prChecksRunsOn).not.toContain("BLACKSMITH");
+		expect(prChecksRunsOn).not.toContain("blacksmith");
 		expect(prChecksRunsOn).not.toContain("evalops-private-ci");
 		expect(prChecksRunsOn).not.toContain("evalops-private-heavy");
 		expect(prChecksRunsOn).toContain("INTERNAL_CONFIRMATION_RUNNER");
 		expect(coverageRunsOn).toContain("ubuntu-latest");
 		expect(coverageRunsOn).not.toContain("PR_COVERAGE_RUNNER");
-		expect(coverageRunsOn).toContain("BLACKSMITH_HEAVY_RUNNER");
-		expect(coverageRunsOn).toContain("blacksmith-8vcpu-ubuntu-2404");
+		expect(coverageRunsOn).not.toContain("BLACKSMITH");
+		expect(coverageRunsOn).not.toContain("blacksmith");
 		expect(coverageRunsOn).not.toContain("evalops-private-heavy");
 		expect(coverageRunsOn).toContain("INTERNAL_CONFIRMATION_RUNNER");
-		expect(coverageRunsOn).toContain("BLACKSMITH_RUNNER");
 	});
 
 	it("runs workflow footgun guardrails in the CI infrastructure smoke lane", () => {
@@ -1229,7 +1227,7 @@ describe("ci workflow guardrails", () => {
 		expect(script).toContain("MAESTRO_REQUIRE_PACKAGED_TUI");
 	});
 
-	it("builds every packaged Rust TUI target on Blacksmith", () => {
+	it("builds every packaged Rust TUI target on GitHub-hosted runners", () => {
 		const workflowPath = new URL(
 			"../../.github/workflows/release.yml",
 			import.meta.url,
@@ -1245,13 +1243,11 @@ describe("ci workflow guardrails", () => {
 			return;
 		}
 
-		for (const runner of [
-			"blacksmith-6vcpu-macos-15",
-			"blacksmith-4vcpu-ubuntu-2404",
-			"blacksmith-4vcpu-ubuntu-2404-arm",
-		]) {
+		for (const runner of ["macos-15", "ubuntu-latest", "ubuntu-24.04-arm"]) {
 			expect(workflow).toContain(runner);
 		}
+		expect(workflow).not.toContain("blacksmith");
+		expect(workflow).not.toContain("Blacksmith");
 		expect(workflow).toContain("release-tui-binaries:");
 		expect(workflow).toContain(
 			"build --release --locked --bin maestro-tui --target",
@@ -1735,8 +1731,8 @@ describe("ci workflow guardrails", () => {
 			should_run: "${{ steps.detect.outputs.result }}",
 		});
 		expect(detectJob?.["runs-on"]).toContain("PUBLIC_PR_VALIDATION_RUNNER");
-		expect(detectJob?.["runs-on"]).toContain("BLACKSMITH_RUNNER");
-		expect(detectJob?.["runs-on"]).toContain("blacksmith-8vcpu-ubuntu-2404");
+		expect(detectJob?.["runs-on"]).not.toContain("BLACKSMITH");
+		expect(detectJob?.["runs-on"]).not.toContain("blacksmith");
 		expect(detectJob?.["runs-on"]).toContain("ubuntu-latest");
 		expect(detectStep?.uses).toBe(
 			"actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea",
@@ -1804,8 +1800,8 @@ describe("ci workflow guardrails", () => {
 			"pull-requests": "read",
 		});
 		expect(labelJob?.["runs-on"]).toContain("PUBLIC_PR_VALIDATION_RUNNER");
-		expect(labelJob?.["runs-on"]).toContain("BLACKSMITH_RUNNER");
-		expect(labelJob?.["runs-on"]).toContain("blacksmith-8vcpu-ubuntu-2404");
+		expect(labelJob?.["runs-on"]).not.toContain("BLACKSMITH");
+		expect(labelJob?.["runs-on"]).not.toContain("blacksmith");
 		expect(labelJob?.["runs-on"]).toContain("ubuntu-latest");
 		expect(
 			steps.some((step) => step.uses?.startsWith("actions/checkout@")),

--- a/test/scripts/workflow-footguns.test.ts
+++ b/test/scripts/workflow-footguns.test.ts
@@ -229,7 +229,7 @@ describe("workflow footgun guardrails", () => {
 		);
 	});
 
-	it("accepts pull request workflows routed through Blacksmith / PR_CHECKS failover vars", () => {
+	it("accepts pull request workflows routed through PR_CHECKS / INTERNAL_CONFIRMATION failover vars", () => {
 		const root = makeFixture();
 		write(
 			join(root, ".github/workflows/ci.yml"),
@@ -237,11 +237,11 @@ describe("workflow footgun guardrails", () => {
 				"name: ci",
 				"jobs:",
 				"  pr-checks:",
-				"    runs-on: ${{ github.event_name == 'pull_request' && (vars.PR_CHECKS_RUNNER || vars.BLACKSMITH_RUNNER || 'ubuntu-latest') || (vars.INTERNAL_CONFIRMATION_RUNNER || vars.BLACKSMITH_RUNNER || 'blacksmith-4vcpu-ubuntu-2404') }}",
+				"    runs-on: ${{ github.event_name == 'pull_request' && (vars.PR_CHECKS_RUNNER || 'ubuntu-latest') || (vars.INTERNAL_CONFIRMATION_RUNNER || 'ubuntu-latest') }}",
 				"    steps:",
 				"      - run: echo ok",
 				"  coverage:",
-				"    runs-on: ${{ github.event_name == 'pull_request' && (vars.BLACKSMITH_HEAVY_RUNNER || 'blacksmith-8vcpu-ubuntu-2404') || (vars.INTERNAL_CONFIRMATION_RUNNER || vars.BLACKSMITH_RUNNER || 'blacksmith-4vcpu-ubuntu-2404') }}",
+				"    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || (vars.INTERNAL_CONFIRMATION_RUNNER || 'ubuntu-latest') }}",
 				"    steps:",
 				"      - run: echo ok",
 				"",
@@ -253,7 +253,7 @@ describe("workflow footgun guardrails", () => {
 				"name: Rust TUI",
 				"jobs:",
 				"  build:",
-				"    runs-on: ${{ github.event_name == 'pull_request' && (vars.BLACKSMITH_HEAVY_RUNNER || 'blacksmith-8vcpu-ubuntu-2404') || (vars.INTERNAL_CONFIRMATION_RUNNER || vars.BLACKSMITH_RUNNER || 'blacksmith-4vcpu-ubuntu-2404') }}",
+				"    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || (vars.INTERNAL_CONFIRMATION_RUNNER || 'ubuntu-latest') }}",
 				"    steps:",
 				"      - run: echo ok",
 				"",
@@ -279,5 +279,61 @@ describe("workflow footgun guardrails", () => {
 		);
 
 		expect(evaluateWorkflowFootguns({ root })).toEqual([]);
+	});
+
+	it("rejects workflows that still reference retired Blacksmith runner labels", () => {
+		const root = makeFixture();
+		write(
+			join(root, ".github/workflows/ci.yml"),
+			[
+				"name: ci",
+				"jobs:",
+				"  pr-checks:",
+				"    runs-on: ${{ github.event_name == 'pull_request' && (vars.PR_CHECKS_RUNNER || 'ubuntu-latest') || (vars.INTERNAL_CONFIRMATION_RUNNER || 'ubuntu-latest') }}",
+				"    steps:",
+				"      - run: echo ok",
+				"",
+			].join("\n"),
+		);
+		write(
+			join(root, ".github/workflows/rust.yml"),
+			[
+				"name: Rust TUI",
+				"jobs:",
+				"  build:",
+				"    runs-on: ${{ vars.BLACKSMITH_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}",
+				"    steps:",
+				"      - run: echo ok",
+				"",
+			].join("\n"),
+		);
+
+		expect(evaluateWorkflowFootguns({ root })).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("rust.yml: Blacksmith runners are retired"),
+			]),
+		);
+	});
+
+	it("rejects workflows that still reference retired Blacksmith runner vars even without a literal label", () => {
+		const root = makeFixture();
+		write(
+			join(root, ".github/workflows/ci.yml"),
+			[
+				"name: ci",
+				"jobs:",
+				"  pr-checks:",
+				"    runs-on: ${{ vars.BLACKSMITH_HEAVY_RUNNER || 'ubuntu-latest' }}",
+				"    steps:",
+				"      - run: echo ok",
+				"",
+			].join("\n"),
+		);
+
+		expect(evaluateWorkflowFootguns({ root })).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("ci.yml: Blacksmith runners are retired"),
+			]),
+		);
 	});
 });

--- a/test/scripts/workflow-footguns.test.ts
+++ b/test/scripts/workflow-footguns.test.ts
@@ -336,4 +336,40 @@ describe("workflow footgun guardrails", () => {
 			]),
 		);
 	});
+
+	it("rejects Blacksmith references outside .github/workflows (composite actions, actionlint.yaml)", () => {
+		const root = makeFixture();
+		write(
+			join(root, ".github/actions/setup-rust/action.yml"),
+			[
+				"name: setup-rust",
+				"runs:",
+				"  using: composite",
+				"  steps:",
+				"    - shell: bash",
+				"      run: echo 'fallback runner: blacksmith-4vcpu-ubuntu-2404'",
+				"",
+			].join("\n"),
+		);
+		write(
+			join(root, ".github/actionlint.yaml"),
+			[
+				"self-hosted-runner:",
+				"  labels:",
+				"    - blacksmith-8vcpu-ubuntu-2404",
+				"",
+			].join("\n"),
+		);
+
+		expect(evaluateWorkflowFootguns({ root })).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining(
+					".github/actions/setup-rust/action.yml: Blacksmith runners are retired",
+				),
+				expect.stringContaining(
+					".github/actionlint.yaml: Blacksmith runners are retired",
+				),
+			]),
+		);
+	});
 });


### PR DESCRIPTION
## Summary

- Mirrored source-of-truth PR: evalops/maestro-internal#2944 (`scripts/check-workflow-footguns.mjs`, `test/scripts/ci-guardrails.test.ts`, and `test/scripts/workflow-footguns.test.ts` are identical in both repos; `.github/actionlint.yaml` and `.github/workflows/*` are edited per-repo since public CI already diverges from internal CI).
- Org-wide decision (Jonathan, 2026-07-20): drop Blacksmith entirely. Tracking issue: evalops/deploy#8126.
- **This repo (maestro) is public, so `ubuntu-latest` is the correct, free target here** -- unlike evalops/maestro-internal#2944, which is private and had to route to the org's owned Hetzner pool instead because GitHub-hosted Actions spend is currently hard-blocked on private repos (org budget exhausted, `prevent_further_usage=true`, will not be raised before it resets in August). Public-repo minutes are free and unaffected. If you're comparing the two PRs' diffs and wondering why they diverge on runner targets, that's why.
- This repo's public-facing CI (`ci.yml`, `rust.yml`, `release.yml`) already routed through `PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest'` with no Blacksmith fallback, so the only live references were:
  - `tag-release.yml` / `version-bump.yml`'s shared main-confirmation lane (used when `github.repository == 'evalops/maestro-internal'`, i.e. dead in this repo's own runs but kept in sync with maestro-internal): `INTERNAL_CONFIRMATION_RUNNER || BLACKSMITH_RUNNER || 'blacksmith-4vcpu-ubuntu-2404'` -> `INTERNAL_CONFIRMATION_RUNNER || 'ubuntu-latest'`.
  - `.github/actionlint.yaml`'s self-hosted-runner label registry, which listed the four `blacksmith-*` labels.
- `scripts/check-workflow-footguns.mjs` no longer requires `vars.BLACKSMITH_RUNNER` as one of the acceptable PR runner failover vars, and gains a new guardrail (`evaluateNoBlacksmithReferences`) that recursively scans all of `.github/` -- workflows, composite actions under `.github/actions/**`, and `.github/actionlint.yaml` -- for a `blacksmith-*` label or `BLACKSMITH_*` var, so the fleet can't silently creep back in from anywhere in `.github/`, not just workflow files.
- `test/scripts/ci-guardrails.test.ts` and `test/scripts/workflow-footguns.test.ts` are updated to match (dead-branch assertions in this repo's test file that referenced Blacksmith -- inherited from the shared maestro-internal test content -- are cleaned up too; new tests cover the ban, including the composite-action/actionlint.yaml coverage).

## `require-internal-pr` gate

This repo's `public-source-provenance.yml` requires PRs that touch mirrored source files to link the matching `evalops/maestro-internal` PR in the body (it is not a blanket ban on direct public PRs -- `.github/workflows/*` and `.github/actionlint.yaml` are explicitly exempt as public-only files; `scripts/check-workflow-footguns.mjs` and the two test files are the mirrored files that triggered it). Added the link above; gate passes.

## Left in place (and why)

- `CHANGELOG.md` mentions of Blacksmith (historical release notes) -- left untouched, it's a record of what was true at the time.

## Test plan

- `node ./scripts/run-vitest.js --run test/scripts/` -- 43 files / 497 tests passed.
- `node scripts/check-workflow-footguns.mjs` -- guardrails passed.
- `actionlint .github/workflows/tag-release.yml .github/workflows/version-bump.yml` -- clean.
- `bunx @biomejs/biome@1.9.4 check` on touched JS/TS files -- clean.

Co-authored by Claude Fable 5.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/evalops/maestro/pull/856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->