### PR TITLE
ci: skip PR image publish runners

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   build-and-publish:
+    if: github.event_name == 'push'
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.repository.id && 'ubuntu-latest' || (github.event_name == 'pull_request' && (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest')) }}
     # Internal main-push image builds can take longer than the public mirror on
     # the private runner because the Rust control-plane layer compiles there.
@@ -24,20 +25,13 @@ jobs:
       packages: write
 
     steps:
-      - name: Publish is push-only
-        if: github.event_name == 'pull_request'
-        run: echo "GHCR publish runs only on main pushes; this PR check satisfies the required status without building an image."
-
       - name: Checkout repository
-        if: github.event_name == 'push'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        if: github.event_name == 'push'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        if: github.event_name == 'push'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
@@ -45,7 +39,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract image metadata
-        if: github.event_name == 'push'
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
@@ -56,7 +49,6 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build image
-        if: github.event_name == 'push'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
@@ -69,7 +61,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Dispatch deploy GitOps image sync
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.RUNTIME_IMAGE_SYNC_TOKEN }}
           SOURCE_SHA: ${{ github.sha }}


### PR DESCRIPTION
## Summary
- retain the required `build-and-publish` PR context as a skipped job
- avoid allocating a runner for the existing PR no-op
- keep main image build and deployment dispatch behavior unchanged

## Test plan
- `actionlint .github/workflows/ghcr-publish.yml`
- `git diff --check`