### PR TITLE
ci: run actionlint on every pull request

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,10 +1,12 @@
 name: actionlint
 
 on:
+  # Run on every PR: actionlint is a required status check, and a
+  # path-filtered required check can never report on PRs that do not touch
+  # these paths, wedging mergeStateStatus at BLOCKED (seen on mirror sync
+  # PRs 868/870). The job is ~20s; align with maestro-internal, which runs
+  # it on all PRs.
   pull_request:
-    paths:
-      - ".github/workflows/**"
-      - ".github/actions/**"
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

Root cause of the recurring auto-merge wedge on mirror sync PRs (868, 870 — both needed admin merges):

- `actionlint` is a **required** status check in branch protection, but its `pull_request` trigger was path-filtered to `.github/workflows/**` / `.github/actions/**`.
- Generated sync PRs never satisfy that filter — the mirror projection strips workflow files by design — so the required context never reports, `mergeStateStatus` stays BLOCKED forever, and auto-merge never fires.
- Sync PR 869 merged normally precisely because it happened to carry an `.github/actions/ensure-ripgrep` change.

Fix: drop the `pull_request` path filter (keep it for `push` to main). Aligns with maestro-internal's actionlint, which already runs on all PRs. The job is ~20s.

## Test plan

- [x] Compared required-context list vs rollup on wedged PR 870: `actionlint` was the only absent context
- [x] Internal twin has no PR path filter
- [ ] CI on this PR (actionlint runs on it since it touches workflows)