### PR TITLE
ci: parallelize native validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  native:
+  native-quality:
     runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 90
     steps:
@@ -20,12 +20,47 @@ jobs:
       - run: npm run check:rust-only-runtime
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+  native-tests:
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: stable }
       - run: cargo test --workspace --locked
+
+  native-release:
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: ./.github/actions/setup-rust
+        with: { toolchain: stable }
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with: { node-version: 22 }
       - run: npm run build
       - run: npm run smoke:release-native-only
 
+  # Preserve the established required-check dependency while the independent
+  # native quality, test, and release lanes run in parallel.
+  native:
+    needs:
+      - native-quality
+      - native-tests
+      - native-release
+    runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
+    if: ${{ always() }}
+    timeout-minutes: 10
+    steps:
+      - name: Require every native lane
+        run: |
+          test "${{ needs.native-quality.result }}" = success
+          test "${{ needs.native-tests.result }}" = success
+          test "${{ needs.native-release.result }}" = success
+
   # Keep the repository's established required-check contexts while making the
-  # Rust-native job their single source of truth.
+  # Rust-native aggregate their single source of truth.
   pr-checks:
     needs: native
     runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(
+	new URL("../.github/workflows/ci.yml", import.meta.url),
+	"utf8",
+);
+
+function jobBody(jobId) {
+	const start = workflow.indexOf(`  ${jobId}:\n`);
+	assert.notEqual(start, -1, `missing ${jobId} job`);
+	const remainder = workflow.slice(start + 1);
+	const next = remainder.search(/\n  [A-Za-z0-9_-]+:\n/);
+	return next === -1 ? workflow.slice(start) : workflow.slice(start, start + 1 + next);
+}
+
+test("native CI runs independent release, test, and quality lanes in parallel", () => {
+	const release = jobBody("native-release");
+	const tests = jobBody("native-tests");
+	const quality = jobBody("native-quality");
+	const aggregate = jobBody("native");
+
+	assert.match(release, /npm run build/);
+	assert.match(release, /npm run smoke:release-native-only/);
+	assert.match(tests, /cargo test --workspace --locked/);
+	assert.match(quality, /cargo clippy --workspace --all-targets --locked -- -D warnings/);
+	assert.match(quality, /cargo fmt --all --check/);
+
+	assert.match(aggregate, /needs:\n      - native-quality\n      - native-tests\n      - native-release/);
+	assert.match(aggregate, /if: \$\{\{ always\(\) \}\}/);
+	for (const lane of ["native-quality", "native-tests", "native-release"]) {
+		assert.match(aggregate, new RegExp(`needs\\.${lane}\\.result`));
+	}
+});


### PR DESCRIPTION
## Why
Recent push CI showed the `native` job taking 13m07s because its release build (~6m56s), workspace tests (~3m36s), and Clippy (~1m55s) ran serially despite having no output dependency.

## What changed
- split native quality, tests, and release build/smoke into independent producer jobs
- keep the existing `native` job as a fail-closed aggregate so downstream required contexts remain stable
- add a workflow regression test that enforces the parallel DAG and command ownership

## Verification
- `node --test scripts/ci-workflow.test.mjs`
- `actionlint .github/workflows/ci.yml`
- `node scripts/check-workflow-footguns.mjs`
- `node --test scripts/check-required-status-checks.test.mjs`
- `git diff --check`