### PR TITLE
feat(headless): preserve governed tool execution ids

### DIFF
--- a/packages/tui-rs/src/headless/async_transport.rs
+++ b/packages/tui-rs/src/headless/async_transport.rs
@@ -415,6 +415,7 @@ impl AsyncAgentTransport {
     pub fn approve_tool(&self, call_id: impl Into<String>) -> Result<(), AsyncTransportError> {
         self.send(ToAgentMessage::ToolResponse {
             call_id: call_id.into(),
+            tool_execution_id: None,
             approved: true,
             result: None,
         })
@@ -424,6 +425,7 @@ impl AsyncAgentTransport {
     pub fn deny_tool(&self, call_id: impl Into<String>) -> Result<(), AsyncTransportError> {
         self.send(ToAgentMessage::ToolResponse {
             call_id: call_id.into(),
+            tool_execution_id: None,
             approved: false,
             result: None,
         })

--- a/packages/tui-rs/src/headless/messages.rs
+++ b/packages/tui-rs/src/headless/messages.rs
@@ -186,6 +186,9 @@ pub enum ToAgentMessage {
     /// Respond to a tool approval request
     ToolResponse {
         call_id: String,
+        /// Durable execution identifier allocated by a governing controller.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_execution_id: Option<String>,
         approved: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         result: Option<ToolResult>,

--- a/packages/tui-rs/src/headless/messages/tests.rs
+++ b/packages/tui-rs/src/headless/messages/tests.rs
@@ -45,6 +45,44 @@ fn tool_end_serializes_typed_receipt_additively() {
 }
 
 #[test]
+fn tool_response_round_trips_governed_execution_id() {
+    let message = ToAgentMessage::ToolResponse {
+        call_id: "call-1".to_string(),
+        tool_execution_id: Some("tool-execution-1".to_string()),
+        approved: true,
+        result: None,
+    };
+
+    let encoded = serde_json::to_value(&message).expect("serialize tool response");
+    assert_eq!(encoded["tool_execution_id"], "tool-execution-1");
+
+    let decoded: ToAgentMessage =
+        serde_json::from_value(encoded).expect("deserialize tool response");
+    assert!(matches!(
+        decoded,
+        ToAgentMessage::ToolResponse {
+            call_id,
+            tool_execution_id: Some(tool_execution_id),
+            approved: true,
+            result: None,
+        } if call_id == "call-1" && tool_execution_id == "tool-execution-1"
+    ));
+}
+
+#[test]
+fn tool_response_omits_absent_execution_id() {
+    let message = ToAgentMessage::ToolResponse {
+        call_id: "call-1".to_string(),
+        tool_execution_id: None,
+        approved: false,
+        result: None,
+    };
+
+    let encoded = serde_json::to_value(&message).expect("serialize tool response");
+    assert_eq!(encoded.get("tool_execution_id"), None);
+}
+
+#[test]
 fn parse_response_chunk() {
     let json =
         r#"{"type":"response_chunk","response_id":"abc","content":"Hello","is_thinking":false}"#;

--- a/packages/tui-rs/src/headless/transport.rs
+++ b/packages/tui-rs/src/headless/transport.rs
@@ -397,6 +397,7 @@ impl AgentTransport {
     pub fn approve_tool(&self, call_id: impl Into<String>) -> Result<(), TransportError> {
         self.send(ToAgentMessage::ToolResponse {
             call_id: call_id.into(),
+            tool_execution_id: None,
             approved: true,
             result: None,
         })
@@ -406,6 +407,7 @@ impl AgentTransport {
     pub fn deny_tool(&self, call_id: impl Into<String>) -> Result<(), TransportError> {
         self.send(ToAgentMessage::ToolResponse {
             call_id: call_id.into(),
+            tool_execution_id: None,
             approved: false,
             result: None,
         })

--- a/packages/tui-rs/src/headless_server.rs
+++ b/packages/tui-rs/src/headless_server.rs
@@ -48,6 +48,8 @@ use crate::headless::HEADLESS_PROTOCOL_VERSION;
 struct RuntimeMeta {
     session_id: Option<String>,
     approval_mode: Option<ApprovalMode>,
+    /// Controller-owned execution ids awaiting a native terminal event.
+    tool_execution_ids: HashMap<String, String>,
 }
 
 struct HeadlessState {
@@ -105,6 +107,7 @@ impl HeadlessState {
             meta: Arc::new(Mutex::new(RuntimeMeta {
                 session_id,
                 approval_mode: None,
+                tool_execution_ids: HashMap::new(),
             })),
             agent: None,
             tool_tx: None,
@@ -127,6 +130,14 @@ impl HeadlessState {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .approval_mode = mode;
+    }
+
+    fn bind_tool_execution_id(&self, call_id: String, tool_execution_id: String) {
+        self.meta
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .tool_execution_ids
+            .insert(call_id, tool_execution_id);
     }
 
     fn ensure_session_id(&self) -> String {
@@ -357,6 +368,7 @@ pub async fn run_headless_server() -> Result<i32> {
             }
             ToAgentMessage::ToolResponse {
                 call_id,
+                tool_execution_id,
                 approved,
                 result,
             } => {
@@ -367,9 +379,16 @@ pub async fn run_headless_server() -> Result<i32> {
                 // and emits ToolStart/ToolOutput/ToolEnd itself.
                 if approved {
                     if let Some(ref tool_result) = agent_result {
-                        for msg in tool_lifecycle_messages(&call_id, None, tool_result) {
+                        for msg in tool_lifecycle_messages(
+                            &call_id,
+                            tool_execution_id.as_deref(),
+                            None,
+                            tool_result,
+                        ) {
                             emit(&msg)?;
                         }
+                    } else if let Some(tool_execution_id) = tool_execution_id {
+                        state.bind_tool_execution_id(call_id.clone(), tool_execution_id);
                     }
                 }
                 if let Some(tool_tx) = state.tool_tx.as_ref() {
@@ -386,7 +405,7 @@ pub async fn run_headless_server() -> Result<i32> {
                 let result = client_content_to_agent_result(content, is_error);
                 if let Some(tool_tx) = state.tool_tx.as_ref() {
                     let _ = tool_tx.send((call_id.clone(), true, Some(result.clone())));
-                    for msg in tool_lifecycle_messages(&call_id, None, &result) {
+                    for msg in tool_lifecycle_messages(&call_id, None, None, &result) {
                         emit(&msg)?;
                     }
                 } else {
@@ -1087,6 +1106,10 @@ async fn handle_agent_event(
                 duration_ms: None,
                 ttft_ms: None,
             })?;
+            meta.lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .tool_execution_ids
+                .clear();
         }
         FromAgent::ToolCall {
             call_id,
@@ -1127,9 +1150,14 @@ async fn handle_agent_event(
             success,
             receipt,
         } => {
+            let tool_execution_id = meta
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .tool_execution_ids
+                .remove(&call_id);
             emit(&FromAgentMessage::ToolEnd {
                 call_id,
-                tool_execution_id: None,
+                tool_execution_id,
                 success,
                 tool: None,
                 details: None,
@@ -1276,6 +1304,7 @@ fn tool_output_content(result: &ToolResult) -> Option<String> {
 /// Protocol messages for a completed tool run: start → output? → end.
 fn tool_lifecycle_messages(
     call_id: &str,
+    tool_execution_id: Option<&str>,
     tool: Option<String>,
     result: &ToolResult,
 ) -> Vec<FromAgentMessage> {
@@ -1291,7 +1320,7 @@ fn tool_lifecycle_messages(
     }
     msgs.push(FromAgentMessage::ToolEnd {
         call_id: call_id.to_string(),
-        tool_execution_id: None,
+        tool_execution_id: tool_execution_id.map(str::to_string),
         success: result.success,
         tool,
         details: result.details.clone(),
@@ -1411,7 +1440,12 @@ mod tests {
     #[test]
     fn tool_lifecycle_messages_include_tool_output() {
         let result = ToolResult::success("file contents");
-        let msgs = tool_lifecycle_messages("call-1", Some("read".into()), &result);
+        let msgs = tool_lifecycle_messages(
+            "call-1",
+            Some("tool-execution-1"),
+            Some("read".into()),
+            &result,
+        );
         assert_eq!(msgs.len(), 3);
         assert!(matches!(
             &msgs[0],
@@ -1426,17 +1460,20 @@ mod tests {
             &msgs[2],
             FromAgentMessage::ToolEnd {
                 call_id,
+                tool_execution_id: Some(tool_execution_id),
                 success: true,
                 tool: Some(t),
                 ..
-            } if call_id == "call-1" && t == "read"
+            } if call_id == "call-1"
+                && tool_execution_id == "tool-execution-1"
+                && t == "read"
         ));
     }
 
     #[test]
     fn tool_lifecycle_messages_omit_empty_success_output() {
         let result = ToolResult::success("");
-        let msgs = tool_lifecycle_messages("call-2", None, &result);
+        let msgs = tool_lifecycle_messages("call-2", None, None, &result);
         assert_eq!(msgs.len(), 2);
         assert!(matches!(msgs[0], FromAgentMessage::ToolStart { .. }));
         assert!(matches!(

--- a/packages/tui-rs/src/remote_attach.rs
+++ b/packages/tui-rs/src/remote_attach.rs
@@ -753,6 +753,7 @@ fn send_approval_response(
             state,
             ToAgentMessage::ToolResponse {
                 call_id: request.call_id.clone(),
+                tool_execution_id: request.tool_execution_id.clone(),
                 approved,
                 result,
             },


### PR DESCRIPTION
## What changed

- adds an optional controller-owned `tool_execution_id` to headless `tool_response` messages
- preserves that identifier on externally completed tool lifecycle events
- binds approved native executions to the same identifier until their terminal `tool_end`
- carries existing governed identifiers through remote-attach approval responses
- keeps existing clients wire-compatible by omitting the field when absent

## Why

A platform control plane can allocate a durable ToolExecution record only after Maestro emits a tool intent. Before this change, the controller could approve or complete the tool, but Maestro's terminal event still emitted `tool_execution_id: null`, breaking durable correlation between runtime events, policy decisions, evidence, and receipts.

This is the first protocol seam for evalops/platform#5204. It intentionally does not add Dex- or channel-specific behavior to Maestro.

Private source-of-truth PR: https://github.com/evalops/maestro-internal/pull/3172

## Developer impact

Governed hosted-runner clients may return `tool_execution_id` with a `tool_response`. Maestro echoes it on the terminal `tool_end`. Existing clients require no changes.

## Checks

- `cargo fmt --all --check`
- `cargo test -p maestro-tui headless --locked` (175 passed)
- `cargo clippy -p maestro-tui --all-targets --locked -- -D warnings`

## Follow-up boundary

Platform will consume this contract from a channel-neutral turn coordinator. Slack, Console Chat, scheduled work, and future channels remain separate projections over the same governed runtime; this PR does not implement that Platform coordinator.