### PR TITLE
feat(tui): improve terminal input and frame rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,6 +2575,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "uncurses",
  "unicode-width 0.2.0",
  "url",
  "urlencoding",
@@ -4953,6 +4954,21 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "uncurses"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476f991ac4af37971265c23605f3cec4be568d3907268c153fd76d07a84c0466"
+dependencies = [
+ "bitflags 2.13.1",
+ "compact_str",
+ "libc",
+ "rustc-hash",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 

--- a/docs/design/GROK_BUILD_PARITY.md
+++ b/docs/design/GROK_BUILD_PARITY.md
@@ -450,9 +450,9 @@ A full inventory pass compared Maestro against the public grok-build repo
   expansion, `/loop <interval> <prompt>` scheduler, `/theme auto`
   (COLORFGBG) (#3050)
 - Mouse click-to-select on the slash completion popup (this change)
-- `/theme auto` follows the terminal background: one-time OSC 11 startup
-  probe behind `tui.theme_follow` (default off); live polling rejected —
-  crossterm 0.28 mangles OSC replies into Alt-key input (this change)
+- `/theme auto` follows the terminal background live behind
+  `tui.theme_follow` (default off); uncurses decodes OSC 11 and DEC light/dark
+  replies without leaking them into keyboard input
 - `maestro import-claude` — MCP + permissions import from Claude Code
   config (in flight)
 

--- a/packages/tui-rs/Cargo.toml
+++ b/packages/tui-rs/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/lib.rs"
 # Terminal handling
 crossterm = { version = "0.28", features = ["bracketed-paste", "event-stream"] }
 ratatui = { version = "0.29", features = ["unstable-widget-ref"] }
+uncurses = "0.0.1"
 
 # Async runtime
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "io-std", "io-util", "sync", "signal", "fs", "net", "process", "time"] }

--- a/packages/tui-rs/docs/user-guide/05-configuration.md
+++ b/packages/tui-rs/docs/user-guide/05-configuration.md
@@ -66,6 +66,7 @@ Prefer `~/.maestro` for new setup; keep legacy paths only if you already depend 
 | `MAESTRO_NO_EGRESS_SHELL=1` | Require approval for network shell |
 | `MAESTRO_REDUCED_MOTION=1` | Reduce UI motion |
 | `MAESTRO_DISABLE_ANIMATIONS=1` | Disable TUI animations |
+| `MAESTRO_UNCURSES_INPUT=0` | Disable protocol-aware terminal input and use the crossterm fallback |
 | `MAESTRO_TUI_BIN` | Path to `maestro-tui` binary |
 | `MAESTRO_KEYBINDINGS_FILE` | Override keybindings path |
 | `MAESTRO_MODELS_FILE` | Custom models registry |

--- a/packages/tui-rs/docs/user-guide/06-theming.md
+++ b/packages/tui-rs/docs/user-guide/06-theming.md
@@ -26,6 +26,17 @@ In the TUI:
 
 With no argument, `/theme` opens the theme selector.
 
+To make the automatic theme follow terminal dark/light changes, enable:
+
+```toml
+[tui]
+theme_follow = true
+```
+
+Maestro listens for terminal color-scheme notifications and periodically
+queries the background color. It requires two consistent background readings
+before switching, which avoids flicker near the light/dark threshold.
+
 ---
 
 ## Custom themes

--- a/packages/tui-rs/src/app.rs
+++ b/packages/tui-rs/src/app.rs
@@ -38,6 +38,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::io::Write;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 // `Arc` (Atomic Reference Counted) is a thread-safe reference-counted pointer.
@@ -50,7 +51,7 @@ use anyhow::{bail, Context, Result};
 // - `.context("msg")` adds context to errors for better debugging
 
 use crossterm::event::{
-    self, Event, KeyCode, KeyEventKind, KeyModifiers as CrosstermModifiers, MouseEventKind,
+    self, KeyCode, KeyEventKind, KeyModifiers as CrosstermModifiers, MouseEventKind,
 };
 // `crossterm` is a cross-platform terminal manipulation library.
 // It handles raw mode, events, and cursor control across Windows/Mac/Linux.
@@ -107,7 +108,8 @@ use crate::session::{
 };
 use crate::skills::{skills_to_prompt, LoadedSkill, SkillLoadError, SkillLoader, SkillRegistry};
 use crate::state::{AppState, ApprovalMode, Message, MessageKind, MessageRole, QueueMode};
-use crate::terminal::{self, TerminalCapabilities};
+use crate::sync_output::{BeginSynchronizedUpdate, EndSynchronizedUpdate};
+use crate::terminal::{self, AppTerminalEvent, TerminalCapabilities, TerminalEventReader};
 use crate::tools::{ToolExecutor, ToolRegistry};
 use chrono::{Datelike, Utc};
 
@@ -515,6 +517,14 @@ pub struct App {
     /// The ratatui terminal handle for rendering.
     terminal: terminal::Terminal,
 
+    /// Protocol-aware terminal input. Falls back to crossterm when unavailable.
+    terminal_events: Option<TerminalEventReader>,
+
+    /// Live terminal-theme state driven by typed OSC/DEC replies.
+    theme_follower: Option<crate::themes::osc11::AutoThemeFollower>,
+    last_theme_query: Option<Instant>,
+    theme_reporting_available: bool,
+
     /// Flag to exit the main loop.
     should_quit: bool,
 
@@ -736,11 +746,9 @@ impl App {
     /// Create an app, optionally submitting `initial_prompt` after the agent is ready.
     pub fn new_with_initial_prompt(initial_prompt: Option<String>) -> Result<Self> {
         let (terminal, capabilities) = terminal::init().context("Failed to initialize terminal")?;
-        Ok(Self::new_with_terminal(
-            terminal,
-            capabilities,
-            initial_prompt,
-        ))
+        let mut app = Self::new_with_terminal(terminal, capabilities, initial_prompt);
+        app.initialize_terminal_events();
+        Ok(app)
     }
 
     fn new_with_terminal(
@@ -769,18 +777,11 @@ impl App {
             .as_ref()
             .and_then(|tui| tui.slash_command_fallback)
             .unwrap_or(true);
-        // Live theme follow: `tui.theme_follow = true` starts in the `auto`
-        // theme and refines dark/light with a one-time OSC 11 probe, gated on
-        // an enhanced terminal. This must run before the event loop starts
-        // consuming input — see themes::osc11 for why polling is unsafe.
         let theme_follow = config
             .tui
             .as_ref()
             .and_then(|tui| tui.theme_follow)
             .unwrap_or(false);
-        if theme_follow && capabilities.enhanced_keys {
-            crate::themes::osc11::apply_auto_theme_from_terminal();
-        }
         let mut app = Self::new_with_terminal_with_history(
             terminal,
             capabilities,
@@ -789,6 +790,14 @@ impl App {
             context_window,
         );
         app.state.unknown_slash_command_fallback = slash_command_fallback;
+        if theme_follow {
+            let current = if crate::themes::current_theme_name() == "light" {
+                "light"
+            } else {
+                "dark"
+            };
+            app.theme_follower = Some(crate::themes::osc11::AutoThemeFollower::new(current));
+        }
         app
     }
 
@@ -871,6 +880,10 @@ impl App {
             tool_completion_rx,
             credential_vault,
             terminal,
+            terminal_events: None,
+            theme_follower: None,
+            last_theme_query: None,
+            theme_reporting_available: false,
             should_quit: false,
             capabilities,
             command_palette: CommandPalette::new(Arc::clone(&command_registry)),
@@ -999,6 +1012,84 @@ Always use tools when they would be helpful. Be concise and direct in your respo
         sections.join("\n\n")
     }
 
+    fn initialize_terminal_events(&mut self) {
+        if uncurses_input_enabled(std::env::var_os("MAESTRO_UNCURSES_INPUT").as_deref()) {
+            self.terminal_events = TerminalEventReader::open().ok();
+        }
+
+        if self.theme_follower.is_some() {
+            if self.terminal_events.is_some() {
+                // Mode 2031 requests push notifications when the terminal's
+                // color scheme changes. OSC 11 covers terminals that only
+                // expose their actual background color.
+                let _ = terminal::enable_theme_reporting();
+                self.last_theme_query = Some(Instant::now());
+            } else if self.capabilities.enhanced_keys {
+                // Compatibility path for terminals where uncurses cannot open
+                // the controlling tty.
+                crate::themes::osc11::apply_auto_theme_from_terminal();
+            }
+        }
+    }
+
+    fn poll_terminal_event(&mut self, timeout: Duration) -> Result<Option<AppTerminalEvent>> {
+        if let Some(reader) = &mut self.terminal_events {
+            return reader.poll(timeout).map_err(Into::into);
+        }
+        if event::poll(timeout)? {
+            return Ok(AppTerminalEvent::from_crossterm(event::read()?));
+        }
+        Ok(None)
+    }
+
+    fn poll_terminal_theme(&mut self) {
+        if !terminal_theme_query_due(
+            self.terminal_events.is_some(),
+            self.theme_follower.is_some(),
+            self.theme_reporting_available,
+            self.last_theme_query.map(|last| last.elapsed()),
+        ) {
+            return;
+        }
+        let _ = terminal::query_theme();
+        self.last_theme_query = Some(Instant::now());
+    }
+
+    fn apply_terminal_theme_event(&mut self, event: &AppTerminalEvent) -> bool {
+        // Theme replies may be unsolicited or left in the input queue from a
+        // previous query. They must never override an explicit opt-out.
+        if self.theme_follower.is_none() {
+            return false;
+        }
+        let next = match event {
+            AppTerminalEvent::ColorScheme(scheme) => {
+                let next = match scheme {
+                    uncurses::event::ColorScheme::Light => "light",
+                    uncurses::event::ColorScheme::Dark => "dark",
+                };
+                self.theme_follower = Some(crate::themes::osc11::AutoThemeFollower::new(next));
+                Some(next)
+            }
+            AppTerminalEvent::BackgroundColor { red, green, blue } => {
+                let luminance = crate::themes::osc11::relative_luminance(*red, *green, *blue);
+                self.theme_follower
+                    .as_mut()
+                    .and_then(|follower| follower.observe_luminance(luminance))
+            }
+            _ => None,
+        };
+        let Some(next) = next else {
+            return false;
+        };
+        if crate::themes::current_theme_name() == next {
+            return false;
+        }
+        if crate::themes::set_theme_by_name(next).is_ok() {
+            return true;
+        }
+        false
+    }
+
     /// Run the main event loop.
     ///
     /// # Rust Concept: Async Main Loop
@@ -1018,6 +1109,11 @@ Always use tools when they would be helpful. Be concise and direct in your respo
     /// Exit code for the process (0 = success, non-zero = error).
     pub async fn run(mut self) -> Result<i32> {
         let result = self.run_inner().await;
+        if self.terminal_events.is_some() && self.theme_follower.is_some() {
+            let _ = terminal::disable_theme_reporting();
+        }
+        // Stop reading from the tty before crossterm restores its modes.
+        self.terminal_events.take();
         // Restore the terminal unconditionally: an error propagated out of
         // the loop (event poll/read, render, agent poll, ...) must not leave
         // raw mode, bracketed paste, and mouse capture enabled. The panic
@@ -1084,13 +1180,16 @@ Always use tools when they would be helpful. Be concise and direct in your respo
             // Poll for terminal events. Shorter timeout while busy (animations);
             // longer while idle to avoid burning CPU on empty frames.
             let poll_ms = if self.state.busy { 33 } else { 100 };
-            if event::poll(std::time::Duration::from_millis(poll_ms))? {
-                match event::read()? {
-                    Event::Key(key) if should_handle_key_event(key.kind) => {
+            self.poll_terminal_theme();
+            if let Some(event) =
+                self.poll_terminal_event(std::time::Duration::from_millis(poll_ms))?
+            {
+                match event {
+                    AppTerminalEvent::Key(key) if should_handle_key_event(key.kind) => {
                         self.handle_key(key.code, key.modifiers).await?;
                         needs_redraw = true;
                     }
-                    Event::Mouse(mouse) => {
+                    AppTerminalEvent::Mouse(mouse) => {
                         // Handle mouse scroll wheel
                         match mouse.kind {
                             MouseEventKind::ScrollUp => {
@@ -1128,24 +1227,31 @@ Always use tools when they would be helpful. Be concise and direct in your respo
                             _ => {} // Ignore other mouse events
                         }
                     }
-                    Event::Resize(_, height) => {
+                    AppTerminalEvent::Resize { height } => {
                         self.handle_resize(height)?;
                         needs_redraw = true;
                     }
                     // Bracketed paste: route to the open modal's text input,
                     // or to the main input (large pastes fold into a
                     // `[Pasted: N lines]` display chip).
-                    Event::Paste(text) => {
+                    AppTerminalEvent::Paste(text) => {
                         self.handle_paste(&text);
                         needs_redraw = true;
                     }
-                    Event::FocusGained => {
+                    AppTerminalEvent::FocusGained => {
                         self.terminal_notifier.record_focus(true);
                     }
-                    Event::FocusLost => {
+                    AppTerminalEvent::FocusLost => {
                         self.terminal_notifier.record_focus(false);
                     }
-                    _ => {} // Ignore other events
+                    AppTerminalEvent::ThemeReportingAvailable(available) => {
+                        self.theme_reporting_available = available;
+                    }
+                    theme_event @ (AppTerminalEvent::BackgroundColor { .. }
+                    | AppTerminalEvent::ColorScheme(_)) => {
+                        needs_redraw |= self.apply_terminal_theme_event(&theme_event);
+                    }
+                    _ => {}
                 }
             }
 
@@ -2259,133 +2365,150 @@ Slash Commands:
         let rewind_picker = &mut self.rewind_picker;
         let detail_view = &self.detail_view;
 
-        self.terminal.draw(|frame| {
-            let area = frame.area();
-            let view = ChatView::new(state);
-            frame.render_widget(view, area);
+        // DEC mode 2026 lets capable terminals present a whole Ratatui diff
+        // atomically, eliminating visible partial-frame tearing. Unknown DEC
+        // modes are ignored, so this is safe on older terminals.
+        {
+            let writer = self.terminal.backend_mut();
+            crossterm::queue!(writer, BeginSynchronizedUpdate)?;
+            Write::flush(writer)?;
+        }
+        let draw_result = self
+            .terminal
+            .draw(|frame| {
+                let area = frame.area();
+                let view = ChatView::new(state);
+                frame.render_widget(view, area);
 
-            // Show error if any. Wrap the full provider message across lines
-            // (extracted upstream from the error body) instead of clipping a
-            // fixed two-line slice of it. Hidden while a modal/overlay is
-            // active so the error text cannot mix with the overlay's cells;
-            // the status-bar alert badge and `/alerts` still surface it.
-            let visible_error = if active_modal == ActiveModal::None {
-                state.error.as_deref()
-            } else {
-                None
-            };
-            if let Some(error) = visible_error {
-                let error_width = area.width.saturating_sub(2).max(1);
-                let wrapped_lines = crate::wrapping::wrapped_line_count(
-                    &ratatui::text::Text::raw(error),
-                    error_width as usize,
-                ) as u16;
-                let error_height = wrapped_lines.clamp(1, 8);
-                let status_height = u16::from(!state.zen_mode);
-                let input_height = calculate_input_height(state, area);
-                let error_y = area
-                    .height
-                    .saturating_sub(status_height)
-                    .saturating_sub(input_height)
-                    .saturating_sub(error_height);
-                let error_area = Rect {
-                    x: area.x + 1,
-                    y: area.y + error_y,
-                    width: error_width,
-                    height: error_height,
+                // Show error if any. Wrap the full provider message across lines
+                // (extracted upstream from the error body) instead of clipping a
+                // fixed two-line slice of it. Hidden while a modal/overlay is
+                // active so the error text cannot mix with the overlay's cells;
+                // the status-bar alert badge and `/alerts` still surface it.
+                let visible_error = if active_modal == ActiveModal::None {
+                    state.error.as_deref()
+                } else {
+                    None
                 };
-                // Blank the covered cells first so no older frame content
-                // shows through the wrapped paragraph.
-                frame.render_widget(ratatui::widgets::Clear, error_area);
-                let error_widget = ratatui::widgets::Paragraph::new(error)
-                    .style(Style::default().fg(Color::Red))
-                    .wrap(ratatui::widgets::Wrap { trim: false });
-                frame.render_widget(error_widget, error_area);
-            }
+                if let Some(error) = visible_error {
+                    let error_width = area.width.saturating_sub(2).max(1);
+                    let wrapped_lines = crate::wrapping::wrapped_line_count(
+                        &ratatui::text::Text::raw(error),
+                        error_width as usize,
+                    ) as u16;
+                    let error_height = wrapped_lines.clamp(1, 8);
+                    let status_height = u16::from(!state.zen_mode);
+                    let input_height = calculate_input_height(state, area);
+                    let error_y = area
+                        .height
+                        .saturating_sub(status_height)
+                        .saturating_sub(input_height)
+                        .saturating_sub(error_height);
+                    let error_area = Rect {
+                        x: area.x + 1,
+                        y: area.y + error_y,
+                        width: error_width,
+                        height: error_height,
+                    };
+                    // Blank the covered cells first so no older frame content
+                    // shows through the wrapped paragraph.
+                    frame.render_widget(ratatui::widgets::Clear, error_area);
+                    let error_widget = ratatui::widgets::Paragraph::new(error)
+                        .style(Style::default().fg(Color::Red))
+                        .wrap(ratatui::widgets::Wrap { trim: false });
+                    frame.render_widget(error_widget, error_area);
+                }
 
-            // Render slash completions if active
-            if active_modal == ActiveModal::None && slash_state.has_completions() {
-                Self::render_slash_completions_static(slash_state, frame, area);
-            }
+                // Render slash completions if active
+                if active_modal == ActiveModal::None && slash_state.has_completions() {
+                    Self::render_slash_completions_static(slash_state, frame, area);
+                }
 
-            // Render modals
-            match active_modal {
-                ActiveModal::FileSearch => {
-                    file_search.render(frame, area);
+                // Render modals
+                match active_modal {
+                    ActiveModal::FileSearch => {
+                        file_search.render(frame, area);
+                    }
+                    ActiveModal::SessionSwitcher => {
+                        session_switcher.render(frame, area);
+                    }
+                    ActiveModal::Operations => {
+                        operations.render(frame, area);
+                    }
+                    ActiveModal::CommandPalette => {
+                        command_palette.render(frame, area);
+                    }
+                    ActiveModal::Approval => {
+                        // Parallel tool calls queue several approvals at once; show
+                        // them together in one batch modal instead of N sequential
+                        // single-call modals.
+                        if approval_controller.total_count() > 1 {
+                            let modal = BatchedApprovalModal::new(approval_controller.pending())
+                                .selected(approval_controller.selected_index());
+                            frame.render_widget(modal, area);
+                        } else if let Some(request) = approval_controller.current() {
+                            let modal = ApprovalModal::new(request);
+                            frame.render_widget(modal, area);
+                        }
+                    }
+                    ActiveModal::ModelSelector => {
+                        model_selector.render(frame, area);
+                    }
+                    ActiveModal::ThemeSelector => {
+                        theme_selector.render(frame, area);
+                    }
+                    ActiveModal::ShortcutsHelp => {
+                        frame.render_widget(shortcuts_help.clone(), area);
+                    }
+                    ActiveModal::RewindPicker => {
+                        rewind_picker.render(frame, area);
+                    }
+                    ActiveModal::DetailView => {
+                        if let Some(detail) = detail_view {
+                            frame.render_widget(detail, area);
+                        }
+                    }
+                    ActiveModal::None => {}
                 }
-                ActiveModal::SessionSwitcher => {
-                    session_switcher.render(frame, area);
-                }
-                ActiveModal::Operations => {
-                    operations.render(frame, area);
-                }
-                ActiveModal::CommandPalette => {
-                    command_palette.render(frame, area);
-                }
-                ActiveModal::Approval => {
-                    // Parallel tool calls queue several approvals at once; show
-                    // them together in one batch modal instead of N sequential
-                    // single-call modals.
-                    if approval_controller.total_count() > 1 {
-                        let modal = BatchedApprovalModal::new(approval_controller.pending())
-                            .selected(approval_controller.selected_index());
-                        frame.render_widget(modal, area);
-                    } else if let Some(request) = approval_controller.current() {
-                        let modal = ApprovalModal::new(request);
-                        frame.render_widget(modal, area);
+
+                // Position terminal cursor in the input area
+                // Layout: [Messages(Min), Input(auto), Status(1)]
+                if active_modal == ActiveModal::None {
+                    // Calculate input area position (same layout as ChatView)
+                    let status_height = u16::from(!state.zen_mode);
+                    let input_height = calculate_input_height(state, area);
+                    let input_area = Rect {
+                        x: area.x,
+                        y: area.y.saturating_add(
+                            area.height.saturating_sub(status_height + input_height),
+                        ),
+                        width: area.width,
+                        height: input_height,
+                    };
+
+                    // Create widget just to calculate cursor position
+                    let input_widget = ChatInputWidget::new(
+                        &state.textarea,
+                        "",
+                        ChatInputWidgetOptions {
+                            busy: state.busy,
+                            pending_input_preview: None,
+                            ghost_text: None,
+                        },
+                    );
+
+                    if let Some((cursor_x, cursor_y)) = input_widget.cursor_pos(input_area) {
+                        frame.set_cursor_position((cursor_x, cursor_y));
                     }
                 }
-                ActiveModal::ModelSelector => {
-                    model_selector.render(frame, area);
-                }
-                ActiveModal::ThemeSelector => {
-                    theme_selector.render(frame, area);
-                }
-                ActiveModal::ShortcutsHelp => {
-                    frame.render_widget(shortcuts_help.clone(), area);
-                }
-                ActiveModal::RewindPicker => {
-                    rewind_picker.render(frame, area);
-                }
-                ActiveModal::DetailView => {
-                    if let Some(detail) = detail_view {
-                        frame.render_widget(detail, area);
-                    }
-                }
-                ActiveModal::None => {}
-            }
-
-            // Position terminal cursor in the input area
-            // Layout: [Messages(Min), Input(auto), Status(1)]
-            if active_modal == ActiveModal::None {
-                // Calculate input area position (same layout as ChatView)
-                let status_height = u16::from(!state.zen_mode);
-                let input_height = calculate_input_height(state, area);
-                let input_area = Rect {
-                    x: area.x,
-                    y: area
-                        .y
-                        .saturating_add(area.height.saturating_sub(status_height + input_height)),
-                    width: area.width,
-                    height: input_height,
-                };
-
-                // Create widget just to calculate cursor position
-                let input_widget = ChatInputWidget::new(
-                    &state.textarea,
-                    "",
-                    ChatInputWidgetOptions {
-                        busy: state.busy,
-                        pending_input_preview: None,
-                        ghost_text: None,
-                    },
-                );
-
-                if let Some((cursor_x, cursor_y)) = input_widget.cursor_pos(input_area) {
-                    frame.set_cursor_position((cursor_x, cursor_y));
-                }
-            }
-        })?;
+            })
+            .map(|_| ());
+        let sync_end_result = {
+            let writer = self.terminal.backend_mut();
+            crossterm::queue!(writer, EndSynchronizedUpdate).and_then(|()| Write::flush(writer))
+        };
+        draw_result?;
+        sync_end_result?;
 
         Ok(())
     }
@@ -2656,6 +2779,22 @@ fn policy_model_id(model: &str) -> String {
 /// Handle presses and repeats (so held keys auto-repeat); ignore releases.
 fn should_handle_key_event(kind: KeyEventKind) -> bool {
     matches!(kind, KeyEventKind::Press | KeyEventKind::Repeat)
+}
+
+fn uncurses_input_enabled(value: Option<&std::ffi::OsStr>) -> bool {
+    value.is_none_or(|value| value != "0")
+}
+
+fn terminal_theme_query_due(
+    has_terminal_events: bool,
+    has_theme_follower: bool,
+    reporting_available: bool,
+    elapsed_since_query: Option<Duration>,
+) -> bool {
+    has_terminal_events
+        && has_theme_follower
+        && !reporting_available
+        && elapsed_since_query.is_none_or(|elapsed| elapsed >= Duration::from_secs(2))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/tui-rs/src/app/tests.rs
+++ b/packages/tui-rs/src/app/tests.rs
@@ -51,6 +51,96 @@ fn test_should_handle_key_event_press_and_repeat() {
 }
 
 #[test]
+fn uncurses_input_kill_switch_defaults_on_and_accepts_only_zero_as_off() {
+    assert!(uncurses_input_enabled(None));
+    assert!(uncurses_input_enabled(Some(std::ffi::OsStr::new("1"))));
+    assert!(!uncurses_input_enabled(Some(std::ffi::OsStr::new("0"))));
+}
+
+#[test]
+fn terminal_theme_query_requires_fallback_and_respects_throttle() {
+    assert!(!terminal_theme_query_due(
+        false,
+        true,
+        false,
+        Some(Duration::from_secs(3))
+    ));
+    assert!(!terminal_theme_query_due(
+        true,
+        false,
+        false,
+        Some(Duration::from_secs(3))
+    ));
+    assert!(!terminal_theme_query_due(
+        true,
+        true,
+        true,
+        Some(Duration::from_secs(3))
+    ));
+    assert!(!terminal_theme_query_due(
+        true,
+        true,
+        false,
+        Some(Duration::from_millis(1999))
+    ));
+    assert!(terminal_theme_query_due(
+        true,
+        true,
+        false,
+        Some(Duration::from_secs(2))
+    ));
+    assert!(terminal_theme_query_due(true, true, false, None));
+}
+
+#[test]
+fn terminal_theme_events_respect_theme_follow_opt_out() {
+    let mut app = new_test_app();
+    app.theme_follower = None;
+    let scheme = if crate::themes::current_theme_name() == "light" {
+        uncurses::event::ColorScheme::Light
+    } else {
+        uncurses::event::ColorScheme::Dark
+    };
+
+    assert!(!app.apply_terminal_theme_event(&AppTerminalEvent::ColorScheme(scheme)));
+    assert!(app.theme_follower.is_none());
+}
+
+#[test]
+fn terminal_theme_events_apply_typed_and_hysteretic_updates() {
+    let original = crate::themes::current_theme_name();
+    crate::themes::set_theme_by_name("dark").expect("built-in dark theme");
+    let mut app = new_test_app();
+    app.theme_follower = Some(crate::themes::osc11::AutoThemeFollower::new("dark"));
+
+    assert!(
+        app.apply_terminal_theme_event(&AppTerminalEvent::ColorScheme(
+            uncurses::event::ColorScheme::Light
+        ))
+    );
+    assert_eq!(crate::themes::current_theme_name(), "light");
+    assert_eq!(
+        app.theme_follower
+            .as_ref()
+            .map(|follower| follower.current()),
+        Some("light")
+    );
+
+    crate::themes::set_theme_by_name("dark").expect("built-in dark theme");
+    app.theme_follower = Some(crate::themes::osc11::AutoThemeFollower::new("dark"));
+    let light_background = AppTerminalEvent::BackgroundColor {
+        red: 255,
+        green: 255,
+        blue: 255,
+    };
+    assert!(!app.apply_terminal_theme_event(&light_background));
+    assert!(app.apply_terminal_theme_event(&light_background));
+    assert_eq!(crate::themes::current_theme_name(), "light");
+
+    crate::themes::set_theme_by_name(&original).expect("restore original theme");
+}
+
+#[test]
 fn test_active_modal_variants_exist() {
     // Ensure all modal variants are defined correctly
     let modals = [

--- a/packages/tui-rs/src/config.rs
+++ b/packages/tui-rs/src/config.rs
@@ -353,10 +353,9 @@ pub struct TuiConfig {
     /// Suppress desktop notifications while the terminal window is focused
     /// (only when the terminal reports focus in/out events). Defaults to true.
     pub focus_gated_notifications: Option<bool>,
-    /// When true (default false), start in the `auto` theme and refine its
-    /// dark/light choice with a one-time OSC 11 background-color probe at
-    /// startup (enhanced terminals only). Live polling is intentionally not
-    /// done — see `themes::osc11` for why.
+    /// When true (default false), follow live terminal light/dark and
+    /// background-color reports through the protocol-aware input reader.
+    /// Falls back to a one-time OSC 11 probe when that reader is unavailable.
     pub theme_follow: Option<bool>,
 }
 

--- a/packages/tui-rs/src/terminal/events.rs
+++ b/packages/tui-rs/src/terminal/events.rs
@@ -26,9 +26,19 @@
 //! to work with in the application layer and can be serialized for IPC communication.
 
 use crossterm::event::{
-    Event, EventStream, KeyCode, KeyEvent, KeyEventKind, MouseEvent, MouseEventKind,
+    Event, EventStream, KeyCode, KeyEvent, KeyEventKind, KeyEventState,
+    KeyModifiers as CrosstermKeyModifiers, MouseButton, MouseEvent, MouseEventKind,
 };
+use std::collections::VecDeque;
+use std::io;
+use std::time::Duration;
 use tokio_stream::StreamExt;
+use uncurses::event::{
+    ColorScheme, Event as UncursesEvent, EventSource, Key as UncursesKey,
+    KeyCode as UncursesKeyCode, KeyModifiers as UncursesKeyModifiers, Mouse as UncursesMouse,
+    MouseButton as UncursesMouseButton,
+};
+use uncurses::terminal::TtyInput;
 
 use crate::protocol::KeyModifiers;
 
@@ -144,6 +154,252 @@ impl Default for TerminalEventStream {
     }
 }
 
+/// Rich terminal events used by the interactive app.
+///
+/// Unlike crossterm 0.28, uncurses decodes terminal query replies as typed
+/// events. That lets the app query color-scheme capabilities without leaking
+/// reply bytes into the composer.
+#[derive(Debug)]
+pub(crate) enum AppTerminalEvent {
+    Key(KeyEvent),
+    Mouse(MouseEvent),
+    Paste(String),
+    Resize { height: u16 },
+    FocusGained,
+    FocusLost,
+    BackgroundColor { red: u8, green: u8, blue: u8 },
+    ColorScheme(ColorScheme),
+    ThemeReportingAvailable(bool),
+}
+
+impl AppTerminalEvent {
+    /// Preserve the legacy crossterm path as a fallback when the controlling
+    /// terminal cannot be opened by uncurses.
+    pub(crate) fn from_crossterm(event: Event) -> Option<Self> {
+        match event {
+            Event::Key(key) => Some(Self::Key(key)),
+            Event::Mouse(mouse) => Some(Self::Mouse(mouse)),
+            Event::Paste(text) => Some(Self::Paste(text)),
+            Event::Resize(_, height) => Some(Self::Resize { height }),
+            Event::FocusGained => Some(Self::FocusGained),
+            Event::FocusLost => Some(Self::FocusLost),
+        }
+    }
+}
+
+/// Synchronous uncurses event reader for the main render loop.
+pub(crate) struct TerminalEventReader {
+    source: EventSource<TtyInput>,
+    state: EventConversionState,
+}
+
+#[derive(Default)]
+struct EventConversionState {
+    pending: VecDeque<UncursesEvent>,
+    paste: Option<Vec<u8>>,
+}
+
+impl TerminalEventReader {
+    /// Open the controlling terminal and create a protocol-aware event source.
+    pub(crate) fn open() -> io::Result<Self> {
+        let terminal = uncurses::terminal::Terminal::open()?;
+        Ok(Self {
+            source: EventSource::new(terminal.input())?,
+            state: EventConversionState::default(),
+        })
+    }
+
+    /// Poll for one application event.
+    ///
+    /// Query replies unsupported by the application are deliberately consumed
+    /// here rather than reinterpreted as user input.
+    pub(crate) fn poll(&mut self, timeout: Duration) -> io::Result<Option<AppTerminalEvent>> {
+        if self.state.pending.is_empty() && !self.source.poll(Some(timeout))? {
+            return Ok(None);
+        }
+
+        while let Some(event) = self
+            .state
+            .pending
+            .pop_front()
+            .or_else(|| self.source.try_read())
+        {
+            if let Some(event) = self.state.convert_event(event) {
+                return Ok(Some(event));
+            }
+        }
+        Ok(None)
+    }
+}
+
+impl EventConversionState {
+    fn convert_event(&mut self, event: UncursesEvent) -> Option<AppTerminalEvent> {
+        match event {
+            UncursesEvent::KeyPress(key) => {
+                convert_uncurses_key(key, KeyEventKind::Press).map(AppTerminalEvent::Key)
+            }
+            UncursesEvent::KeyRepeat(key) => {
+                convert_uncurses_key(key, KeyEventKind::Repeat).map(AppTerminalEvent::Key)
+            }
+            UncursesEvent::KeyRelease(_) => None,
+            UncursesEvent::MouseClick(mouse) => {
+                convert_uncurses_mouse(mouse, false).map(AppTerminalEvent::Mouse)
+            }
+            UncursesEvent::MouseRelease(mouse) => {
+                convert_uncurses_mouse(mouse, true).map(AppTerminalEvent::Mouse)
+            }
+            UncursesEvent::MouseWheel(mouse) => {
+                convert_uncurses_mouse(mouse, false).map(AppTerminalEvent::Mouse)
+            }
+            UncursesEvent::MouseMove(_) => None,
+            UncursesEvent::Resize(size) => Some(AppTerminalEvent::Resize { height: size.row }),
+            UncursesEvent::FocusIn => Some(AppTerminalEvent::FocusGained),
+            UncursesEvent::FocusOut => Some(AppTerminalEvent::FocusLost),
+            UncursesEvent::PasteStart => {
+                self.paste = Some(Vec::new());
+                None
+            }
+            UncursesEvent::PasteChunk(chunk) => {
+                self.paste.get_or_insert_with(Vec::new).extend(chunk);
+                None
+            }
+            UncursesEvent::PasteEnd => self
+                .paste
+                .take()
+                .map(|bytes| AppTerminalEvent::Paste(String::from_utf8_lossy(&bytes).into_owned())),
+            UncursesEvent::BackgroundColor(color) => {
+                let (red, green, blue) = color.to_rgb();
+                Some(AppTerminalEvent::BackgroundColor { red, green, blue })
+            }
+            UncursesEvent::ColorScheme(scheme) => Some(AppTerminalEvent::ColorScheme(scheme)),
+            UncursesEvent::ModeReport { mode, setting }
+                if mode == uncurses::ansi::mode::Mode::LIGHT_DARK =>
+            {
+                Some(AppTerminalEvent::ThemeReportingAvailable(
+                    setting.is_available(),
+                ))
+            }
+            UncursesEvent::Multi(events) => {
+                self.pending.extend(events);
+                None
+            }
+            _ => None,
+        }
+    }
+}
+
+fn convert_uncurses_key(key: UncursesKey, kind: KeyEventKind) -> Option<KeyEvent> {
+    let code = if key.code == UncursesKeyCode::Tab
+        && key.modifiers.contains(UncursesKeyModifiers::SHIFT)
+    {
+        KeyCode::BackTab
+    } else if matches!(key.code, UncursesKeyCode::Char(_)) {
+        match key.text.as_deref() {
+            Some(text) => {
+                let mut chars = text.chars();
+                match (chars.next(), chars.next()) {
+                    (Some(character), None) if !character.is_control() => KeyCode::Char(character),
+                    _ => convert_uncurses_key_code(key.code)?,
+                }
+            }
+            None => convert_uncurses_key_code(key.code)?,
+        }
+    } else {
+        convert_uncurses_key_code(key.code)?
+    };
+    Some(KeyEvent {
+        code,
+        modifiers: convert_uncurses_modifiers(key.modifiers),
+        kind,
+        state: KeyEventState::NONE,
+    })
+}
+
+fn convert_uncurses_key_code(code: UncursesKeyCode) -> Option<KeyCode> {
+    Some(match code {
+        UncursesKeyCode::Char(character) => KeyCode::Char(character),
+        UncursesKeyCode::F(number) => KeyCode::F(number),
+        UncursesKeyCode::Up | UncursesKeyCode::KpUp => KeyCode::Up,
+        UncursesKeyCode::Down | UncursesKeyCode::KpDown => KeyCode::Down,
+        UncursesKeyCode::Left | UncursesKeyCode::KpLeft => KeyCode::Left,
+        UncursesKeyCode::Right | UncursesKeyCode::KpRight => KeyCode::Right,
+        UncursesKeyCode::Home | UncursesKeyCode::KpHome => KeyCode::Home,
+        UncursesKeyCode::End | UncursesKeyCode::KpEnd => KeyCode::End,
+        UncursesKeyCode::PageUp | UncursesKeyCode::KpPageUp => KeyCode::PageUp,
+        UncursesKeyCode::PageDown | UncursesKeyCode::KpPageDown => KeyCode::PageDown,
+        UncursesKeyCode::Backspace => KeyCode::Backspace,
+        UncursesKeyCode::Delete | UncursesKeyCode::KpDelete => KeyCode::Delete,
+        UncursesKeyCode::Insert | UncursesKeyCode::KpInsert => KeyCode::Insert,
+        UncursesKeyCode::Tab => KeyCode::Tab,
+        UncursesKeyCode::Enter | UncursesKeyCode::KpEnter => KeyCode::Enter,
+        UncursesKeyCode::Space => KeyCode::Char(' '),
+        UncursesKeyCode::Escape => KeyCode::Esc,
+        UncursesKeyCode::KpAdd => KeyCode::Char('+'),
+        UncursesKeyCode::KpSubtract => KeyCode::Char('-'),
+        UncursesKeyCode::KpMultiply => KeyCode::Char('*'),
+        UncursesKeyCode::KpDivide => KeyCode::Char('/'),
+        UncursesKeyCode::KpDecimal => KeyCode::Char('.'),
+        UncursesKeyCode::KpEqual => KeyCode::Char('='),
+        UncursesKeyCode::KpSeparator => KeyCode::Char(','),
+        UncursesKeyCode::Kp0 => KeyCode::Char('0'),
+        UncursesKeyCode::Kp1 => KeyCode::Char('1'),
+        UncursesKeyCode::Kp2 => KeyCode::Char('2'),
+        UncursesKeyCode::Kp3 => KeyCode::Char('3'),
+        UncursesKeyCode::Kp4 => KeyCode::Char('4'),
+        UncursesKeyCode::Kp5 => KeyCode::Char('5'),
+        UncursesKeyCode::Kp6 => KeyCode::Char('6'),
+        UncursesKeyCode::Kp7 => KeyCode::Char('7'),
+        UncursesKeyCode::Kp8 => KeyCode::Char('8'),
+        UncursesKeyCode::Kp9 => KeyCode::Char('9'),
+        _ => return None,
+    })
+}
+
+fn convert_uncurses_modifiers(modifiers: UncursesKeyModifiers) -> CrosstermKeyModifiers {
+    let mut converted = CrosstermKeyModifiers::empty();
+    for (source, target) in [
+        (UncursesKeyModifiers::SHIFT, CrosstermKeyModifiers::SHIFT),
+        (UncursesKeyModifiers::ALT, CrosstermKeyModifiers::ALT),
+        (UncursesKeyModifiers::CTRL, CrosstermKeyModifiers::CONTROL),
+        (UncursesKeyModifiers::META, CrosstermKeyModifiers::META),
+        (UncursesKeyModifiers::SUPER, CrosstermKeyModifiers::SUPER),
+        (UncursesKeyModifiers::HYPER, CrosstermKeyModifiers::HYPER),
+    ] {
+        if modifiers.contains(source) {
+            converted.insert(target);
+        }
+    }
+    converted
+}
+
+fn convert_uncurses_mouse(mouse: UncursesMouse, release: bool) -> Option<MouseEvent> {
+    let kind = match mouse.button {
+        UncursesMouseButton::WheelUp => MouseEventKind::ScrollUp,
+        UncursesMouseButton::WheelDown => MouseEventKind::ScrollDown,
+        UncursesMouseButton::WheelLeft => MouseEventKind::ScrollLeft,
+        UncursesMouseButton::WheelRight => MouseEventKind::ScrollRight,
+        UncursesMouseButton::Left => button_event(MouseButton::Left, release),
+        UncursesMouseButton::Middle => button_event(MouseButton::Middle, release),
+        UncursesMouseButton::Right => button_event(MouseButton::Right, release),
+        UncursesMouseButton::None => MouseEventKind::Moved,
+        _ => return None,
+    };
+    Some(MouseEvent {
+        kind,
+        column: mouse.x,
+        row: mouse.y,
+        modifiers: convert_uncurses_modifiers(mouse.modifiers),
+    })
+}
+
+fn button_event(button: MouseButton, release: bool) -> MouseEventKind {
+    if release {
+        MouseEventKind::Up(button)
+    } else {
+        MouseEventKind::Down(button)
+    }
+}
+
 /// Convert crossterm event to our normalized event type.
 ///
 /// This function maps crossterm's raw events to our simplified `TerminalEvent` enum,
@@ -239,6 +495,9 @@ fn key_code_to_string(code: KeyCode) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uncurses::event::{
+        Key as UncursesKey, KeyCode as UncursesKeyCode, KeyModifiers as UncursesKeyModifiers,
+    };
 
     #[test]
     fn test_key_code_to_string() {
@@ -252,5 +511,145 @@ mod tests {
         );
         assert_eq!(key_code_to_string(KeyCode::F(1)), Some("F1".to_string()));
         assert_eq!(key_code_to_string(KeyCode::Null), None);
+    }
+
+    #[test]
+    fn uncurses_shifted_text_preserves_the_typed_character() {
+        let mut key = UncursesKey::new(UncursesKeyCode::Char('/'), UncursesKeyModifiers::SHIFT);
+        key.text = Some("?".to_string());
+
+        let converted = convert_uncurses_key(key, crossterm::event::KeyEventKind::Press)
+            .expect("printable key should convert");
+
+        assert_eq!(converted.code, KeyCode::Char('?'));
+        assert!(converted
+            .modifiers
+            .contains(crossterm::event::KeyModifiers::SHIFT));
+    }
+
+    #[test]
+    fn uncurses_named_keys_ignore_protocol_text() {
+        let mut key = UncursesKey::new(UncursesKeyCode::Enter, UncursesKeyModifiers::empty());
+        key.text = Some("\r".to_string());
+
+        let converted = convert_uncurses_key(key, crossterm::event::KeyEventKind::Press)
+            .expect("named key should convert");
+
+        assert_eq!(converted.code, KeyCode::Enter);
+    }
+
+    #[test]
+    fn uncurses_control_characters_keep_their_logical_key() {
+        let mut key = UncursesKey::new(UncursesKeyCode::Char('c'), UncursesKeyModifiers::CTRL);
+        key.text = Some("\u{3}".to_string());
+
+        let converted = convert_uncurses_key(key, crossterm::event::KeyEventKind::Press)
+            .expect("control key should convert");
+
+        assert_eq!(converted.code, KeyCode::Char('c'));
+        assert!(converted
+            .modifiers
+            .contains(crossterm::event::KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn uncurses_modifier_mapping_keeps_modern_modifier_bits() {
+        let key = UncursesKey::new(
+            UncursesKeyCode::Char('x'),
+            UncursesKeyModifiers::CTRL
+                | UncursesKeyModifiers::ALT
+                | UncursesKeyModifiers::META
+                | UncursesKeyModifiers::SUPER
+                | UncursesKeyModifiers::HYPER,
+        );
+
+        let converted = convert_uncurses_key(key, crossterm::event::KeyEventKind::Press)
+            .expect("character key should convert");
+
+        let modifiers = converted.modifiers;
+        assert!(modifiers.contains(crossterm::event::KeyModifiers::CONTROL));
+        assert!(modifiers.contains(crossterm::event::KeyModifiers::ALT));
+        assert!(modifiers.contains(crossterm::event::KeyModifiers::META));
+        assert!(modifiers.contains(crossterm::event::KeyModifiers::SUPER));
+        assert!(modifiers.contains(crossterm::event::KeyModifiers::HYPER));
+    }
+
+    #[test]
+    fn uncurses_paste_chunks_are_reassembled_lossily() {
+        let mut state = EventConversionState::default();
+        assert!(state.convert_event(UncursesEvent::PasteStart).is_none());
+        assert!(state
+            .convert_event(UncursesEvent::PasteChunk(vec![b'a', 0xff]))
+            .is_none());
+
+        let event = state
+            .convert_event(UncursesEvent::PasteEnd)
+            .expect("paste end should emit the assembled paste");
+        assert!(matches!(event, AppTerminalEvent::Paste(text) if text == "a\u{fffd}"));
+    }
+
+    #[test]
+    fn uncurses_multi_events_preserve_fifo_order() {
+        let mut state = EventConversionState::default();
+        assert!(state
+            .convert_event(UncursesEvent::Multi(vec![
+                UncursesEvent::FocusIn,
+                UncursesEvent::Resize(uncurses::terminal::Winsize {
+                    row: 42,
+                    col: 120,
+                    xpixel: 0,
+                    ypixel: 0,
+                }),
+            ]))
+            .is_none());
+
+        let first = state.pending.pop_front().expect("first nested event");
+        let second = state.pending.pop_front().expect("second nested event");
+        assert!(matches!(
+            state.convert_event(first),
+            Some(AppTerminalEvent::FocusGained)
+        ));
+        assert!(matches!(
+            state.convert_event(second),
+            Some(AppTerminalEvent::Resize { height: 42 })
+        ));
+    }
+
+    #[test]
+    fn uncurses_theme_replies_stay_typed() {
+        let mut state = EventConversionState::default();
+        assert!(matches!(
+            state.convert_event(UncursesEvent::BackgroundColor(uncurses::color::Color::Rgb(
+                1, 2, 3
+            ))),
+            Some(AppTerminalEvent::BackgroundColor {
+                red: 1,
+                green: 2,
+                blue: 3
+            })
+        ));
+        assert!(matches!(
+            state.convert_event(UncursesEvent::ColorScheme(ColorScheme::Light)),
+            Some(AppTerminalEvent::ColorScheme(ColorScheme::Light))
+        ));
+        assert!(matches!(
+            state.convert_event(UncursesEvent::ModeReport {
+                mode: uncurses::ansi::mode::Mode::LIGHT_DARK,
+                setting: uncurses::ansi::mode::ModeSetting::Set,
+            }),
+            Some(AppTerminalEvent::ThemeReportingAvailable(true))
+        ));
+    }
+
+    #[test]
+    fn crossterm_fallback_keeps_resize_and_focus_events() {
+        assert!(matches!(
+            AppTerminalEvent::from_crossterm(Event::Resize(120, 42)),
+            Some(AppTerminalEvent::Resize { height: 42 })
+        ));
+        assert!(matches!(
+            AppTerminalEvent::from_crossterm(Event::FocusLost),
+            Some(AppTerminalEvent::FocusLost)
+        ));
     }
 }

--- a/packages/tui-rs/src/terminal/mod.rs
+++ b/packages/tui-rs/src/terminal/mod.rs
@@ -52,9 +52,11 @@ mod events;
 mod history;
 mod setup;
 
+pub(crate) use events::{AppTerminalEvent, TerminalEventReader};
 pub use events::{TerminalEvent, TerminalEventStream};
 pub use history::push_history_lines;
 pub use setup::{
     calculate_viewport, check_tty, init, init_fallback, is_tty_available, recreate_with_viewport,
     restore, size, write_raw, Terminal, TerminalCapabilities,
 };
+pub(crate) use setup::{disable_theme_reporting, enable_theme_reporting, query_theme};

--- a/packages/tui-rs/src/terminal/setup.rs
+++ b/packages/tui-rs/src/terminal/setup.rs
@@ -69,6 +69,11 @@ use crossterm::{
 };
 use ratatui::backend::CrosstermBackend;
 use ratatui::{TerminalOptions, Viewport};
+use uncurses::ansi::color::REQUEST_BACKGROUND_COLOR;
+use uncurses::ansi::mode::{self, Mode};
+use uncurses::ansi::status::REQUEST_LIGHT_DARK_REPORT;
+
+use crate::sync_output::EndSynchronizedUpdate;
 
 /// Global terminal device handle for terminal output.
 ///
@@ -324,6 +329,54 @@ pub fn write_raw(data: &str) -> io::Result<()> {
     Ok(())
 }
 
+/// Enable live light/dark reports and request the terminal's current theme.
+pub(crate) fn enable_theme_reporting() -> io::Result<()> {
+    write_raw_bytes(&theme_reporting_enable_sequence()?)
+}
+
+/// Request the terminal's current light/dark preference and background color.
+pub(crate) fn query_theme() -> io::Result<()> {
+    write_raw_bytes(&theme_query_sequence())
+}
+
+/// Stop live light/dark reports.
+pub(crate) fn disable_theme_reporting() -> io::Result<()> {
+    write_raw_bytes(&theme_reporting_disable_sequence()?)
+}
+
+fn theme_reporting_enable_sequence() -> io::Result<Vec<u8>> {
+    let mut data = Vec::new();
+    mode::write_set_mode(&mut data, &[Mode::LIGHT_DARK])?;
+    mode::write_request_mode(&mut data, Mode::LIGHT_DARK)?;
+    data.extend_from_slice(&theme_query_sequence());
+    Ok(data)
+}
+
+fn theme_query_sequence() -> Vec<u8> {
+    let mut data =
+        Vec::with_capacity(REQUEST_LIGHT_DARK_REPORT.len() + REQUEST_BACKGROUND_COLOR.len());
+    data.extend_from_slice(REQUEST_LIGHT_DARK_REPORT);
+    data.extend_from_slice(REQUEST_BACKGROUND_COLOR);
+    data
+}
+
+fn theme_reporting_disable_sequence() -> io::Result<Vec<u8>> {
+    let mut data = Vec::new();
+    mode::write_reset_mode(&mut data, &[Mode::LIGHT_DARK])?;
+    Ok(data)
+}
+
+fn write_raw_bytes(data: &[u8]) -> io::Result<()> {
+    let mut guard = TTY
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(ref mut tty) = *guard {
+        tty.write_all(data)?;
+        tty.flush()?;
+    }
+    Ok(())
+}
+
 fn restore_impl() -> io::Result<()> {
     // Get the TTY handle - recover from poisoned lock to ensure terminal cleanup
     let mut guard = TTY
@@ -331,6 +384,11 @@ fn restore_impl() -> io::Result<()> {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     if let Some(ref mut tty) = *guard {
+        // Never leave a terminal holding a synchronized frame or subscribed
+        // to live light/dark notifications, including from the panic hook.
+        let _ = execute!(tty, EndSynchronizedUpdate);
+        let _ = mode::write_reset_mode(tty, &[Mode::LIGHT_DARK]);
+
         // Pop keyboard enhancement flags
         let _ = execute!(tty, PopKeyboardEnhancementFlags);
 
@@ -422,6 +480,15 @@ pub fn recreate_with_viewport(viewport_height: u16) -> io::Result<Terminal> {
 
 #[cfg(test)]
 mod tests {
-    // Note: Terminal tests are tricky because they require an actual TTY
-    // These would typically be integration tests
+    use super::*;
+
+    #[test]
+    fn theme_reporting_sequences_are_balanced_and_query_both_signals() {
+        assert_eq!(
+            theme_reporting_enable_sequence().unwrap(),
+            b"\x1b[?2031h\x1b[?2031$p\x1b[?996n\x1b]11;?\x07"
+        );
+        assert_eq!(theme_query_sequence(), b"\x1b[?996n\x1b]11;?\x07");
+        assert_eq!(theme_reporting_disable_sequence().unwrap(), b"\x1b[?2031l");
+    }
 }

--- a/packages/tui-rs/src/themes/mod.rs
+++ b/packages/tui-rs/src/themes/mod.rs
@@ -93,9 +93,9 @@
 //!
 //! # The `auto` Theme
 //!
-//! `auto` resolves to `dark` or `light` from the terminal's reported
-//! background: `COLORFGBG` always, refined by a one-time OSC 11 probe at
-//! startup when `tui.theme_follow = true` (see [`osc11`]).
+//! `auto` resolves to `dark` or `light` from `COLORFGBG`. With
+//! `tui.theme_follow = true`, typed OSC 11 and DEC light/dark events keep it
+//! synchronized with the terminal (see [`osc11`]).
 
 use ratatui::style::{Color, Style};
 use serde::{Deserialize, Serialize};

--- a/packages/tui-rs/src/themes/osc11.rs
+++ b/packages/tui-rs/src/themes/osc11.rs
@@ -1,33 +1,11 @@
 //! OSC 11 terminal background-color probing for the `auto` theme.
 //!
-//! # Why a one-time startup probe instead of live polling
-//!
-//! The goal (grok-build parity) is for the `auto` theme to *follow* the
-//! terminal background live, re-querying with OSC 11 (`ESC ] 11 ; ? ESC \`)
-//! every few seconds. That is not safely implementable on this codebase's
-//! input stack:
-//!
-//! - The reply arrives on the same tty input stream as user keystrokes, and
-//!   crossterm 0.28 has no OSC event variant. Its parser
-//!   (`crossterm::event::sys::unix::parse::parse_event`) treats any
-//!   `ESC ] …` sequence as an Alt-modified key: an OSC 11 reply read by
-//!   crossterm first becomes `Alt+]` followed by the literal reply text
-//!   (`11;rgb:…`) typed into the composer.
-//! - Interposing our own stdin/`/dev/tty` reader races crossterm's internal
-//!   mio-based reader on the same file descriptor: whichever side reads
-//!   first keeps the bytes, and bytes we consume cannot be pushed back into
-//!   crossterm's buffer — so a peek reader would occasionally eat user
-//!   keystrokes.
-//!
-//! Until the input stack can surface OSC replies, `auto` therefore resolves
-//! from `COLORFGBG` and, when `tui.theme_follow = true` and the terminal
-//! supports the enhanced keyboard protocol, refines that choice with a
-//! single bounded OSC 11 probe at startup (before the event loop starts
-//! consuming input, so no reader race exists).
-//!
-//! The luminance threshold/hysteresis state machine ([`AutoThemeFollower`])
-//! is kept separate and fully tested so a future safe reply path can drive
-//! live following without re-deriving the policy.
+//! The interactive app uses uncurses as its sole tty reader, so OSC 11 and
+//! DEC light/dark replies arrive as typed events instead of being mistaken
+//! for Alt-modified input by crossterm 0.28. [`AutoThemeFollower`] applies
+//! hysteresis to those live readings. The bounded one-time probe remains as
+//! a compatibility fallback when the controlling tty cannot be opened by
+//! uncurses.
 
 use std::io::Write;
 use std::time::Duration;
@@ -112,8 +90,8 @@ pub fn theme_for_luminance(luminance: f64, current: &'static str) -> &'static st
 /// stream of luminance samples: a flip requires
 /// [`REQUIRED_CONSECUTIVE_READINGS`] consecutive samples past the threshold.
 ///
-/// Not wired to a live source yet — see the module docs for why. Kept pub
-/// (and tested) so a future OSC-reply-capable input stack can drive it.
+/// Driven by the uncurses terminal event reader when live theme following is
+/// enabled.
 pub struct AutoThemeFollower {
     current: &'static str,
     pending: Option<&'static str>,
@@ -233,8 +211,8 @@ pub fn probe_terminal_background(_timeout: Duration) -> Option<(u8, u8, u8)> {
 /// Resolve the initial `auto` theme: `COLORFGBG` first, refined by a
 /// one-time OSC 11 probe when the terminal answers in time.
 ///
-/// Intended to run once at startup, gated on `tui.theme_follow = true` and
-/// an enhanced terminal, before the event loop begins (see module docs).
+/// Compatibility fallback used when the protocol-aware terminal reader cannot
+/// be opened. It must run before the crossterm event loop begins.
 pub fn apply_auto_theme_from_terminal() {
     let seed = super::resolve_auto_theme_name();
     let resolved = probe_terminal_background(PROBE_TIMEOUT)


### PR DESCRIPTION
## Summary

- Terminal input now has one protocol-aware reader, so modern keyboard metadata, paste, focus, mouse, resize, and terminal theme replies are decoded without OSC replies leaking into the composer.
- Automatic themes can follow live light/dark changes, while synchronized frame updates reduce partial-frame tearing. Crossterm remains the fallback, and `MAESTRO_UNCURSES_INPUT=0` is an immediate kill switch.
- Terminal protocol modes are balanced during normal and error cleanup so Maestro returns the shell to a usable state.

## Checklist

- [x] `cargo fmt --all -- --check` and package clippy
- [x] `cargo test -p maestro-tui --lib -- --test-threads=1` (3,477 passed)
- [x] `cargo check -p maestro-tui --all-targets`
- [x] Staging is unnecessary for this local TUI path: uncurses initialization falls back safely, and the environment kill switch restores the previous reader without a new build.

## Optional

- [ ] Add the `run-evals` label to run evals on this PR (otherwise evals are skipped on PRs).
- [ ] Add the `skip-integration` label to skip integration tests when appropriate (include justification in the PR body).
- [ ] If skipping CI validators (`[skip ci]`, `[skip nix]`), explain why below.

## Post-Deploy Monitoring & Validation

- Validate prompt submission, shifted punctuation, control chords, paste, resize, mouse/focus events, and dark/light transitions in the first release containing this change.
- Treat input freezes, protocol text appearing in the composer, theme changes while `theme_follow` is off, partial frames, or a shell left in raw mode as rollback signals.
- First mitigation: set `MAESTRO_UNCURSES_INPUT=0`. Revert this change if reports are widespread or the fallback does not restore normal behavior.
- Review Maestro issue reports for one release cycle and the following seven days; the Maestro maintainers own the check.

## New concepts

### One owner for terminal input

Terminal replies and user keystrokes share the same byte stream. Letting two parsers read that stream creates a race: whichever reader wins consumes bytes the other can never recover.

This change gives uncurses sole ownership of the controlling terminal input and translates its typed events into Maestro's existing crossterm-shaped application events. That preserves the current widget and keybinding layers while allowing OSC and DEC replies to coexist safely with ordinary input.

Use this pattern when an application both queries terminal capabilities and accepts interactive input. It is unnecessary for simple line-oriented commands that never request terminal replies.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/evalops/maestro/pull/885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->