### PR TITLE
CI: restore fail-closed required context reporters

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -55,3 +55,62 @@ jobs:
 
       - name: Run actionlint
         run: actionlint -shellcheck= -pyflakes=
+
+      - name: Set up Node.js for workflow contract tests
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: 22
+
+      - name: Run required-context contract tests
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import assert from "node:assert/strict";
+          import { readFileSync } from "node:fs";
+          import { evaluateIntegrationRequiredGate } from "./scripts/check-integration-required-gate.mjs";
+
+          function jobBlock(workflow, job) {
+            return workflow.match(
+              new RegExp(`^  ${job}:\\n([\\s\\S]*?)(?=^  [a-z][a-z0-9-]+:\\n|(?![\\s\\S]))`, "m"),
+            )?.[0] ?? "";
+          }
+
+          assert.equal(evaluateIntegrationRequiredGate({
+            pathCheckResult: "success",
+            integrationPathsChanged: "false",
+            integrationSuiteResult: "skipped",
+          }).ok, true);
+          assert.equal(evaluateIntegrationRequiredGate({
+            pathCheckResult: "success",
+            integrationPathsChanged: "true",
+            integrationSuiteResult: "success",
+          }).ok, true);
+          assert.equal(evaluateIntegrationRequiredGate({
+            pathCheckResult: "success",
+            integrationPathsChanged: "true",
+            integrationSuiteResult: "failure",
+          }).ok, false);
+
+          const integration = readFileSync(".github/workflows/integration.yml", "utf8");
+          const suite = jobBlock(integration, "integration-suite");
+          const integrationGate = jobBlock(integration, "integration-tests");
+          assert.match(suite, /integration_paths_changed == 'true'/);
+          assert.match(suite, /cargo test --locked -p maestro-control-plane/);
+          assert.match(integrationGate, /needs: \[pull-request-path-check, integration-suite\]/);
+          assert.match(integrationGate, /if: \$\{\{ always\(\) \}\}/);
+          assert.match(integrationGate, /run: node scripts\/check-integration-required-gate\.mjs/);
+
+          const publish = readFileSync(".github/workflows/ghcr-publish.yml", "utf8");
+          const publishImage = jobBlock(publish, "publish-image");
+          const publishGate = jobBlock(publish, "build-and-publish");
+          assert.match(publishImage, /if: github\.event_name == 'push'/);
+          assert.match(publishImage, /packages: write/);
+          assert.match(publishImage, /push: true/);
+          assert.match(publishImage, /maestro_runtime_image_published/);
+          assert.match(publishGate, /needs: publish-image/);
+          assert.match(publishGate, /if: \$\{\{ always\(\) \}\}/);
+          assert.match(publishGate, /permissions: \{\}/);
+          assert.match(publishGate, /PUBLISH_RESULT: \$\{\{ needs\.publish-image\.result \}\}/);
+          assert.match(publishGate, /github\.event\.pull_request\.head\.repo\.id != github\.event\.repository\.id && 'ubuntu-latest'/);
+          assert.doesNotMatch(publishGate, /packages: write|docker\/login-action|docker\/build-push-action|repos\/evalops\/deploy\/dispatches/);
+          NODE

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -14,7 +14,7 @@ env:
   IMAGE_NAME: ghcr.io/evalops/maestro
 
 jobs:
-  build-and-publish:
+  publish-image:
     if: github.event_name == 'push'
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.repository.id && 'ubuntu-latest' || (github.event_name == 'pull_request' && (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest')) }}
     # Internal main-push image builds can take longer than the public mirror on
@@ -78,3 +78,38 @@ jobs:
             -f event_type=maestro_runtime_image_published \
             -f "client_payload[source_sha]=${SOURCE_SHA}" \
             -f "client_payload[image_tag]=${image_tag}"
+
+  # Branch protection requires this context on pull requests. Keep the
+  # mutating publisher above push-only and expose its result through a
+  # read-only, always-reporting gate.
+  build-and-publish:
+    needs: publish-image
+    if: ${{ always() }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.repository.id && 'ubuntu-latest' || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') }}
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Validate required publication gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_RESULT: ${{ needs.publish-image.result }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            push)
+              if [[ "$PUBLISH_RESULT" != "success" ]]; then
+                echo "publish-image did not succeed on a main push: $PUBLISH_RESULT" >&2
+                exit 1
+              fi
+              ;;
+            pull_request)
+              if [[ "$PUBLISH_RESULT" != "skipped" ]]; then
+                echo "publish-image must remain skipped on pull requests: $PUBLISH_RESULT" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "unsupported GHCR publication event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,9 +60,12 @@ jobs:
 
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
-  integration-tests:
+  integration-suite:
     needs: pull-request-path-check
-    if: ${{ needs.pull-request-path-check.outputs.integration_paths_changed == 'true' && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-integration')) }}
+    # Keep the expensive service-container suite scoped to integration-relevant
+    # changes. The required integration-tests job below always materializes and
+    # converts this conditional result into an explicit pass or failure.
+    if: ${{ needs.pull-request-path-check.outputs.integration_paths_changed == 'true' }}
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.repository.id && 'ubuntu-latest' || (github.event_name == 'pull_request' && (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest')) }}
     timeout-minutes: 45
     services:
@@ -108,6 +111,27 @@ jobs:
           PGPASSWORD: maestro
         run: |
           cargo test --locked -p maestro-control-plane
+
+  integration-tests:
+    needs: [pull-request-path-check, integration-suite]
+    if: ${{ always() }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.repository.id && 'ubuntu-latest' || (vars.PUBLIC_PR_VALIDATION_RUNNER || vars.PR_CHECKS_RUNNER || 'ubuntu-latest') }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: 22
+
+      - name: Validate required integration gate
+        env:
+          PATH_CHECK_RESULT: ${{ needs.pull-request-path-check.result }}
+          INTEGRATION_PATHS_CHANGED: ${{ needs.pull-request-path-check.outputs.integration_paths_changed }}
+          INTEGRATION_SUITE_RESULT: ${{ needs.integration-suite.result }}
+        run: node scripts/check-integration-required-gate.mjs
 
   capability-gated-tests:
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-capability-integration') }}


### PR DESCRIPTION
## Summary
- separate conditional integration and publication work from their branch-protection reporter jobs
- keep required `integration-tests` and `build-and-publish` contexts always materialized and fail closed
- enforce fork-safe runners and executable workflow contract checks

## Validation
- `node --test scripts/check-integration-required-gate.test.mjs` (4/4 pass)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 -shellcheck= -pyflakes=`
- extracted inline required-context semantic contract
- `git diff --check`

## Boundaries
- no package publication or deployment
- no generated-source-owned helper changes
