### PR TITLE
ci: slim generated public mirror PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Generated public mirror PRs re-sync already-reviewed internal main. Full
+# cargo test / heavy lanes already ran on evalops/maestro-internal for that
+# SHA; re-running them here only burns 15–25 minutes and finds runner skew.
+# Detected via head branch name `sync/public-release-mirror`.
+env:
+  IS_GENERATED_MIRROR_PR: ${{ github.event_name == 'pull_request' && github.head_ref == 'sync/public-release-mirror' }}
+
 jobs:
   native-quality:
     runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
@@ -25,10 +32,21 @@ jobs:
     runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: ./.github/actions/setup-rust
+      - name: Skip full tests on generated mirror PR
+        if: ${{ env.IS_GENERATED_MIRROR_PR == 'true' }}
+        run: |
+          echo "Skipping cargo test on generated public mirror PR."
+          echo "Correctness for this tree already ran on evalops/maestro-internal for the mirrored source SHA."
+      - name: Checkout
+        if: ${{ env.IS_GENERATED_MIRROR_PR != 'true' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Setup Rust
+        if: ${{ env.IS_GENERATED_MIRROR_PR != 'true' }}
+        uses: ./.github/actions/setup-rust
         with: { toolchain: stable }
-      - run: cargo test --workspace --locked
+      - name: cargo test
+        if: ${{ env.IS_GENERATED_MIRROR_PR != 'true' }}
+        run: cargo test --workspace --locked
 
   native-release:
     runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -53,6 +53,12 @@ jobs:
               return "false";
             }
 
+            // Generated public mirror PRs re-sync already-evaluated internal main.
+            if (pull.head?.ref === "sync/public-release-mirror") {
+              core.info("Generated public mirror PR; skipping evals (ran on internal).");
+              return "false";
+            }
+
             const labels = new Set((pull.labels ?? []).map((label) => label.name));
             if (labels.has("run-evals")) {
               core.info("run-evals label present; running evals.");

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,6 +47,13 @@ jobs:
             exit 0
           fi
 
+          # Generated public mirror PRs re-sync already-integrated internal main.
+          if [ "${{ github.head_ref }}" = "sync/public-release-mirror" ]; then
+            echo "Generated public mirror PR; skipping integration suite."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           git fetch --no-tags --depth=1 origin "$BASE_REF"
           changed="false"
           while IFS= read -r path; do

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" != "pull_request" ]; then
@@ -48,7 +49,7 @@ jobs:
           fi
 
           # Generated public mirror PRs re-sync already-integrated internal main.
-          if [ "${{ github.head_ref }}" = "sync/public-release-mirror" ]; then
+          if [ "$HEAD_REF" = "sync/public-release-mirror" ]; then
             echo "Generated public mirror PR; skipping integration suite."
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,10 +9,19 @@ jobs:
   test:
     runs-on: ${{ vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 90
+    env:
+      IS_GENERATED_MIRROR_PR: ${{ github.event_name == 'pull_request' && github.head_ref == 'sync/public-release-mirror' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: ./.github/actions/setup-rust
         with: { toolchain: stable, components: "rustfmt,clippy" }
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
-      - run: cargo test --workspace --locked
+      - name: cargo test
+        if: ${{ env.IS_GENERATED_MIRROR_PR != 'true' }}
+        run: cargo test --workspace --locked
+      - name: Skip cargo test on generated mirror PR
+        if: ${{ env.IS_GENERATED_MIRROR_PR == 'true' }}
+        run: |
+          echo "Skipping cargo test on generated public mirror PR."
+          echo "Correctness for this tree already ran on evalops/maestro-internal."

--- a/.github/workflows/scenario-replay.yml
+++ b/.github/workflows/scenario-replay.yml
@@ -23,23 +23,37 @@ jobs:
       id-token: write
     runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.id != github.event.repository.id && 'ubuntu-latest' || (github.event_name == 'pull_request' && (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest') || (vars.PUBLIC_PR_VALIDATION_RUNNER || 'ubuntu-latest')) }}
     timeout-minutes: 15
+    env:
+      IS_GENERATED_MIRROR_PR: ${{ github.event_name == 'pull_request' && github.head_ref == 'sync/public-release-mirror' }}
     steps:
+      - name: Skip scenario replay on generated mirror PR
+        if: ${{ env.IS_GENERATED_MIRROR_PR == 'true' }}
+        run: |
+          echo "Skipping scenario replay on generated public mirror PR."
+          echo "Replay gate already ran on evalops/maestro-internal for the mirrored SHA."
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ env.IS_GENERATED_MIRROR_PR != 'true' }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        if: ${{ env.IS_GENERATED_MIRROR_PR != 'true' }}
         with: { node-version: 22 }
 
       - uses: ./.github/actions/setup-rust
+        if: ${{ env.IS_GENERATED_MIRROR_PR != 'true' }}
         with:
           toolchain: stable
 
       - name: Build native scenario runner
+        if: ${{ env.IS_GENERATED_MIRROR_PR != 'true' }}
         run: cargo build --locked -p maestro
 
       - name: Validate replay gate governance reporter
+        if: ${{ env.IS_GENERATED_MIRROR_PR != 'true' }}
         run: node --test scripts/scenario-replay-governance.test.mjs
 
       - name: Run replay gate scenario suite
+        if: ${{ env.IS_GENERATED_MIRROR_PR != 'true' }}
         env:
           MAESTRO_TOOL_EXECUTION_SERVICE_URL: ${{ vars.MAESTRO_TOOL_EXECUTION_SERVICE_URL }}
           MAESTRO_TOOL_EXECUTION_SERVICE_TOKEN: ${{ secrets.MAESTRO_TOOL_EXECUTION_SERVICE_TOKEN }}


### PR DESCRIPTION
## Summary

Skip full cargo test, evals, integration suite, and scenario-replay on `sync/public-release-mirror` PRs. Keep fmt/clippy, release smoke, and provenance.

## Test plan

- [ ] CI green
- [ ] Non-mirror PRs still run full matrix