### PR TITLE
fix(ci): green main for GHCR publish and release contract

### DIFF
--- a/.github/workflows/check-release-workflow-contract.mjs
+++ b/.github/workflows/check-release-workflow-contract.mjs
@@ -264,8 +264,15 @@ export function validateReleaseWorkflow(source) {
 			failures.push(`${name} permissions must be exactly contents: read`);
 		}
 	}
-	if (!hasExactPermissions(publish.permissions, { contents: "read" })) {
-		failures.push("publish permissions must be exactly contents: read");
+	if (
+		!hasExactPermissions(publish.permissions, {
+			contents: "read",
+			"id-token": "write",
+		})
+	) {
+		failures.push(
+			"publish permissions must be exactly contents: read and id-token: write",
+		);
 	}
 	if (!hasExactPermissions(release.permissions, { contents: "write" })) {
 		failures.push("github-release permissions must be exactly contents: write");
@@ -290,8 +297,10 @@ export function validateReleaseWorkflow(source) {
 		["github-release", release],
 		["post-publish-canary", canary],
 	]) {
-		if (job.runsOn !== "${{ vars.INTERNAL_CONFIRMATION_RUNNER }}") {
-			failures.push(`${name} must run on INTERNAL_CONFIRMATION_RUNNER`);
+		if (job.runsOn !== "${{ vars.PUBLIC_RELEASE_RUNNER || 'ubuntu-latest' }}") {
+			failures.push(
+				`${name} must run on PUBLIC_RELEASE_RUNNER with an ubuntu-latest fallback`,
+			);
 		}
 	}
 
@@ -482,28 +491,41 @@ export function validateReleaseWorkflow(source) {
 	) {
 		failures.push("token-backed npm publication must not be bypassed");
 	}
-	const tokenCalls = publishLines.filter(
+	const oidcCalls = topLevelPublishLines.filter(
+		(line) => line === "if publish_or_verify publish_with_oidc; then",
+	).length;
+	const tokenCalls = topLevelPublishLines.filter(
 		(line) => line === "publish_or_verify publish_with_token",
 	).length;
+	const oidcCallIndex = topLevelPublishLines.indexOf(
+		"if publish_or_verify publish_with_oidc; then",
+	);
 	const npmPublishLines = publishLines.filter((line) =>
-		line.startsWith("command npm publish "),
+		line.startsWith("npx --yes npm@11.10.0 publish "),
 	);
 	const expectedPublishLines = new Set([
-		'command npm publish "${{ steps.pack.outputs.tarball }}" --access public --registry "$NPM_CONFIG_REGISTRY"',
+		'npx --yes npm@11.10.0 publish "$TARBALL" --access public --registry "$NPM_CONFIG_REGISTRY"',
 	]);
 	if (
+		oidcCalls !== 1 ||
 		tokenCalls !== 1 ||
+		oidcCallIndex < 0 ||
+		tokenPublishIndex <= oidcCallIndex ||
+		!publishLines.includes("publish_with_oidc() {") ||
+		!publishLines.includes("publish_with_token() {") ||
+		!publishLines.includes('if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then') ||
 		publishLines.some(
 			(line) =>
-				line.includes("trusted_publisher") ||
 				line.includes("NPM_PUBLISH_AUTH_MODE") ||
 				line.includes("--provenance"),
 		)
 	) {
-		failures.push("the self-hosted release lane must use token-backed npm publication only");
+		failures.push(
+			"the public release lane must publish OIDC-first with a token-backed npm publication fallback",
+		);
 	}
 	if (
-		npmPublishLines.length !== expectedPublishLines.size ||
+		npmPublishLines.length !== 2 ||
 		npmPublishLines.some((line) => !expectedPublishLines.has(line))
 	) {
 		failures.push("trusted and token modes must execute exact unswallowed npm publish commands");
@@ -530,6 +552,7 @@ export function validateReleaseWorkflow(source) {
 			PACKAGE_NAME: "${{ needs.prepare.outputs.package_name }}",
 			PACKED_INTEGRITY: "${{ steps.pack.outputs.integrity }}",
 			RELEASE_VERSION: "${{ needs.prepare.outputs.release_version }}",
+			TARBALL: "${{ steps.pack.outputs.tarball }}",
 			NPM_CONFIG_FETCH_RETRIES: "1",
 			NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "2000",
 			NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "1000",

--- a/.github/workflows/check-release-workflow-contract.test.mjs
+++ b/.github/workflows/check-release-workflow-contract.test.mjs
@@ -15,7 +15,7 @@ concurrency:
   group: \${{ github.workflow }}-\${{ github.event_name == 'workflow_dispatch' && (startsWith(inputs.version, 'v') && inputs.version || format('v{0}', inputs.version)) || github.ref_name }}
 jobs:
   prepare:
-    runs-on: \${{ vars.INTERNAL_CONFIRMATION_RUNNER }}
+    runs-on: \${{ vars.PUBLIC_RELEASE_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
     outputs:
@@ -69,11 +69,12 @@ jobs:
           ref: ${releaseSha}
   publish:
     needs: [prepare, binaries]
-    runs-on: \${{ vars.INTERNAL_CONFIRMATION_RUNNER }}
+    runs-on: \${{ vars.PUBLIC_RELEASE_RUNNER || 'ubuntu-latest' }}
     environment:
       name: npm-release
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@sha
         with:
@@ -94,6 +95,7 @@ jobs:
           PACKAGE_NAME: \${{ needs.prepare.outputs.package_name }}
           PACKED_INTEGRITY: \${{ steps.pack.outputs.integrity }}
           RELEASE_VERSION: \${{ needs.prepare.outputs.release_version }}
+          TARBALL: \${{ steps.pack.outputs.tarball }}
           NPM_CONFIG_FETCH_RETRIES: "1"
           NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "2000"
           NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "1000"
@@ -101,8 +103,16 @@ jobs:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org
         run: |
           set -euo pipefail
+          publish_with_oidc() {
+            npx --yes npm@11.10.0 publish "\$TARBALL" --access public --registry "$NPM_CONFIG_REGISTRY"
+          }
           publish_with_token() {
-            command npm publish "\${{ steps.pack.outputs.tarball }}" --access public --registry "$NPM_CONFIG_REGISTRY"
+            if [[ -z "\${NODE_AUTH_TOKEN:-}" ]]; then
+              return 1
+            fi
+            NPM_CONFIG_USERCONFIG="\$RUNNER_TEMP/npmrc" \\
+              NODE_AUTH_TOKEN="\$NODE_AUTH_TOKEN" \\
+              npx --yes npm@11.10.0 publish "\$TARBALL" --access public --registry "$NPM_CONFIG_REGISTRY"
           }
           verify_published_tarball() {
             registry_integrity="\$(
@@ -140,6 +150,9 @@ jobs:
           if [[ "\$registry_status" -eq 2 ]]; then
             exit 2
           fi
+          if publish_or_verify publish_with_oidc; then
+            exit 0
+          fi
           publish_or_verify publish_with_token
       - name: Smoke packed package without JS runtime
         env:
@@ -161,7 +174,7 @@ jobs:
           path: maestro-web-dist.tar.gz
   github-release:
     needs: [prepare, binaries, publish]
-    runs-on: \${{ vars.INTERNAL_CONFIRMATION_RUNNER }}
+    runs-on: \${{ vars.PUBLIC_RELEASE_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: write
     steps:
@@ -212,7 +225,7 @@ jobs:
     needs:
       - prepare
       - publish
-    runs-on: \${{ vars.INTERNAL_CONFIRMATION_RUNNER }}
+    runs-on: \${{ vars.PUBLIC_RELEASE_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:
@@ -279,8 +292,8 @@ test("rejects swallowed npm publish failures", () => {
 test("comments cannot spoof environment, permissions, or dependencies", () => {
 	const spoofed = completeWorkflow
 		.replace(
-			"  publish:\n    needs: [prepare, binaries]\n    runs-on: ${{ vars.INTERNAL_CONFIRMATION_RUNNER }}\n    environment:\n      name: npm-release\n    permissions:\n      contents: read\n",
-			"  publish:\n    needs: [prepare, binaries]\n    runs-on: ${{ vars.INTERNAL_CONFIRMATION_RUNNER }}\n    environment:\n      name: npm-release\n    permissions:\n      # contents: read\n",
+			"  publish:\n    needs: [prepare, binaries]\n    runs-on: ${{ vars.PUBLIC_RELEASE_RUNNER || 'ubuntu-latest' }}\n    environment:\n      name: npm-release\n    permissions:\n      contents: read\n      id-token: write\n",
+			"  publish:\n    needs: [prepare, binaries]\n    runs-on: ${{ vars.PUBLIC_RELEASE_RUNNER || 'ubuntu-latest' }}\n    environment:\n      name: npm-release\n    permissions:\n      # contents: read\n      id-token: write\n",
 		)
 		.replace("    environment:\n      name: npm-release\n", "    # environment: npm-release\n")
 		.replace("      - publish\n", "      # - publish # needs: publish\n");
@@ -321,8 +334,8 @@ test("rejects extra workflow or job write permissions", () => {
 
 test("rejects publish checkout without contents read", () => {
 	const unreadablePublish = completeWorkflow.replace(
-		"  publish:\n    needs: [prepare, binaries]\n    runs-on: ${{ vars.INTERNAL_CONFIRMATION_RUNNER }}\n    environment:\n      name: npm-release\n    permissions:\n      contents: read\n",
-		"  publish:\n    needs: [prepare, binaries]\n    runs-on: ${{ vars.INTERNAL_CONFIRMATION_RUNNER }}\n    environment:\n      name: npm-release\n    permissions:\n",
+		"  publish:\n    needs: [prepare, binaries]\n    runs-on: ${{ vars.PUBLIC_RELEASE_RUNNER || 'ubuntu-latest' }}\n    environment:\n      name: npm-release\n    permissions:\n      contents: read\n      id-token: write\n",
+		"  publish:\n    needs: [prepare, binaries]\n    runs-on: ${{ vars.PUBLIC_RELEASE_RUNNER || 'ubuntu-latest' }}\n    environment:\n      name: npm-release\n    permissions:\n      id-token: write\n",
 	);
 	assert.ok(
 		validateReleaseWorkflow(unreadablePublish).some((failure) =>
@@ -603,8 +616,8 @@ test("rejects unauthorized early success or a shell function that shadows npm", 
 	);
 
 	const swallowedTokenFailure = completeWorkflow.replace(
-		'            command npm publish "${{ steps.pack.outputs.tarball }}" --access public --registry "$NPM_CONFIG_REGISTRY"\n',
-		'            command npm publish "${{ steps.pack.outputs.tarball }}" --access public --registry "$NPM_CONFIG_REGISTRY"\n            return 0\n',
+		'            npx --yes npm@11.10.0 publish "$TARBALL" --access public --registry "$NPM_CONFIG_REGISTRY"\n',
+		'            npx --yes npm@11.10.0 publish "$TARBALL" --access public --registry "$NPM_CONFIG_REGISTRY"\n            return 0\n',
 	);
 	assert.ok(
 		validateReleaseWorkflow(swallowedTokenFailure).some((failure) =>
@@ -677,14 +690,14 @@ test("rejects npm publication or reconciliation without the public registry", ()
 	);
 });
 
-test("rejects trusted publishing on the self-hosted release lane", () => {
+test("rejects removing the token-backed publish fallback", () => {
 	const trusted = completeWorkflow.replace(
 		"          publish_with_token() {\n",
 		"          publish_with_trusted_publisher() {\n",
 	);
 	assert.ok(
 		validateReleaseWorkflow(trusted).some((failure) =>
-			failure.includes("token-backed npm publication only"),
+			failure.includes("token-backed npm publication"),
 		),
 	);
 });
@@ -726,14 +739,14 @@ test("rejects an unbounded immutable tag fetch", () => {
 	);
 });
 
-test("rejects release control jobs outside the internal confirmation runner", () => {
+test("rejects release control jobs outside the public release runner", () => {
 	const wrongRunner = completeWorkflow.replace(
-		"    runs-on: ${{ vars.INTERNAL_CONFIRMATION_RUNNER }}",
+		"    runs-on: ${{ vars.PUBLIC_RELEASE_RUNNER || 'ubuntu-latest' }}",
 		"    runs-on: ubuntu-latest",
 	);
 	assert.ok(
 		validateReleaseWorkflow(wrongRunner).some((failure) =>
-			failure.includes("must run on INTERNAL_CONFIRMATION_RUNNER"),
+			failure.includes("must run on PUBLIC_RELEASE_RUNNER"),
 		),
 	);
 });

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -67,8 +67,8 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${GH_TOKEN}" ]]; then
-            echo "error: RUNTIME_IMAGE_SYNC_TOKEN is required to dispatch evalops/deploy image sync." >&2
-            exit 1
+            echo "::notice::RUNTIME_IMAGE_SYNC_TOKEN is not configured; skipping evalops/deploy image sync dispatch. The internal repo performs this dispatch."
+            exit 0
           fi
 
           image_tag="sha-${SOURCE_SHA:0:7}"


### PR DESCRIPTION
## Summary

- **GHCR Publish**: skip the evalops/deploy GitOps dispatch with a notice when `RUNTIME_IMAGE_SYNC_TOKEN` is not configured instead of hard-failing. The public mirror has no access to that internal secret; the internal repo performs this dispatch. This was the only failing step on main pushes.
- **actionlint**: update the release workflow contract (validator + fixtures) to the design shipped in #947 — `PUBLIC_RELEASE_RUNNER || 'ubuntu-latest'` instead of `INTERNAL_CONFIRMATION_RUNNER`, `id-token: write` on publish for OIDC trusted publishing, OIDC-first publish with fail-fast `NPM_TOKEN` fallback, exact `npx npm@11.10.0 publish` invocations, and `TARBALL` in the publish env binding.

## Test plan

- [x] `node --test .github/workflows/check-release-workflow-contract.test.mjs` — 37/37 pass
- [x] `node .github/workflows/check-release-workflow-contract.mjs` — passes against current release.yml
- [x] `node --test scripts/version.test.mjs` — 6/6 pass
- [x] `actionlint -shellcheck= -pyflakes=` — clean
- [x] Inline required-context contract from actionlint.yml — passes
- [ ] actionlint and GHCR Publish green on main after merge