### PR TITLE
fix(ci): verify published registry package with release-tag scripts

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -123,6 +123,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Verify with the smoke scripts from the release tag, not main:
+          # the published binary only supports what its own version shipped,
+          # so main's newer smoke must not run against an older binary.
+          ref: ${{ needs.tag-current-version.outputs.release_tag }}
 
       - name: Setup registry install smoke tools
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020


### PR DESCRIPTION
## Summary

- `tag-release` → `verify-published-registry-package` now checks out the release tag instead of main before running the registry smoke.

## Why

The job ran **main's** smoke scripts against the **published** npm binary. Once the published-replay smoke moved to `maestro scenario run --execute` (#3260, mirrored in #951), main's smoke ran against `@evalops/maestro@0.10.61`, which predates `--execute`: the flag was silently ignored, the write tool never executed, and the workspace `file_exists`/`file_contents` assertions failed — red `tag-release` on every main push.

Pinning the checkout to the release tag keeps smoke scripts and published binary on the same version, matching what `release.yml`'s post-publish canary already does (it checks out the release SHA).

## Test plan

- [x] `actionlint -shellcheck= -pyflakes=` clean
- [ ] `tag-release` green on main after merge (verify job runs 0.10.61's tag smoke against the 0.10.61 binary — that combination was verified passing locally earlier today)