### PR TITLE
fix(ci): verify published registry package with main's smoke

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -123,10 +123,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          # Verify with the smoke scripts from the release tag, not main:
-          # the published binary only supports what its own version shipped,
-          # so main's newer smoke must not run against an older binary.
-          ref: ${{ needs.tag-current-version.outputs.release_tag }}
 
       - name: Setup registry install smoke tools
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020


### PR DESCRIPTION
## Summary

- Reverts the release-tag checkout pin from #952 in `verify-published-registry-package`.

## Why

The pin moved the skew, not fixed it: v0.10.61's tag predates the smoke fix, so its smoke is the original broken `--replay` variant — it fails against the 0.10.61 binary forever (the tag is immutable). The correct fix for the version skew is `--execute` capability detection in the smoke itself (internal PR incoming, mirrors to public via the release-mirror sync): main's smoke will probe the binary and gracefully skip execute-only evidence for pre-`--execute` releases, while still failing loudly on any binary that advertises `--execute` but breaks it.

## Test plan

- [ ] `tag-release` green on main once the capability-detection smoke lands via mirror sync